### PR TITLE
Harden workflow-policy YAML handling for lint-safe workflows and escaped-quote comment parsing

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,18 +2,26 @@ name: Dependabot auto-merge
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   dependabot:
     name: Enable auto-merge for Dependabot PRs
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.draft == false
+    timeout-minutes: 5
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.sender.login == 'dependabot[bot]' && github.event.pull_request.draft == false
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
+      - name: Log Dependabot auto-merge context
+        run: |
+          echo "action=${{ github.event.action }}"
+          echo "pr_author=${{ github.event.pull_request.user.login }}"
+          echo "event_sender=${{ github.event.sender.login }}"
+          echo "base_ref=${{ github.event.pull_request.base.ref }}"
+          echo "head_ref=${{ github.event.pull_request.head.ref }}"
       - name: Enable auto-merge
         run: gh pr merge --auto --merge "$PR_URL"
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Enable auto-merge for Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.draft == false
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,10 @@ jobs:
     name: Enable auto-merge for Dependabot PRs
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.sender.login == 'dependabot[bot]' && github.event.pull_request.draft == false
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.sender.login == 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   dependabot:
     name: Enable auto-merge for Dependabot PRs
@@ -16,12 +23,18 @@ jobs:
       pull-requests: write
     steps:
       - name: Log Dependabot auto-merge context
+        env:
+          ACTION: ${{ github.event.action }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EVENT_SENDER: ${{ github.event.sender.login }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          echo "action=${{ github.event.action }}"
-          echo "pr_author=${{ github.event.pull_request.user.login }}"
-          echo "event_sender=${{ github.event.sender.login }}"
-          echo "base_ref=${{ github.event.pull_request.base.ref }}"
-          echo "head_ref=${{ github.event.pull_request.head.ref }}"
+          echo "action=$ACTION"
+          echo "pr_author=$PR_AUTHOR"
+          echo "event_sender=$EVENT_SENDER"
+          echo "base_ref=$BASE_REF"
+          echo "head_ref=$HEAD_REF"
       - name: Enable auto-merge
         run: gh pr merge --auto --merge "$PR_URL"
         env:

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -7023,8 +7023,9 @@ fn test_dependabot_auto_merge_workflow_hardening() {
                 workflow_path.display()
             )
         });
-    let is_within_dependabot_job_block =
-        |line: &&str| line.trim().is_empty() || line.starts_with("    ");
+    let is_within_dependabot_job_block = |line: &&str| {
+        line.starts_with("    ") || (line.trim().is_empty() && line.starts_with(' '))
+    };
     let dependabot_job = dependabot_rest
         .lines()
         .take_while(is_within_dependabot_job_block)

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -5579,33 +5579,18 @@ fn test_workflow_hygiene_requirements() {
     // `check`:   (&str, &str) -> Vec<String> — receives (filename, content),
     //            returns a list of violation descriptions (empty = pass).
 
-    // Workflows that must have concurrency groups. All workflows except
-    // docs-deploy.yml (which uses a special `pages` concurrency group that
-    // is intentionally different from the standard pattern).
-    let concurrency_allowlist: &[&str] = &[
-        "actionlint.yml",
-        "ci.yml",
-        "ci-safety.yml",
-        "dependabot-auto-merge.yml",
-        "doc-validation.yml",
-        "link-check.yml",
-        "markdownlint.yml",
-        "release.yml",
-        "spellcheck.yml",
-        "unused-deps.yml",
-        "workflow-hygiene.yml",
-        "yaml-lint.yml",
-    ];
+    // Workflows exempt from standard concurrency validation.
+    // docs-deploy.yml uses a specialized `pages` group pattern intentionally.
+    let concurrency_exceptions: &[&str] = &["docs-deploy.yml"];
 
     let rules: Vec<HygieneRule> = vec![
         // Rule 1: Concurrency groups -----------------------------------------
         HygieneRule {
             name: "concurrency groups",
-            // Applies to the explicit allowlist (docs-deploy.yml is excluded
-            // because it uses a special `pages` concurrency group).
+            // Applies to all workflows except explicit exceptions.
             filter: Box::new({
-                let list = concurrency_allowlist.to_vec();
-                move |filename: &str| list.contains(&filename)
+                let exceptions = concurrency_exceptions.to_vec();
+                move |filename: &str| !exceptions.contains(&filename)
             }),
             check: Box::new(|filename: &str, content: &str| {
                 let mut violations = Vec::new();
@@ -7023,9 +7008,8 @@ fn test_dependabot_auto_merge_workflow_hardening() {
                 workflow_path.display()
             )
         });
-    let is_within_dependabot_job_block = |line: &&str| {
-        line.starts_with("    ") || (line.trim().is_empty() && line.starts_with(' '))
-    };
+    let is_within_dependabot_job_block =
+        |line: &&str| line.starts_with("    ") || line.trim().is_empty();
     let dependabot_job = dependabot_rest
         .lines()
         .take_while(is_within_dependabot_job_block)

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -338,17 +338,54 @@ fn yaml_first_child_indent(content: &str) -> Option<usize> {
         .map(yaml_indent_spaces)
 }
 
-/// Strip YAML inline comments while preserving `#` inside quoted strings.
+/// Strip YAML inline comments while preserving `#` inside quoted strings,
+/// including escaped quotes in double-quoted scalars and doubled quotes in
+/// single-quoted scalars.
 fn strip_yaml_inline_comment(value: &str) -> &str {
     let mut in_single_quotes = false;
     let mut in_double_quotes = false;
     let mut previous_char: Option<char> = None;
+    let mut consecutive_backslashes = 0usize;
+    let mut chars = value.char_indices().peekable();
 
-    for (idx, ch) in value.char_indices() {
+    while let Some((idx, ch)) = chars.next() {
+        if in_single_quotes {
+            if ch == '\'' {
+                if matches!(chars.peek(), Some((_, '\''))) {
+                    chars.next();
+                    previous_char = Some('\'');
+                    continue;
+                }
+                in_single_quotes = false;
+            }
+
+            previous_char = Some(ch);
+            continue;
+        }
+
+        if in_double_quotes {
+            match ch {
+                '\\' => consecutive_backslashes += 1,
+                '"' => {
+                    if consecutive_backslashes.is_multiple_of(2) {
+                        in_double_quotes = false;
+                    }
+                    consecutive_backslashes = 0;
+                }
+                _ => consecutive_backslashes = 0,
+            }
+
+            previous_char = Some(ch);
+            continue;
+        }
+
         match ch {
-            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
-            '"' if !in_single_quotes => in_double_quotes = !in_double_quotes,
-            '#' if !in_single_quotes && !in_double_quotes => {
+            '\'' => in_single_quotes = true,
+            '"' => {
+                in_double_quotes = true;
+                consecutive_backslashes = 0;
+            }
+            '#' => {
                 if idx == 0 || previous_char.is_some_and(char::is_whitespace) {
                     return &value[..idx];
                 }
@@ -449,6 +486,24 @@ fn test_extract_yaml_mapping_block_allows_trailing_comments() {
     let extracted = extract_yaml_mapping_block(content, "permissions", 0)
         .expect("expected key with trailing comment to be treated as block mapping");
     assert!(extracted.contains("contents: read"));
+}
+
+#[test]
+fn test_strip_yaml_inline_comment_preserves_hash_after_escaped_double_quote() {
+    let value = "\"value with escaped quote \\\" and # still scalar\" # comment";
+    assert_eq!(
+        strip_yaml_inline_comment(value),
+        "\"value with escaped quote \\\" and # still scalar\" "
+    );
+}
+
+#[test]
+fn test_strip_yaml_inline_comment_preserves_hash_in_single_quoted_scalar() {
+    let value = "'value with '' escaped quote and # still scalar' # comment";
+    assert_eq!(
+        strip_yaml_inline_comment(value),
+        "'value with '' escaped quote and # still scalar' "
+    );
 }
 
 /// Extract the display name of a job from workflow YAML content.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -287,18 +287,23 @@ fn yaml_indent_spaces(line: &str) -> usize {
     line.chars().take_while(|c| *c == ' ').count()
 }
 
-/// Returns true if a line defines `key:` at exactly `indent` leading spaces.
-fn is_yaml_key_at_indent(line: &str, key: &str, indent: usize) -> bool {
+/// Returns true when `<indent><key>:` starts a block mapping, meaning there is
+/// no inline scalar/flow value after `:` other than optional whitespace/comment.
+fn yaml_key_starts_block_mapping(line: &str, key: &str, indent: usize) -> bool {
     if yaml_indent_spaces(line) != indent {
         return false;
     }
 
     let trimmed = line.trim_start();
-    if let Some(rest) = trimmed.strip_prefix(key) {
-        return rest.trim_start().starts_with(':');
-    }
+    let Some(rest) = trimmed.strip_prefix(key) else {
+        return false;
+    };
+    let Some(after_colon) = rest.trim_start().strip_prefix(':') else {
+        return false;
+    };
 
-    false
+    let trailing = strip_yaml_inline_comment(after_colon).trim();
+    trailing.is_empty()
 }
 
 /// Extract a YAML mapping block that starts with `<indent><key>:` and continues
@@ -307,7 +312,7 @@ fn extract_yaml_mapping_block(content: &str, key: &str, indent: usize) -> Option
     let lines: Vec<&str> = content.lines().collect();
 
     for (idx, line) in lines.iter().enumerate() {
-        if !is_yaml_key_at_indent(line, key, indent) {
+        if !yaml_key_starts_block_mapping(line, key, indent) {
             continue;
         }
 
@@ -415,6 +420,35 @@ fn extract_yaml_field_values(block: &str, field: &str) -> Vec<String> {
     }
 
     values
+}
+
+#[test]
+fn test_extract_yaml_mapping_block_ignores_inline_mapping_values() {
+    let content = concat!(
+        "permissions: read-all\n",
+        "concurrency: { group: test, cancel-in-progress: true }\n",
+        "permissions:\n",
+        "  contents: read\n",
+    );
+
+    let extracted = extract_yaml_mapping_block(content, "permissions", 0)
+        .expect("expected block-mapping permissions key to be extracted");
+    assert!(
+        extracted.contains("contents: read"),
+        "block mapping should be extracted, not inline scalar form"
+    );
+    assert!(
+        !extracted.contains("read-all"),
+        "inline scalar value must be ignored by block-mapping extraction"
+    );
+}
+
+#[test]
+fn test_extract_yaml_mapping_block_allows_trailing_comments() {
+    let content = concat!("permissions: # baseline\n", "  contents: read\n");
+    let extracted = extract_yaml_mapping_block(content, "permissions", 0)
+        .expect("expected key with trailing comment to be treated as block mapping");
+    assert!(extracted.contains("contents: read"));
 }
 
 /// Extract the display name of a job from workflow YAML content.
@@ -7085,7 +7119,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let normalized_content = content.replace("\r\n", "\n");
     let on_block = extract_yaml_mapping_block(&normalized_content, "on", 0).unwrap_or_else(|| {
         panic!(
-            "dependabot-auto-merge.yml must define top-level `on` trigger configuration.\n\
+            "dependabot-auto-merge.yml must define top-level `on` trigger configuration as a block mapping.\n\
              File: {}",
             workflow_path.display()
         )
@@ -7100,7 +7134,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let pull_request_block = extract_yaml_mapping_block(&on_block, "pull_request", on_child_indent)
         .unwrap_or_else(|| {
             panic!(
-                "dependabot-auto-merge.yml must define `on.pull_request` for hardening checks.\n\
+                "dependabot-auto-merge.yml must define `on.pull_request` as a block mapping for hardening checks.\n\
                  File: {}",
                 workflow_path.display()
             )
@@ -7128,14 +7162,14 @@ fn test_dependabot_auto_merge_workflow_hardening() {
          Fix:\n\
            on:\n\
              pull_request:\n\
-                types: [opened, synchronize, reopened, ready_for_review]",
+               types: [opened, synchronize, reopened, ready_for_review]",
         workflow_path.display()
     );
 
     let permissions_block = extract_yaml_mapping_block(&normalized_content, "permissions", 0)
         .unwrap_or_else(|| {
             panic!(
-                "dependabot-auto-merge.yml must define top-level `permissions`.\n\
+                "dependabot-auto-merge.yml must define top-level `permissions` as a block mapping.\n\
                  File: {}",
                 workflow_path.display()
             )
@@ -7155,7 +7189,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let concurrency_block = extract_yaml_mapping_block(&normalized_content, "concurrency", 0)
         .unwrap_or_else(|| {
             panic!(
-                "dependabot-auto-merge.yml must define top-level `concurrency`.\n\
+                "dependabot-auto-merge.yml must define top-level `concurrency` as a block mapping.\n\
                  File: {}",
                 workflow_path.display()
             )
@@ -7179,7 +7213,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let jobs_content = extract_yaml_mapping_block(&normalized_content, "jobs", 0)
         .unwrap_or_else(|| {
             panic!(
-                "dependabot-auto-merge.yml must contain a top-level `jobs` block for hardening checks.\n\
+                "dependabot-auto-merge.yml must contain top-level `jobs` as a block mapping for hardening checks.\n\
                  File: {}",
                 workflow_path.display()
             )
@@ -7195,7 +7229,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
         extract_yaml_mapping_block(&jobs_content, "dependabot", jobs_child_indent).unwrap_or_else(
             || {
                 panic!(
-                    "dependabot-auto-merge.yml must define a `jobs.dependabot` block for hardening checks.\n\
+                    "dependabot-auto-merge.yml must define `jobs.dependabot` as a block mapping for hardening checks.\n\
                      File: {}",
                     workflow_path.display()
                 )

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -6987,7 +6987,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let jobs_index = content.find("jobs:").unwrap_or(0);
     let pre_jobs = &content[..jobs_index];
     assert!(
-        pre_jobs.contains("\npermissions:") && pre_jobs.contains("contents: read"),
+        pre_jobs.contains("permissions:\n  contents: read"),
         "dependabot-auto-merge.yml must declare a minimal top-level workflow permissions baseline.\n\
          Keep elevated write permissions scoped only to the dependabot job.\n\
          File: {}\n\
@@ -6997,7 +6997,9 @@ fn test_dependabot_auto_merge_workflow_hardening() {
         workflow_path.display()
     );
     assert!(
-        pre_jobs.contains("\nconcurrency:") && pre_jobs.contains("cancel-in-progress: true"),
+        pre_jobs.contains(
+            "concurrency:\n  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}\n  cancel-in-progress: true",
+        ),
         "dependabot-auto-merge.yml must declare workflow-level concurrency with cancellation.\n\
          File: {}\n\
          Fix:\n\

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -7016,13 +7016,15 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let dependabot_rest = jobs_content
         .split_once("  dependabot:\n")
         .map(|(_, rest)| rest)
-        .expect(&format!(
-            "dependabot-auto-merge.yml must define a 'jobs.dependabot' block for hardening checks.\n\
-             File: {}",
-            workflow_path.display()
-        ));
+        .unwrap_or_else(|| {
+            panic!(
+                "dependabot-auto-merge.yml must define a 'jobs.dependabot' block for hardening checks.\n\
+                 File: {}",
+                workflow_path.display()
+            )
+        });
     let is_within_dependabot_job_block =
-        |line: &&str| !line.starts_with("  ") || line.starts_with("    ");
+        |line: &&str| line.trim().is_empty() || line.starts_with("    ");
     let dependabot_job = dependabot_rest
         .lines()
         .take_while(is_within_dependabot_job_block)

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -6969,11 +6969,12 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let root = repo_root();
     let workflow_path = root.join(".github/workflows/dependabot-auto-merge.yml");
     let content = read_file(&workflow_path);
+    let normalized_content = content.replace("\r\n", "\n");
 
     assert!(
-        content.contains("pull_request:")
-            && content.contains("branches: [main]")
-            && content.contains("types: [opened, synchronize, reopened, ready_for_review]"),
+        normalized_content.contains(
+            "pull_request:\n    branches: [main]\n    types: [opened, synchronize, reopened, ready_for_review]",
+        ),
         "dependabot-auto-merge.yml must scope pull_request triggers to main and expected events.\n\
          File: {}\n\
          Fix:\n\
@@ -6984,8 +6985,10 @@ fn test_dependabot_auto_merge_workflow_hardening() {
         workflow_path.display()
     );
 
-    let jobs_index = content.find("jobs:").unwrap_or(0);
-    let pre_jobs = &content[..jobs_index];
+    let jobs_index = normalized_content.find("jobs:").expect(
+        "dependabot-auto-merge.yml must contain a top-level 'jobs:' block before workflow-level hardening checks can run.",
+    );
+    let pre_jobs = &normalized_content[..jobs_index];
     assert!(
         pre_jobs.contains("permissions:\n  contents: read"),
         "dependabot-auto-merge.yml must declare a minimal top-level workflow permissions baseline.\n\
@@ -7009,7 +7012,7 @@ fn test_dependabot_auto_merge_workflow_hardening() {
         workflow_path.display()
     );
 
-    let dependabot_job = content
+    let dependabot_job = normalized_content
         .split_once("  dependabot:\n")
         .map(|(_, rest)| rest)
         .unwrap_or_default();

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -282,6 +282,121 @@ fn extract_job_if_condition(content: &str, job_key: &str) -> Option<String> {
     None
 }
 
+/// Return the number of leading spaces in a line.
+fn yaml_indent_spaces(line: &str) -> usize {
+    line.chars().take_while(|c| *c == ' ').count()
+}
+
+/// Returns true if a line defines `key:` at exactly `indent` leading spaces.
+fn is_yaml_key_at_indent(line: &str, key: &str, indent: usize) -> bool {
+    if yaml_indent_spaces(line) != indent {
+        return false;
+    }
+
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix(key) {
+        return rest.trim_start().starts_with(':');
+    }
+
+    false
+}
+
+/// Extract a YAML mapping block that starts with `<indent><key>:` and continues
+/// until the next non-empty line with indentation <= `indent` (or EOF).
+fn extract_yaml_mapping_block(content: &str, key: &str, indent: usize) -> Option<String> {
+    let lines: Vec<&str> = content.lines().collect();
+
+    for (idx, line) in lines.iter().enumerate() {
+        if !is_yaml_key_at_indent(line, key, indent) {
+            continue;
+        }
+
+        let mut block_lines = Vec::new();
+        for follow in lines.iter().skip(idx + 1) {
+            if !follow.trim().is_empty() && yaml_indent_spaces(follow) <= indent {
+                break;
+            }
+            block_lines.push(*follow);
+        }
+
+        return Some(block_lines.join("\n"));
+    }
+
+    None
+}
+
+/// Detect the indentation level of the first non-empty line in a YAML block.
+fn yaml_first_child_indent(content: &str) -> Option<usize> {
+    content
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(yaml_indent_spaces)
+}
+
+/// Extract values from a YAML field that may be inline (`field: [a, b]`) or
+/// multi-line list form:
+///   field:
+///     - a
+///     - b
+fn extract_yaml_field_values(block: &str, field: &str) -> Vec<String> {
+    let mut values = Vec::new();
+    let lines: Vec<&str> = block.lines().collect();
+
+    for (idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with(field) {
+            continue;
+        }
+
+        let Some(rest) = trimmed.strip_prefix(field) else {
+            continue;
+        };
+        let Some(rest_after_colon) = rest.trim_start().strip_prefix(':') else {
+            continue;
+        };
+
+        let field_indent = yaml_indent_spaces(line);
+        let scalar = rest_after_colon.split('#').next().unwrap_or("").trim();
+        if scalar.starts_with('[') && scalar.ends_with(']') {
+            let inner = &scalar[1..scalar.len().saturating_sub(1)];
+            for item in inner.split(',') {
+                let value = item.trim().trim_matches('"').trim_matches('\'');
+                if !value.is_empty() {
+                    values.push(value.to_string());
+                }
+            }
+            return values;
+        }
+
+        if !scalar.is_empty() {
+            values.push(scalar.trim_matches('"').trim_matches('\'').to_string());
+            return values;
+        }
+
+        for follow in lines.iter().skip(idx + 1) {
+            if follow.trim().is_empty() {
+                continue;
+            }
+            let follow_indent = yaml_indent_spaces(follow);
+            if follow_indent <= field_indent {
+                break;
+            }
+
+            let trimmed_follow = follow.trim_start();
+            if let Some(item) = trimmed_follow.strip_prefix("- ") {
+                let item = item.split('#').next().unwrap_or("").trim();
+                if !item.is_empty() {
+                    values.push(item.trim_matches('"').trim_matches('\'').to_string());
+                }
+            }
+        }
+
+        return values;
+    }
+
+    values
+}
+
 /// Extract the display name of a job from workflow YAML content.
 ///
 /// Searches for a job key at 2-space indentation (`  job_key:`) and then
@@ -5579,19 +5694,12 @@ fn test_workflow_hygiene_requirements() {
     // `check`:   (&str, &str) -> Vec<String> — receives (filename, content),
     //            returns a list of violation descriptions (empty = pass).
 
-    // Workflows exempt from standard concurrency validation.
-    // docs-deploy.yml uses a specialized `pages` group pattern intentionally.
-    let concurrency_exceptions: &[&str] = &["docs-deploy.yml"];
-
     let rules: Vec<HygieneRule> = vec![
         // Rule 1: Concurrency groups -----------------------------------------
         HygieneRule {
             name: "concurrency groups",
-            // Applies to all workflows except explicit exceptions.
-            filter: Box::new({
-                let exceptions = concurrency_exceptions.to_vec();
-                move |filename: &str| !exceptions.contains(&filename)
-            }),
+            // Applies to all workflows.
+            filter: Box::new(|_: &str| true),
             check: Box::new(|filename: &str, content: &str| {
                 let mut violations = Vec::new();
                 if !content.contains("concurrency:") {
@@ -6955,27 +7063,67 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let workflow_path = root.join(".github/workflows/dependabot-auto-merge.yml");
     let content = read_file(&workflow_path);
     let normalized_content = content.replace("\r\n", "\n");
+    let on_block = extract_yaml_mapping_block(&normalized_content, "on", 0).unwrap_or_else(|| {
+        panic!(
+            "dependabot-auto-merge.yml must define top-level `on` trigger configuration.\n\
+             File: {}",
+            workflow_path.display()
+        )
+    });
+    let on_child_indent = yaml_first_child_indent(&on_block).unwrap_or_else(|| {
+        panic!(
+            "dependabot-auto-merge.yml `on` block must contain at least one event trigger.\n\
+             File: {}",
+            workflow_path.display()
+        )
+    });
+    let pull_request_block = extract_yaml_mapping_block(&on_block, "pull_request", on_child_indent)
+        .unwrap_or_else(|| {
+            panic!(
+                "dependabot-auto-merge.yml must define `on.pull_request` for hardening checks.\n\
+                 File: {}",
+                workflow_path.display()
+            )
+        });
 
     assert!(
-        normalized_content.contains(
-            "pull_request:\n    branches: [main]\n    types: [opened, synchronize, reopened, ready_for_review]",
-        ),
-        "dependabot-auto-merge.yml must scope pull_request triggers to main and expected events.\n\
+        extract_yaml_field_values(&pull_request_block, "branches")
+            .iter()
+            .any(|branch| branch == "main"),
+        "dependabot-auto-merge.yml must scope pull_request trigger branches to main.\n\
          File: {}\n\
          Fix:\n\
            on:\n\
              pull_request:\n\
-               branches: [main]\n\
-               types: [opened, synchronize, reopened, ready_for_review]",
+               branches: [main]",
+        workflow_path.display()
+    );
+    let pull_request_types = extract_yaml_field_values(&pull_request_block, "types");
+    assert!(
+        ["opened", "synchronize", "reopened", "ready_for_review"]
+            .iter()
+            .all(|event| pull_request_types.iter().any(|actual| actual == event)),
+        "dependabot-auto-merge.yml must scope pull_request trigger types to opened/synchronize/reopened/ready_for_review.\n\
+         File: {}\n\
+         Fix:\n\
+           on:\n\
+             pull_request:\n\
+                types: [opened, synchronize, reopened, ready_for_review]",
         workflow_path.display()
     );
 
-    let jobs_index = normalized_content.find("jobs:").expect(
-        "dependabot-auto-merge.yml must contain a top-level 'jobs:' block before workflow-level hardening checks can run.",
-    );
-    let pre_jobs = &normalized_content[..jobs_index];
+    let permissions_block = extract_yaml_mapping_block(&normalized_content, "permissions", 0)
+        .unwrap_or_else(|| {
+            panic!(
+                "dependabot-auto-merge.yml must define top-level `permissions`.\n\
+                 File: {}",
+                workflow_path.display()
+            )
+        });
     assert!(
-        pre_jobs.contains("permissions:\n  contents: read"),
+        permissions_block
+            .lines()
+            .any(|line| line.trim_start() == "contents: read"),
         "dependabot-auto-merge.yml must declare a minimal top-level workflow permissions baseline.\n\
          Keep elevated write permissions scoped only to the dependabot job.\n\
          File: {}\n\
@@ -6984,10 +7132,21 @@ fn test_dependabot_auto_merge_workflow_hardening() {
              contents: read",
         workflow_path.display()
     );
+    let concurrency_block = extract_yaml_mapping_block(&normalized_content, "concurrency", 0)
+        .unwrap_or_else(|| {
+            panic!(
+                "dependabot-auto-merge.yml must define top-level `concurrency`.\n\
+                 File: {}",
+                workflow_path.display()
+            )
+        });
     assert!(
-        pre_jobs.contains(
-            "concurrency:\n  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}\n  cancel-in-progress: true",
-        ),
+        concurrency_block
+            .lines()
+            .any(|line| line.trim_start() == "cancel-in-progress: true")
+            && concurrency_block.contains("group:")
+            && concurrency_block.contains("${{ github.workflow }}")
+            && concurrency_block.contains("${{ github.head_ref || github.run_id }}"),
         "dependabot-auto-merge.yml must declare workflow-level concurrency with cancellation.\n\
          File: {}\n\
          Fix:\n\
@@ -6997,24 +7156,31 @@ fn test_dependabot_auto_merge_workflow_hardening() {
         workflow_path.display()
     );
 
-    let jobs_content = &normalized_content[jobs_index + "jobs:\n".len()..];
-    let dependabot_rest = jobs_content
-        .split_once("  dependabot:\n")
-        .map(|(_, rest)| rest)
+    let jobs_content = extract_yaml_mapping_block(&normalized_content, "jobs", 0)
         .unwrap_or_else(|| {
             panic!(
-                "dependabot-auto-merge.yml must define a 'jobs.dependabot' block for hardening checks.\n\
+                "dependabot-auto-merge.yml must contain a top-level `jobs` block for hardening checks.\n\
                  File: {}",
                 workflow_path.display()
             )
         });
-    let is_within_dependabot_job_block =
-        |line: &&str| line.starts_with("    ") || line.trim().is_empty();
-    let dependabot_job = dependabot_rest
-        .lines()
-        .take_while(is_within_dependabot_job_block)
-        .collect::<Vec<_>>()
-        .join("\n");
+    let jobs_child_indent = yaml_first_child_indent(&jobs_content).unwrap_or_else(|| {
+        panic!(
+            "dependabot-auto-merge.yml `jobs` block must contain at least one job definition.\n\
+             File: {}",
+            workflow_path.display()
+        )
+    });
+    let dependabot_job =
+        extract_yaml_mapping_block(&jobs_content, "dependabot", jobs_child_indent).unwrap_or_else(
+            || {
+                panic!(
+                    "dependabot-auto-merge.yml must define a `jobs.dependabot` block for hardening checks.\n\
+                     File: {}",
+                    workflow_path.display()
+                )
+            },
+        );
     assert!(
         dependabot_job.contains("timeout-minutes: 5"),
         "dependabot-auto-merge.yml must define a small job timeout to prevent hung runs.\n\

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -7016,12 +7016,16 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let dependabot_rest = jobs_content
         .split_once("  dependabot:\n")
         .map(|(_, rest)| rest)
-        .expect(
-            "dependabot-auto-merge.yml must define a 'jobs.dependabot' block for hardening checks.",
-        );
+        .expect(&format!(
+            "dependabot-auto-merge.yml must define a 'jobs.dependabot' block for hardening checks.\n\
+             File: {}",
+            workflow_path.display()
+        ));
+    let is_within_dependabot_job_block =
+        |line: &&str| !line.starts_with("  ") || line.starts_with("    ");
     let dependabot_job = dependabot_rest
         .lines()
-        .take_while(|line| !line.starts_with("  ") || line.starts_with("    "))
+        .take_while(is_within_dependabot_job_block)
         .collect::<Vec<_>>()
         .join("\n");
     assert!(

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -6964,6 +6964,71 @@ fn test_release_workflow_requires_preflight() {
 }
 
 #[test]
+fn test_dependabot_auto_merge_workflow_hardening() {
+    let root = repo_root();
+    let workflow_path = root.join(".github/workflows/dependabot-auto-merge.yml");
+    let content = read_file(&workflow_path);
+
+    assert!(
+        content.contains("pull_request:")
+            && content.contains("branches: [main]")
+            && content.contains("types: [opened, synchronize, reopened, ready_for_review]"),
+        "dependabot-auto-merge.yml must scope pull_request triggers to main and expected events.\n\
+         File: {}\n\
+         Fix:\n\
+           on:\n\
+             pull_request:\n\
+               branches: [main]\n\
+               types: [opened, synchronize, reopened, ready_for_review]",
+        workflow_path.display()
+    );
+
+    let jobs_index = content.find("jobs:").unwrap_or(0);
+    let pre_jobs = &content[..jobs_index];
+    assert!(
+        !pre_jobs.contains("\npermissions:"),
+        "dependabot-auto-merge.yml should not grant top-level workflow permissions.\n\
+         Keep elevated write permissions scoped only to the dependabot job.\n\
+         File: {}",
+        workflow_path.display()
+    );
+
+    let dependabot_job = content
+        .split_once("  dependabot:\n")
+        .map(|(_, rest)| rest)
+        .unwrap_or_default();
+    assert!(
+        dependabot_job.contains("timeout-minutes: 5"),
+        "dependabot-auto-merge.yml must define a small job timeout to prevent hung runs.\n\
+         File: {}\n\
+         Fix: add 'timeout-minutes: 5' under jobs.dependabot.",
+        workflow_path.display()
+    );
+    assert!(
+        dependabot_job.contains("permissions:")
+            && dependabot_job.contains("contents: write")
+            && dependabot_job.contains("pull-requests: write"),
+        "dependabot-auto-merge.yml dependabot job must explicitly scope write permissions.\n\
+         File: {}\n\
+         Fix:\n\
+           jobs:\n\
+             dependabot:\n\
+               permissions:\n\
+                 contents: write\n\
+                 pull-requests: write",
+        workflow_path.display()
+    );
+    assert!(
+        dependabot_job.contains("github.event.pull_request.user.login == 'dependabot[bot]'")
+            && dependabot_job.contains("github.event.sender.login == 'dependabot[bot]'"),
+        "dependabot-auto-merge.yml must gate on both PR author and event sender as dependabot[bot].\n\
+         File: {}\n\
+         Fix: include both checks in jobs.dependabot.if.",
+        workflow_path.display()
+    );
+}
+
+#[test]
 fn test_release_workflow_handles_path_filtered_workflows() {
     // This test validates that the release workflow's preflight job handles
     // path-filtered workflows (like Documentation Validation) that may be

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -5586,6 +5586,7 @@ fn test_workflow_hygiene_requirements() {
         "actionlint.yml",
         "ci.yml",
         "ci-safety.yml",
+        "dependabot-auto-merge.yml",
         "doc-validation.yml",
         "link-check.yml",
         "markdownlint.yml",
@@ -6986,10 +6987,23 @@ fn test_dependabot_auto_merge_workflow_hardening() {
     let jobs_index = content.find("jobs:").unwrap_or(0);
     let pre_jobs = &content[..jobs_index];
     assert!(
-        !pre_jobs.contains("\npermissions:"),
-        "dependabot-auto-merge.yml should not grant top-level workflow permissions.\n\
+        pre_jobs.contains("\npermissions:") && pre_jobs.contains("contents: read"),
+        "dependabot-auto-merge.yml must declare a minimal top-level workflow permissions baseline.\n\
          Keep elevated write permissions scoped only to the dependabot job.\n\
-         File: {}",
+         File: {}\n\
+         Fix:\n\
+           permissions:\n\
+             contents: read",
+        workflow_path.display()
+    );
+    assert!(
+        pre_jobs.contains("\nconcurrency:") && pre_jobs.contains("cancel-in-progress: true"),
+        "dependabot-auto-merge.yml must declare workflow-level concurrency with cancellation.\n\
+         File: {}\n\
+         Fix:\n\
+           concurrency:\n\
+             group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}\n\
+             cancel-in-progress: true",
         workflow_path.display()
     );
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -7012,10 +7012,18 @@ fn test_dependabot_auto_merge_workflow_hardening() {
         workflow_path.display()
     );
 
-    let dependabot_job = normalized_content
+    let jobs_content = &normalized_content[jobs_index + "jobs:\n".len()..];
+    let dependabot_rest = jobs_content
         .split_once("  dependabot:\n")
         .map(|(_, rest)| rest)
-        .unwrap_or_default();
+        .expect(
+            "dependabot-auto-merge.yml must define a 'jobs.dependabot' block for hardening checks.",
+        );
+    let dependabot_job = dependabot_rest
+        .lines()
+        .take_while(|line| !line.starts_with("  ") || line.starts_with("    "))
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(
         dependabot_job.contains("timeout-minutes: 5"),
         "dependabot-auto-merge.yml must define a small job timeout to prevent hung runs.\n\

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -333,6 +333,30 @@ fn yaml_first_child_indent(content: &str) -> Option<usize> {
         .map(yaml_indent_spaces)
 }
 
+/// Strip YAML inline comments while preserving `#` inside quoted strings.
+fn strip_yaml_inline_comment(value: &str) -> &str {
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut previous_char: Option<char> = None;
+
+    for (idx, ch) in value.char_indices() {
+        match ch {
+            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
+            '"' if !in_single_quotes => in_double_quotes = !in_double_quotes,
+            '#' if !in_single_quotes && !in_double_quotes => {
+                if idx == 0 || previous_char.is_some_and(char::is_whitespace) {
+                    return &value[..idx];
+                }
+            }
+            _ => {}
+        }
+
+        previous_char = Some(ch);
+    }
+
+    value
+}
+
 /// Extract values from a YAML field that may be inline (`field: [a, b]`) or
 /// multi-line list form:
 ///   field:
@@ -344,10 +368,6 @@ fn extract_yaml_field_values(block: &str, field: &str) -> Vec<String> {
 
     for (idx, line) in lines.iter().enumerate() {
         let trimmed = line.trim_start();
-        if !trimmed.starts_with(field) {
-            continue;
-        }
-
         let Some(rest) = trimmed.strip_prefix(field) else {
             continue;
         };
@@ -356,7 +376,7 @@ fn extract_yaml_field_values(block: &str, field: &str) -> Vec<String> {
         };
 
         let field_indent = yaml_indent_spaces(line);
-        let scalar = rest_after_colon.split('#').next().unwrap_or("").trim();
+        let scalar = strip_yaml_inline_comment(rest_after_colon).trim();
         if scalar.starts_with('[') && scalar.ends_with(']') {
             let inner = &scalar[1..scalar.len().saturating_sub(1)];
             for item in inner.split(',') {
@@ -384,7 +404,7 @@ fn extract_yaml_field_values(block: &str, field: &str) -> Vec<String> {
 
             let trimmed_follow = follow.trim_start();
             if let Some(item) = trimmed_follow.strip_prefix("- ") {
-                let item = item.split('#').next().unwrap_or("").trim();
+                let item = strip_yaml_inline_comment(item).trim();
                 if !item.is_empty() {
                     values.push(item.trim_matches('"').trim_matches('\'').to_string());
                 }


### PR DESCRIPTION
Workflow-policy checks were hardened to reduce YAML-format fragility, but follow-up review identified two remaining gaps: a lint-risky long workflow `if:` expression and incomplete inline-comment parsing around escaped quotes. This update closes both gaps while keeping the lightweight parser approach.

- **Workflow YAML lint resilience**
  - Rewrote `dependabot-auto-merge.yml` job `if:` into folded multiline YAML to avoid line-length violations without changing semantics.

- **Inline-comment parsing correctness**
  - Updated `strip_yaml_inline_comment(...)` to correctly preserve `#` inside:
    - double-quoted scalars with escaped quotes (`\"`)
    - single-quoted scalars with doubled quote escapes (`''`)

- **Regression coverage for quote-escape cases**
  - Added focused tests to lock behavior for both escaped-quote patterns so future parser changes do not regress this class of bug.

```yaml
if: >
  github.event.pull_request.user.login == 'dependabot[bot]' &&
  github.event.sender.login == 'dependabot[bot]' &&
  github.event.pull_request.draft == false
```

```rust
if in_double_quotes {
    match ch {
        '\\' => consecutive_backslashes += 1,
        '"' => {
            if consecutive_backslashes.is_multiple_of(2) {
                in_double_quotes = false;
            }
            consecutive_backslashes = 0;
        }
        _ => consecutive_backslashes = 0,
    }
}
```