### PR TITLE
Fix README formatting and CI hygiene coverage

### DIFF
--- a/.llm/skills/supply-chain-audit-policy.md
+++ b/.llm/skills/supply-chain-audit-policy.md
@@ -27,6 +27,7 @@ or setting up reproducible builds.
 ## TL;DR
 
 - Run `cargo audit` and `cargo deny check` in CI on every PR — block merges on failure.
+- Run `cargo audit` in CI; it scans `Cargo.lock` directly and does not support `--locked`.
 - Pin security-critical dependencies with exact versions (`=1.2.3`) and always commit `Cargo.lock`.
 - Build with `cargo build --locked` in CI to guarantee reproducibility.
 
@@ -35,12 +36,15 @@ or setting up reproducible builds.
 ## 1. Cargo Audit and Advisory Database
 
 ```bash
-cargo audit              # Check against RustSec Advisory Database
+cargo audit              # Check Cargo.lock against RustSec Advisory Database
 cargo audit --json       # JSON output for CI parsing
 ```
 
 Every advisory must result in: **Fix** (update the crate), **Ignore with justification** (document in `audit.toml`),
 or **Deny** (replace the crate).
+
+Do not add `--locked` to `cargo audit`; unlike build/test/check commands,
+cargo-audit already reads `Cargo.lock` directly.
 
 Document ignored advisories in `audit.toml` with rationale and expiry dates.
 Never silently ignore — every ignore must have a justification and a revisit date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unmaintained `rustls-pemfile` dependency (RUSTSEC-2025-0134); PEM parsing now uses
   `rustls-pki-types` built-in `PemObject` trait.
 
+### Fixed
+
+- Fixed README protocol-reference formatting for the `Reconnect` row and typical session-flow diagram alignment.
+
 ### Changed
 
 - Upgraded `sha2` from `0.10.9` to `0.11.0` and `hmac` from `0.12.1` to `0.13.0-rc.6` to align

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Canonical sample: [.llm/code-samples/protocol/v2-client-messages.jsonl](.llm/cod
 | `AuthorityRequest` | Request or release game authority                                                |
 | `PlayerReady`      | Toggle your ready/unready state in the lobby                                     |
 | `ProvideConnectionInfo` | Share peer connection information for P2P establishment                     |
-| `Reconnect`        | Reconnect after disconnect using `player_id`, `room_id`, and `auth_token`       |
+| `Reconnect`        | Reconnect after disconnect using `player_id`, `room_id`, and `auth_token`        |
 | `JoinAsSpectator`  | Join a room as a spectator (read-only observer)                                  |
 | `LeaveSpectator`   | Leave spectator mode                                                             |
 | `LeaveRoom`        | Leave the current room                                                           |
@@ -320,8 +320,8 @@ Client                              Server
   |         (other client joins)       |
   |<-- PlayerJoined -------------------|
   |                                    |
-  |--- PlayerReady -------------------->|
-  |<-- LobbyStateChanged (lobby) -------|
+  |--- PlayerReady ------------------->|
+  |<-- LobbyStateChanged (lobby) ------|
   |                                    |
   |--- GameData ---------------------->|
   |<-- GameData (from other player) ---|

--- a/scripts/check-workflow-hygiene.sh
+++ b/scripts/check-workflow-hygiene.sh
@@ -593,6 +593,7 @@ normalize_run_block_commands() {
 }
 
 # Commands that are exempt from the --locked requirement:
+#   - cargo audit: Reads Cargo.lock directly and does not support --locked
 #   - cargo fmt: Formatter only, does not resolve dependencies
 #   - cargo publish: Intentionally resolves from registry for crates.io compatibility
 #   - cargo install: Installing tools, not building the project
@@ -602,7 +603,7 @@ normalize_run_block_commands() {
 #   - cargo init/new/search/login/owner/yank: Registry or scaffolding commands,
 #     not project builds (unlikely in CI but listed for completeness)
 #   - cargo bench: Benchmarking, not a correctness gate
-LOCKED_EXEMPT_PATTERNS="fmt|publish|install|machete|sbom|clean|init|new|search|login|owner|yank|bench"
+LOCKED_EXEMPT_PATTERNS="audit|fmt|publish|install|machete|sbom|clean|init|new|search|login|owner|yank|bench"
 
 MISSING_LOCKED=0
 for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -9710,8 +9710,8 @@ fn test_audit_job_installs_cargo_audit() {
 
 #[test]
 fn test_audit_job_runs_cargo_audit() {
-    // Validates that the audit job actually runs `cargo audit` to scan for
-    // known vulnerabilities in the RustSec advisory database.
+    // Validates that the audit job runs `cargo audit` to scan Cargo.lock for
+    // known RustSec vulnerabilities.
 
     let root = repo_root();
     let ci_content = read_file(&root.join(".github/workflows/ci.yml"));
@@ -9722,6 +9722,12 @@ fn test_audit_job_runs_cargo_audit() {
         audit_section.contains("cargo audit"),
         "Audit job must run `cargo audit` to scan for vulnerabilities.\n\
          The audit job should invoke cargo-audit against the RustSec advisory database."
+    );
+
+    assert!(
+        !audit_section.contains("cargo audit --locked"),
+        "cargo-audit reads Cargo.lock directly and does not support --locked.\n\
+         Fix: use `cargo audit` without --locked in .github/workflows/ci.yml."
     );
 }
 

--- a/tests/workflow_hygiene_script_tests.rs
+++ b/tests/workflow_hygiene_script_tests.rs
@@ -133,6 +133,31 @@ jobs:
 }
 
 #[test]
+fn test_workflow_hygiene_exempts_cargo_audit_from_locked_warning() {
+    let workflow = r#"name: Audit Workflow
+on: [push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Run cargo-audit
+        run: cargo audit
+"#;
+
+    let (success, output) = run_hygiene_with_workflow("audit.yml", workflow);
+
+    assert!(
+        success,
+        "Workflow hygiene script should succeed for cargo-audit.\nOutput:\n{output}"
+    );
+    assert!(
+        !output.contains("missing --locked flag"),
+        "cargo-audit reads Cargo.lock directly and should not require --locked.\nOutput:\n{output}"
+    );
+}
+
+#[test]
 fn test_workflow_hygiene_flags_multiline_cargo_sbom_locked_as_error() {
     let workflow = r#"name: SBOM Workflow
 on: [push]


### PR DESCRIPTION
> [!NOTE]
> **Low Risk**
> Documentation and CI/tooling validation only; no runtime or API impact.
>
> **Overview**
> Aligns **README** markdown table and ASCII session-flow diagram whitespace: the **`Reconnect`** client-message row and the **`PlayerReady` / `LobbyStateChanged`** sequence lines are padded so columns and arrows line up with neighboring rows.
>
> Also records the README formatting fix in **CHANGELOG**, and hardens CI workflow hygiene guidance/tests so `cargo audit` is correctly treated as a `Cargo.lock` scanner that does not support `--locked`. No protocol, config, or runtime behavior changes.