### PR TITLE
Version BUMP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,6 +444,14 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Verify build and tests with MSRV
+        # Plain `cargo test` (NOT nextest) runs every test binary in parallel
+        # with no `process-spawning` isolation, so the multiprocess and
+        # idle-timeout tests share CPU with ~40 other binaries. The timeout
+        # multiplier gives the idle-timeout tests proportional headroom so a
+        # starved task still resets the idle timer in time (see
+        # idle_timeout_test_multiplier in tests/e2e_tests.rs).
+        env:
+          SIGNAL_FISH_TEST_TIMEOUT_MULTIPLIER: "3"
         run: |
           cargo test --locked --all-features --no-fail-fast
           echo "✓ Build and tests successful with MSRV ${{ steps.msrv.outputs.msrv }}"
@@ -462,8 +470,26 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.3
+      - name: Set up Docker Buildx
+        # Buildx unlocks the GitHub Actions layer cache below. Mirrors the proven
+        # pattern in docker-publish.yml (same pinned action versions), turning a
+        # cold ~3-5 min image build into a warm sub-minute one on cache hits.
+        uses: docker/setup-buildx-action@v4.1.0
       - name: Build Docker image
-        run: docker build -t signal-fish-server:ci .
+        uses: docker/build-push-action@v7.2.0
+        with:
+          context: .
+          # load (not push): import the built image into the local Docker daemon
+          # so the smoke test below can `docker run` it.
+          load: true
+          tags: signal-fish-server:ci
+          # Reads are always safe; only EXPORT the layer cache from same-repo runs.
+          # A fork PR gets a read-only GITHUB_TOKEN that cannot write the Actions
+          # cache, and a `cache-to: type=gha` export failure is fatal by default —
+          # so gate the export the same way rust-cache's `save-if` does. An empty
+          # cache-to is a no-op export, leaving the cold build correct on forks.
+          cache-from: type=gha
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'type=gha,mode=max' || '' }}
 
       - name: Smoke test
         run: |
@@ -526,6 +552,15 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Generate coverage report
+        # cargo-llvm-cov runs the suite via plain `cargo test` (NOT nextest), so
+        # the `.config/nextest.toml` `process-spawning` isolation never applies
+        # here, and coverage instrumentation slows execution ~2-4x. The timeout
+        # multiplier widens the idle-timeout tests' windows proportionally so a
+        # briefly CPU-starved task on this oversubscribed, instrumented lane
+        # cannot slip the window and flake (see idle_timeout_test_multiplier in
+        # tests/e2e_tests.rs and the multiprocess backoff in v3_multiprocess_e2e.rs).
+        env:
+          SIGNAL_FISH_TEST_TIMEOUT_MULTIPLIER: "3"
         run: cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info
 
       - name: Enforce coverage threshold

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -10,7 +10,7 @@
 - **Repository:** `signal-fish-server` — extracted from the matchbox-signaling-server with
   production-ready signaling stripped down to a single self-contained binary
 - **Crate name:** Binary: `signal-fish-server` | Library: `signal_fish_server`
-- **Version:** 0.2.0
+- **Version:** 0.3.0
 - **Code name:** Signal Fish
 - **Not Matchbox:** This project is built by Ambiguous Interactive, not the upstream Matchbox team.
   The upstream `matchbox` crate/project (by Johan Helsing) is a dependency we build upon,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a class of CI failure where a root version bump silently invalidated the committed
+  `clients/native` lockfile: it kept pinning the previous `signal-fish-server` version, so the
+  `--locked` Browser Interop and WebRTC Interop builds failed with a cryptic "lock file needs to be
+  updated" error after a multi-minute cold build. The lockfile is regenerated, and a new offline
+  guard (`tests/workspace_lockfile_consistency.rs`) now fails fast in the always-on test suite if
+  any git-tracked lockfile drifts from the root crate version — replacing that late, confusing
+  failure with an instant, actionable one.
+- Hardened the timing-sensitive end-to-end tests against CPU starvation on oversubscribed CI
+  runners (the rare flake the `nextest`/`msrv`/`coverage` lanes hit then passed on re-run): the
+  multi-process restart spawn now retries its fixed port with exponential backoff, the
+  idle-timeout tests scale their window via `SIGNAL_FISH_TEST_TIMEOUT_MULTIPLIER` on the
+  non-isolated `msrv`/`coverage` lanes, and redundant fixed startup sleeps were removed from the
+  in-process server harnesses (also trimming suite wall-clock).
 - Fixed the noisy `##[error]ENOENT` annotations that every full-test-suite CI job emitted (the
   `nextest`, `msrv`, and `coverage` jobs in `ci.yml`, plus `asan` in `ci-safety.yml`). Those jobs
   compile the `trybuild` UI test, which materializes a nested `<target>/tests` cargo workspace at
@@ -582,6 +595,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgraded the dependency tree to current releases. The only direct major bump is `tower-http`
+  0.6 → 0.7 (the CORS/trace middleware the server mounts); `bytes` moved 1.11 → 1.12 and every
+  other crate advanced to its latest semver-compatible version via a lockfile refresh. The root and
+  reference-client lockfiles were regenerated together so the `--locked` CI, interop, and fuzz
+  builds all resolve the same graph.
 - **Lobby start is now explicit and `max_players` is a ceiling, not a required count.** In both
   protocol v2 and v3 the game no longer starts automatically when every player is ready, and a room
   no longer needs to be full to start. Players may `PlayerReady` / unready at any time while the room

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -172,15 +172,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -332,9 +332,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -347,18 +347,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -392,15 +392,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
 
 [[package]]
 name = "cast"
@@ -410,21 +410,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -446,7 +440,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -551,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0758edba32d61d1fd9f4d69491b47604b91ee2f7e6b33de7e54ca4ebe55dc3"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -727,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -745,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1005a6d4446f5120ef475ad3d2af2b30c49c2c9c6904258e3bb30219bebed5e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
 ]
@@ -768,18 +762,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -822,21 +813,21 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -851,9 +842,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "email_address"
@@ -904,7 +895,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "typetag",
  "uuid",
 ]
@@ -1112,16 +1103,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1142,9 +1131,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1187,15 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1237,14 +1220,14 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -1287,18 +1270,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1318,15 +1301,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1381,12 +1363,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1394,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1407,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1421,15 +1404,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1441,15 +1424,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1459,12 +1442,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -1479,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1489,14 +1466,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1510,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8062b737e5389949f477d4760a2ebbff0c366f97798f2419b8d8f366363d3342"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1546,27 +1521,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1600,13 +1580,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1617,16 +1596,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1636,9 +1609,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1651,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -1661,7 +1634,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1696,10 +1669,10 @@ dependencies = [
  "matchbox_protocol",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
  "uuid",
 ]
@@ -1721,9 +1694,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -1749,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1832,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2002,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2035,16 +2008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,7 +2026,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2112,7 +2075,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -2128,13 +2091,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2186,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2201,8 +2164,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.0",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2235,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2250,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2344,7 +2307,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2358,7 +2321,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2383,7 +2346,7 @@ checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck",
  "bytes",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "munge",
  "ptr_meta",
@@ -2437,7 +2400,7 @@ dependencies = [
  "http",
  "mime",
  "rand 0.10.1",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2485,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2507,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2772,7 +2735,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2783,7 +2746,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2797,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-server"
@@ -2820,7 +2783,7 @@ dependencies = [
  "fastrand",
  "futures",
  "futures-util",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hdrhistogram",
  "hmac",
  "lru",
@@ -2847,11 +2810,11 @@ dependencies = [
  "subtle",
  "syn",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-test",
  "tokio-tungstenite",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2876,6 +2839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,9 +2871,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2932,9 +2905,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2974,7 +2947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2991,31 +2964,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -3040,12 +2993,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3055,15 +3007,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3071,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3263,6 +3215,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,7 +3263,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
  "tracing-subscriber",
 ]
@@ -3394,9 +3363,9 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1 0.10.6",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3407,9 +3376,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -3449,9 +3418,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -3505,7 +3474,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3559,27 +3528,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3590,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3600,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3610,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3623,52 +3583,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3686,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3785,15 +3711,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3817,21 +3734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3869,12 +3771,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3887,12 +3783,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3902,12 +3792,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3935,12 +3819,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3950,12 +3828,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3971,12 +3843,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3986,12 +3852,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4013,97 +3873,15 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yansi"
@@ -4113,9 +3891,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4124,9 +3902,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4136,18 +3914,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4156,18 +3934,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4177,15 +3955,15 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4194,9 +3972,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4205,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,7 +2803,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-fish-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
 
 # Web framework
 axum = { version = "0.8", features = ["ws"] }
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { version = "0.7", features = ["cors", "trace"] }
 tokio-tungstenite = "0.29"
 
 # Serialization
@@ -69,7 +69,7 @@ async-trait = "0.1"
 futures-util = { version = "0.3", features = ["std"] }
 
 # Performance primitives
-bytes = "1.11"
+bytes = "1.12"
 smallvec = { version = "1.15", features = ["union", "const_generics", "serde"] }
 dashmap = "6.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-fish-server"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]

--- a/clients/native/Cargo.lock
+++ b/clients/native/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -350,9 +350,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cbc"
@@ -365,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -704,9 +704,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -726,7 +723,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -870,12 +867,6 @@ dependencies = [
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1013,16 +1004,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1054,22 +1043,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1321,12 +1301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,8 +1329,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1410,9 +1382,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.100"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1424,12 +1396,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1500,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -1807,16 +1773,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,7 +1857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2371,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2384,7 +2340,7 @@ dependencies = [
  "dashmap",
  "fastrand",
  "futures-util",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hdrhistogram",
  "hmac 0.13.0",
  "lru",
@@ -2449,9 +2405,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -2549,9 +2505,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2582,7 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2639,12 +2595,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2654,15 +2609,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2764,14 +2719,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "http",
  "http-body",
+ "percent-encoding",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -2934,12 +2890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2985,7 +2935,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -3020,27 +2970,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3051,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3061,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3074,45 +3015,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3449,97 +3356,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3652,18 +3471,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -7,7 +7,7 @@ Rust application.
 
 ```toml
 [dependencies]
-signal-fish-server = "0.2.0"
+signal-fish-server = "0.3.0"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 
@@ -308,7 +308,7 @@ Enable optional features:
 
 ```toml
 [dependencies]
-signal-fish-server = { version = "0.2.0", features = ["tls", "legacy-fullmesh"] }
+signal-fish-server = { version = "0.3.0", features = ["tls", "legacy-fullmesh"] }
 
 ```
 

--- a/scripts/check-doc-consistency.sh
+++ b/scripts/check-doc-consistency.sh
@@ -32,6 +32,7 @@ fi
 
 ERRORS=0
 WARNINGS=0
+VERSION_DRIFT=0
 CHANGED_MODE=none
 SKIP_CHANGELOG_GATE=0
 
@@ -177,6 +178,7 @@ validate_signal_fish_dependency_versions() {
 
         if [ "$observed" != "$CARGO_VERSION" ]; then
             action_error "$file has stale signal-fish-server version '$observed' (expected '$CARGO_VERSION' from Cargo.toml)"
+            VERSION_DRIFT=1
         fi
     done < <(grep -E 'signal-fish-server[[:space:]]*=' "$file" || true)
 
@@ -197,6 +199,7 @@ if [ -n "$CARGO_VERSION" ]; then
             action_ok ".llm/context.md version line matches Cargo.toml"
         else
             action_error ".llm/context.md must contain exact line: $expected_context_line"
+            VERSION_DRIFT=1
         fi
     fi
 fi
@@ -559,6 +562,11 @@ fi
 
 echo
 if [ "$ERRORS" -gt 0 ]; then
+    if [ "$VERSION_DRIFT" -ne 0 ]; then
+        action_info "Crate version drift detected. Cargo.toml [package].version is the single source of truth."
+        action_info "The Signal Fish pre-commit hook auto-syncs these docs on commit; to fix the working tree now run:"
+        action_info "  pwsh -NoLogo -NoProfile -NonInteractive -File scripts/hooks/pre-commit.ps1 -Worktree"
+    fi
     action_error "Doc consistency checks failed with $ERRORS error(s) and $WARNINGS warning(s)"
     exit 1
 fi

--- a/scripts/hooks/pre-commit.ps1
+++ b/scripts/hooks/pre-commit.ps1
@@ -2107,6 +2107,215 @@ function Repair-SkillsIndexIfNeeded {
     }
 }
 
+# ---------------------------------------------------------------------------
+# Doc version sync (auto-repair)
+#
+# Cargo.toml [package].version is the single source of truth for the crate
+# version. A version bump must propagate to the human-facing docs that quote it,
+# or scripts/check-doc-consistency.sh (run in CI and run-local-ci) fails. This
+# check regenerates those quoted versions from Cargo.toml and re-stages them, so
+# a bump can never land a stale doc and break CI.
+#
+# SITES (must mirror the version-sync section of
+# scripts/check-doc-consistency.sh; the parity is locked by
+# tests/doc_consistency_policy_tests.rs):
+#   - docs/library-usage.md : signal-fish-server = "X"
+#                             signal-fish-server = { version = "X", ... }
+#   - .llm/context.md       : - **Version:** X
+# Dependency lines containing a <version> placeholder are intentionally left
+# untouched, matching the checker.
+$script:DocVersionSyncFiles = @("docs/library-usage.md", ".llm/context.md")
+
+function Read-CargoPackageVersion {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][AllowNull()][string]$CargoTomlText)
+
+    if ([string]::IsNullOrEmpty($CargoTomlText)) {
+        return $null
+    }
+
+    # Mirror read_cargo_package_version() in scripts/check-doc-consistency.sh:
+    # the first `version = "..."` inside the [package] table, and only there.
+    $inPackage = $false
+    foreach ($rawLine in ($CargoTomlText -split "`n")) {
+        $line = $rawLine.TrimEnd("`r")
+        if ($line -match '^\s*\[package\]\s*$') {
+            $inPackage = $true
+            continue
+        }
+        if ($line -match '^\s*\[[^\]]+\]\s*$') {
+            $inPackage = $false
+            continue
+        }
+        if ($inPackage -and $line -match '^\s*version\s*=\s*"([^"]+)"') {
+            return $Matches[1]
+        }
+    }
+    $null
+}
+
+function Get-DocVersionSyncedContent {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+
+    switch ($Path) {
+        "docs/library-usage.md" {
+            # Rewrite the version inside any signal-fish-server dependency
+            # assignment, both the plain (= "X") and table
+            # (= { version = "X", ... }) forms. The leading group captures
+            # everything up to and including the opening quote; [^"<]+ matches
+            # the version without spanning the closing quote and without
+            # matching <version> placeholders. Line-ending bytes stay outside
+            # the match, so LF/CRLF is preserved verbatim.
+            return [regex]::Replace(
+                $Content,
+                '(signal-fish-server[ \t]*=[ \t]*(?:\{[^}\r\n]*?\bversion[ \t]*=[ \t]*)?")[^"<]+(")',
+                { param($m) "$($m.Groups[1].Value)$Version$($m.Groups[2].Value)" })
+        }
+        ".llm/context.md" {
+            # Rewrite the exact metadata line. [^\r\n]* stops before the line
+            # ending so LF/CRLF is preserved verbatim.
+            return [regex]::Replace(
+                $Content,
+                '(?m)^(- \*\*Version:\*\* )[^\r\n]*',
+                { param($m) "$($m.Groups[1].Value)$Version" })
+        }
+        default {
+            return $Content
+        }
+    }
+}
+
+# Report the residual reason the CI checker (scripts/check-doc-consistency.sh)
+# would STILL reject $Content after an auto-sync attempt, or $null if it is
+# compliant. This keeps the hook honest: it must never report success on a
+# state CI rejects (e.g. a path/git dependency with no version key to rewrite,
+# or a context.md whose required version line was deleted entirely and cannot
+# be re-synthesized). Mirrors the checker's per-file rules.
+function Get-DocVersionResidualProblem {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Version
+    )
+
+    switch ($Path) {
+        "docs/library-usage.md" {
+            # Mirror validate_signal_fish_dependency_versions() in
+            # scripts/check-doc-consistency.sh EXACTLY: parse each
+            # signal-fish-server dependency line's version (table form first,
+            # then plain form) and require it to equal the crate version.
+            # A <version> placeholder is exempt; a line with no extractable
+            # version (path/git dep) is unfixable. We extract-and-compare rather
+            # than substring-test so a version-less line that merely mentions
+            # the crate version elsewhere (e.g. a git tag) is still flagged.
+            $unfixable = [System.Collections.Generic.List[string]]::new()
+            foreach ($match in [regex]::Matches($Content, '(?m)^.*signal-fish-server[ \t]*=.*$')) {
+                $line = $match.Value
+                if ($line -match '<version>') {
+                    continue
+                }
+                $observed = $null
+                $tableForm = [regex]::Match($line, 'signal-fish-server[ \t]*=[ \t]*\{[^}]*version[ \t]*=[ \t]*"([^"]+)"')
+                if ($tableForm.Success) {
+                    $observed = $tableForm.Groups[1].Value
+                } else {
+                    $plainForm = [regex]::Match($line, 'signal-fish-server[ \t]*=[ \t]*"([^"]+)"')
+                    if ($plainForm.Success) {
+                        $observed = $plainForm.Groups[1].Value
+                    }
+                }
+                if ($null -eq $observed -or $observed -ne $Version) {
+                    [void]$unfixable.Add($line)
+                }
+            }
+            if ($unfixable.Count -gt 0) {
+                return "docs/library-usage.md has a signal-fish-server dependency line that cannot be auto-synced to $Version (e.g. a path/git dependency without a version key). Fix it by hand:`n  $($unfixable -join "`n  ")"
+            }
+            return $null
+        }
+        ".llm/context.md" {
+            # The checker requires the exact line; if it was deleted entirely the
+            # regex has nothing to rewrite and we must not silently pass.
+            $expectedLine = "- **Version:** $Version"
+            foreach ($line in ($Content -split "`n")) {
+                if ($line.TrimEnd("`r") -eq $expectedLine) {
+                    return $null
+                }
+            }
+            return ".llm/context.md is missing the required line '$expectedLine' and cannot be auto-created. Add it under the project identity section."
+        }
+        default {
+            return $null
+        }
+    }
+}
+
+function Repair-DocVersionsIfNeeded {
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$ChangedFiles)
+
+    # Only meaningful when the crate version or a tracked version-doc changed.
+    # Mirrors the trigger gate of Repair-SkillsIndexIfNeeded so the common
+    # commit pays no extra git calls.
+    $triggerFiles = @("Cargo.toml") + $script:DocVersionSyncFiles
+    if (@($ChangedFiles | Where-Object { $triggerFiles -contains $_ }).Count -eq 0) {
+        Skip "Doc version sync" "no Cargo.toml or version-doc changes"
+        return
+    }
+
+    $cargoText = Get-PolicyText -Path "Cargo.toml"
+    $version = Read-CargoPackageVersion -CargoTomlText $cargoText
+    if ([string]::IsNullOrEmpty($version)) {
+        Skip "Doc version sync" "Cargo.toml [package].version not readable"
+        return
+    }
+
+    $repaired = [System.Collections.Generic.List[string]]::new()
+    foreach ($path in $script:DocVersionSyncFiles) {
+        $actual = Get-PolicyText -Path $path
+        if ($null -eq $actual) {
+            # File not tracked in this commit / not present: nothing to sync.
+            continue
+        }
+
+        $expected = Get-DocVersionSyncedContent -Path $path -Content $actual -Version $version
+
+        $problem = Get-DocVersionResidualProblem -Path $path -Content $expected -Version $version
+        if ($null -ne $problem) {
+            Fail "Doc version sync" $problem
+            return
+        }
+
+        if ($expected -eq $actual) {
+            continue
+        }
+
+        if ($script:InspectWorktree) {
+            $absolutePath = Join-Path $script:RepoRoot $path
+            [System.IO.File]::WriteAllText($absolutePath, $expected, [System.Text.UTF8Encoding]::new($false))
+            $script:WorktreeTextCache[$path] = $expected
+            [void]$repaired.Add($path)
+            continue
+        }
+
+        $expectedHash = Set-IndexText -Path $path -Content $expected
+        $updatedHash = Get-IndexObjectId -Path $path
+        if ($updatedHash -ne $expectedHash) {
+            Fail "Doc version sync" "Unable to re-stage $path with crate version $version."
+            return
+        }
+        [void]$repaired.Add($path)
+    }
+
+    if ($repaired.Count -gt 0) {
+        Pass "Doc version sync (auto-repaired: $($repaired -join ', '))"
+    } else {
+        Pass "Doc version sync"
+    }
+}
+
 function Test-LlmFileSizes {
     if ($null -ne $script:PreloadError) {
         Skip "LLM file sizes" "staged content preload failed"
@@ -2218,8 +2427,9 @@ $worktreePolicyPathspecs = @(
     "src",
     ".llm",
     "README.md",
-    "scripts/generate-skills-index.sh"
-) + $script:HookPolicyFiles
+    "scripts/generate-skills-index.sh",
+    "Cargo.toml"
+) + $script:DocVersionSyncFiles + $script:HookPolicyFiles
 $allChangedFiles = [string[]]@(if ($script:InspectWorktree) {
         Get-WorktreeChangedFiles -Pathspecs $worktreePolicyPathspecs
     } else {
@@ -2233,6 +2443,12 @@ if ($script:InspectWorktree) {
 } else {
     Write-Step "Running fast last-resort checks..."
 }
+
+# Keep the crate version and the docs that quote it in lockstep for every
+# commit shape (runs before the Rust early-exit below so a Cargo.toml bump that
+# also touches Rust still auto-syncs).
+if (-not (Invoke-Check "Doc version sync" { Repair-DocVersionsIfNeeded -ChangedFiles $allChangedFiles })) { Complete-PreCommit }
+
 $hasProductionRust = @($script:StagedFiles | Where-Object { Test-ProductionRustSourcePath -Path $_ }).Count -gt 0
 if ($hasProductionRust) {
     if ($script:HookPolicyChangedFiles.Count -gt 0) {

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -20,7 +20,7 @@ use std::sync::OnceLock;
 
 #[cfg(unix)]
 use common::bash_command;
-use common::{read_file, repo_root};
+use common::{read_file, repo_root, unique_temp_dir, write_file};
 use proc_macro2::{Delimiter, Span, TokenStream, TokenTree};
 use regex::Regex;
 use saphyr::{LoadableYamlNode, Yaml};
@@ -15760,6 +15760,176 @@ fn test_powershell_native_bytes_helper_returns_single_result_object_when_availab
          stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_pre_commit_doc_version_sync_logic_when_pwsh_available() {
+    let root = repo_root();
+    let output = Command::new("pwsh")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            r##"
+                . ./scripts/hooks/pre-commit.ps1 -SourceOnly
+                function Assert($condition, $message) {
+                    if (-not $condition) { throw $message }
+                }
+
+                # 1) Version is read from the [package] table only.
+                $toml = "[package]`nname = `"x`"`nversion = `"1.2.3`"`n`n[dependencies]`nversion = `"9.9.9`"`n"
+                Assert ((Read-CargoPackageVersion -CargoTomlText $toml) -eq "1.2.3") "version must be parsed from the [package] table, not other tables"
+                Assert ($null -eq (Read-CargoPackageVersion -CargoTomlText "")) "empty Cargo.toml text must yield a null version"
+
+                # 2) library-usage: both dependency forms rewritten; <version>
+                #    placeholder skipped; CRLF preserved verbatim.
+                $lib = "signal-fish-server = `"0.2.0`"`r`nsignal-fish-server = { version = `"0.2.0`", features = [`"tls`"] }`r`nsignal-fish-server = `"<version>`"`r`n"
+                $libOut = Get-DocVersionSyncedContent -Path "docs/library-usage.md" -Content $lib -Version "0.3.0"
+                Assert ($libOut.Contains("signal-fish-server = `"0.3.0`"")) "plain dependency form must be synced"
+                Assert ($libOut.Contains("version = `"0.3.0`", features")) "table dependency form must be synced"
+                Assert ($libOut.Contains("signal-fish-server = `"<version>`"")) "the <version> placeholder must be left untouched"
+                Assert (-not $libOut.Contains("0.2.0")) "no stale version must remain"
+                Assert ($libOut.Contains("`r`n")) "CRLF line endings must be preserved"
+
+                # 3) context.md metadata line rewritten exactly; CRLF preserved
+                #    (this branch uses a different regex than library-usage).
+                $ctx = "# Title`r`n- **Version:** 0.2.0`r`n- **Code name:** Signal Fish`r`n"
+                $ctxOut = Get-DocVersionSyncedContent -Path ".llm/context.md" -Content $ctx -Version "0.3.0"
+                Assert ($ctxOut.Contains("- **Version:** 0.3.0")) "context.md version line must be synced"
+                Assert (-not $ctxOut.Contains("0.2.0")) "no stale context.md version must remain"
+                Assert ($ctxOut.Contains("- **Version:** 0.3.0`r`n")) "context.md CRLF line endings must be preserved"
+
+                # 4) Idempotent: re-syncing already-correct content is a no-op.
+                $again = Get-DocVersionSyncedContent -Path "docs/library-usage.md" -Content $libOut -Version "0.3.0"
+                Assert ($again -ceq $libOut) "version sync must be idempotent"
+
+                # 5) Non-site files are returned byte-for-byte unchanged, AND the
+                #    library-usage regex is anchored on `signal-fish-server` so a
+                #    bare JSON `"version": "0.2.0"` line is never rewritten. This
+                #    is why .vscode/launch.json (schema version) and
+                #    spec/*.asyncapi.yaml (protocol version) can never be corrupted.
+                $jsonVersion = "  `"version`": `"0.2.0`","
+                Assert ((Get-DocVersionSyncedContent -Path ".vscode/launch.json" -Content $jsonVersion -Version "0.3.0") -ceq $jsonVersion) "non-site files must be left untouched"
+                Assert ((Get-DocVersionSyncedContent -Path "docs/library-usage.md" -Content $jsonVersion -Version "0.3.0") -ceq $jsonVersion) "a bare JSON version line must not match the signal-fish-server-anchored regex"
+
+                # 6) Honesty guard: never report compliant on a state the checker
+                #    still rejects (path/git dep with no version key; a context.md
+                #    whose required version line was deleted).
+                Assert ($null -ne (Get-DocVersionResidualProblem -Path "docs/library-usage.md" -Content "signal-fish-server = { path = `"../..`" }" -Version "0.3.0")) "a version-less signal-fish-server dependency must be flagged unfixable"
+                Assert ($null -ne (Get-DocVersionResidualProblem -Path "docs/library-usage.md" -Content "signal-fish-server = { git = `"https://x`", tag = `"0.3.0`" }" -Version "0.3.0")) "a version-less dep that merely mentions the crate version elsewhere (git tag) must still be flagged"
+                Assert ($null -eq (Get-DocVersionResidualProblem -Path "docs/library-usage.md" -Content $libOut -Version "0.3.0")) "fully-synced library-usage content must have no residual problem"
+                Assert ($null -ne (Get-DocVersionResidualProblem -Path ".llm/context.md" -Content "# Title`nno version line here`n" -Version "0.3.0")) "a missing context.md version line must be flagged unfixable"
+                Assert ($null -eq (Get-DocVersionResidualProblem -Path ".llm/context.md" -Content $ctxOut -Version "0.3.0")) "synced context.md content must have no residual problem"
+            "##,
+        ])
+        .current_dir(&root)
+        .output();
+
+    let Ok(output) = output else {
+        eprintln!("Skipping doc version sync logic test because pwsh is unavailable.");
+        return;
+    };
+
+    assert!(
+        output.status.success(),
+        "pre-commit.ps1 doc version sync helpers must satisfy the version-sync contract.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn test_pre_commit_doc_version_sync_restages_corrected_docs_end_to_end_when_pwsh_available() {
+    let root = repo_root();
+    let hook = root.join("scripts/hooks/pre-commit.ps1");
+
+    // Throwaway repo so we exercise the REAL index re-staging path
+    // (Set-IndexText / git update-index), proving fixer output satisfies the
+    // checker's contract, without mutating this repository.
+    let temp = unique_temp_dir("docver-e2e");
+    let dir = temp.path();
+
+    let git = |args: &[&str]| -> std::io::Result<std::process::Output> {
+        Command::new("git").args(args).current_dir(dir).output()
+    };
+
+    let Ok(init) = git(&["init", "-q"]) else {
+        eprintln!("Skipping doc version sync e2e test because git is unavailable.");
+        return;
+    };
+    if !init.status.success() {
+        eprintln!("Skipping doc version sync e2e test because git init failed.");
+        return;
+    }
+    let _ = git(&["config", "user.email", "test@example.com"]);
+    let _ = git(&["config", "user.name", "Test"]);
+    let _ = git(&["config", "commit.gpgsign", "false"]);
+
+    // Seed a repo whose docs match the original crate version, then commit.
+    write_file(
+        &dir.join("Cargo.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.2.0\"\n",
+    );
+    write_file(
+        &dir.join("docs/library-usage.md"),
+        "signal-fish-server = \"0.2.0\"\nsignal-fish-server = { version = \"0.2.0\", features = [\"tls\"] }\n",
+    );
+    write_file(&dir.join(".llm/context.md"), "- **Version:** 0.2.0\n");
+    assert!(git(&["add", "-A"]).unwrap().status.success());
+    assert!(git(&["commit", "-q", "-m", "init", "--no-verify"])
+        .unwrap()
+        .status
+        .success());
+
+    // Bump ONLY the manifest and stage it, exactly like a real version bump
+    // that forgets the docs — the scenario that broke CI.
+    write_file(
+        &dir.join("Cargo.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.9.9\"\n",
+    );
+    assert!(git(&["add", "Cargo.toml"]).unwrap().status.success());
+
+    let output = Command::new("pwsh")
+        .args(["-NoLogo", "-NoProfile", "-NonInteractive", "-File"])
+        .arg(&hook)
+        .current_dir(dir)
+        .output();
+    let Ok(output) = output else {
+        eprintln!("Skipping doc version sync e2e test because pwsh is unavailable.");
+        return;
+    };
+    assert!(
+        output.status.success(),
+        "pre-commit hook must succeed and auto-sync docs from the bumped Cargo.toml.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The STAGED (index) docs must now carry the bumped version, so the commit
+    // that lands is internally consistent and the checker would pass.
+    let staged = |path: &str| -> String {
+        let out = git(&["show", &format!(":{path}")]).expect("git show staged blob");
+        String::from_utf8_lossy(&out.stdout).to_string()
+    };
+    let lib = staged("docs/library-usage.md");
+    assert!(
+        lib.contains("signal-fish-server = \"0.9.9\""),
+        "plain dependency form must be re-staged at 0.9.9, got:\n{lib}"
+    );
+    assert!(
+        lib.contains("version = \"0.9.9\""),
+        "table dependency form must be re-staged at 0.9.9, got:\n{lib}"
+    );
+    assert!(
+        !lib.contains("0.2.0"),
+        "no stale version may remain in the staged docs, got:\n{lib}"
+    );
+    let ctx = staged(".llm/context.md");
+    assert!(
+        ctx.contains("- **Version:** 0.9.9"),
+        "context.md version line must be re-staged at 0.9.9, got:\n{ctx}"
     );
 }
 

--- a/tests/doc_consistency_policy_tests.rs
+++ b/tests/doc_consistency_policy_tests.rs
@@ -177,6 +177,57 @@ fn test_ci_dep_detect_internal_paths_match_script() {
 }
 
 #[test]
+fn test_pre_commit_doc_version_sync_sites_match_checker() {
+    let root = repo_root();
+    let hook = read_file(&root.join("scripts/hooks/pre-commit.ps1"));
+    let checker = read_file(&root.join("scripts/check-doc-consistency.sh"));
+
+    // The pre-commit auto-repair and the CI checker are two implementations of
+    // one policy: every doc that quotes the crate version must equal
+    // Cargo.toml [package].version. If they target different sites they drift
+    // (auto-fix one file, gate another), which is the exact fragility this
+    // automation exists to prevent. Lock the shared sites and markers here so
+    // the fixer can never cover less than the checker validates.
+    let version_sync_sites = ["docs/library-usage.md", ".llm/context.md"];
+    for site in version_sync_sites {
+        assert!(
+            hook.contains(site),
+            "scripts/hooks/pre-commit.ps1 must auto-sync the crate version in '{site}'."
+        );
+        assert!(
+            checker.contains(site),
+            "scripts/check-doc-consistency.sh must validate the crate version in '{site}'."
+        );
+    }
+
+    let shared_markers = ["signal-fish-server", "- **Version:**"];
+    for marker in shared_markers {
+        assert!(
+            hook.contains(marker),
+            "scripts/hooks/pre-commit.ps1 version sync must handle the '{marker}' marker."
+        );
+        assert!(
+            checker.contains(marker),
+            "scripts/check-doc-consistency.sh version check must handle the '{marker}' marker."
+        );
+    }
+
+    // Assert the canonical site list is actually *declared* with both sites
+    // (not merely mentioned in a comment), so the fixer cannot quietly cover
+    // fewer files than the checker validates.
+    assert!(
+        hook.contains(
+            "$script:DocVersionSyncFiles = @(\"docs/library-usage.md\", \".llm/context.md\")"
+        ),
+        "pre-commit.ps1 must declare $script:DocVersionSyncFiles with both canonical version-sync sites."
+    );
+    assert!(
+        hook.contains("Repair-DocVersionsIfNeeded"),
+        "pre-commit.ps1 must run Repair-DocVersionsIfNeeded so a Cargo.toml version bump auto-syncs docs on commit."
+    );
+}
+
+#[test]
 fn test_local_ci_includes_doc_consistency_gate_and_tests() {
     let root = repo_root();
     let local_ci = read_file(&root.join("scripts/run-local-ci.sh"));

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -80,10 +80,32 @@ async fn start_server_with_instance(game_server: Arc<EnhancedGameServer>) -> std
         .unwrap();
     });
 
-    // Give server time to start (longer timeout for CI environments)
-    tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
-
+    // No startup sleep: the listener is already bound above before the serve
+    // task spawns, so the kernel queues the client's connection until axum
+    // begins accepting — `connect_client` then connects under its own timeout.
+    // A fixed sleep here only added 2s of dead wall-clock to every consumer and
+    // could not actually guarantee readiness; the bound-listener handshake does.
     addr
+}
+
+/// Wall-clock scaling for the timing-sensitive idle-timeout tests below.
+///
+/// Defaults to 1 (local runs and the `Nextest (*)` lanes, where the suite is
+/// fast and the multiprocess group is CPU-reserved). The two CI lanes that run
+/// the suite WITHOUT nextest's isolation — `MSRV Verification` (plain
+/// `cargo test`) and `Coverage (llvm-cov)` (instrumented, ~2-4x slower) — export
+/// `SIGNAL_FISH_TEST_TIMEOUT_MULTIPLIER` to widen the idle window (and the
+/// heartbeat budget that must outlast it) proportionally. A test task that is
+/// briefly CPU-starved on a 48-binary oversubscribed runner then still resets
+/// the idle timer in time instead of flaking. Scaling the window and the
+/// heartbeat duration together preserves the invariant under test
+/// (heartbeat interval << idle window) at any multiplier.
+fn idle_timeout_test_multiplier() -> u64 {
+    std::env::var("SIGNAL_FISH_TEST_TIMEOUT_MULTIPLIER")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|&m| m >= 1)
+        .unwrap_or(1)
 }
 
 /// Helper to connect a WebSocket client
@@ -1564,10 +1586,12 @@ async fn collect_frames_until_closed(
 /// coordinator (a coordinator-routed error would be silently dropped here).
 #[tokio::test]
 async fn test_idle_client_is_disconnected_after_idle_timeout() {
-    let mut config = idle_timeout_server_config(2);
+    let mult = idle_timeout_test_multiplier();
+    let mut config = idle_timeout_server_config(2 * mult);
     // Reaper window (500ms) + cleanup interval (1s, from `test_server_config`)
-    // elapse before the 2s idle window: the client is reaped first, exactly as
-    // with production defaults.
+    // elapse before the (2 * mult)s idle window: the client is reaped first,
+    // exactly as with production defaults. ping_timeout stays at 500ms so the
+    // reaper-before-idle ordering holds at every multiplier.
     config.ping_timeout = tokio::time::Duration::from_millis(500);
     let game_server = create_test_server_with_config(config, test_protocol_config()).await;
     // Run the maintenance reaper (main.rs spawns it the same way); the e2e
@@ -1603,7 +1627,7 @@ async fn test_idle_client_is_disconnected_after_idle_timeout() {
     // socket well within this window (timeout is 2s; allow CI slack).
     let frames = collect_frames_until_closed(
         &mut receiver,
-        tokio::time::Duration::from_secs(10),
+        tokio::time::Duration::from_secs(10 * mult),
         "idle client",
     )
     .await;
@@ -1628,12 +1652,17 @@ async fn test_idle_client_is_disconnected_after_idle_timeout() {
 /// idle window: every inbound frame resets the timeout.
 #[tokio::test]
 async fn test_active_client_survives_past_idle_timeout_window() {
-    let addr = start_test_server_with_config(idle_timeout_server_config(2)).await;
+    let mult = idle_timeout_test_multiplier();
+    let addr = start_test_server_with_config(idle_timeout_server_config(2 * mult)).await;
     let (mut sender, mut receiver) = connect_client(addr, "/v2/ws").await;
 
-    // Heartbeat every 500ms for 2.5s total — strictly longer than the 2s idle
-    // window — asserting the Pong response each round (no silent drains).
-    for round in 0..5 {
+    // Heartbeat every 500ms for (2.5 * mult)s total — strictly longer than the
+    // (2 * mult)s idle window — asserting the Pong response each round (no silent
+    // drains). Scaling the round count with the window keeps "total heartbeat
+    // span > idle window" true at any multiplier, while the per-round 500ms
+    // interval stays far below the window so a briefly-starved scheduler still
+    // resets the idle timer in time.
+    for round in 0..(5 * mult) {
         tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         let response = send_and_receive(&mut sender, &mut receiver, ClientMessage::Ping)
             .await
@@ -1701,9 +1730,11 @@ async fn test_idle_timeout_zero_disables_idle_enforcement() {
     // RoomJoined. Drain it before asserting the connection then goes silent.
     expect_lobby_state_changed_notification(&mut receiver, "idle-disabled lobby entry").await;
 
-    // Stay silent for 3s — strictly longer than the 1–2s windows used by the
-    // sibling tests. With the idle timeout disabled the server must send
-    // nothing at all: no `CONNECTION_IDLE_TIMEOUT` error, no Close frame.
+    // Stay silent for 3s — long enough to surface any spurious idle close. With
+    // the idle timeout disabled the server must send nothing at all: no
+    // `CONNECTION_IDLE_TIMEOUT` error, no Close frame. This test does not race
+    // the idle window (there is none), so it needs no timeout multiplier, and
+    // ping_timeout's 10s reaper stays well clear of this 3s window.
     let silence = tokio::time::timeout(tokio::time::Duration::from_secs(3), receiver.next()).await;
     assert!(
         silence.is_err(),

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -274,6 +274,10 @@ fn test_large_room_broadcast_simulation() {
 // ============================================================================
 
 #[test]
+#[ignore = "wall-clock micro-benchmark: ~microseconds of real work against a tens-of-ms budget, so the \
+            only failure mode is a >budget scheduler preemption on an oversubscribed/instrumented CI \
+            lane (the unisolated MSRV/Coverage lanes) — never a real regression (even a deep-copy clone \
+            would pass). Run on demand with `--ignored`, or measure via benches/."]
 fn test_broadcast_clone_performance() {
     let message = MockServerMessage::GameData {
         from_player: Uuid::new_v4(),
@@ -304,6 +308,10 @@ fn test_broadcast_clone_performance() {
 }
 
 #[test]
+#[ignore = "wall-clock micro-benchmark: ~microseconds of real work against a tens-of-ms budget, so the \
+            only failure mode is a >budget scheduler preemption on an oversubscribed/instrumented CI \
+            lane (the unisolated MSRV/Coverage lanes) — never a real regression (even a deep-copy clone \
+            would pass). Run on demand with `--ignored`, or measure via benches/."]
 fn test_bytes_clone_performance() {
     let payload = Bytes::from(vec![0u8; 4096]); // 4KB payload
 
@@ -528,6 +536,10 @@ fn test_real_broadcast_message_json_serialization() {
 }
 
 #[test]
+#[ignore = "wall-clock micro-benchmark: ~microseconds of real work against a tens-of-ms budget, so the \
+            only failure mode is a >budget scheduler preemption on an oversubscribed/instrumented CI \
+            lane (the unisolated MSRV/Coverage lanes) — never a real regression (even a deep-copy clone \
+            would pass). Run on demand with `--ignored`, or measure via benches/."]
 fn test_real_broadcast_message_performance() {
     use signal_fish_server::broadcast::BroadcastMessage;
     use signal_fish_server::protocol::ServerMessage;

--- a/tests/v3_ice_pregather_e2e.rs
+++ b/tests/v3_ice_pregather_e2e.rs
@@ -157,7 +157,9 @@ async fn start_server(game_server: Arc<EnhancedGameServer>) -> std::net::SocketA
         .unwrap();
     });
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    // No startup sleep: the listener is already bound above, so connections
+    // issued immediately are accepted by the kernel and served once the
+    // spawned `axum::serve` task polls them.
     addr
 }
 

--- a/tests/v3_multiprocess_e2e.rs
+++ b/tests/v3_multiprocess_e2e.rs
@@ -82,7 +82,14 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const SOCKET_CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
 const HEALTH_DEADLINE: Duration = Duration::from_secs(60);
 const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
-const SPAWN_ATTEMPTS: usize = 3;
+/// Fresh-port spawn attempts. Each retry reserves a NEW port, so this absorbs
+/// the reserve-release-spawn race cheaply; a few attempts make a stolen port
+/// vanishingly unlikely to fail a run.
+const SPAWN_ATTEMPTS: usize = 5;
+/// Fixed-port (restart) spawn attempts. This path CANNOT dodge a transient race
+/// by picking a fresh port — it must reuse the SIGKILL'd port — so it gets more
+/// attempts and exponential backoff (see `spawn_server_on_fixed_port`).
+const FIXED_PORT_SPAWN_ATTEMPTS: usize = 6;
 
 /// Guard around the spawned server binary. Dropping it kills the child
 /// (`start_kill` here plus `kill_on_drop(true)` at spawn), so a panicking test
@@ -159,18 +166,30 @@ async fn spawn_server(default_topology: &str) -> ServerProcess {
 }
 
 /// Spawn the server binary on a FIXED port (restart-on-same-port semantics),
-/// retrying the same port to absorb transient socket-teardown races.
+/// retrying the same port with exponential backoff to absorb transient
+/// socket-teardown races. After a SIGKILL the kernel may briefly hold the
+/// listening port (the dead server's accepted connections linger in TIME_WAIT;
+/// Windows' `TerminateProcess` tears the socket down more slowly than a Unix
+/// signal), so a single flat retry can expire before the port frees under load.
+/// Backoff — not a bigger fixed sleep — is the right tool: the happy path
+/// rebinds on attempt 1 and returns immediately, while a genuinely slow teardown
+/// gets progressively more time without inflating the common case.
 async fn spawn_server_on_fixed_port(port: u16, default_topology: &str) -> ServerProcess {
     let mut failures = Vec::new();
-    for attempt in 1..=SPAWN_ATTEMPTS {
+    let mut backoff = Duration::from_millis(100);
+    for attempt in 1..=FIXED_PORT_SPAWN_ATTEMPTS {
         match try_spawn_server(port, default_topology).await {
             Ok(server) => return server,
             Err(failure) => failures.push(format!("attempt {attempt}: {failure}")),
         }
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        if attempt < FIXED_PORT_SPAWN_ATTEMPTS {
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(Duration::from_millis(1600));
+        }
     }
     panic!(
-        "server binary failed to restart on port {port} after {SPAWN_ATTEMPTS} attempts:\n{}",
+        "server binary failed to restart on port {port} after {FIXED_PORT_SPAWN_ATTEMPTS} \
+         attempts:\n{}",
         failures.join("\n")
     );
 }
@@ -261,7 +280,8 @@ async fn wait_until_healthy(server: &mut ServerProcess) -> Result<(), String> {
         .timeout(Duration::from_secs(2))
         .build()
         .expect("build health-poll client");
-    let deadline = std::time::Instant::now() + HEALTH_DEADLINE;
+    let start = std::time::Instant::now();
+    let deadline = start + HEALTH_DEADLINE;
 
     loop {
         let child = server
@@ -283,8 +303,11 @@ async fn wait_until_healthy(server: &mut ServerProcess) -> Result<(), String> {
         }
 
         if std::time::Instant::now() >= deadline {
+            let elapsed = start.elapsed();
             return Err(format!(
-                "health endpoint {url} not ready within {HEALTH_DEADLINE:?}"
+                "health endpoint {url} (port {}) never answered 200 within {HEALTH_DEADLINE:?} \
+                 (waited {elapsed:?}); the child stayed alive but unready",
+                server.port
             ));
         }
         tokio::time::sleep(HEALTH_POLL_INTERVAL).await;

--- a/tests/v3_negotiation_e2e.rs
+++ b/tests/v3_negotiation_e2e.rs
@@ -110,7 +110,9 @@ async fn start_server(game_server: Arc<EnhancedGameServer>) -> std::net::SocketA
         .unwrap();
     });
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    // No startup sleep: the listener is already bound above, so connections
+    // issued immediately are accepted by the kernel and served once the
+    // spawned `axum::serve` task polls them.
     addr
 }
 

--- a/tests/v3_session_plan_e2e.rs
+++ b/tests/v3_session_plan_e2e.rs
@@ -121,7 +121,9 @@ async fn start_server(game_server: Arc<EnhancedGameServer>) -> std::net::SocketA
         .unwrap();
     });
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    // No startup sleep: the listener is already bound above, so connections
+    // issued immediately are accepted by the kernel and served once the
+    // spawned `axum::serve` task polls them.
     addr
 }
 

--- a/tests/v3_signaling_e2e.rs
+++ b/tests/v3_signaling_e2e.rs
@@ -102,7 +102,9 @@ async fn start_server(game_server: Arc<EnhancedGameServer>) -> std::net::SocketA
         .unwrap();
     });
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    // No startup sleep: the listener is already bound above, so connections
+    // issued immediately are accepted by the kernel and served once the
+    // spawned `axum::serve` task polls them.
     addr
 }
 

--- a/tests/workspace_lockfile_consistency.rs
+++ b/tests/workspace_lockfile_consistency.rs
@@ -1,0 +1,208 @@
+//! Workspace lockfile consistency guard.
+//!
+//! Every **git-tracked** `Cargo.lock` that references the workspace crate
+//! `signal-fish-server` MUST record the same version as the root `Cargo.toml`
+//! `[package].version`.
+//!
+//! ## Why this exists (the class of bug it prevents)
+//!
+//! The nested crate `clients/native` depends on the root crate via a `path`
+//! dependency, so it carries its OWN committed `Cargo.lock` that pins
+//! `signal-fish-server` at a concrete version. When the root version bumps
+//! (e.g. `0.2.0` -> `0.3.0`), that nested lockfile keeps pinning the OLD version
+//! until it is regenerated. CI builds the nested crate with `--locked`, which
+//! then fails with the cryptic:
+//!
+//! ```text
+//! error: the lock file .../clients/native/Cargo.lock needs to be updated
+//!        but --locked was passed to prevent this
+//! ```
+//!
+//! That is exactly what broke the Browser Interop and WebRTC Interop jobs after
+//! a version bump: a confusing, late failure (after a multi-minute cold build)
+//! in a path-filtered workflow that does not even run on most PRs.
+//!
+//! This guard turns that whole class into an instant, actionable failure in the
+//! always-on main test suite. It is offline (pure file parsing — no registry, no
+//! network), sub-millisecond, deterministic across platforms, and **discovers
+//! lockfiles from git** so any future committed nested crate is covered
+//! automatically with no list to keep in sync.
+//!
+//! ## Scope: only *committed* lockfiles
+//!
+//! Discovery uses `git ls-files`, so the protected set is exactly the lockfiles
+//! under version control — the only ones that can go stale-in-git and break a
+//! `--locked` build. Gitignored lockfiles (e.g. `fuzz/Cargo.lock`, which is
+//! regenerated fresh and built *without* `--locked` because cargo-fuzz rejects
+//! it) are correctly excluded; requiring one would wrongly fail on a clean
+//! checkout where it does not exist.
+
+#![cfg(test)]
+
+mod common;
+
+use common::{read_file, repo_root};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The workspace crate that committed nested lockfiles pin via a path dep.
+const ROOT_CRATE: &str = "signal-fish-server";
+
+/// Committed nested lockfile that must always be covered. Discovery is dynamic,
+/// but this is asserted present so a broken discovery can never make the guard
+/// pass vacuously — mirroring the "missing client manifest is a hard failure"
+/// philosophy in `msrv_consistency_script_tests.rs`. (`fuzz/Cargo.lock` is
+/// deliberately absent here: it is gitignored and built without `--locked`.)
+const REQUIRED_NESTED_LOCK: &str = "clients/native/Cargo.lock";
+
+#[test]
+fn every_tracked_cargo_lock_pins_current_root_crate_version() {
+    let root = repo_root();
+    let expected = root_crate_version(&root);
+    let locks = tracked_cargo_locks(&root);
+
+    let mut checked: Vec<String> = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+    for lock in &locks {
+        let rel = lock
+            .strip_prefix(&root)
+            .unwrap_or(lock)
+            .display()
+            .to_string();
+        let text = read_file(lock);
+        match locked_root_crate_version(&text) {
+            // Lockfiles that do not reference the workspace crate are irrelevant
+            // to this guard (none today, but stay future-proof).
+            None => continue,
+            Some(found) if found == expected => checked.push(rel),
+            Some(found) => {
+                checked.push(rel.clone());
+                problems.push(format!(
+                    "  - {rel}  pins {ROOT_CRATE} {found}, but root Cargo.toml is {expected}\n    \
+                     fix: cargo update -p {ROOT_CRATE} --manifest-path {rel}"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "Stale committed lockfile(s) detected — these pin an outdated {ROOT_CRATE} version and \
+         will fail `--locked` CI builds (e.g. the interop workflows) with a cryptic \
+         \"lock file needs to be updated\" error:\n{}\n\n\
+         The root Cargo.toml version is the single source of truth; regenerate the lockfile(s) \
+         above and commit them.",
+        problems.join("\n")
+    );
+
+    // Discovery sanity: a broken walk/ls-files must fail loudly, not pass empty.
+    assert!(
+        checked
+            .iter()
+            .any(|rel| rel.replace('\\', "/") == REQUIRED_NESTED_LOCK),
+        "expected to verify the committed nested lockfile `{REQUIRED_NESTED_LOCK}`, but only \
+         checked {checked:?}; lockfile discovery may be broken or the crate moved (update \
+         REQUIRED_NESTED_LOCK in tests/workspace_lockfile_consistency.rs)"
+    );
+}
+
+/// Parse `[package].version` from the root `Cargo.toml`.
+///
+/// A tiny hand-rolled section scan (no toml dependency): read `version = "..."`
+/// inside the first `[package]` table. Mirrors the awk in
+/// `scripts/check-doc-consistency.sh` so the two stay behaviorally aligned.
+fn root_crate_version(root: &Path) -> String {
+    let manifest = read_file(&root.join("Cargo.toml"));
+    let mut in_package = false;
+    for line in manifest.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[package]" {
+            in_package = true;
+            continue;
+        }
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_package = false; // any other table header ends [package]
+            continue;
+        }
+        if in_package {
+            if let Some(version) = parse_version_assignment(trimmed) {
+                return version;
+            }
+        }
+    }
+    panic!("could not parse [package].version from root Cargo.toml");
+}
+
+/// Extract the value of a `version = "X"` (or `'X'`) assignment, ignoring
+/// surrounding whitespace. Returns `None` for any other line.
+fn parse_version_assignment(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("version")?.trim_start();
+    let rest = rest.strip_prefix('=')?.trim();
+    let value = rest
+        .strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .or_else(|| rest.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')))?;
+    Some(value.to_string())
+}
+
+/// Find the version `signal-fish-server` is pinned at inside a `Cargo.lock`.
+///
+/// Cargo writes each `[[package]]` block as `name` then `version` on the next
+/// line; we still scan forward to the first `version = "..."` within the block
+/// (bounded by the next `[[package]]` / blank line) so a future cargo lockfile
+/// field-ordering change cannot silently break the parse.
+fn locked_root_crate_version(lock_text: &str) -> Option<String> {
+    let needle = format!("name = \"{ROOT_CRATE}\"");
+    let mut lines = lock_text.lines();
+    while let Some(line) = lines.next() {
+        if line.trim() != needle {
+            continue;
+        }
+        for block_line in lines.by_ref() {
+            let trimmed = block_line.trim();
+            if trimmed.is_empty() || trimmed.starts_with("[[") {
+                break; // end of this package block without a version
+            }
+            if let Some(version) = parse_version_assignment(trimmed) {
+                return Some(version);
+            }
+        }
+        return None;
+    }
+    None
+}
+
+/// Committed `Cargo.lock` paths (absolute), discovered via `git ls-files` — the
+/// exact "what is under version control" contract, and the only lockfiles that
+/// can drift in git and break a `--locked` build.
+///
+/// Integration tests always run inside the git checkout (CI checks out with
+/// `.git`; the repo's sibling guards likewise shell out to git), so a
+/// missing/failed git or an empty result is a loud hard error here rather than a
+/// silently-degraded scan that could pass vacuously.
+fn tracked_cargo_locks(root: &Path) -> Vec<PathBuf> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z", "--", "*Cargo.lock", "Cargo.lock"])
+        .output()
+        .unwrap_or_else(|e| {
+            panic!("`git ls-files` failed ({e}); this guard requires a git checkout")
+        });
+    assert!(
+        output.status.success(),
+        "`git ls-files` exited with {}; this guard requires a git checkout",
+        output.status
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let locks: Vec<PathBuf> = stdout
+        .split('\0')
+        .filter(|rel| !rel.is_empty())
+        .map(|rel| root.join(rel))
+        .collect();
+    assert!(
+        !locks.is_empty(),
+        "`git ls-files` found no tracked Cargo.lock files; lockfile discovery is broken"
+    );
+    locks
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The tower-http major bump touches mounted HTTP middleware, and broad lockfile changes affect all locked builds; risk is mitigated by extensive CI/test hardening rather than protocol or auth logic changes.
> 
> **Overview**
> **Release 0.3.0** with a refreshed dependency graph: direct **`tower-http` 0.6 → 0.7** (CORS/trace middleware), **`bytes` 1.11 → 1.12**, and synchronized root plus **`clients/native`** lockfiles so `--locked` interop builds stay aligned.
> 
> **CI reliability:** MSRV and coverage jobs set **`SIGNAL_FISH_TEST_TIMEOUT_MULTIPLIER=3`** for plain `cargo test` / llvm-cov lanes (no nextest isolation). The Docker job switches to **Buildx + `docker/build-push-action`** with **GHA layer cache** (fork-safe `cache-to` gating).
> 
> **Test and guard changes:** Idle-timeout e2e tests scale windows via the env multiplier; fixed startup sleeps are removed from in-process harnesses; multiprocess restart uses **more attempts and exponential backoff** on a fixed port; wall-clock micro-benchmarks are **`#[ignore]`**. New **`tests/workspace_lockfile_consistency.rs`** fails fast if any tracked lockfile pins an old crate version. **Pre-commit** auto-syncs quoted versions in `docs/library-usage.md` and `.llm/context.md` from `Cargo.toml`, with parity tests and clearer doc-checker hints on version drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50214305846273d42dc23691677e46a8b2940719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->