### PR TITLE
bugfix: never silently drop relayed messages — backpressure + loud slow-consumer disconnects (fixes #131)

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -10,7 +10,7 @@
 - **Repository:** `signal-fish-server` — extracted from the matchbox-signaling-server with
   production-ready signaling stripped down to a single self-contained binary
 - **Crate name:** Binary: `signal-fish-server` | Library: `signal_fish_server`
-- **Version:** 0.3.0
+- **Version:** 0.4.0
 - **Code name:** Signal Fish
 - **Not Matchbox:** This project is built by Ambiguous Interactive, not the upstream Matchbox team.
   The upstream `matchbox` crate/project (by Johan Helsing) is a dependency we build upon,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added two WebSocket delivery config fields: `websocket.send_queue_capacity` (default `1024`
+  messages; must be ≥ 1) bounds the per-connection outbound message queue — previously
+  hard-derived as `batch_size * 4` (40) — and `websocket.slow_consumer_timeout_ms` (default
+  `5000`; must be > 0 and ≤ 600000) bounds how long delivery may wait on a full queue before the
+  recipient is disconnected as a slow consumer. Both are documented in `docs/configuration.md`
+  and pinned by the config-reference drift guards in `tests/config_and_endpoints_tests.rs`.
+- Added the `SLOW_CONSUMER` error code (connection lifecycle): sent best-effort as a final
+  `Error` frame before the server closes a connection whose outbound queue stayed full past
+  `websocket.slow_consumer_timeout_ms`, so clients can distinguish "you could not keep up" from
+  other disconnects.
+- Added two Prometheus counters for delivery health:
+  `signal_fish_websocket_backpressure_events_total` (times a full outbound queue forced delivery
+  to wait for capacity; the message was still delivered) and
+  `signal_fish_websocket_slow_consumer_disconnects_total` (connections force-closed because
+  their outbound queue stayed full past the timeout). The existing
+  `signal_fish_websocket_messages_dropped_total` help text now clarifies it counts server
+  messages abandoned together with a closed or closing connection.
 - Cross-platform prebuilt release binaries: `release.yml` now builds a standalone
   `signal-fish-server` executable for Linux (x86_64, aarch64), macOS (x86_64, Apple
   Silicon), and Windows (x86_64, aarch64) and attaches each as a SHA-256-checksummed
@@ -438,6 +455,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed [#131](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/131): the relay
+  silently dropped `GameData` under burst — each connection's outbound queue was a small bounded
+  channel (`batch_size * 4` = 40 messages) written with a fire-and-forget `try_send`, so a burst
+  that outpaced one recipient's drain rate discarded messages with only a metric to show for it.
+  The server now NEVER silently drops a delivery: the fast path is still a lock-free `try_send`,
+  but a full queue makes delivery wait (true backpressure) for up to
+  `websocket.slow_consumer_timeout_ms`, and only a recipient that stays full past that timeout is
+  disconnected as a slow consumer (metrics + warning log + best-effort `SLOW_CONSUMER` error
+  frame, then the close). Room senders are paced to their slowest healthy recipient; a dead
+  recipient costs senders at most one timeout window before it is evicted. Covered end to end by
+  `tests/relay_backpressure_e2e.rs`; delivery semantics are documented in `docs/protocol.md`.
+- Undeliverable binary game data is no longer silently dropped by the send path: a payload that
+  cannot be converted for a recipient (e.g. an internal binary encoding relayed to a JSON-only
+  client) now surfaces an explicit `Error` frame with code `UNSUPPORTED_GAME_DATA_FORMAT` to that
+  recipient in place of each undeliverable payload, and the drop metric still increments.
 - Hardened release and documentation validation: `release.yml` now skips binary
   attachment with a clear diagnostic when no `release-binary-*` artifacts exist,
   uses an existing `actions/download-artifact` tag, and the workflow hygiene job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Error` frame before the server closes a connection whose outbound queue stayed full past
   `websocket.slow_consumer_timeout_ms`, so clients can distinguish "you could not keep up" from
   other disconnects.
+- Added the `ACTIVITY_TIMEOUT` error code (connection lifecycle): sent best-effort by the
+  activity reaper before it evicts a connection that produced no messages within
+  `server.ping_timeout`, keeping it distinct from the socket-level `CONNECTION_IDLE_TIMEOUT`
+  close.
 - Added two Prometheus counters for delivery health:
   `signal_fish_websocket_backpressure_events_total` (times a full outbound queue forced delivery
   to wait for capacity; the message was still delivered) and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -2766,7 +2766,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-fish-server"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]
@@ -25,8 +25,15 @@ legacy-fullmesh = ["matchbox_signaling"]
 tls = ["axum-server", "rustls", "rustls-pki-types"]
 
 [dependencies]
-# Async runtime
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros"] }
+# Async runtime. `sync` (mpsc/watch delivery channels) and `time` (backpressure
+# timeouts) are load-bearing for the no-silent-drop delivery path — keep them
+# explicit rather than relying on feature unification from other dependencies.
+tokio = { version = "1.52", features = [
+    "rt-multi-thread",
+    "macros",
+    "sync",
+    "time",
+] }
 
 # Web framework
 axum = { version = "0.8", features = ["ws"] }

--- a/clients/native/Cargo.lock
+++ b/clients/native/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"
@@ -824,7 +824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2084,7 +2084,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -2541,7 +2541,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -39,7 +39,8 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
 use serde_json::json;
 use signal_fish_server::protocol::{
-    ClientMessage, GameDataEncoding, IceServer, LobbyState, PlayerId, ServerMessage, Transport,
+    ClientMessage, ErrorCode, GameDataEncoding, IceServer, LobbyState, PlayerId, ServerMessage,
+    Transport,
 };
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant};
@@ -547,6 +548,20 @@ impl Orchestrator<'_> {
                     peer: peer_id,
                     transport,
                     connected,
+                });
+            }
+            ServerMessage::Error {
+                message,
+                error_code: Some(ErrorCode::SlowConsumer),
+            } => {
+                // The server is closing this connection because it could not
+                // drain its outbound queue in time. Surface it distinctly so a
+                // run failure is attributable to consumption speed rather than
+                // a generic server error; the imminent socket close (not this
+                // frame) decides the outcome.
+                tracing::warn!(%message, "server disconnected this client as a slow consumer");
+                emit(&Event::Error {
+                    message: format!("server disconnecting us as a slow consumer: {message}"),
                 });
             }
             ServerMessage::Error {

--- a/config.example.json
+++ b/config.example.json
@@ -99,6 +99,8 @@
     "batch_size": 10,
     "batch_interval_ms": 16,
     "auth_timeout_secs": 10,
-    "idle_timeout_secs": 300
+    "idle_timeout_secs": 300,
+    "send_queue_capacity": 1024,
+    "slow_consumer_timeout_ms": 5000
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -374,7 +374,11 @@ Current ADRs:
 ### Graceful Degradation
 
 - Handle partial failures
-- Implement backpressure
+- Apply backpressure instead of dropping data: message delivery waits on a
+  full per-connection outbound queue (`websocket.send_queue_capacity`) for up
+  to `websocket.slow_consumer_timeout_ms`, then disconnects the recipient as
+  a slow consumer (best-effort `SLOW_CONSUMER` error) rather than silently
+  dropping messages
 - Timeout on slow operations
 
 ### Observable by Default

--- a/docs/configuration-recipes.md
+++ b/docs/configuration-recipes.md
@@ -278,7 +278,9 @@ size and flush interval.
     "batch_size": 10,
     "batch_interval_ms": 16,
     "auth_timeout_secs": 10,
-    "idle_timeout_secs": 300
+    "idle_timeout_secs": 300,
+    "send_queue_capacity": 1024,
+    "slow_consumer_timeout_ms": 5000
   }
 }
 ```
@@ -300,6 +302,19 @@ frame interval at 60 fps) suit most games. Raise `batch_size` and
 per-flush delay matters more than syscall amortization. Keep `idle_timeout_secs`
 positive in production — it reclaims zombie sockets (`0` disables it);
 `auth_timeout_secs` must be between 5 and 60.
+
+High-rate game data (rollback netcode): the server never silently drops a
+relayed message — a recipient whose outbound queue fills paces its senders via
+backpressure instead of losing messages. Size `send_queue_capacity` for your
+worst-case burst headroom: the default `1024` messages is roughly 17 seconds of
+buffering at 60 messages/second from a sending peer, and queue slots hold
+pointers, so a generous capacity costs almost nothing until messages actually
+queue. `slow_consumer_timeout_ms` (default `5000`) trades tolerance for pacing:
+higher values ride out longer client stalls (GC pauses, Wi-Fi hiccups) but let
+one unresponsive recipient slow its room's senders for longer; lower values
+evict slow consumers sooner. A dead recipient costs senders at most one timeout
+window before it is disconnected with a `SLOW_CONSUMER` error (see
+[delivery semantics](protocol.md#delivery-semantics)).
 
 ## Rate limits
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,6 +196,8 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__WEBSOCKET__BATCH_INTERVAL_MS` | `websocket.batch_interval_ms` | `16` | Batch flush interval in milliseconds (must be > 0 when `enable_batching` is true) |
 | `SIGNAL_FISH__WEBSOCKET__AUTH_TIMEOUT_SECS` | `websocket.auth_timeout_secs` | `10` | Seconds to wait for auth after connect |
 | `SIGNAL_FISH__WEBSOCKET__IDLE_TIMEOUT_SECS` | `websocket.idle_timeout_secs` | `300` | Seconds without any inbound frame before an authenticated connection is closed (`0` disables) |
+| `SIGNAL_FISH__WEBSOCKET__SEND_QUEUE_CAPACITY` | `websocket.send_queue_capacity` | `1024` | Per-connection outbound message queue capacity in messages (must be ≥ 1); a full queue applies backpressure to senders |
+| `SIGNAL_FISH__WEBSOCKET__SLOW_CONSUMER_TIMEOUT_MS` | `websocket.slow_consumer_timeout_ms` | `5000` | Milliseconds delivery may wait on a full outbound queue before the recipient is disconnected as a slow consumer (must be > 0 and ≤ `600000`) |
 | `RUST_LOG` | -- | `info` | Standard `tracing` log filter used when `logging.level` is `null` |
 
 ## Common Configurations
@@ -299,7 +301,9 @@ Complete reference of all configuration options with environment variable overri
     "batch_size": 10,
     "batch_interval_ms": 16,
     "auth_timeout_secs": 10,
-    "idle_timeout_secs": 300
+    "idle_timeout_secs": 300,
+    "send_queue_capacity": 1024,
+    "slow_consumer_timeout_ms": 5000
   }
 }
 
@@ -320,6 +324,20 @@ Complete reference of all configuration options with environment variable overri
   that heartbeat (which `server.ping_timeout` already requires) are never
   affected by the 300s default. Keep this enabled in production — it reclaims
   zombie sockets that would otherwise hold file descriptors open indefinitely.
+- `send_queue_capacity` - Per-connection outbound message queue capacity in
+  messages (default: 1024; must be ≥ 1). Bounds how many undelivered server
+  messages may queue for one connection before delivery applies backpressure
+  to senders. Larger values absorb bigger relay bursts without slowing
+  senders; queue slots hold pointers, so a generous capacity costs almost
+  nothing until messages actually queue.
+- `slow_consumer_timeout_ms` - How long (milliseconds) delivery may wait for
+  space in a full outbound queue before the recipient is disconnected as a
+  slow consumer (default: 5000; must be > 0 and ≤ 600000). This is the loud
+  alternative to silently dropping messages: a connection that cannot absorb
+  traffic for this long — on top of the buffering `send_queue_capacity`
+  provides — is closed with a best-effort `SLOW_CONSUMER` error through the
+  normal disconnect flow. The server never silently drops a delivery; see
+  [Delivery semantics](protocol.md#delivery-semantics).
 
 ## Session Topology (Protocol v3)
 

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -7,7 +7,7 @@ Rust application.
 
 ```toml
 [dependencies]
-signal-fish-server = "0.3.0"
+signal-fish-server = "0.4.0"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 
@@ -308,7 +308,7 @@ Enable optional features:
 
 ```toml
 [dependencies]
-signal-fish-server = { version = "0.3.0", features = ["tls", "legacy-fullmesh"] }
+signal-fish-server = { version = "0.4.0", features = ["tls", "legacy-fullmesh"] }
 
 ```
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -474,6 +474,39 @@ MessagePack map:
 Clients that did not negotiate `game_data_format: "message_pack"` receive the
 JSON `GameData` fallback instead.
 
+### Delivery semantics
+
+Relayed messages — `GameData`, `GameDataBinary`, and every other server
+message — are delivered reliably and in order per connection over the
+WebSocket. The server never silently drops a delivery: when a recipient
+cannot keep up, its bounded outbound queue
+(`websocket.send_queue_capacity`, default 1024 messages) fills and delivery
+applies backpressure to senders, waiting up to
+`websocket.slow_consumer_timeout_ms` (default 5000) for space. A recipient
+whose queue stays full past that timeout is disconnected as a slow consumer:
+the server sends a best-effort `Error` with code `SLOW_CONSUMER`, then
+closes the socket through the normal disconnect flow (so the reconnection
+grace period still applies).
+
+Practical consequences:
+
+- Clients driving async runtimes must continuously poll/drive their
+  connection. A runtime that is merely "ticked" occasionally starves the
+  transport: inbound frames back up on the server side and manifest as
+  apparent stalls, ending in a `SLOW_CONSUMER` disconnect.
+- Sustainable throughput is bounded by the slowest recipient's ability to
+  drain its connection: room senders are paced to their slowest healthy
+  recipient, and a dead recipient costs senders at most one timeout window
+  before it is evicted. Operators can watch the
+  `signal_fish_websocket_backpressure_events_total` and
+  `signal_fish_websocket_slow_consumer_disconnects_total` Prometheus
+  counters to spot backpressure and slow-consumer evictions in production.
+
+A binary game-data payload that cannot be converted for a recipient (for
+example, an internal binary encoding relayed to a JSON-only client) is not
+silently dropped either: the recipient receives an explicit `Error` with
+code `UNSUPPORTED_GAME_DATA_FORMAT` in place of each undeliverable payload.
+
 ### LobbyStateChanged
 
 Lobby state transitioned.
@@ -604,7 +637,10 @@ Response to client `Ping`.
 
 ### Reconnected
 
-Reconnection successful. Includes current room state and missed events.
+Reconnection successful. Includes current room state. The `missed_events`
+field is reserved for future use and is always an empty list today — messages
+sent while the player was disconnected are not buffered or replayed (see
+[Reconnection Flow](#reconnection-flow)).
 
 ```json
 
@@ -631,15 +667,7 @@ Reconnection successful. Includes current room state and missed events.
     "ready_players": ["player-id-1"],
     "relay_type": "matchbox",
     "current_spectators": [],
-    "missed_events": [
-      {
-        "type": "GameData",
-        "data": {
-          "from_player": "player-id",
-          "data": {"action": "move"}
-        }
-      }
-    ]
+    "missed_events": []
   }
 }
 
@@ -855,8 +883,13 @@ and `room_id` (from the original `RoomJoined` response) to reconnect:
 
 ```
 
-On successful reconnection, the server sends a `Reconnected` message with the current room state and any
-missed events that occurred during the disconnection.
+On successful reconnection, the server sends a `Reconnected` message with the current room state.
+
+Note: messages sent while a player is disconnected are **not** buffered or
+replayed — the `missed_events` field in the `Reconnected` payload is always
+empty today. Clients must treat reconnection as requiring an
+application-level state resync (for example, have the authority or another
+peer re-send the current game state after `PlayerReconnected`).
 
 ## Protocol v3 additions
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -72,6 +72,7 @@ establishment.
 | `AUTHENTICATION_TIMEOUT` | Authentication took too long to complete. |
 | `CONNECTION_IDLE_TIMEOUT` | The connection was closed because no messages were received within the idle timeout (`websocket.idle_timeout_secs`). Send periodic `Ping` messages to keep the connection alive. |
 | `SLOW_CONSUMER` | The connection could not keep up with the messages sent to it -- its outbound queue stayed full past `websocket.slow_consumer_timeout_ms` -- so the server closed it instead of silently dropping data. Drain messages faster (or reconnect) and consider pacing senders. |
+| `ACTIVITY_TIMEOUT` | The server's activity reaper (`server.ping_timeout`) evicted the connection because no messages of any kind were received within the window. Distinct from `CONNECTION_IDLE_TIMEOUT` (the socket-level `websocket.idle_timeout_secs` close). Send periodic `Ping` messages (or any traffic) to stay connected. |
 | `SDK_VERSION_UNSUPPORTED` | The SDK version is no longer supported. Upgrade to the latest version. |
 | `UNSUPPORTED_GAME_DATA_FORMAT` | The requested game data format is not supported by this server. |
 

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -71,6 +71,7 @@ establishment.
 | `MISSING_APP_ID` | Application ID is required but was not provided in the request. |
 | `AUTHENTICATION_TIMEOUT` | Authentication took too long to complete. |
 | `CONNECTION_IDLE_TIMEOUT` | The connection was closed because no messages were received within the idle timeout (`websocket.idle_timeout_secs`). Send periodic `Ping` messages to keep the connection alive. |
+| `SLOW_CONSUMER` | The connection could not keep up with the messages sent to it -- its outbound queue stayed full past `websocket.slow_consumer_timeout_ms` -- so the server closed it instead of silently dropping data. Drain messages faster (or reconnect) and consider pacing senders. |
 | `SDK_VERSION_UNSUPPORTED` | The SDK version is no longer supported. Upgrade to the latest version. |
 | `UNSUPPORTED_GAME_DATA_FORMAT` | The requested game data format is not supported by this server. |
 

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -438,6 +438,7 @@ components:
         - CONNECTION_IDLE_TIMEOUT
         - GAME_START_NOT_READY
         - GAME_START_FORBIDDEN
+        - SLOW_CONSUMER
 
     # ---------------------------------------------------------------------
     # Shared object schemas

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -439,6 +439,7 @@ components:
         - GAME_START_NOT_READY
         - GAME_START_FORBIDDEN
         - SLOW_CONSUMER
+        - ACTIVITY_TIMEOUT
 
     # ---------------------------------------------------------------------
     # Shared object schemas

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -405,3 +405,27 @@ pub const fn default_auth_timeout_secs() -> u64 {
 pub const fn default_idle_timeout_secs() -> u64 {
     300
 }
+
+/// Default per-connection outbound queue capacity (messages).
+///
+/// Sized to absorb realistic relay bursts (e.g. rollback-netcode input
+/// catch-up at 60 Hz) without engaging backpressure: 1024 messages is ~17
+/// seconds of headroom at 60 messages/second from a sending peer. Queue slots
+/// hold `Arc` pointers, so a generous default costs almost nothing until
+/// messages actually queue.
+pub const fn default_send_queue_capacity() -> usize {
+    1024
+}
+
+/// Default slow-consumer disconnect timeout in milliseconds.
+///
+/// When a recipient's outbound queue is full, delivery waits up to this long
+/// for capacity before the recipient is disconnected as a slow consumer.
+/// Messages are never silently dropped: each is delivered, or the
+/// unresponsive connection is closed loudly (metric + log + best-effort error
+/// frame). 5s tolerates transient stalls (GC pauses, WiFi hiccups) on top of
+/// the buffering the queue itself provides, while bounding how long one dead
+/// connection can stall senders in the same room.
+pub const fn default_slow_consumer_timeout_ms() -> u64 {
+    5_000
+}

--- a/src/config/websocket.rs
+++ b/src/config/websocket.rs
@@ -2,7 +2,8 @@
 
 use super::defaults::{
     default_auth_timeout_secs, default_batch_interval_ms, default_batch_size,
-    default_enable_batching, default_idle_timeout_secs,
+    default_enable_batching, default_idle_timeout_secs, default_send_queue_capacity,
+    default_slow_consumer_timeout_ms,
 };
 use serde::{Deserialize, Serialize};
 
@@ -30,6 +31,24 @@ pub struct WebSocketConfig {
     /// [`auth_timeout_secs`](Self::auth_timeout_secs).
     #[serde(default = "default_idle_timeout_secs")]
     pub idle_timeout_secs: u64,
+    /// Per-connection outbound message queue capacity.
+    ///
+    /// Bounds how many undelivered server messages may queue for one
+    /// connection before delivery applies backpressure to senders. Larger
+    /// values absorb bigger relay bursts without slowing senders; the cost is
+    /// only pointer-sized per slot until messages actually queue.
+    #[serde(default = "default_send_queue_capacity")]
+    pub send_queue_capacity: usize,
+    /// How long (milliseconds) delivery may wait for space in a full outbound
+    /// queue before the recipient is disconnected as a slow consumer.
+    ///
+    /// This is the loud alternative to silently dropping messages: a
+    /// connection that cannot absorb traffic for this long (on top of the
+    /// buffering provided by [`send_queue_capacity`](Self::send_queue_capacity))
+    /// is closed with a best-effort `SLOW_CONSUMER` error, and the room is
+    /// notified through the normal disconnect flow.
+    #[serde(default = "default_slow_consumer_timeout_ms")]
+    pub slow_consumer_timeout_ms: u64,
 }
 
 impl Default for WebSocketConfig {
@@ -40,6 +59,8 @@ impl Default for WebSocketConfig {
             batch_interval_ms: default_batch_interval_ms(),
             auth_timeout_secs: default_auth_timeout_secs(),
             idle_timeout_secs: default_idle_timeout_secs(),
+            send_queue_capacity: default_send_queue_capacity(),
+            slow_consumer_timeout_ms: default_slow_consumer_timeout_ms(),
         }
     }
 }
@@ -76,6 +97,152 @@ impl WebSocketConfig {
                  is true (it is the batch-flush interval, which cannot be zero)"
             );
         }
+        // A zero-capacity queue cannot accept any message (`mpsc::channel`
+        // panics on 0), and delivery semantics require at least one slot of
+        // real buffering per connection.
+        if self.send_queue_capacity == 0 {
+            anyhow::bail!(
+                "websocket.send_queue_capacity must be at least 1 (configured: 0); \
+                 it bounds the per-connection outbound message queue"
+            );
+        }
+        // A zero timeout would disconnect a peer the instant its queue fills,
+        // turning routine bursts into disconnect storms; a multi-minute value
+        // lets one dead connection stall room senders far past any useful
+        // recovery window. Bound it to a sane operational range.
+        if self.slow_consumer_timeout_ms == 0 {
+            anyhow::bail!(
+                "websocket.slow_consumer_timeout_ms must be greater than 0; \
+                 it is the grace period before a backpressured connection is disconnected"
+            );
+        }
+        if self.slow_consumer_timeout_ms > 600_000 {
+            anyhow::bail!(
+                "websocket.slow_consumer_timeout_ms must not exceed 600000 (10 minutes); \
+                 configured: {}",
+                self.slow_consumer_timeout_ms
+            );
+        }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Data-driven validation coverage: each case mutates one field on an
+    /// otherwise-default config and states whether validation must accept it
+    /// (plus a substring the rejection message must contain, so error text
+    /// stays actionable).
+    #[test]
+    fn validate_accepts_and_rejects_expected_configurations() {
+        struct Case {
+            name: &'static str,
+            mutate: fn(&mut WebSocketConfig),
+            expect_ok: bool,
+            expect_error_containing: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "defaults are valid",
+                mutate: |_config| {},
+                expect_ok: true,
+                expect_error_containing: "",
+            },
+            Case {
+                name: "auth timeout below floor",
+                mutate: |config| config.auth_timeout_secs = 4,
+                expect_ok: false,
+                expect_error_containing: "auth_timeout_secs must be at least 5",
+            },
+            Case {
+                name: "auth timeout above ceiling",
+                mutate: |config| config.auth_timeout_secs = 61,
+                expect_ok: false,
+                expect_error_containing: "auth_timeout_secs must not exceed 60",
+            },
+            Case {
+                name: "zero batch interval rejected only while batching",
+                mutate: |config| {
+                    config.enable_batching = true;
+                    config.batch_interval_ms = 0;
+                },
+                expect_ok: false,
+                expect_error_containing: "batch_interval_ms must be greater than 0",
+            },
+            Case {
+                name: "zero batch interval accepted when batching disabled",
+                mutate: |config| {
+                    config.enable_batching = false;
+                    config.batch_interval_ms = 0;
+                },
+                expect_ok: true,
+                expect_error_containing: "",
+            },
+            Case {
+                name: "zero send queue capacity",
+                mutate: |config| config.send_queue_capacity = 0,
+                expect_ok: false,
+                expect_error_containing: "send_queue_capacity must be at least 1",
+            },
+            Case {
+                name: "single-slot send queue is the floor",
+                mutate: |config| config.send_queue_capacity = 1,
+                expect_ok: true,
+                expect_error_containing: "",
+            },
+            Case {
+                name: "zero slow-consumer timeout",
+                mutate: |config| config.slow_consumer_timeout_ms = 0,
+                expect_ok: false,
+                expect_error_containing: "slow_consumer_timeout_ms must be greater than 0",
+            },
+            Case {
+                name: "slow-consumer timeout at ceiling",
+                mutate: |config| config.slow_consumer_timeout_ms = 600_000,
+                expect_ok: true,
+                expect_error_containing: "",
+            },
+            Case {
+                name: "slow-consumer timeout above ceiling",
+                mutate: |config| config.slow_consumer_timeout_ms = 600_001,
+                expect_ok: false,
+                expect_error_containing: "slow_consumer_timeout_ms must not exceed 600000",
+            },
+        ];
+
+        for case in cases {
+            let mut config = WebSocketConfig::default();
+            (case.mutate)(&mut config);
+            let result = config.validate();
+            match (case.expect_ok, result) {
+                (true, Ok(())) => {}
+                (true, Err(err)) => panic!("case `{}` should validate, got: {err}", case.name),
+                (false, Ok(())) => panic!("case `{}` should be rejected", case.name),
+                (false, Err(err)) => {
+                    let message = err.to_string();
+                    assert!(
+                        message.contains(case.expect_error_containing),
+                        "case `{}`: rejection message `{message}` should contain `{}`",
+                        case.name,
+                        case.expect_error_containing
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn defaults_match_documented_values() {
+        let config = WebSocketConfig::default();
+        assert!(config.enable_batching);
+        assert_eq!(config.batch_size, 10);
+        assert_eq!(config.batch_interval_ms, 16);
+        assert_eq!(config.auth_timeout_secs, 10);
+        assert_eq!(config.idle_timeout_secs, 300);
+        assert_eq!(config.send_queue_capacity, 1024);
+        assert_eq!(config.slow_consumer_timeout_ms, 5_000);
     }
 }

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -21,6 +21,179 @@ pub use room_coordinator::{
 use crate::protocol::{PlayerId, RoomId, ServerMessage};
 use std::sync::Arc;
 
+/// Why the server requested a connection be closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloseReason {
+    /// The connection's outbound queue stayed full past the configured
+    /// slow-consumer timeout. Keeping it would force either unbounded
+    /// buffering or silent message drops; disconnecting loudly is the only
+    /// behavior that preserves the delivery contract.
+    SlowConsumer,
+    /// The connection was unregistered server-side (activity reaper, explicit
+    /// disconnect, normal teardown). Socket tasks should flush whatever is
+    /// already queued and exit instead of lingering until a socket timeout.
+    Unregistered,
+}
+
+/// Server-side kill switch for one connection.
+///
+/// Held by the delivery layer (message coordinator / connection manager);
+/// requesting a close wakes the connection's I/O tasks, which write a
+/// best-effort error frame and tear the socket down. Every clone addresses
+/// the same connection; the first requested reason wins.
+///
+/// Dropping *all* signal clones (the natural consequence of unregistering a
+/// connection everywhere) also completes the paired
+/// [`ConnectionCloseListener`], so unregistration alone is enough to end the
+/// connection's I/O tasks — no message can be quietly routed into a
+/// half-alive socket.
+#[derive(Debug, Clone)]
+pub struct ConnectionCloseSignal {
+    tx: tokio::sync::watch::Sender<Option<CloseReason>>,
+}
+
+impl ConnectionCloseSignal {
+    /// Create a connected signal/listener pair for one connection.
+    pub fn channel() -> (Self, ConnectionCloseListener) {
+        let (tx, rx) = tokio::sync::watch::channel(None);
+        (Self { tx }, ConnectionCloseListener { rx })
+    }
+
+    /// Create a signal whose listener side is discarded.
+    ///
+    /// Used by test paths that register clients without real socket tasks;
+    /// close requests become no-ops instead of errors.
+    pub fn detached() -> Self {
+        Self::channel().0
+    }
+
+    /// Request the connection be closed. The first reason wins; repeat
+    /// requests are no-ops. Returns whether this call set the reason.
+    pub fn request_close(&self, reason: CloseReason) -> bool {
+        self.tx.send_if_modified(|current| {
+            if current.is_none() {
+                *current = Some(reason);
+                true
+            } else {
+                false
+            }
+        })
+    }
+}
+
+/// Listener half of [`ConnectionCloseSignal`], owned by a connection's I/O
+/// tasks.
+#[derive(Debug, Clone)]
+pub struct ConnectionCloseListener {
+    rx: tokio::sync::watch::Receiver<Option<CloseReason>>,
+}
+
+impl ConnectionCloseListener {
+    /// Wait until the connection should close.
+    ///
+    /// Resolves with `Some(reason)` for an explicit close request, or `None`
+    /// when every [`ConnectionCloseSignal`] clone has been dropped (i.e. the
+    /// connection was unregistered from all delivery maps). Cancel-safe.
+    pub async fn closed(&mut self) -> Option<CloseReason> {
+        loop {
+            if let Some(reason) = *self.rx.borrow_and_update() {
+                return Some(reason);
+            }
+            if self.rx.changed().await.is_err() {
+                // All signal holders are gone; report any reason set right
+                // before the final drop, otherwise a plain unregistration.
+                return *self.rx.borrow();
+            }
+        }
+    }
+}
+
+/// Everything the delivery layer needs to reach one connection: the bounded
+/// outbound message queue plus the kill switch used when that queue cannot
+/// absorb traffic.
+#[derive(Debug, Clone)]
+pub struct ClientDeliveryHandle {
+    pub sender: tokio::sync::mpsc::Sender<Arc<ServerMessage>>,
+    pub close: ConnectionCloseSignal,
+}
+
+/// Result of attempting to deliver one message to one connection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    /// The message was enqueued on the recipient's outbound queue.
+    Delivered,
+    /// The recipient's connection is already tearing down (its queue receiver
+    /// is gone). This is a normal disconnect race, not a delivery fault.
+    ChannelClosed,
+    /// The recipient's queue stayed full past the slow-consumer timeout; the
+    /// message was abandoned and the recipient's connection was asked to
+    /// close.
+    SlowConsumer,
+}
+
+/// Deliver one message to one connection without ever silently dropping it.
+///
+/// This is the single implementation of the server's delivery contract, used
+/// by the message coordinator (relay/broadcast paths) and by the WebSocket
+/// layer's direct control-message sends alike:
+///
+/// - fast path: lock-free `try_send`;
+/// - full queue: wait (true backpressure) up to `slow_consumer_timeout`,
+///   counting a backpressure event;
+/// - still full after the timeout: count and log the failure, signal the
+///   recipient's connection to close ([`CloseReason::SlowConsumer`]), and
+///   report [`DeliveryOutcome::SlowConsumer`] so the caller can prune the
+///   recipient. The message is abandoned only together with the connection
+///   itself — never silently.
+pub async fn deliver_or_disconnect(
+    metrics: &crate::metrics::ServerMetrics,
+    slow_consumer_timeout: std::time::Duration,
+    player_id: &PlayerId,
+    handle: &ClientDeliveryHandle,
+    message: Arc<ServerMessage>,
+) -> DeliveryOutcome {
+    let message = match handle.sender.try_send(message) {
+        Ok(()) => return DeliveryOutcome::Delivered,
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+            tracing::debug!(
+                %player_id,
+                "Recipient connection already closing; message unroutable"
+            );
+            return DeliveryOutcome::ChannelClosed;
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Full(message)) => message,
+    };
+
+    metrics.increment_websocket_backpressure_events();
+    match tokio::time::timeout(slow_consumer_timeout, handle.sender.send(message)).await {
+        Ok(Ok(())) => DeliveryOutcome::Delivered,
+        Ok(Err(_receiver_gone)) => {
+            tracing::debug!(%player_id, "Recipient connection closed while backpressured");
+            DeliveryOutcome::ChannelClosed
+        }
+        Err(_elapsed) => {
+            // Several deliveries (e.g. concurrent broadcasts from different
+            // senders) can time out against the same stuck recipient; only the
+            // one that actually initiates the close counts a disconnect, so
+            // the metric tallies connections rather than delivery attempts.
+            // Every abandoned message counts as dropped regardless.
+            let initiated_close = handle.close.request_close(CloseReason::SlowConsumer);
+            if initiated_close {
+                metrics.increment_websocket_slow_consumer_disconnects();
+            }
+            metrics.increment_websocket_messages_dropped();
+            tracing::warn!(
+                %player_id,
+                timeout_ms = slow_consumer_timeout.as_millis() as u64,
+                initiated_close,
+                "Outbound queue full past the slow-consumer timeout; disconnecting recipient \
+                 instead of silently dropping messages"
+            );
+            DeliveryOutcome::SlowConsumer
+        }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait MessageCoordinator: Send + Sync {
     async fn send_to_player(
@@ -46,7 +219,7 @@ pub trait MessageCoordinator: Send + Sync {
         &self,
         player_id: PlayerId,
         room_id: Option<RoomId>,
-        sender: tokio::sync::mpsc::Sender<Arc<ServerMessage>>,
+        delivery: ClientDeliveryHandle,
     ) -> anyhow::Result<()>;
 
     async fn unregister_local_client(&self, player_id: &PlayerId) -> anyhow::Result<()>;

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -210,15 +210,15 @@ pub trait MessageCoordinator: Send + Sync {
     /// slow-consumer disconnect — the close itself, with its lifecycle
     /// reason, is the authoritative signal. Returns whether the message was
     /// enqueued.
+    ///
+    /// CONTRACT: implementations must not wait on recipient queue capacity.
+    /// There is deliberately no default implementation — falling back to the
+    /// reliable (backpressured) path would silently violate this contract.
     async fn try_send_to_player(
         &self,
         player_id: &PlayerId,
         message: Arc<ServerMessage>,
-    ) -> anyhow::Result<bool> {
-        // Default: fall back to the reliable delivery path (test doubles
-        // don't distinguish the two).
-        self.send_to_player(player_id, message).await.map(|()| true)
-    }
+    ) -> anyhow::Result<bool>;
 
     async fn broadcast_to_room(
         &self,

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -202,6 +202,24 @@ pub trait MessageCoordinator: Send + Sync {
         message: Arc<ServerMessage>,
     ) -> anyhow::Result<()>;
 
+    /// Best-effort, non-waiting delivery for pre-close farewells.
+    ///
+    /// Use ONLY for advisory frames sent to a connection that is about to be
+    /// terminated (reaper eviction, timeout notices): a full queue must
+    /// neither delay the teardown nor reclassify the close as a
+    /// slow-consumer disconnect — the close itself, with its lifecycle
+    /// reason, is the authoritative signal. Returns whether the message was
+    /// enqueued.
+    async fn try_send_to_player(
+        &self,
+        player_id: &PlayerId,
+        message: Arc<ServerMessage>,
+    ) -> anyhow::Result<bool> {
+        // Default: fall back to the reliable delivery path (test doubles
+        // don't distinguish the two).
+        self.send_to_player(player_id, message).await.map(|()| true)
+    }
+
     async fn broadcast_to_room(
         &self,
         room_id: &RoomId,

--- a/src/coordination/room_coordinator.rs
+++ b/src/coordination/room_coordinator.rs
@@ -312,9 +312,19 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
                 Err(e) => return Err(anyhow::anyhow!("Failed to get room: {e}")),
             }
 
-            // Persist Waiting -> Lobby, then broadcast the single transition.
+            // Persist Waiting -> Lobby under the lock; the broadcast happens
+            // after release (see below).
             self.database.transition_room_to_lobby(room_id).await?;
+            Ok(true)
+        }
+        .await;
 
+        // The room-operation lock protects state, never delivery: coordinator
+        // sends apply backpressure (bounded by the slow-consumer timeout) and
+        // must not extend a distributed-lock critical section past its TTL.
+        lock_guard.release().await;
+
+        if matches!(result, Ok(true)) {
             let message = crate::protocol::ServerMessage::LobbyStateChanged {
                 lobby_state: crate::protocol::LobbyState::Lobby,
                 ready_players: Vec::new(),
@@ -324,11 +334,7 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
                 .broadcast_to_room(room_id, Arc::new(message))
                 .await?;
             tracing::info!(%room_id, "Room transitioned to lobby state (in-memory)");
-            Ok(true)
         }
-        .await;
-
-        lock_guard.release().await;
         result
     }
 
@@ -347,23 +353,20 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
         )
         .await?;
 
-        let result = async {
-            // Simulate successful authority transfer
-            let message = crate::protocol::ServerMessage::AuthorityChanged {
-                authority_player: Some(*new_authority),
-                you_are_authority: false, // Will be customized per client
-            };
-
-            self.coordinator
-                .broadcast_to_room(room_id, Arc::new(message))
-                .await?;
-            tracing::info!(%room_id, %new_authority, "Authority transferred (in-memory)");
-            Ok(true)
-        }
-        .await;
-
+        // Nothing to mutate for the in-memory simulation; release the
+        // room-operation lock before delivery (sends can be backpressured and
+        // must never run inside a TTL-bounded critical section).
         lock_guard.release().await;
-        result
+
+        let message = crate::protocol::ServerMessage::AuthorityChanged {
+            authority_player: Some(*new_authority),
+            you_are_authority: false, // Will be customized per client
+        };
+        self.coordinator
+            .broadcast_to_room(room_id, Arc::new(message))
+            .await?;
+        tracing::info!(%room_id, %new_authority, "Authority transferred (in-memory)");
+        Ok(true)
     }
 
     async fn execute_distributed_operation(&self, operation: &str, room_id: &RoomId) -> Result<()> {
@@ -398,6 +401,11 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
         )
         .await?;
 
+        // The locked section performs the state mutation and *collects* the
+        // notifications; delivery happens after the lock is released because
+        // coordinator sends can be backpressured (bounded by the slow-consumer
+        // timeout) and must never stretch a TTL-bounded critical section.
+        let mut outbound: Vec<(PlayerId, crate::protocol::ServerMessage)> = Vec::new();
         let result = async {
             tracing::info!(%room_id, %player_id, %become_authority, "InMemory: Processing authority request");
 
@@ -417,30 +425,18 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
                             None
                         };
 
-                        // First send specific authority response to the requesting player
-                        tracing::info!(%room_id, %player_id, "Sending AuthorityResponse to player");
-                        let response_message = crate::protocol::ServerMessage::AuthorityResponse {
-                            granted,
-                            reason: reason.clone(),
-                            error_code: if granted {
-                                None
-                            } else {
-                                Some(crate::protocol::ErrorCode::AuthorityDenied)
+                        // First queue the specific authority response for the requester
+                        outbound.push((
+                            *player_id,
+                            crate::protocol::ServerMessage::AuthorityResponse {
+                                granted,
+                                reason: reason.clone(),
+                                error_code: None,
                             },
-                        };
-
-                        if let Err(e) = self
-                            .coordinator
-                            .send_to_player(player_id, Arc::new(response_message))
-                            .await
-                        {
-                            tracing::error!("Failed to send authority response to player: {}", e);
-                        }
+                        ));
 
                         // Instead of broadcasting, we need to send a custom message to each player
-                        // to set the you_are_authority flag correctly
-                        tracing::info!(%room_id, "Sending customized AuthorityChanged messages");
-
+                        // to set the you_are_authority flag correctly.
                         // Get all player IDs in the room from database
                         let room = match self.database.get_room_by_id(room_id).await {
                             Ok(Some(room)) => room,
@@ -454,55 +450,29 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
                             }
                         };
 
-                        // Send a customized message to each player in the room
                         for room_player_id in room.players.keys() {
                             // This player is the authority if they requested authority and it was granted
                             let is_authority = become_authority && room_player_id == player_id;
-
-                            let auth_message = crate::protocol::ServerMessage::AuthorityChanged {
-                                authority_player: new_authority,
-                                you_are_authority: is_authority,
-                            };
-
-                            tracing::info!(
-                                %room_id,
-                                %room_player_id,
-                                %is_authority,
-                                "Sending customized AuthorityChanged message"
-                            );
-
-                            if let Err(e) = self
-                                .coordinator
-                                .send_to_player(room_player_id, Arc::new(auth_message))
-                                .await
-                            {
-                                tracing::error!(%room_player_id, "Failed to send authority change: {}", e);
-                            }
+                            outbound.push((
+                                *room_player_id,
+                                crate::protocol::ServerMessage::AuthorityChanged {
+                                    authority_player: new_authority,
+                                    you_are_authority: is_authority,
+                                },
+                            ));
                         }
 
                         tracing::info!(%room_id, %player_id, %become_authority, "Authority request granted (in-memory)");
                     } else {
-                        // Send denial response to the requesting player
-                        let response_message = crate::protocol::ServerMessage::AuthorityResponse {
-                            granted,
-                            reason: reason.clone(),
-                            error_code: if granted {
-                                None
-                            } else {
-                                Some(crate::protocol::ErrorCode::AuthorityDenied)
+                        // Queue the denial response for the requester
+                        outbound.push((
+                            *player_id,
+                            crate::protocol::ServerMessage::AuthorityResponse {
+                                granted,
+                                reason: reason.clone(),
+                                error_code: Some(crate::protocol::ErrorCode::AuthorityDenied),
                             },
-                        };
-
-                        if let Err(e) = self
-                            .coordinator
-                            .send_to_player(player_id, Arc::new(response_message))
-                            .await
-                        {
-                            tracing::error!(
-                                "Failed to send authority denial response to player: {}",
-                                e
-                            );
-                        }
+                        ));
 
                         tracing::info!(%room_id, %player_id, %become_authority, ?reason, "Authority request denied (in-memory)");
                     }
@@ -512,20 +482,14 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
                 Err(e) => {
                     tracing::error!(%room_id, %player_id, %become_authority, "Authority request failed: {}", e);
 
-                    // Send error response to the requesting player
-                    let response_message = crate::protocol::ServerMessage::AuthorityResponse {
-                        granted: false,
-                        reason: Some("Storage error".to_string()),
-                        error_code: Some(crate::protocol::ErrorCode::StorageError),
-                    };
-
-                    if let Err(send_err) = self
-                        .coordinator
-                        .send_to_player(player_id, Arc::new(response_message))
-                        .await
-                    {
-                        tracing::error!("Failed to send error response to player: {}", send_err);
-                    }
+                    outbound.push((
+                        *player_id,
+                        crate::protocol::ServerMessage::AuthorityResponse {
+                            granted: false,
+                            reason: Some("Storage error".to_string()),
+                            error_code: Some(crate::protocol::ErrorCode::StorageError),
+                        },
+                    ));
 
                     Ok((false, Some("Storage error".to_string())))
                 }
@@ -534,6 +498,17 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
         .await;
 
         lock_guard.release().await;
+
+        for (target, message) in outbound {
+            if let Err(e) = self
+                .coordinator
+                .send_to_player(&target, Arc::new(message))
+                .await
+            {
+                tracing::error!(%target, "Failed to send authority notification: {}", e);
+            }
+        }
+
         result
     }
 
@@ -611,31 +586,36 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
 
             drop(ready_map); // Release write lock
 
-            // Broadcast lobby state change
-            let message = crate::protocol::ServerMessage::LobbyStateChanged {
-                lobby_state: crate::protocol::LobbyState::Lobby,
-                ready_players: ready_players_vec.clone(),
-                all_ready,
-            };
-
-            self.coordinator
-                .broadcast_to_room(room_id, Arc::new(message))
-                .await
-                .map_err(PlayerReadyError::Internal)?;
-
             // Readiness no longer starts the game. `max_players` is a ceiling,
             // not a required count, and the game begins only on an explicit
             // `StartGame` (see `handle_start_game`) — so a `PlayerReady` toggle
-            // just records readiness and broadcasts the new lobby snapshot
-            // (with `all_ready` so clients know `StartGame` is now permitted).
-            let _ = all_ready;
+            // just records readiness; the new lobby snapshot (with `all_ready`
+            // so clients know `StartGame` is now permitted) is broadcast after
+            // the lock releases below.
             tracing::info!(%room_id, %player_id, ready = !was_ready, "Player ready state toggled (in-memory)");
-            Ok(())
+            Ok((ready_players_vec, all_ready))
         }
         .await;
 
+        // Broadcast outside the TTL-bounded critical section: delivery can be
+        // backpressured by a slow recipient and must never hold the room lock.
         lock_guard.release().await;
-        result
+
+        match result {
+            Ok((ready_players, all_ready)) => {
+                let message = crate::protocol::ServerMessage::LobbyStateChanged {
+                    lobby_state: crate::protocol::LobbyState::Lobby,
+                    ready_players,
+                    all_ready,
+                };
+                self.coordinator
+                    .broadcast_to_room(room_id, Arc::new(message))
+                    .await
+                    .map_err(PlayerReadyError::Internal)?;
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Handle an explicit `StartGame`: finalize the room with its *current*
@@ -660,12 +640,15 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
         )
         .await?;
 
+        // Captured under the lock for the post-release broadcast.
+        let mut relay_type_for_broadcast: Option<String> = None;
         let result = async {
             let room = match self.database.get_room_by_id(room_id).await {
                 Ok(Some(room)) => room,
                 Ok(None) => return Err(anyhow::anyhow!("Room not found")),
                 Err(e) => return Err(anyhow::anyhow!("Failed to get room: {e}")),
             };
+            relay_type_for_broadcast = Some(room.relay_type.clone());
 
             // Already started: a finalized room cannot be started again.
             if room.lobby_state == crate::protocol::LobbyState::Finalized {
@@ -730,23 +713,6 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
                 _ => room_players,
             };
 
-            // Preserve the legacy GameStarting metadata; v3 transport proof comes
-            // from negotiation and TransportStatus, not this payload.
-            let peer_connections =
-                PeerConnectionInfo::from_players(&finalized_members, &room.relay_type);
-            let game_start_message =
-                Arc::new(crate::protocol::ServerMessage::GameStarting { peer_connections });
-            self.coordinator
-                .broadcast_to_room(room_id, game_start_message)
-                .await?;
-
-            // Clear ready players for this room since the game is starting.
-            let mut ready_map = self.ready_players.write().await;
-            ready_map.remove(room_id);
-            drop(ready_map);
-
-            tracing::info!(%room_id, %player_id, "Game started via explicit StartGame (in-memory)");
-
             Ok(StartGameOutcome::Started(FinalizedRoom {
                 game_name: room.game_name.clone(),
                 authority_player: room.authority_player,
@@ -755,7 +721,34 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
         }
         .await;
 
+        // Broadcast + ready-set cleanup happen outside the TTL-bounded
+        // critical section: delivery can be backpressured by a slow recipient
+        // and must never hold the room lock. State is already consistent —
+        // the room is persisted `Finalized`, so a concurrent `PlayerReady`
+        // is rejected regardless of the ready-set contents, and clearing the
+        // set afterwards is idempotent cleanup.
         lock_guard.release().await;
+
+        if let Ok(StartGameOutcome::Started(finalized)) = &result {
+            // Preserve the legacy GameStarting metadata; v3 transport proof comes
+            // from negotiation and TransportStatus, not this payload.
+            let relay_type = relay_type_for_broadcast.unwrap_or_default();
+            let peer_connections =
+                PeerConnectionInfo::from_players(&finalized.members, &relay_type);
+            let game_start_message =
+                Arc::new(crate::protocol::ServerMessage::GameStarting { peer_connections });
+            self.coordinator
+                .broadcast_to_room(room_id, game_start_message)
+                .await?;
+
+            // Clear ready players for this room since the game has started.
+            let mut ready_map = self.ready_players.write().await;
+            ready_map.remove(room_id);
+            drop(ready_map);
+
+            tracing::info!(%room_id, %player_id, "Game started via explicit StartGame (in-memory)");
+        }
+
         result
     }
 
@@ -1464,12 +1457,18 @@ mod tests {
             coordinator.wait_for_broadcast_start(),
         )
         .await
-        .expect("ready operation should reach the post-acquire broadcast");
+        .expect("ready operation should reach the post-release broadcast");
+        // Delivery can be backpressured by a slow recipient (bounded by the
+        // slow-consumer timeout), so the TTL-bounded room-operation lock must
+        // be released BEFORE any coordinator send starts — otherwise a slow
+        // consumer could stretch the critical section past the lock TTL and
+        // break mutual exclusion for concurrent room operations.
         assert!(
-            lock.is_locked(&lock_key)
+            !lock
+                .is_locked(&lock_key)
                 .await
                 .expect("lock state can be read"),
-            "ready-state lock should be held while the operation is suspended after acquisition"
+            "ready-state lock must be released before the lobby broadcast starts"
         );
 
         ready_task.abort();

--- a/src/coordination/room_coordinator.rs
+++ b/src/coordination/room_coordinator.rs
@@ -924,6 +924,17 @@ mod tests {
             Ok(())
         }
 
+        async fn try_send_to_player(
+            &self,
+            player_id: &PlayerId,
+            message: Arc<ServerMessage>,
+        ) -> Result<bool> {
+            // Test double: send_to_player is non-blocking here, so delegating
+            // honors the non-waiting farewell contract while preserving
+            // whatever recording/blocking behavior the double implements.
+            self.send_to_player(player_id, message).await.map(|()| true)
+        }
+
         async fn broadcast_to_room(
             &self,
             room_id: &RoomId,
@@ -1016,6 +1027,17 @@ mod tests {
             _message: Arc<ServerMessage>,
         ) -> Result<()> {
             Ok(())
+        }
+
+        async fn try_send_to_player(
+            &self,
+            player_id: &PlayerId,
+            message: Arc<ServerMessage>,
+        ) -> Result<bool> {
+            // Test double: send_to_player is non-blocking here, so delegating
+            // honors the non-waiting farewell contract while preserving
+            // whatever recording/blocking behavior the double implements.
+            self.send_to_player(player_id, message).await.map(|()| true)
         }
 
         async fn broadcast_to_room(

--- a/src/coordination/room_coordinator.rs
+++ b/src/coordination/room_coordinator.rs
@@ -499,15 +499,33 @@ impl RoomOperationCoordinatorTrait for InMemoryRoomOperationCoordinator {
 
         lock_guard.release().await;
 
+        // Deliver concurrently ACROSS recipients (a single backpressured
+        // recipient must not delay everyone else's notification by up to the
+        // slow-consumer timeout) while preserving each recipient's OWN
+        // message order (the requester sees AuthorityResponse before its
+        // AuthorityChanged). Rooms are small, so the quadratic grouping scan
+        // is trivially cheap and keeps first-queued-first-sent order.
+        let mut per_recipient: Vec<(PlayerId, Vec<crate::protocol::ServerMessage>)> = Vec::new();
         for (target, message) in outbound {
-            if let Err(e) = self
-                .coordinator
-                .send_to_player(&target, Arc::new(message))
-                .await
-            {
-                tracing::error!(%target, "Failed to send authority notification: {}", e);
+            match per_recipient.iter_mut().find(|(pid, _)| *pid == target) {
+                Some((_, messages)) => messages.push(message),
+                None => per_recipient.push((target, vec![message])),
             }
         }
+        futures_util::future::join_all(per_recipient.into_iter().map(
+            |(target, messages)| async move {
+                for message in messages {
+                    if let Err(e) = self
+                        .coordinator
+                        .send_to_player(&target, Arc::new(message))
+                        .await
+                    {
+                        tracing::error!(%target, "Failed to send authority notification: {}", e);
+                    }
+                }
+            },
+        ))
+        .await;
 
         result
     }

--- a/src/coordination/room_coordinator.rs
+++ b/src/coordination/room_coordinator.rs
@@ -805,7 +805,7 @@ mod tests {
     use async_trait::async_trait;
     use std::collections::{BTreeMap, HashSet};
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use tokio::sync::{mpsc, Mutex, Notify};
+    use tokio::sync::{Mutex, Notify};
     use tokio::time::{sleep, timeout};
 
     use crate::protocol::ErrorCode;
@@ -949,7 +949,7 @@ mod tests {
             &self,
             _player_id: PlayerId,
             _room_id: Option<RoomId>,
-            _sender: mpsc::Sender<Arc<ServerMessage>>,
+            _delivery: crate::coordination::ClientDeliveryHandle,
         ) -> Result<()> {
             Ok(())
         }
@@ -1030,7 +1030,7 @@ mod tests {
             &self,
             _player_id: PlayerId,
             _room_id: Option<RoomId>,
-            _sender: mpsc::Sender<Arc<ServerMessage>>,
+            _delivery: crate::coordination::ClientDeliveryHandle,
         ) -> Result<()> {
             Ok(())
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,6 +15,13 @@ pub struct ServerMetrics {
     pub disconnections: AtomicU64,
     pub connection_errors: AtomicU64,
     pub websocket_messages_dropped: AtomicU64,
+    /// Times a full outbound queue forced delivery to wait for capacity
+    /// (the send eventually succeeded; nothing was lost). A rising rate means
+    /// clients are close to the slow-consumer limit.
+    pub websocket_backpressure_events: AtomicU64,
+    /// Connections force-closed because their outbound queue stayed full past
+    /// `websocket.slow_consumer_timeout_ms`.
+    pub websocket_slow_consumer_disconnects: AtomicU64,
 
     // Room operation metrics
     pub rooms_created: AtomicU64,
@@ -225,6 +232,8 @@ pub struct ConnectionMetrics {
     pub disconnections: u64,
     pub connection_errors: u64,
     pub websocket_messages_dropped: u64,
+    pub websocket_backpressure_events: u64,
+    pub websocket_slow_consumer_disconnects: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -400,6 +409,8 @@ impl ServerMetrics {
             disconnections: AtomicU64::new(0),
             connection_errors: AtomicU64::new(0),
             websocket_messages_dropped: AtomicU64::new(0),
+            websocket_backpressure_events: AtomicU64::new(0),
+            websocket_slow_consumer_disconnects: AtomicU64::new(0),
             rooms_created: AtomicU64::new(0),
             rooms_joined: AtomicU64::new(0),
             room_creation_failures: AtomicU64::new(0),
@@ -515,6 +526,25 @@ impl ServerMetrics {
 
     pub fn increment_websocket_messages_dropped(&self) {
         self.websocket_messages_dropped
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Record several dropped messages at once (e.g. a slow consumer's
+    /// abandoned queue at disconnect), keeping the drop counter honest.
+    pub fn add_websocket_messages_dropped(&self, count: u64) {
+        if count > 0 {
+            self.websocket_messages_dropped
+                .fetch_add(count, Ordering::Relaxed);
+        }
+    }
+
+    pub fn increment_websocket_backpressure_events(&self) {
+        self.websocket_backpressure_events
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_websocket_slow_consumer_disconnects(&self) {
+        self.websocket_slow_consumer_disconnects
             .fetch_add(1, Ordering::Relaxed);
     }
 
@@ -1035,6 +1065,12 @@ impl ServerMetrics {
                 disconnections: self.disconnections.load(Ordering::Relaxed),
                 connection_errors: self.connection_errors.load(Ordering::Relaxed),
                 websocket_messages_dropped: self.websocket_messages_dropped.load(Ordering::Relaxed),
+                websocket_backpressure_events: self
+                    .websocket_backpressure_events
+                    .load(Ordering::Relaxed),
+                websocket_slow_consumer_disconnects: self
+                    .websocket_slow_consumer_disconnects
+                    .load(Ordering::Relaxed),
             },
             rooms: RoomMetrics {
                 rooms_created: self.rooms_created.load(Ordering::Relaxed),

--- a/src/protocol/error_codes.rs
+++ b/src/protocol/error_codes.rs
@@ -89,6 +89,14 @@ pub enum ErrorCode {
     /// `StartGame` was sent by a player not permitted to start the game (the
     /// room has a designated authority and the sender is not it).
     GameStartForbidden,
+
+    // Connection lifecycle errors (1xxx category, appended at the END for rkyv
+    // discriminant stability — see the signaling-errors note above).
+    /// The connection's outbound queue stayed full past
+    /// `websocket.slow_consumer_timeout_ms`, so the server disconnected it
+    /// rather than silently dropping relayed messages. Sent best-effort as a
+    /// final `Error` frame before the close.
+    SlowConsumer,
 }
 
 impl ErrorCode {
@@ -263,6 +271,11 @@ impl ErrorCode {
             Self::GameStartForbidden => {
                 "You are not permitted to start the game. Only the room's authority player may start it."
             }
+
+            // Connection lifecycle errors (1xxx), continued
+            Self::SlowConsumer => {
+                "This connection could not keep up with the messages sent to it, so the server closed it instead of silently dropping data. Drain messages faster (or reconnect) and consider pacing senders."
+            }
         }
     }
 }
@@ -329,6 +342,7 @@ mod tests {
             ErrorCode::ConnectionIdleTimeout,
             ErrorCode::GameStartNotReady,
             ErrorCode::GameStartForbidden,
+            ErrorCode::SlowConsumer,
         ];
 
         for error_code in &error_codes {

--- a/src/protocol/error_codes.rs
+++ b/src/protocol/error_codes.rs
@@ -97,6 +97,12 @@ pub enum ErrorCode {
     /// rather than silently dropping relayed messages. Sent best-effort as a
     /// final `Error` frame before the close.
     SlowConsumer,
+    /// The server's activity reaper (`server.ping_timeout`) evicted this
+    /// connection because no messages of any kind were received within the
+    /// window. Distinct from [`Self::ConnectionIdleTimeout`], which is the
+    /// socket-level `websocket.idle_timeout_secs` close. Sent best-effort as
+    /// a final `Error` frame before the close.
+    ActivityTimeout,
 }
 
 impl ErrorCode {
@@ -276,6 +282,9 @@ impl ErrorCode {
             Self::SlowConsumer => {
                 "This connection could not keep up with the messages sent to it, so the server closed it instead of silently dropping data. Drain messages faster (or reconnect) and consider pacing senders."
             }
+            Self::ActivityTimeout => {
+                "The server received no messages from this connection within its activity window and evicted it. Send periodic Ping messages (or any traffic) to stay connected."
+            }
         }
     }
 }
@@ -343,6 +352,7 @@ mod tests {
             ErrorCode::GameStartNotReady,
             ErrorCode::GameStartForbidden,
             ErrorCode::SlowConsumer,
+            ErrorCode::ActivityTimeout,
         ];
 
         for error_code in &error_codes {

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -521,7 +521,15 @@ impl ReconnectionManager {
         true
     }
 
-    /// Get missed events for a reconnecting player
+    /// Get missed events for a reconnecting player.
+    ///
+    /// HONESTY NOTE: nothing on the production delivery path calls
+    /// [`Self::buffer_event`] today, so this always returns an empty list and
+    /// the `missed_events` field of the `Reconnected` payload is always empty.
+    /// Messages sent while a player is disconnected are NOT replayed; clients
+    /// must treat reconnection as requiring an application-level resync. The
+    /// buffer machinery is retained for embedders that wire `buffer_event`
+    /// into their own delivery layer.
     pub async fn get_missed_events(
         &self,
         room_id: &RoomId,

--- a/src/server.rs
+++ b/src/server.rs
@@ -747,6 +747,35 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
         Ok(())
     }
 
+    async fn try_send_to_player(
+        &self,
+        player_id: &PlayerId,
+        message: Arc<ServerMessage>,
+    ) -> anyhow::Result<bool> {
+        let handle = { self.local_clients.read().await.get(player_id).cloned() };
+        let Some(handle) = handle else {
+            tracing::debug!(%player_id, "Farewell skipped: player not registered with coordinator");
+            return Ok(false);
+        };
+        match handle.sender.try_send(message) {
+            Ok(()) => Ok(true),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                // Advisory frame to a connection that is being closed anyway:
+                // do not wait, do not escalate, do not overwrite the close
+                // reason. The teardown itself is the loud signal.
+                tracing::debug!(
+                    %player_id,
+                    "Farewell skipped: outbound queue full on a closing connection"
+                );
+                Ok(false)
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                tracing::debug!(%player_id, "Farewell skipped: connection already closed");
+                Ok(false)
+            }
+        }
+    }
+
     async fn broadcast_to_room(
         &self,
         room_id: &RoomId,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,8 @@
 use crate::auth::AppInfo;
 use crate::config::AppAuthEntry;
 use crate::coordination::{
-    InMemoryRoomOperationCoordinator, MessageCoordinator, RoomOperationCoordinatorTrait,
+    ClientDeliveryHandle, ConnectionCloseSignal, DeliveryOutcome, InMemoryRoomOperationCoordinator,
+    MessageCoordinator, RoomOperationCoordinatorTrait,
 };
 use crate::database::{create_database, DatabaseConfig, GameDatabase};
 use crate::distributed::{DistributedLock, InMemoryDistributedLock};
@@ -221,7 +222,10 @@ impl EnhancedGameServer {
 
         // Setup distributed coordination - in-memory only
         let distributed_lock = Arc::new(InMemoryDistributedLock::new());
-        let message_coordinator = Arc::new(InMemoryMessageCoordinator::new());
+        let message_coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(
+            Duration::from_millis(config.websocket_config.slow_consumer_timeout_ms),
+            metrics.clone(),
+        ));
 
         let connection_manager = ConnectionManager::new(
             config.max_connections_per_ip,
@@ -320,15 +324,41 @@ impl EnhancedGameServer {
         )
     }
 
-    /// Register a new client connection
+    /// Register a new client connection.
+    ///
+    /// The connection is registered with a detached close signal: delivery
+    /// failures still prune it from routing, but there are no socket tasks to
+    /// tear down. The WebSocket layer uses
+    /// [`register_client_with_close`](Self::register_client_with_close) so
+    /// slow-consumer disconnects actually close the socket.
     pub async fn register_client(
         &self,
         sender: mpsc::Sender<Arc<ServerMessage>>,
         client_addr: SocketAddr,
     ) -> Result<PlayerId, RegisterClientError> {
-        self.connection_manager
-            .register_client(sender, client_addr, self.instance_id)
+        self.register_client_with_close(sender, ConnectionCloseSignal::detached(), client_addr)
             .await
+    }
+
+    /// Register a new client connection along with the close signal that lets
+    /// the delivery layer terminate it (slow consumer, server-side eviction).
+    pub async fn register_client_with_close(
+        &self,
+        sender: mpsc::Sender<Arc<ServerMessage>>,
+        close: ConnectionCloseSignal,
+        client_addr: SocketAddr,
+    ) -> Result<PlayerId, RegisterClientError> {
+        self.connection_manager
+            .register_client(sender, close, client_addr, self.instance_id)
+            .await
+    }
+
+    /// Record inbound activity for a client so the activity reaper
+    /// (`server.ping_timeout`) treats it as alive. Called for every routed
+    /// client message — not just `Ping` — because a client streaming game
+    /// data at a high rate without heartbeats is emphatically alive.
+    pub(crate) fn record_client_activity(&self, player_id: &PlayerId) {
+        self.connection_manager.record_ping(player_id);
     }
 
     /// Update a client's preferred game data encoding.
@@ -509,18 +539,20 @@ impl EnhancedGameServer {
             // Tests should properly handle the asynchronous nature of message delivery
         }
 
-        // Remove client connection
-        if self.connection_manager.remove_client(player_id).is_some() {
-            self.metrics.decrement_active_connections();
-        }
-
-        // Unregister from message coordinator
+        // Unregister from the message coordinator BEFORE tearing the socket
+        // down: once routing stops, no new message can be enqueued into a
+        // connection whose send task is already flushing its final drain.
         if let Err(e) = self
             .message_coordinator
             .unregister_local_client(player_id)
             .await
         {
             tracing::warn!(%player_id, "Failed to unregister client from coordinator: {}", e);
+        }
+
+        // Remove client connection (also requests the socket tasks to close)
+        if self.connection_manager.remove_client(player_id).is_some() {
+            self.metrics.decrement_active_connections();
         }
 
         tracing::info!(%player_id, instance_id = %self.instance_id, "Client unregistered");
@@ -563,10 +595,22 @@ impl EnhancedGameServer {
     }
 }
 
-/// In-memory message coordinator for testing
+/// In-memory message coordinator: the production (single-instance) delivery
+/// layer that routes server messages onto per-connection outbound queues.
+///
+/// Delivery contract: **a message is never silently dropped.** Each delivery
+/// either enqueues the message (waiting — backpressure — for queue space when
+/// the recipient is momentarily full) or, if the recipient cannot absorb a
+/// single message for the whole `slow_consumer_timeout`, disconnects that
+/// recipient loudly (metrics + log + close signal). Senders in the same room
+/// are therefore paced to their slowest healthy recipient instead of having
+/// messages vanish, and an unhealthy recipient costs the room at most one
+/// timeout window before being evicted.
 pub struct InMemoryMessageCoordinator {
-    local_clients: Arc<RwLock<HashMap<PlayerId, mpsc::Sender<Arc<ServerMessage>>>>>,
+    local_clients: Arc<RwLock<HashMap<PlayerId, ClientDeliveryHandle>>>,
     room_players: Arc<RwLock<HashMap<RoomId, HashSet<PlayerId>>>>,
+    metrics: Arc<crate::metrics::ServerMetrics>,
+    slow_consumer_timeout: Duration,
     #[allow(dead_code)]
     instance_id: Uuid,
 }
@@ -574,12 +618,113 @@ pub struct InMemoryMessageCoordinator {
 use std::collections::HashSet;
 
 impl InMemoryMessageCoordinator {
+    /// Create a coordinator with default delivery policy and private metrics.
+    ///
+    /// Production wiring uses [`Self::with_delivery_policy`] so backpressure
+    /// events surface in the server-wide metrics; this constructor remains for
+    /// tests and embedders that only need routing behavior.
     pub fn new() -> Self {
+        Self::with_delivery_policy(
+            Duration::from_millis(crate::config::defaults::default_slow_consumer_timeout_ms()),
+            Arc::new(crate::metrics::ServerMetrics::new()),
+        )
+    }
+
+    /// Create a coordinator with an explicit slow-consumer timeout and shared
+    /// metrics sink.
+    pub fn with_delivery_policy(
+        slow_consumer_timeout: Duration,
+        metrics: Arc<crate::metrics::ServerMetrics>,
+    ) -> Self {
         Self {
             local_clients: Arc::new(RwLock::new(HashMap::new())),
             room_players: Arc::new(RwLock::new(HashMap::new())),
+            metrics,
+            slow_consumer_timeout,
             instance_id: Uuid::new_v4(),
         }
+    }
+
+    /// Deliver a message to many recipients concurrently, then prune every
+    /// recipient flagged as a slow consumer so subsequent deliveries stop
+    /// waiting on a connection that is already being torn down.
+    ///
+    /// Concurrency here bounds a broadcast's latency to the *slowest single
+    /// recipient* rather than the sum over recipients, while per-recipient
+    /// ordering is preserved because each caller awaits the whole broadcast
+    /// before issuing its next message.
+    async fn deliver_to_all(
+        &self,
+        recipients: Vec<(PlayerId, ClientDeliveryHandle)>,
+        message: Arc<ServerMessage>,
+    ) {
+        if recipients.is_empty() {
+            return;
+        }
+
+        let outcomes =
+            futures_util::future::join_all(recipients.iter().map(|(player_id, handle)| {
+                let message = Arc::clone(&message);
+                async move {
+                    let outcome = crate::coordination::deliver_or_disconnect(
+                        &self.metrics,
+                        self.slow_consumer_timeout,
+                        player_id,
+                        handle,
+                        message,
+                    )
+                    .await;
+                    (*player_id, outcome)
+                }
+            }))
+            .await;
+
+        let slow_consumers: Vec<PlayerId> = outcomes
+            .into_iter()
+            .filter(|(_, outcome)| *outcome == DeliveryOutcome::SlowConsumer)
+            .map(|(player_id, _)| player_id)
+            .collect();
+
+        if !slow_consumers.is_empty() {
+            // Remove immediately so senders stop paying the timeout for a
+            // connection that is already closing; the connection's own
+            // unregister flow performs the full cleanup (room membership,
+            // reconnection window, peer notifications).
+            let mut clients = self.local_clients.write().await;
+            for player_id in &slow_consumers {
+                clients.remove(player_id);
+            }
+        }
+    }
+
+    /// Snapshot the delivery handles for a room's members (optionally skipping
+    /// one player) and release both locks before any await on delivery, so a
+    /// backpressured recipient can never stall registration or other
+    /// broadcasts through held locks.
+    async fn collect_room_recipients(
+        &self,
+        room_id: &RoomId,
+        except_player: Option<&PlayerId>,
+    ) -> Vec<(PlayerId, ClientDeliveryHandle)> {
+        // Lock ordering: room_players first, then local_clients (matches
+        // register/unregister to prevent ABBA deadlocks).
+        let room_players = self.room_players.read().await;
+        let clients = self.local_clients.read().await;
+
+        room_players
+            .get(room_id)
+            .map(|players| {
+                players
+                    .iter()
+                    .filter(|player_id| Some(*player_id) != except_player)
+                    .filter_map(|player_id| {
+                        clients
+                            .get(player_id)
+                            .map(|handle| (*player_id, handle.clone()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -590,14 +735,14 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
         player_id: &PlayerId,
         message: Arc<ServerMessage>,
     ) -> anyhow::Result<()> {
-        let clients = self.local_clients.read().await;
-        if let Some(sender) = clients.get(player_id) {
-            if sender.try_send(Arc::clone(&message)).is_err() {
-                tracing::warn!(%player_id, "Failed to send message to local client");
-            }
-            tracing::info!(%player_id, ?message, "Message sent to player");
+        let handle = { self.local_clients.read().await.get(player_id).cloned() };
+        if let Some(handle) = handle {
+            self.deliver_to_all(vec![(*player_id, handle)], message)
+                .await;
         } else {
-            tracing::warn!(%player_id, ?message, "Player not found in local_clients map, message not sent");
+            // Normal during disconnect races (e.g. a room notification issued
+            // while the target is unregistering); nothing to deliver to.
+            tracing::debug!(%player_id, "Player not registered with coordinator; message unroutable");
         }
         Ok(())
     }
@@ -607,18 +752,8 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
         room_id: &RoomId,
         message: Arc<ServerMessage>,
     ) -> anyhow::Result<()> {
-        let room_players = self.room_players.read().await;
-        let clients = self.local_clients.read().await;
-
-        if let Some(players) = room_players.get(room_id) {
-            for player_id in players {
-                if let Some(sender) = clients.get(player_id) {
-                    if sender.try_send(Arc::clone(&message)).is_err() {
-                        tracing::warn!(%player_id, "Failed to broadcast message to player in room");
-                    }
-                }
-            }
-        }
+        let recipients = self.collect_room_recipients(room_id, None).await;
+        self.deliver_to_all(recipients, message).await;
         Ok(())
     }
 
@@ -628,20 +763,10 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
         except_player: &PlayerId,
         message: Arc<ServerMessage>,
     ) -> anyhow::Result<()> {
-        let room_players = self.room_players.read().await;
-        let clients = self.local_clients.read().await;
-
-        if let Some(players) = room_players.get(room_id) {
-            for player_id in players {
-                if player_id != except_player {
-                    if let Some(sender) = clients.get(player_id) {
-                        if sender.try_send(Arc::clone(&message)).is_err() {
-                            tracing::warn!(%player_id, "Failed to broadcast message to player in room");
-                        }
-                    }
-                }
-            }
-        }
+        let recipients = self
+            .collect_room_recipients(room_id, Some(except_player))
+            .await;
+        self.deliver_to_all(recipients, message).await;
         Ok(())
     }
 
@@ -649,7 +774,7 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
         &self,
         player_id: PlayerId,
         room_id: Option<RoomId>,
-        sender: mpsc::Sender<Arc<ServerMessage>>,
+        delivery: ClientDeliveryHandle,
     ) -> anyhow::Result<()> {
         // Lock ordering: room_players first, then local_clients
         // (consistent with broadcast_to_room / broadcast_to_room_except read paths
@@ -661,11 +786,11 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
                 .or_insert_with(HashSet::new)
                 .insert(player_id);
             let mut clients = self.local_clients.write().await;
-            clients.insert(player_id, sender);
+            clients.insert(player_id, delivery);
         } else {
             // No room_players lock needed when room_id is None
             let mut clients = self.local_clients.write().await;
-            clients.insert(player_id, sender);
+            clients.insert(player_id, delivery);
         }
         Ok(())
     }

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -511,6 +511,17 @@ mod tests {
             Ok(())
         }
 
+        async fn try_send_to_player(
+            &self,
+            player_id: &PlayerId,
+            message: Arc<ServerMessage>,
+        ) -> Result<bool> {
+            // Test double: send_to_player is non-blocking here, so delegating
+            // honors the non-waiting farewell contract while preserving
+            // whatever recording/blocking behavior the double implements.
+            self.send_to_player(player_id, message).await.map(|()| true)
+        }
+
         async fn broadcast_to_room(
             &self,
             _room_id: &RoomId,

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -8,7 +8,7 @@ use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::auth::AppInfo;
-use crate::coordination::MessageCoordinator;
+use crate::coordination::{ClientDeliveryHandle, ConnectionCloseSignal, MessageCoordinator};
 use crate::metrics::ServerMetrics;
 use crate::protocol::{GameDataEncoding, PlayerId, RoomId, ServerMessage, Topology, Transport};
 
@@ -46,6 +46,10 @@ pub(crate) struct ClientConnection {
     /// than the configured threshold (default 30 seconds).
     pub last_heartbeat_update: Option<Instant>,
     pub sender: mpsc::Sender<Arc<ServerMessage>>,
+    /// Kill switch for this connection's socket tasks (slow-consumer
+    /// disconnects, server-side eviction). Paired with `sender`: together they
+    /// form the connection's [`ClientDeliveryHandle`].
+    pub close: ConnectionCloseSignal,
     pub client_addr: SocketAddr,
     pub game_data_format: GameDataEncoding,
     pub app_info: Option<AppInfo>,
@@ -56,6 +60,17 @@ pub(crate) struct ClientConnection {
     /// (v3 only). `None` until the client reports — the relay floor is the implicit
     /// default and never closes regardless of what is (or is not) reported.
     pub transport_status: Option<(Transport, bool)>,
+}
+
+impl ClientConnection {
+    /// The pair (outbound queue, close signal) the delivery layer needs to
+    /// reach — or, failing that, terminate — this connection.
+    pub fn delivery_handle(&self) -> ClientDeliveryHandle {
+        ClientDeliveryHandle {
+            sender: self.sender.clone(),
+            close: self.close.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -93,6 +108,7 @@ impl ConnectionManager {
     pub async fn register_client(
         &self,
         sender: mpsc::Sender<Arc<ServerMessage>>,
+        close: ConnectionCloseSignal,
         client_addr: SocketAddr,
         instance_id: Uuid,
     ) -> Result<PlayerId, RegisterClientError> {
@@ -116,6 +132,7 @@ impl ConnectionManager {
             last_ping: Instant::now(),
             last_heartbeat_update: None,
             sender: sender.clone(),
+            close: close.clone(),
             client_addr,
             game_data_format: GameDataEncoding::Json,
             app_info: None,
@@ -128,7 +145,7 @@ impl ConnectionManager {
 
         if let Err(err) = self
             .message_coordinator
-            .register_local_client(player_id, None, sender)
+            .register_local_client(player_id, None, ClientDeliveryHandle { sender, close })
             .await
         {
             warn!(%player_id, %err, "Failed to register client with coordinator");
@@ -144,11 +161,13 @@ impl ConnectionManager {
         sender: mpsc::Sender<Arc<ServerMessage>>,
         client_addr: SocketAddr,
     ) {
+        let close = ConnectionCloseSignal::detached();
         let connection = ClientConnection {
             room_id: None,
             last_ping: Instant::now(),
             last_heartbeat_update: None,
             sender: sender.clone(),
+            close: close.clone(),
             client_addr,
             game_data_format: GameDataEncoding::Json,
             app_info: None,
@@ -162,7 +181,7 @@ impl ConnectionManager {
 
         if let Err(err) = self
             .message_coordinator
-            .register_local_client(player_id, None, sender)
+            .register_local_client(player_id, None, ClientDeliveryHandle { sender, close })
             .await
         {
             warn!(%player_id, %err, "Failed to register test client with coordinator");
@@ -172,11 +191,11 @@ impl ConnectionManager {
     pub async fn assign_client_to_room(&self, player_id: &PlayerId, room_id: RoomId) {
         if let Some(mut client) = self.clients.get_mut(player_id) {
             client.room_id = Some(room_id);
-            let sender = client.sender.clone();
+            let delivery = client.delivery_handle();
             drop(client);
             if let Err(err) = self
                 .message_coordinator
-                .register_local_client(*player_id, Some(room_id), sender)
+                .register_local_client(*player_id, Some(room_id), delivery)
                 .await
             {
                 warn!(
@@ -294,13 +313,10 @@ impl ConnectionManager {
         self.app_info(player_id).map(|info| info.id)
     }
 
-    pub fn clear_room_assignment(
-        &self,
-        player_id: &PlayerId,
-    ) -> Option<mpsc::Sender<Arc<ServerMessage>>> {
+    pub fn clear_room_assignment(&self, player_id: &PlayerId) -> Option<ClientDeliveryHandle> {
         self.clients.get_mut(player_id).map(|mut client| {
             client.room_id = None;
-            client.sender.clone()
+            client.delivery_handle()
         })
     }
 
@@ -354,15 +370,16 @@ impl ConnectionManager {
         current_player_id: &PlayerId,
         reconnect_player_id: &PlayerId,
         room_id: RoomId,
-    ) -> Option<mpsc::Sender<Arc<ServerMessage>>> {
+    ) -> Option<ClientDeliveryHandle> {
         // Atomically remove the old entry (no separate get-then-remove race)
         if let Some((_, old_connection)) = self.clients.remove(current_player_id) {
-            let sender = old_connection.sender.clone();
+            let delivery = old_connection.delivery_handle();
             let new_client = ClientConnection {
                 room_id: Some(room_id),
                 last_ping: Instant::now(),
                 last_heartbeat_update: None, // Reset on reconnection, will update immediately
-                sender: sender.clone(),
+                sender: delivery.sender.clone(),
+                close: delivery.close.clone(),
                 client_addr: old_connection.client_addr,
                 game_data_format: old_connection.game_data_format,
                 app_info: old_connection.app_info,
@@ -377,7 +394,7 @@ impl ConnectionManager {
             // IP slot is already reserved from the old entry -- no need to
             // release and re-reserve for the same IP address.
             self.clients.insert(*reconnect_player_id, new_client);
-            Some(sender)
+            Some(delivery)
         } else {
             None
         }
@@ -386,6 +403,16 @@ impl ConnectionManager {
     pub fn remove_client(&self, player_id: &PlayerId) -> Option<ClientConnection> {
         self.clients.remove(player_id).map(|(_, connection)| {
             self.release_ip_slot(connection.client_addr.ip());
+            // Every unregistration positively tears down the socket tasks:
+            // without this, a connection unregistered by the activity reaper
+            // lingers half-alive (undeliverable but still holding its socket)
+            // until an idle timeout fires. First requested reason wins, so a
+            // slow-consumer close initiated by the delivery layer is not
+            // overwritten. Reconnection reassignment deliberately bypasses
+            // this method, so surviving connections are never closed here.
+            connection
+                .close
+                .request_close(crate::coordination::CloseReason::Unregistered);
             connection
         })
     }
@@ -505,7 +532,7 @@ mod tests {
             &self,
             player_id: PlayerId,
             room_id: Option<RoomId>,
-            _sender: mpsc::Sender<Arc<ServerMessage>>,
+            _delivery: crate::coordination::ClientDeliveryHandle,
         ) -> Result<()> {
             self.registrations.lock().await.push((player_id, room_id));
             Ok(())
@@ -553,13 +580,13 @@ mod tests {
 
         let (tx1, _rx1) = channel();
         let first_id = manager
-            .register_client(tx1, addr, Uuid::new_v4())
+            .register_client(tx1, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("first registration succeeds");
 
         let (tx2, _rx2) = channel();
         let err = manager
-            .register_client(tx2, addr, Uuid::new_v4())
+            .register_client(tx2, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect_err("second client hits per-IP limit");
         match err {
@@ -573,7 +600,7 @@ mod tests {
 
         let (tx3, _rx3) = channel();
         manager
-            .register_client(tx3, addr, Uuid::new_v4())
+            .register_client(tx3, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("registrations resume after slot release");
     }
@@ -591,7 +618,7 @@ mod tests {
         let (tx, _rx) = channel();
         let addr: SocketAddr = "127.0.0.1:6000".parse().unwrap();
         let player_id = manager
-            .register_client(tx, addr, Uuid::new_v4())
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("registration succeeds");
 
@@ -632,7 +659,9 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 barrier.wait().await;
                 let (tx, _rx) = channel();
-                manager.register_client(tx, addr, Uuid::new_v4()).await
+                manager
+                    .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
+                    .await
             }));
         }
 
@@ -660,7 +689,9 @@ mod tests {
 
         // After removal, new registrations should work (counter is back to 0)
         let (tx, _rx) = channel();
-        let result = manager.register_client(tx, addr, Uuid::new_v4()).await;
+        let result = manager
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
+            .await;
         assert!(
             result.is_ok(),
             "Registration should succeed after all clients removed"
@@ -680,7 +711,7 @@ mod tests {
 
         let (tx, _rx) = channel();
         let original_id = manager
-            .register_client(tx, addr, Uuid::new_v4())
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("registration should succeed");
 
@@ -707,7 +738,12 @@ mod tests {
             let port = 9001 + i;
             let new_addr: SocketAddr = format!("10.0.0.2:{port}").parse().unwrap();
             manager
-                .register_client(tx, new_addr, Uuid::new_v4())
+                .register_client(
+                    tx,
+                    ConnectionCloseSignal::detached(),
+                    new_addr,
+                    Uuid::new_v4(),
+                )
                 .await
                 .expect("should succeed within limit");
         }
@@ -715,7 +751,14 @@ mod tests {
         // 5th attempt from same IP should fail (already at limit)
         let (tx, _rx) = channel();
         let new_addr: SocketAddr = "10.0.0.2:10000".parse().unwrap();
-        let result = manager.register_client(tx, new_addr, Uuid::new_v4()).await;
+        let result = manager
+            .register_client(
+                tx,
+                ConnectionCloseSignal::detached(),
+                new_addr,
+                Uuid::new_v4(),
+            )
+            .await;
         assert!(
             result.is_err(),
             "6th connection from same IP should be rejected"
@@ -733,7 +776,12 @@ mod tests {
         let (tx_verify, _rx_verify) = channel();
         let verify_addr: SocketAddr = "10.0.0.2:10001".parse().unwrap();
         let result = manager
-            .register_client(tx_verify, verify_addr, Uuid::new_v4())
+            .register_client(
+                tx_verify,
+                ConnectionCloseSignal::detached(),
+                verify_addr,
+                Uuid::new_v4(),
+            )
             .await;
         assert!(
             result.is_ok(),
@@ -751,7 +799,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:7100".parse().unwrap();
         let (tx, _rx) = channel();
         let pid = manager
-            .register_client(tx, addr, Uuid::new_v4())
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("register");
 
@@ -771,7 +819,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:7101".parse().unwrap();
         let (tx, _rx) = channel();
         let pid = manager
-            .register_client(tx, addr, Uuid::new_v4())
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("register");
 
@@ -811,7 +859,7 @@ mod tests {
         let addr: SocketAddr = "127.0.0.1:7102".parse().unwrap();
         let (tx, _rx) = channel();
         let original = manager
-            .register_client(tx, addr, Uuid::new_v4())
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
             .await
             .expect("register");
 
@@ -852,7 +900,12 @@ mod tests {
             let (tx, _rx) = channel();
             let port_addr: SocketAddr = format!("10.0.0.3:{}", 9000 + i).parse().unwrap();
             let pid = manager
-                .register_client(tx, port_addr, Uuid::new_v4())
+                .register_client(
+                    tx,
+                    ConnectionCloseSignal::detached(),
+                    port_addr,
+                    Uuid::new_v4(),
+                )
                 .await
                 .expect("registration should succeed");
             player_ids.push(pid);
@@ -879,7 +932,14 @@ mod tests {
         for i in 0..10u16 {
             let (tx, _rx) = channel();
             let port_addr: SocketAddr = format!("10.0.0.3:{}", 8000 + i).parse().unwrap();
-            let result = manager.register_client(tx, port_addr, Uuid::new_v4()).await;
+            let result = manager
+                .register_client(
+                    tx,
+                    ConnectionCloseSignal::detached(),
+                    port_addr,
+                    Uuid::new_v4(),
+                )
+                .await;
             assert!(
                 result.is_ok(),
                 "Registration #{} should succeed after complete removal (no underflow)",

--- a/src/server/game_data.rs
+++ b/src/server/game_data.rs
@@ -69,6 +69,10 @@ impl EnhancedGameServer {
         encoding: GameDataEncoding,
         payload: Bytes,
     ) {
+        // Binary frames bypass the message router, so record liveness here
+        // (mirrors `handle_client_message`): a client streaming binary game
+        // data must never be reaped as inactive.
+        self.record_client_activity(player_id);
         if payload.len() > self.config.max_message_size {
             tracing::warn!(
                 %player_id,

--- a/src/server/heartbeat.rs
+++ b/src/server/heartbeat.rs
@@ -89,7 +89,12 @@ mod tests {
 
         let player_id = server
             .connection_manager
-            .register_client(sender, addr, server.instance_id)
+            .register_client(
+                sender,
+                crate::coordination::ConnectionCloseSignal::detached(),
+                addr,
+                server.instance_id,
+            )
             .await
             .expect("client registration");
 

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -94,6 +94,34 @@ impl EnhancedGameServer {
                     .add_expired_players_cleaned(expired_client_count);
             }
 
+            // Loud eviction: tell each expired client WHY it is being closed
+            // before the unregister tears its socket down. Sends run
+            // concurrently so one backpressured (already-dead) connection
+            // cannot serialize the whole sweep; the delivery layer's
+            // slow-consumer handling bounds each attempt.
+            futures_util::future::join_all(expired_clients.iter().map(|player_id| {
+                let timeout_secs = self.config.ping_timeout.as_secs();
+                async move {
+                    if let Err(err) = self
+                        .send_error_to_player(
+                            player_id,
+                            format!(
+                                "Disconnected: no activity received for {timeout_secs} seconds"
+                            ),
+                            Some(crate::protocol::ErrorCode::ConnectionIdleTimeout),
+                        )
+                        .await
+                    {
+                        tracing::debug!(
+                            %player_id,
+                            error = %err,
+                            "Failed to notify expired client before unregistering"
+                        );
+                    }
+                }
+            }))
+            .await;
+
             for player_id in expired_clients {
                 tracing::info!(%player_id, instance_id = %self.instance_id, "Removing expired client");
                 self.unregister_client(&player_id).await;

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -97,30 +97,35 @@ impl EnhancedGameServer {
             // Loud eviction: tell each expired client WHY it is being closed
             // before the unregister tears its socket down. Sends run
             // concurrently so one backpressured (already-dead) connection
-            // cannot serialize the whole sweep; the delivery layer's
-            // slow-consumer handling bounds each attempt.
-            futures_util::future::join_all(expired_clients.iter().map(|player_id| {
-                let timeout_secs = self.config.ping_timeout.as_secs();
-                async move {
-                    if let Err(err) = self
-                        .send_error_to_player(
-                            player_id,
-                            format!(
-                                "Disconnected: no activity received for {timeout_secs} seconds"
-                            ),
-                            Some(crate::protocol::ErrorCode::ConnectionIdleTimeout),
-                        )
-                        .await
-                    {
-                        tracing::debug!(
-                            %player_id,
-                            error = %err,
-                            "Failed to notify expired client before unregistering"
-                        );
+            // cannot serialize the whole sweep, but with bounded parallelism
+            // so a mass-expiry tick cannot spawn thousands of in-flight sends
+            // at once; the delivery layer's slow-consumer handling bounds each
+            // individual attempt.
+            const REAPER_NOTIFY_CONCURRENCY: usize = 64;
+            use futures_util::StreamExt as _;
+            futures_util::stream::iter(expired_clients.iter())
+                .for_each_concurrent(REAPER_NOTIFY_CONCURRENCY, |player_id| {
+                    let timeout_secs = self.config.ping_timeout.as_secs();
+                    async move {
+                        if let Err(err) = self
+                            .send_error_to_player(
+                                player_id,
+                                format!(
+                                    "Disconnected: no activity received for {timeout_secs} seconds"
+                                ),
+                                Some(crate::protocol::ErrorCode::ConnectionIdleTimeout),
+                            )
+                            .await
+                        {
+                            tracing::debug!(
+                                %player_id,
+                                error = %err,
+                                "Failed to notify expired client before unregistering"
+                            );
+                        }
                     }
-                }
-            }))
-            .await;
+                })
+                .await;
 
             for player_id in expired_clients {
                 tracing::info!(%player_id, instance_id = %self.instance_id, "Removing expired client");

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -111,9 +111,13 @@ impl EnhancedGameServer {
                             .send_error_to_player(
                                 player_id,
                                 format!(
-                                    "Disconnected: no activity received for {timeout_secs} seconds"
+                                    "Disconnected: no activity received for {timeout_secs} seconds \
+                                     (server.ping_timeout)"
                                 ),
-                                Some(crate::protocol::ErrorCode::ConnectionIdleTimeout),
+                                // Deliberately NOT ConnectionIdleTimeout: that code is
+                                // the socket-level `websocket.idle_timeout_secs` close;
+                                // this eviction is the activity reaper's.
+                                Some(crate::protocol::ErrorCode::ActivityTimeout),
                             )
                             .await
                         {

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -101,12 +101,14 @@ impl EnhancedGameServer {
             // eviction itself is the authoritative signal) — so this sweep is
             // non-blocking regardless of how many clients expired at once.
             for player_id in &expired_clients {
-                let timeout_secs = self.config.ping_timeout.as_secs();
+                // Milliseconds, not truncated seconds: sub-second windows
+                // (tests, aggressive deployments) must not read as "0 seconds".
+                let timeout_ms = self.config.ping_timeout.as_millis();
                 let enqueued = self
                     .send_farewell_to_player(
                         player_id,
                         format!(
-                            "Disconnected: no activity received for {timeout_secs} seconds \
+                            "Disconnected: no activity received for {timeout_ms} ms \
                              (server.ping_timeout)"
                         ),
                         // Deliberately NOT ConnectionIdleTimeout: that code is

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -95,41 +95,33 @@ impl EnhancedGameServer {
             }
 
             // Loud eviction: tell each expired client WHY it is being closed
-            // before the unregister tears its socket down. Sends run
-            // concurrently so one backpressured (already-dead) connection
-            // cannot serialize the whole sweep, but with bounded parallelism
-            // so a mass-expiry tick cannot spawn thousands of in-flight sends
-            // at once; the delivery layer's slow-consumer handling bounds each
-            // individual attempt.
-            const REAPER_NOTIFY_CONCURRENCY: usize = 64;
-            use futures_util::StreamExt as _;
-            futures_util::stream::iter(expired_clients.iter())
-                .for_each_concurrent(REAPER_NOTIFY_CONCURRENCY, |player_id| {
-                    let timeout_secs = self.config.ping_timeout.as_secs();
-                    async move {
-                        if let Err(err) = self
-                            .send_error_to_player(
-                                player_id,
-                                format!(
-                                    "Disconnected: no activity received for {timeout_secs} seconds \
-                                     (server.ping_timeout)"
-                                ),
-                                // Deliberately NOT ConnectionIdleTimeout: that code is
-                                // the socket-level `websocket.idle_timeout_secs` close;
-                                // this eviction is the activity reaper's.
-                                Some(crate::protocol::ErrorCode::ActivityTimeout),
-                            )
-                            .await
-                        {
-                            tracing::debug!(
-                                %player_id,
-                                error = %err,
-                                "Failed to notify expired client before unregistering"
-                            );
-                        }
-                    }
-                })
-                .await;
+            // before the unregister tears its socket down. Farewells are
+            // best-effort by contract — they never wait on a full queue and
+            // never reclassify the close as a slow-consumer disconnect (the
+            // eviction itself is the authoritative signal) — so this sweep is
+            // non-blocking regardless of how many clients expired at once.
+            for player_id in &expired_clients {
+                let timeout_secs = self.config.ping_timeout.as_secs();
+                let enqueued = self
+                    .send_farewell_to_player(
+                        player_id,
+                        format!(
+                            "Disconnected: no activity received for {timeout_secs} seconds \
+                             (server.ping_timeout)"
+                        ),
+                        // Deliberately NOT ConnectionIdleTimeout: that code is
+                        // the socket-level `websocket.idle_timeout_secs` close;
+                        // this eviction is the activity reaper's.
+                        Some(crate::protocol::ErrorCode::ActivityTimeout),
+                    )
+                    .await;
+                if !enqueued {
+                    tracing::debug!(
+                        %player_id,
+                        "Expired client did not receive the eviction farewell (queue full or gone)"
+                    );
+                }
+            }
 
             for player_id in expired_clients {
                 tracing::info!(%player_id, instance_id = %self.instance_id, "Removing expired client");

--- a/src/server/message_router.rs
+++ b/src/server/message_router.rs
@@ -7,6 +7,12 @@ use super::{EnhancedGameServer, TransportStatusUpdate};
 impl EnhancedGameServer {
     /// Handle incoming client message with enhanced coordination.
     pub async fn handle_client_message(&self, player_id: &PlayerId, message: ClientMessage) {
+        // EVERY inbound message is liveness, not just `Ping`: the activity
+        // reaper (`server.ping_timeout`) must never disconnect a client that
+        // is actively streaming GameData/Signal traffic but not heartbeating.
+        // This matches the socket-level idle timeout, which already counts
+        // any inbound frame as activity.
+        self.record_client_activity(player_id);
         match message {
             ClientMessage::Authenticate { app_id, .. } => {
                 tracing::warn!(

--- a/src/server/message_router_tests.rs
+++ b/src/server/message_router_tests.rs
@@ -37,7 +37,12 @@ async fn delayed_authenticate_is_rejected_with_warning_only() {
     let addr: SocketAddr = "127.0.0.1:50000".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 
@@ -75,7 +80,12 @@ async fn client_protocol_round_trips_through_server() {
     let addr: SocketAddr = "127.0.0.1:50050".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 
@@ -110,7 +120,12 @@ async fn duplicate_transport_status_reports_do_not_inflate_metrics() {
     let addr: SocketAddr = "127.0.0.1:50060".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 
@@ -160,7 +175,12 @@ async fn transport_status_for_unnegotiated_transport_is_ignored() {
     let addr: SocketAddr = "127.0.0.1:50062".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 
@@ -273,7 +293,12 @@ async fn transport_status_update_results_are_distinct() {
     let addr: SocketAddr = "127.0.0.1:50061".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 
@@ -331,7 +356,12 @@ async fn join_room_request_is_forwarded_to_room_service() {
     let addr: SocketAddr = "127.0.0.1:50001".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 

--- a/src/server/messaging.rs
+++ b/src/server/messaging.rs
@@ -20,4 +20,29 @@ impl EnhancedGameServer {
             )
             .await
     }
+
+    /// Best-effort pre-close farewell: never waits and never escalates.
+    ///
+    /// For connections the caller is about to terminate (reaper eviction and
+    /// similar lifecycle closes): the close itself carries the authoritative
+    /// reason, so a full queue skips this advisory frame instead of stalling
+    /// the teardown or reclassifying the close as a slow-consumer disconnect.
+    /// Returns whether the frame was enqueued.
+    pub async fn send_farewell_to_player(
+        &self,
+        player_id: &PlayerId,
+        message: String,
+        error_code: Option<ErrorCode>,
+    ) -> bool {
+        self.message_coordinator
+            .try_send_to_player(
+                player_id,
+                Arc::new(ServerMessage::Error {
+                    message,
+                    error_code,
+                }),
+            )
+            .await
+            .unwrap_or(false)
+    }
 }

--- a/src/server/messaging.rs
+++ b/src/server/messaging.rs
@@ -21,7 +21,10 @@ impl EnhancedGameServer {
             .await
     }
 
-    /// Best-effort pre-close farewell: never waits and never escalates.
+    /// Best-effort pre-close farewell: never waits on recipient queue
+    /// capacity and never escalates (a trait-level contract of
+    /// [`try_send_to_player`](crate::coordination::MessageCoordinator::try_send_to_player),
+    /// which deliberately has no default implementation).
     ///
     /// For connections the caller is about to terminate (reaper eviction and
     /// similar lifecycle closes): the close itself carries the authoritative

--- a/src/server/ready_state_tests.rs
+++ b/src/server/ready_state_tests.rs
@@ -53,7 +53,12 @@ async fn register_client(
     let (sender, receiver) = mpsc::channel(16);
     let player_id = server
         .connection_manager
-        .register_client(sender, next_addr(), server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            next_addr(),
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
     (player_id, receiver)

--- a/src/server/reconnection_service.rs
+++ b/src/server/reconnection_service.rs
@@ -416,7 +416,7 @@ impl EnhancedGameServer {
         };
 
         // Update client connection to use the reconnecting player's original id.
-        let Some(reassigned_sender) = self.connection_manager.reassign_connection(
+        let Some(reassigned_delivery) = self.connection_manager.reassign_connection(
             current_player_id,
             reconnect_player_id,
             *room_id,
@@ -449,7 +449,7 @@ impl EnhancedGameServer {
             .await;
         if let Err(err) = self
             .message_coordinator
-            .register_local_client(*reconnect_player_id, Some(*room_id), reassigned_sender)
+            .register_local_client(*reconnect_player_id, Some(*room_id), reassigned_delivery)
             .await
         {
             tracing::warn!(

--- a/src/server/room_service.rs
+++ b/src/server/room_service.rs
@@ -370,15 +370,15 @@ impl EnhancedGameServer {
         self.metrics.increment_players_left();
 
         // Update client connection and coordinator
-        let existing_sender = self.connection_manager.clear_room_assignment(player_id);
+        let existing_delivery = self.connection_manager.clear_room_assignment(player_id);
 
-        if let Some(sender) = existing_sender {
+        if let Some(delivery) = existing_delivery {
             let _ = self
                 .message_coordinator
-                .register_local_client(*player_id, None, sender)
+                .register_local_client(*player_id, None, delivery)
                 .await;
         } else {
-            tracing::warn!(%player_id, "Could not find existing sender for player when leaving room");
+            tracing::warn!(%player_id, "Could not find existing delivery handle for player when leaving room");
         }
 
         // First send confirmation to the leaving player

--- a/src/server/room_service_tests.rs
+++ b/src/server/room_service_tests.rs
@@ -40,7 +40,12 @@ async fn register_client(
     let (sender, receiver) = mpsc::channel(8);
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
     (player_id, receiver)
@@ -54,7 +59,12 @@ async fn leave_room_sends_confirmation_and_clears_membership() {
     let addr: SocketAddr = "127.0.0.1:48000".parse().unwrap();
     let player_id = server
         .connection_manager
-        .register_client(sender, addr, server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
 

--- a/src/server/session_policy_tests.rs
+++ b/src/server/session_policy_tests.rs
@@ -1233,7 +1233,12 @@ async fn register_client(
     let (sender, receiver) = mpsc::channel(16);
     let player_id = server
         .connection_manager
-        .register_client(sender, next_addr(), server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            next_addr(),
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
     (player_id, receiver)

--- a/src/server/signaling_tests.rs
+++ b/src/server/signaling_tests.rs
@@ -294,7 +294,12 @@ async fn register_client(
     let (sender, receiver) = mpsc::channel(16);
     let player_id = server
         .connection_manager
-        .register_client(sender, next_addr(), server.instance_id)
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            next_addr(),
+            server.instance_id,
+        )
         .await
         .expect("client registration succeeds");
     (player_id, receiver)

--- a/src/server/spectator_service.rs
+++ b/src/server/spectator_service.rs
@@ -283,7 +283,7 @@ mod tests {
     use crate::distributed::SequencedMessage;
     use anyhow::Result;
     use async_trait::async_trait;
-    use tokio::sync::{mpsc, Mutex};
+    use tokio::sync::Mutex;
 
     struct RecordingCoordinator {
         sent: Mutex<Vec<(PlayerId, ServerMessage)>>,
@@ -350,7 +350,7 @@ mod tests {
             &self,
             _player_id: PlayerId,
             _room_id: Option<RoomId>,
-            _sender: mpsc::Sender<Arc<ServerMessage>>,
+            _delivery: crate::coordination::ClientDeliveryHandle,
         ) -> Result<()> {
             Ok(())
         }

--- a/src/server/spectator_service.rs
+++ b/src/server/spectator_service.rs
@@ -323,6 +323,17 @@ mod tests {
             Ok(())
         }
 
+        async fn try_send_to_player(
+            &self,
+            player_id: &PlayerId,
+            message: Arc<ServerMessage>,
+        ) -> Result<bool> {
+            // Test double: send_to_player is non-blocking here, so delegating
+            // honors the non-waiting farewell contract while preserving
+            // whatever recording/blocking behavior the double implements.
+            self.send_to_player(player_id, message).await.map(|()| true)
+        }
+
         async fn broadcast_to_room(
             &self,
             room_id: &RoomId,

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -46,7 +46,6 @@ impl MessageBatcher {
     }
 
     /// Get pending message count
-    #[cfg(test)]
     pub(super) fn len(&self) -> usize {
         self.pending.len()
     }

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -1,5 +1,6 @@
 use crate::protocol::{PlayerId, ServerMessage};
 use axum::extract::ws::{Message, WebSocket};
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -11,7 +12,7 @@ use super::sending::send_single_message;
 /// Message batcher for WebSocket connections
 /// Batches multiple messages together to reduce syscall overhead
 pub(super) struct MessageBatcher {
-    pending: Vec<Arc<ServerMessage>>,
+    pending: VecDeque<Arc<ServerMessage>>,
     batch_size: usize,
     batch_interval: Duration,
     last_flush: Instant,
@@ -20,7 +21,7 @@ pub(super) struct MessageBatcher {
 impl MessageBatcher {
     pub(super) fn new(batch_size: usize, batch_interval_ms: u64) -> Self {
         Self {
-            pending: Vec::with_capacity(batch_size),
+            pending: VecDeque::with_capacity(batch_size),
             batch_size,
             batch_interval: Duration::from_millis(batch_interval_ms),
             last_flush: Instant::now(),
@@ -29,7 +30,7 @@ impl MessageBatcher {
 
     /// Queue a message for batching
     pub(super) fn queue(&mut self, message: Arc<ServerMessage>) {
-        self.pending.push(message);
+        self.pending.push_back(message);
     }
 
     /// Check if batch should be flushed
@@ -39,10 +40,24 @@ impl MessageBatcher {
             || (!self.pending.is_empty() && self.last_flush.elapsed() >= self.batch_interval)
     }
 
-    /// Flush all pending messages
+    /// Flush all pending messages at once (unit-test convenience; production
+    /// sends drain incrementally via [`Self::pop_front`] so a cancelled write
+    /// cannot lose the rest of the batch).
+    #[cfg(test)]
     pub(super) fn flush(&mut self) -> Vec<Arc<ServerMessage>> {
         self.last_flush = Instant::now();
-        std::mem::take(&mut self.pending)
+        std::mem::take(&mut self.pending).into_iter().collect()
+    }
+
+    /// Take the oldest pending message (FIFO), if any.
+    pub(super) fn pop_front(&mut self) -> Option<Arc<ServerMessage>> {
+        self.pending.pop_front()
+    }
+
+    /// Record that a (possibly incremental) flush completed, resetting the
+    /// batch-interval timer.
+    pub(super) fn mark_flushed(&mut self) {
+        self.last_flush = Instant::now();
     }
 
     /// Get pending message count
@@ -57,30 +72,33 @@ impl MessageBatcher {
 }
 
 /// Helper function to send a batch of messages
+///
+/// Messages are popped one at a time rather than taken out wholesale, so that
+/// cancellation (the send task's close-signal select racing an in-flight
+/// socket write) leaves every unsent message inside the batcher where the
+/// finalize path can still flush or count it. Only the single message
+/// actively being written can be lost with the connection — it is already
+/// (partially) on the wire.
 pub(super) async fn send_batch(
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     batcher: &mut MessageBatcher,
     player_id: &PlayerId,
     server: &Arc<EnhancedGameServer>,
 ) -> Result<(), ()> {
-    let messages = batcher.flush();
-    if messages.is_empty() {
-        return Ok(());
-    }
-
-    let batch_size = messages.len();
-
-    // Send each message in the batch
-    for message in messages {
+    let mut batch_size = 0_usize;
+    while let Some(message) = batcher.pop_front() {
         if send_single_message(sender, message, player_id, server)
             .await
             .is_err()
         {
             return Err(());
         }
+        batch_size += 1;
     }
-
-    tracing::trace!(%player_id, batch_size, "Flushed message batch");
+    if batch_size > 0 {
+        tracing::trace!(%player_id, batch_size, "Flushed message batch");
+    }
+    batcher.mark_flushed();
     Ok(())
 }
 

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -1,6 +1,10 @@
+use crate::coordination::{
+    deliver_or_disconnect, ClientDeliveryHandle, CloseReason, ConnectionCloseSignal,
+    DeliveryOutcome,
+};
 use crate::protocol::{
-    ClientMessage, ErrorCode, GameDataEncoding, PlayerNameRulesPayload, ProtocolInfoPayload,
-    RateLimitInfo, ServerMessage, Topology, Transport,
+    ClientMessage, ErrorCode, GameDataEncoding, PlayerId, PlayerNameRulesPayload,
+    ProtocolInfoPayload, RateLimitInfo, ServerMessage, Topology, Transport,
 };
 use crate::server::{EnhancedGameServer, NegotiatedProtocol, RegisterClientError};
 use axum::extract::ws::{Message, WebSocket};
@@ -8,13 +12,167 @@ use futures_util::{SinkExt, StreamExt};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, RwLock};
 use tokio::time::Instant;
 
 use super::batching::{send_batch, MessageBatcher};
 use super::sending::{send_immediate_server_message, send_single_message};
 use super::token_binding::{parse_client_message, TokenBindingHandshake};
+
+/// Upper bound on the farewell error frame + close handshake writes issued
+/// while force-closing a connection. The client's TCP window is often already
+/// full when this runs (that is usually why its queue overflowed), so these
+/// writes are strictly best-effort.
+const CLOSE_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Enqueue a message on this connection's own outbound queue, honoring the
+/// server-wide no-silent-drop contract: backpressure while the queue is
+/// momentarily full, then a loud slow-consumer close if it never drains.
+/// Used for control messages (auth responses, protocol info, timeout errors)
+/// that are sent outside the message coordinator.
+async fn enqueue_connection_message(
+    tx: &mpsc::Sender<Arc<ServerMessage>>,
+    close_signal: &ConnectionCloseSignal,
+    server: &Arc<EnhancedGameServer>,
+    slow_consumer_timeout: Duration,
+    player_id: &PlayerId,
+    message: ServerMessage,
+    context: &'static str,
+) {
+    let handle = ClientDeliveryHandle {
+        sender: tx.clone(),
+        close: close_signal.clone(),
+    };
+    let outcome = deliver_or_disconnect(
+        &server.metrics(),
+        slow_consumer_timeout,
+        player_id,
+        &handle,
+        Arc::new(message),
+    )
+    .await;
+    if outcome != DeliveryOutcome::Delivered {
+        tracing::warn!(
+            %player_id,
+            ?outcome,
+            context,
+            "Connection control message was not delivered"
+        );
+    }
+}
+
+/// Final actions of the send task once a server-side close was requested.
+///
+/// - Slow consumer: the queue contents are abandoned **by design** (the
+///   recipient proved unable to drain them); they are counted as dropped, and
+///   a best-effort farewell error tells the client why it is being closed.
+/// - Unregistration (or all delivery handles dropped): the recipient is
+///   healthy — flush whatever is already queued (e.g. a final error emitted
+///   just before unregistering), then close.
+async fn finalize_closed_connection(
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    rx: &mut mpsc::Receiver<Arc<ServerMessage>>,
+    batcher: Option<&mut MessageBatcher>,
+    reason: Option<CloseReason>,
+    player_id: &PlayerId,
+    server: &Arc<EnhancedGameServer>,
+) {
+    match reason {
+        Some(CloseReason::SlowConsumer) => {
+            let abandoned = rx.len() + batcher.map_or(0, |batcher| batcher.len());
+            server
+                .metrics()
+                .add_websocket_messages_dropped(abandoned as u64);
+            tracing::warn!(
+                %player_id,
+                abandoned_messages = abandoned,
+                "Closing slow-consumer connection; abandoning its undeliverable queue"
+            );
+
+            let farewell = ServerMessage::Error {
+                message: format!(
+                    "Disconnected as a slow consumer: this connection's outbound queue \
+                     stayed full for more than {} ms",
+                    server.config().websocket_config.slow_consumer_timeout_ms
+                ),
+                error_code: Some(ErrorCode::SlowConsumer),
+            };
+            match tokio::time::timeout(
+                CLOSE_WRITE_TIMEOUT,
+                send_immediate_server_message(sender, &farewell),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => {
+                    tracing::debug!(%player_id, error = %err, "Failed to write slow-consumer farewell frame");
+                }
+                Err(_elapsed) => {
+                    tracing::debug!(%player_id, "Timed out writing slow-consumer farewell frame");
+                }
+            }
+        }
+        Some(CloseReason::Unregistered) | None => {
+            // Drain whatever is already buffered. Both terminal channel states
+            // end the drain: `Empty` means the flush is complete, and
+            // `Disconnected` means every delivery handle is gone AND the
+            // buffer is empty — also a completed flush.
+            if let Some(batcher) = batcher {
+                // Not a `while let`: the repo-wide try_recv policy
+                // (tests/async_timeout_policy_scan.rs) requires both terminal
+                // channel states to be matched explicitly.
+                #[allow(clippy::while_let_loop)]
+                loop {
+                    match rx.try_recv() {
+                        Ok(message) => batcher.queue(message),
+                        Err(
+                            mpsc::error::TryRecvError::Empty
+                            | mpsc::error::TryRecvError::Disconnected,
+                        ) => break,
+                    }
+                }
+                if !batcher.is_empty() {
+                    if let Err(()) = send_batch(sender, batcher, player_id, server).await {
+                        tracing::debug!(
+                            %player_id,
+                            "Failed to flush queued messages while closing unregistered connection"
+                        );
+                    }
+                }
+            } else {
+                loop {
+                    let message = match rx.try_recv() {
+                        Ok(message) => message,
+                        Err(
+                            mpsc::error::TryRecvError::Empty
+                            | mpsc::error::TryRecvError::Disconnected,
+                        ) => break,
+                    };
+                    if send_single_message(sender, message, player_id, server)
+                        .await
+                        .is_err()
+                    {
+                        tracing::debug!(
+                            %player_id,
+                            "Failed to flush queued messages while closing unregistered connection"
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    match tokio::time::timeout(CLOSE_WRITE_TIMEOUT, sender.close()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            tracing::debug!(%player_id, error = %err, "WebSocket close handshake failed");
+        }
+        Err(_elapsed) => {
+            tracing::debug!(%player_id, "Timed out closing WebSocket sink");
+        }
+    }
+}
 
 /// Resolve the negotiated transport/topology capability sets for a connection.
 ///
@@ -75,14 +233,32 @@ pub(super) async fn handle_socket(
     default_protocol_version: u16,
 ) {
     let (mut sender, mut receiver) = socket.split();
-    let queue_capacity = server.config().websocket_config.batch_size.max(1) * 4;
+    // Validated >= 1 at startup; clamp anyway because `mpsc::channel` panics on 0.
+    let queue_capacity = server.config().websocket_config.send_queue_capacity.max(1);
+    let slow_consumer_timeout = Duration::from_millis(
+        server
+            .config()
+            .websocket_config
+            .slow_consumer_timeout_ms
+            .max(1),
+    );
     let (tx, mut rx) = mpsc::channel::<Arc<ServerMessage>>(queue_capacity);
+
+    // One close signal per connection: the delivery layer requests closes
+    // through its registered handle (slow consumer) or via unregistration;
+    // both socket tasks listen and tear the connection down.
+    let (close_signal, close_listener) = ConnectionCloseSignal::channel();
+    let mut send_task_close = close_listener.clone();
+    let mut receive_task_close = close_listener;
 
     // Keep a clone of tx for sending auth responses
     let tx_clone = tx.clone();
 
     // Register client with server
-    let player_id = match server.register_client(tx, addr).await {
+    let player_id = match server
+        .register_client_with_close(tx, close_signal.clone(), addr)
+        .await
+    {
         Ok(player_id) => {
             tracing::info!(%player_id, client_addr = %addr, "WebSocket connection established");
             player_id
@@ -214,17 +390,60 @@ pub(super) async fn handle_socket(
                             break;
                         }
                     }
+                    // Server-side close request (slow consumer, unregistration)
+                    reason = send_task_close.closed() => {
+                        let current_player_id = *effective_player_id_for_send.read().await;
+                        finalize_closed_connection(
+                            &mut sender,
+                            &mut rx,
+                            Some(&mut batcher),
+                            reason,
+                            &current_player_id,
+                            &server_clone,
+                        )
+                        .await;
+                        break;
+                    }
                 }
             }
         } else {
             // Non-batching mode: send each message immediately (legacy behavior)
-            while let Some(message) = rx.recv().await {
-                let current_player_id = *effective_player_id_for_send.read().await;
-                if send_single_message(&mut sender, message, &current_player_id, &server_clone)
-                    .await
-                    .is_err()
-                {
-                    break;
+            loop {
+                tokio::select! {
+                    message_opt = rx.recv() => {
+                        match message_opt {
+                            Some(message) => {
+                                let current_player_id =
+                                    *effective_player_id_for_send.read().await;
+                                if send_single_message(
+                                    &mut sender,
+                                    message,
+                                    &current_player_id,
+                                    &server_clone,
+                                )
+                                .await
+                                .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            None => break, // Channel closed
+                        }
+                    }
+                    // Server-side close request (slow consumer, unregistration)
+                    reason = send_task_close.closed() => {
+                        let current_player_id = *effective_player_id_for_send.read().await;
+                        finalize_closed_connection(
+                            &mut sender,
+                            &mut rx,
+                            None,
+                            reason,
+                            &current_player_id,
+                            &server_clone,
+                        )
+                        .await;
+                        break;
+                    }
                 }
             }
         }
@@ -239,9 +458,11 @@ pub(super) async fn handle_socket(
     let server_clone = server.clone();
     let effective_player_id_for_receive = Arc::clone(&effective_player_id);
     let auth_timeout_secs = server.config().websocket_config.auth_timeout_secs;
+    let close_signal_for_receive = close_signal.clone();
     let receive_task = tokio::spawn(async move {
         let mut active_player_id = player_id;
         let token_binding = token_binding_for_receive;
+        let close_signal = close_signal_for_receive;
         // Create authentication timeout timer
         let auth_deadline = tokio::time::sleep_until(connection_start + auth_timeout);
         tokio::pin!(auth_deadline);
@@ -256,9 +477,26 @@ pub(super) async fn handle_socket(
         loop {
             let msg = if authenticated {
                 // If authenticated, enforce only the idle timeout (when enabled)
-                let next_frame = match idle_timeout {
-                    Some(window) => match tokio::time::timeout(window, receiver.next()).await {
-                        Ok(frame_opt) => frame_opt,
+                tokio::select! {
+                    // Server-side close request (slow consumer, unregistration):
+                    // stop reading; the send task writes the farewell and
+                    // closes the sink.
+                    reason = receive_task_close.closed() => {
+                        tracing::debug!(
+                            %active_player_id,
+                            ?reason,
+                            "Connection close requested; ending receive task"
+                        );
+                        break;
+                    }
+                    next_frame = async {
+                        match idle_timeout {
+                            Some(window) => tokio::time::timeout(window, receiver.next()).await,
+                            None => Ok(receiver.next().await),
+                        }
+                    } => match next_frame {
+                        Ok(Some(msg)) => msg,
+                        Ok(None) => break, // Connection closed
                         Err(_elapsed) => {
                             // Idle timeout: deliver the error through this
                             // connection's OWN outbound channel, not the
@@ -266,48 +504,47 @@ pub(super) async fn handle_socket(
                             // `server.ping_timeout` reaper (30s) unregisters a
                             // silent client from the coordinator long before
                             // the idle window (300s) elapses, so a
-                            // coordinator-routed error would be silently
-                            // dropped. The send task drains this channel and
-                            // flushes before the socket is torn down, so the
-                            // frame reaches the client regardless of
-                            // registration state. Then close via the normal
-                            // disconnect path so the reconnection grace period
-                            // still applies.
+                            // coordinator-routed error would be unroutable.
+                            // The send task flushes this channel before the
+                            // socket is torn down, so the frame reaches the
+                            // client regardless of registration state. Then
+                            // close via the normal disconnect path so the
+                            // reconnection grace period still applies.
                             tracing::info!(
                                 %active_player_id,
                                 timeout_secs = idle_timeout_secs,
                                 "Idle timeout - no frames received, closing connection"
                             );
-                            let idle_error = Arc::new(ServerMessage::Error {
-                                message: format!(
-                                    "Idle timeout - no messages received for {idle_timeout_secs} seconds"
-                                ),
-                                error_code: Some(ErrorCode::ConnectionIdleTimeout),
-                            });
-                            if let Err(err) = tx_clone.try_send(idle_error) {
-                                if matches!(err, TrySendError::Full(_)) {
-                                    server_clone
-                                        .metrics()
-                                        .increment_websocket_messages_dropped();
-                                }
-                                tracing::warn!(
-                                    %active_player_id,
-                                    error = %err,
-                                    "Failed to enqueue idle timeout error"
-                                );
-                            }
+                            enqueue_connection_message(
+                                &tx_clone,
+                                &close_signal,
+                                &server_clone,
+                                slow_consumer_timeout,
+                                &active_player_id,
+                                ServerMessage::Error {
+                                    message: format!(
+                                        "Idle timeout - no messages received for {idle_timeout_secs} seconds"
+                                    ),
+                                    error_code: Some(ErrorCode::ConnectionIdleTimeout),
+                                },
+                                "idle timeout error",
+                            )
+                            .await;
                             break;
                         }
-                    },
-                    None => receiver.next().await,
-                };
-                match next_frame {
-                    Some(msg) => msg,
-                    None => break, // Connection closed
+                    }
                 }
             } else {
                 // If not authenticated, enforce timeout
                 tokio::select! {
+                    reason = receive_task_close.closed() => {
+                        tracing::debug!(
+                            %active_player_id,
+                            ?reason,
+                            "Connection close requested during authentication; ending receive task"
+                        );
+                        break;
+                    }
                     msg_opt = receiver.next() => {
                         match msg_opt {
                             Some(msg) => msg,
@@ -428,23 +665,19 @@ pub(super) async fn handle_socket(
                                                 error = %error_message,
                                                 "SDK compatibility check failed"
                                             );
-                                            if let Err(err) = tx_clone.try_send(Arc::new(
+                                            enqueue_connection_message(
+                                                &tx_clone,
+                                                &close_signal,
+                                                &server_clone,
+                                                slow_consumer_timeout,
+                                                &active_player_id,
                                                 ServerMessage::AuthenticationError {
                                                     error: error_message,
                                                     error_code: ErrorCode::SdkVersionUnsupported,
                                                 },
-                                            )) {
-                                                if matches!(err, TrySendError::Full(_)) {
-                                                    server_clone
-                                                        .metrics()
-                                                        .increment_websocket_messages_dropped();
-                                                }
-                                                tracing::warn!(
-                                                    %active_player_id,
-                                                    error = %err,
-                                                    "Failed to enqueue SDK compatibility error"
-                                                );
-                                            }
+                                                "SDK compatibility error",
+                                            )
+                                            .await;
                                             continue;
                                         }
                                     };
@@ -478,25 +711,21 @@ pub(super) async fn handle_socket(
                                                 "Client requested unsupported game_data_format"
                                             );
                                             // Send error message to client about capability mismatch
-                                            if let Err(err) =
-                                                tx_clone.try_send(Arc::new(ServerMessage::Error {
+                                            enqueue_connection_message(
+                                                &tx_clone,
+                                                &close_signal,
+                                                &server_clone,
+                                                slow_consumer_timeout,
+                                                &active_player_id,
+                                                ServerMessage::Error {
                                                     message: error_message,
                                                     error_code: Some(
                                                         ErrorCode::UnsupportedGameDataFormat,
                                                     ),
-                                                }))
-                                            {
-                                                if matches!(err, TrySendError::Full(_)) {
-                                                    server_clone
-                                                        .metrics()
-                                                        .increment_websocket_messages_dropped();
-                                                }
-                                                tracing::warn!(
-                                                    %active_player_id,
-                                                    error = %err,
-                                                    "Failed to enqueue game data format error"
-                                                );
-                                            }
+                                                },
+                                                "game data format error",
+                                            )
+                                            .await;
                                             GameDataEncoding::Json
                                         }
                                         None => GameDataEncoding::Json,
@@ -592,30 +821,26 @@ pub(super) async fn handle_socket(
                                             max_protocol_version: response_max_protocol_version,
                                         });
 
-                                    if let Err(err) = tx_clone.try_send(Arc::new(auth_response)) {
-                                        if matches!(err, TrySendError::Full(_)) {
-                                            server_clone
-                                                .metrics()
-                                                .increment_websocket_messages_dropped();
-                                        }
-                                        tracing::warn!(
-                                            %active_player_id,
-                                            error = %err,
-                                            "Failed to enqueue authentication success response"
-                                        );
-                                    }
-                                    if let Err(err) = tx_clone.try_send(Arc::new(protocol_info)) {
-                                        if matches!(err, TrySendError::Full(_)) {
-                                            server_clone
-                                                .metrics()
-                                                .increment_websocket_messages_dropped();
-                                        }
-                                        tracing::warn!(
-                                            %active_player_id,
-                                            error = %err,
-                                            "Failed to enqueue protocol info response"
-                                        );
-                                    }
+                                    enqueue_connection_message(
+                                        &tx_clone,
+                                        &close_signal,
+                                        &server_clone,
+                                        slow_consumer_timeout,
+                                        &active_player_id,
+                                        auth_response,
+                                        "authentication success response",
+                                    )
+                                    .await;
+                                    enqueue_connection_message(
+                                        &tx_clone,
+                                        &close_signal,
+                                        &server_clone,
+                                        slow_consumer_timeout,
+                                        &active_player_id,
+                                        protocol_info,
+                                        "protocol info response",
+                                    )
+                                    .await;
                                 }
                                 Err(e) => {
                                     tracing::warn!(%active_player_id, %app_id, "Authentication failed: {:?}", e);
@@ -645,23 +870,19 @@ pub(super) async fn handle_socket(
                                         _ => ErrorCode::InternalError,
                                     };
 
-                                    let auth_error = Arc::new(ServerMessage::AuthenticationError {
-                                        error: format!("{e:?}"),
-                                        error_code,
-                                    });
-
-                                    if let Err(err) = tx_clone.try_send(auth_error) {
-                                        if matches!(err, TrySendError::Full(_)) {
-                                            server_clone
-                                                .metrics()
-                                                .increment_websocket_messages_dropped();
-                                        }
-                                        tracing::warn!(
-                                            %active_player_id,
-                                            error = %err,
-                                            "Failed to enqueue authentication failure response"
-                                        );
-                                    }
+                                    enqueue_connection_message(
+                                        &tx_clone,
+                                        &close_signal,
+                                        &server_clone,
+                                        slow_consumer_timeout,
+                                        &active_player_id,
+                                        ServerMessage::AuthenticationError {
+                                            error: format!("{e:?}"),
+                                            error_code,
+                                        },
+                                        "authentication failure response",
+                                    )
+                                    .await;
 
                                     // Close connection after auth failure
                                     break;

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -72,14 +72,16 @@ async fn enqueue_connection_message(
 async fn finalize_closed_connection(
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
     rx: &mut mpsc::Receiver<Arc<ServerMessage>>,
-    batcher: Option<&mut MessageBatcher>,
+    batcher: &mut MessageBatcher,
     reason: Option<CloseReason>,
     player_id: &PlayerId,
     server: &Arc<EnhancedGameServer>,
 ) {
     match reason {
         Some(CloseReason::SlowConsumer) => {
-            let abandoned = rx.len() + batcher.map_or(0, |batcher| batcher.len());
+            // Undercounts by at most one in-flight batch cancelled mid-write;
+            // the connection-level disconnect signal is the primary indicator.
+            let abandoned = rx.len() + batcher.len();
             server
                 .metrics()
                 .add_websocket_messages_dropped(abandoned as u64);
@@ -113,11 +115,15 @@ async fn finalize_closed_connection(
             }
         }
         Some(CloseReason::Unregistered) | None => {
-            // Drain whatever is already buffered. Both terminal channel states
-            // end the drain: `Empty` means the flush is complete, and
+            // Drain whatever is already buffered and flush it, bounded by the
+            // close-write budget: an unregistered connection is usually
+            // healthy (flush completes in milliseconds), but if its socket is
+            // wedged this must not pin the task — the whole point of the
+            // close path is to reclaim the connection. Both terminal channel
+            // states end the drain: `Empty` means the flush is complete, and
             // `Disconnected` means every delivery handle is gone AND the
             // buffer is empty — also a completed flush.
-            if let Some(batcher) = batcher {
+            let flush = tokio::time::timeout(CLOSE_WRITE_TIMEOUT, async {
                 // Not a `while let`: the repo-wide try_recv policy
                 // (tests/async_timeout_policy_scan.rs) requires both terminal
                 // channel states to be matched explicitly.
@@ -131,33 +137,25 @@ async fn finalize_closed_connection(
                         ) => break,
                     }
                 }
-                if !batcher.is_empty() {
-                    if let Err(()) = send_batch(sender, batcher, player_id, server).await {
-                        tracing::debug!(
-                            %player_id,
-                            "Failed to flush queued messages while closing unregistered connection"
-                        );
-                    }
+                if batcher.is_empty() {
+                    return Ok(());
                 }
-            } else {
-                loop {
-                    let message = match rx.try_recv() {
-                        Ok(message) => message,
-                        Err(
-                            mpsc::error::TryRecvError::Empty
-                            | mpsc::error::TryRecvError::Disconnected,
-                        ) => break,
-                    };
-                    if send_single_message(sender, message, player_id, server)
-                        .await
-                        .is_err()
-                    {
-                        tracing::debug!(
-                            %player_id,
-                            "Failed to flush queued messages while closing unregistered connection"
-                        );
-                        break;
-                    }
+                send_batch(sender, batcher, player_id, server).await
+            })
+            .await;
+            match flush {
+                Ok(Ok(())) => {}
+                Ok(Err(())) => {
+                    tracing::debug!(
+                        %player_id,
+                        "Failed to flush queued messages while closing unregistered connection"
+                    );
+                }
+                Err(_elapsed) => {
+                    tracing::debug!(
+                        %player_id,
+                        "Timed out flushing queued messages while closing unregistered connection"
+                    );
                 }
             }
         }
@@ -319,133 +317,125 @@ pub(super) async fn handle_socket(
         let batch_size = config.websocket_config.batch_size;
         let batch_interval_ms = config.websocket_config.batch_interval_ms;
 
-        if batching_enabled {
-            // Batching mode: collect multiple messages and send together
-            let mut batcher = MessageBatcher::new(batch_size, batch_interval_ms);
-            // Clamp to a 1ms floor: `batch_interval_ms` is validated `> 0` (when
-            // batching is enabled) at startup, but `tokio::time::interval`
-            // panics on a zero period, so guard the timer regardless of how this
-            // config was constructed.
-            let mut flush_interval =
-                tokio::time::interval(Duration::from_millis(batch_interval_ms.max(1)));
-            flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut batcher = MessageBatcher::new(batch_size, batch_interval_ms);
 
-            loop {
-                tokio::select! {
-                    // Receive new message from channel
-                    message_opt = rx.recv() => {
-                        if let Some(message) = message_opt {
-                            batcher.queue(message);
+        // The write loop runs INSIDE this select so a close request interrupts
+        // it at ANY await point — including a socket write wedged against a
+        // peer that stopped reading, which is precisely the slow-consumer
+        // state that triggers the close. Handling the close as a sibling loop
+        // arm would only observe it BETWEEN writes, and a wedged write never
+        // finishes; the sink half would then never drop and the connection
+        // would linger as a zombie socket.
+        let close_request: Option<Option<CloseReason>> = tokio::select! {
+            reason = send_task_close.closed() => Some(reason),
+            () = async {
+                if batching_enabled {
+                    // Batching mode: collect multiple messages and send together.
+                    // Clamp to a 1ms floor: `batch_interval_ms` is validated `> 0`
+                    // (when batching is enabled) at startup, but
+                    // `tokio::time::interval` panics on a zero period, so guard
+                    // the timer regardless of how this config was constructed.
+                    let mut flush_interval =
+                        tokio::time::interval(Duration::from_millis(batch_interval_ms.max(1)));
+                    flush_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-                            // Flush if batch is full or time threshold exceeded
-                            if batcher.should_flush()
-                                && {
-                                    let current_player_id =
-                                        *effective_player_id_for_send.read().await;
-                                    send_batch(
-                                        &mut sender,
-                                        &mut batcher,
-                                        &current_player_id,
-                                        &server_clone,
-                                    )
-                                    .await
-                                    .is_err()
+                    loop {
+                        tokio::select! {
+                            // Receive new message from channel
+                            message_opt = rx.recv() => {
+                                if let Some(message) = message_opt {
+                                    batcher.queue(message);
+
+                                    // Flush if batch is full or time threshold exceeded
+                                    if batcher.should_flush()
+                                        && {
+                                            let current_player_id =
+                                                *effective_player_id_for_send.read().await;
+                                            send_batch(
+                                                &mut sender,
+                                                &mut batcher,
+                                                &current_player_id,
+                                                &server_clone,
+                                            )
+                                            .await
+                                            .is_err()
+                                        }
+                                    {
+                                        break;
+                                    }
+                                } else {
+                                    // Channel closed, flush remaining messages and exit
+                                    if !batcher.is_empty() {
+                                        let current_player_id =
+                                            *effective_player_id_for_send.read().await;
+                                        let _ = send_batch(
+                                            &mut sender,
+                                            &mut batcher,
+                                            &current_player_id,
+                                            &server_clone,
+                                        )
+                                        .await;
+                                    }
+                                    break;
                                 }
-                            {
-                                break;
                             }
-                        } else {
-                            // Channel closed, flush remaining messages and exit
-                            if !batcher.is_empty() {
-                                let current_player_id =
-                                    *effective_player_id_for_send.read().await;
-                                let _ = send_batch(
-                                    &mut sender,
-                                    &mut batcher,
-                                    &current_player_id,
-                                    &server_clone,
-                                )
-                                .await;
-                            }
-                            break;
-                        }
-                    }
-                    // Periodic flush based on time interval
-                    _ = flush_interval.tick() => {
-                        if !batcher.is_empty()
-                            && batcher.should_flush()
-                            && {
-                                let current_player_id =
-                                    *effective_player_id_for_send.read().await;
-                                send_batch(
-                                    &mut sender,
-                                    &mut batcher,
-                                    &current_player_id,
-                                    &server_clone,
-                                )
-                                .await
-                                .is_err()
-                            }
-                        {
-                            break;
-                        }
-                    }
-                    // Server-side close request (slow consumer, unregistration)
-                    reason = send_task_close.closed() => {
-                        let current_player_id = *effective_player_id_for_send.read().await;
-                        finalize_closed_connection(
-                            &mut sender,
-                            &mut rx,
-                            Some(&mut batcher),
-                            reason,
-                            &current_player_id,
-                            &server_clone,
-                        )
-                        .await;
-                        break;
-                    }
-                }
-            }
-        } else {
-            // Non-batching mode: send each message immediately (legacy behavior)
-            loop {
-                tokio::select! {
-                    message_opt = rx.recv() => {
-                        match message_opt {
-                            Some(message) => {
-                                let current_player_id =
-                                    *effective_player_id_for_send.read().await;
-                                if send_single_message(
-                                    &mut sender,
-                                    message,
-                                    &current_player_id,
-                                    &server_clone,
-                                )
-                                .await
-                                .is_err()
+                            // Periodic flush based on time interval
+                            _ = flush_interval.tick() => {
+                                if !batcher.is_empty()
+                                    && batcher.should_flush()
+                                    && {
+                                        let current_player_id =
+                                            *effective_player_id_for_send.read().await;
+                                        send_batch(
+                                            &mut sender,
+                                            &mut batcher,
+                                            &current_player_id,
+                                            &server_clone,
+                                        )
+                                        .await
+                                        .is_err()
+                                    }
                                 {
                                     break;
                                 }
                             }
-                            None => break, // Channel closed
                         }
                     }
-                    // Server-side close request (slow consumer, unregistration)
-                    reason = send_task_close.closed() => {
+                } else {
+                    // Non-batching mode: send each message immediately (legacy behavior)
+                    while let Some(message) = rx.recv().await {
                         let current_player_id = *effective_player_id_for_send.read().await;
-                        finalize_closed_connection(
+                        if send_single_message(
                             &mut sender,
-                            &mut rx,
-                            None,
-                            reason,
+                            message,
                             &current_player_id,
                             &server_clone,
                         )
-                        .await;
-                        break;
+                        .await
+                        .is_err()
+                        {
+                            break;
+                        }
                     }
                 }
-            }
+            } => None,
+        };
+
+        // A close was requested (slow consumer, unregistration): the write
+        // loop above was cancelled wherever it was; run the bounded farewell/
+        // flush/close sequence. When the loop ended by itself (socket error or
+        // channel closed after a full flush) there is nothing more to write.
+        if let Some(reason) = close_request {
+            let current_player_id = *effective_player_id_for_send.read().await;
+            finalize_closed_connection(
+                &mut sender,
+                &mut rx,
+                &mut batcher,
+                reason,
+                &current_player_id,
+                &server_clone,
+            )
+            .await;
         }
 
         // Cleanup when send task ends

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -62,6 +62,33 @@ async fn enqueue_connection_message(
     }
 }
 
+/// Best-effort enqueue of a pre-close farewell on this connection's own queue.
+///
+/// Never waits and never escalates to a slow-consumer close: the caller is
+/// about to terminate the connection, and the close itself (with its
+/// lifecycle reason) is the authoritative, loud signal — this frame is
+/// advisory. The send task's final drain flushes it when the queue has room.
+fn enqueue_farewell_message(
+    tx: &mpsc::Sender<Arc<ServerMessage>>,
+    player_id: &PlayerId,
+    message: ServerMessage,
+    context: &'static str,
+) {
+    match tx.try_send(Arc::new(message)) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            tracing::debug!(
+                %player_id,
+                context,
+                "Farewell not enqueued: outbound queue full on a closing connection"
+            );
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            tracing::debug!(%player_id, context, "Farewell not enqueued: connection already closed");
+        }
+    }
+}
+
 /// Final actions of the send task once a server-side close was requested.
 ///
 /// - Slow consumer: the queue contents are abandoned **by design** (the
@@ -146,18 +173,22 @@ async fn finalize_closed_connection(
                 send_batch(sender, batcher, player_id, server).await
             })
             .await;
+            let flush_timed_out = flush.is_err();
             match flush {
                 Ok(Ok(())) => {}
-                Ok(Err(())) => {
+                Ok(Err(())) | Err(_) => {
+                    // Whatever the flush could not deliver dies with the
+                    // connection; keep the drop counter honest (misses at
+                    // most the single frame that was actively on the wire).
+                    let abandoned = rx.len() + batcher.len();
+                    server
+                        .metrics()
+                        .add_websocket_messages_dropped(abandoned as u64);
                     tracing::debug!(
                         %player_id,
-                        "Failed to flush queued messages while closing unregistered connection"
-                    );
-                }
-                Err(_elapsed) => {
-                    tracing::debug!(
-                        %player_id,
-                        "Timed out flushing queued messages while closing unregistered connection"
+                        abandoned_messages = abandoned,
+                        flush_timed_out,
+                        "Flush failed while closing unregistered connection; abandoning remainder"
                     );
                 }
             }
@@ -528,11 +559,12 @@ pub(super) async fn handle_socket(
                                 timeout_secs = idle_timeout_secs,
                                 "Idle timeout - no frames received, closing connection"
                             );
-                            enqueue_connection_message(
+                            // Farewell semantics (best-effort, no waiting):
+                            // this connection is closing as idle; a full
+                            // queue must not stall the teardown nor
+                            // reclassify the close as a slow-consumer one.
+                            enqueue_farewell_message(
                                 &tx_clone,
-                                &close_signal,
-                                &server_clone,
-                                slow_consumer_timeout,
                                 &active_player_id,
                                 ServerMessage::Error {
                                     message: format!(
@@ -541,8 +573,7 @@ pub(super) async fn handle_socket(
                                     error_code: Some(ErrorCode::ConnectionIdleTimeout),
                                 },
                                 "idle timeout error",
-                            )
-                            .await;
+                            );
                             break;
                         }
                     }
@@ -883,19 +914,18 @@ pub(super) async fn handle_socket(
                                         _ => ErrorCode::InternalError,
                                     };
 
-                                    enqueue_connection_message(
+                                    // Farewell semantics: the connection is
+                                    // closed immediately below, so this frame
+                                    // is advisory and must not wait/escalate.
+                                    enqueue_farewell_message(
                                         &tx_clone,
-                                        &close_signal,
-                                        &server_clone,
-                                        slow_consumer_timeout,
                                         &active_player_id,
                                         ServerMessage::AuthenticationError {
                                             error: format!("{e:?}"),
                                             error_code,
                                         },
                                         "authentication failure response",
-                                    )
-                                    .await;
+                                    );
 
                                     // Close connection after auth failure
                                     break;

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -43,8 +43,9 @@ async fn enqueue_connection_message(
         sender: tx.clone(),
         close: close_signal.clone(),
     };
+    let metrics = server.metrics();
     let outcome = deliver_or_disconnect(
-        &server.metrics(),
+        &metrics,
         slow_consumer_timeout,
         player_id,
         &handle,
@@ -425,19 +426,39 @@ pub(super) async fn handle_socket(
 
         // A close was requested (slow consumer, unregistration): the write
         // loop above was cancelled wherever it was; run the bounded farewell/
-        // flush/close sequence. When the loop ended by itself (socket error or
-        // channel closed after a full flush) there is nothing more to write.
-        if let Some(reason) = close_request {
-            let current_player_id = *effective_player_id_for_send.read().await;
-            finalize_closed_connection(
-                &mut sender,
-                &mut rx,
-                &mut batcher,
-                reason,
-                &current_player_id,
-                &server_clone,
-            )
-            .await;
+        // flush/close sequence. When the loop ended by itself there is nothing
+        // more to write, but the drop metric must stay honest: a clean
+        // channel-close exits only after a full flush (nothing buffered),
+        // while a socket write error abandons whatever is still buffered with
+        // the dead connection — count that instead of losing it silently from
+        // an observability standpoint.
+        match close_request {
+            Some(reason) => {
+                let current_player_id = *effective_player_id_for_send.read().await;
+                finalize_closed_connection(
+                    &mut sender,
+                    &mut rx,
+                    &mut batcher,
+                    reason,
+                    &current_player_id,
+                    &server_clone,
+                )
+                .await;
+            }
+            None => {
+                let abandoned = rx.len() + batcher.len();
+                if abandoned > 0 {
+                    server_clone
+                        .metrics()
+                        .add_websocket_messages_dropped(abandoned as u64);
+                    let current_player_id = *effective_player_id_for_send.read().await;
+                    tracing::warn!(
+                        player_id = %current_player_id,
+                        abandoned_messages = abandoned,
+                        "Connection ended with a failed socket write; abandoning its buffered messages"
+                    );
+                }
+            }
         }
 
         // Cleanup when send task ends

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -79,8 +79,10 @@ async fn finalize_closed_connection(
 ) {
     match reason {
         Some(CloseReason::SlowConsumer) => {
-            // Undercounts by at most one in-flight batch cancelled mid-write;
-            // the connection-level disconnect signal is the primary indicator.
+            // `send_batch` pops messages one at a time, so a cancelled
+            // in-flight write leaves everything unsent inside the batcher;
+            // the count below misses at most the single message that was
+            // actively (partially) on the wire when the close fired.
             let abandoned = rx.len() + batcher.len();
             server
                 .metrics()

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -596,15 +596,22 @@ pub(super) async fn handle_socket(
                         }
                     }
                     () = &mut auth_deadline => {
-                        // Authentication timeout
+                        // Authentication timeout. Farewell semantics: the
+                        // connection closes right below, so this frame must
+                        // neither wait on queue capacity nor let a full queue
+                        // reclassify the close as a slow-consumer disconnect.
                         tracing::warn!(%active_player_id, timeout_secs = auth_timeout_secs, "Authentication timeout, closing connection");
-                        let _ = server_clone
-                            .send_error_to_player(
-                                &active_player_id,
-                                format!("Authentication timeout - must authenticate within {auth_timeout_secs} seconds"),
-                                Some(ErrorCode::AuthenticationTimeout),
-                            )
-                            .await;
+                        enqueue_farewell_message(
+                            &tx_clone,
+                            &active_player_id,
+                            ServerMessage::Error {
+                                message: format!(
+                                    "Authentication timeout - must authenticate within {auth_timeout_secs} seconds"
+                                ),
+                                error_code: Some(ErrorCode::AuthenticationTimeout),
+                            },
+                            "authentication timeout",
+                        );
                         break;
                     }
                 }
@@ -652,6 +659,22 @@ pub(super) async fn handle_socket(
                                 error = %err,
                                 "Rejected client WebSocket frame"
                             );
+                            if err.should_disconnect() {
+                                // Farewell semantics: closing immediately, so
+                                // never wait or escalate on a full queue.
+                                enqueue_farewell_message(
+                                    &tx_clone,
+                                    &active_player_id,
+                                    ServerMessage::Error {
+                                        message: err.user_message().to_string(),
+                                        error_code: Some(err.error_code()),
+                                    },
+                                    "rejected frame (disconnecting)",
+                                );
+                                break;
+                            }
+                            // Connection stays alive: the rejection notice
+                            // rides the reliable delivery path.
                             let _ = server_clone
                                 .send_error_to_player(
                                     &active_player_id,
@@ -659,9 +682,6 @@ pub(super) async fn handle_socket(
                                     Some(err.error_code()),
                                 )
                                 .await;
-                            if err.should_disconnect() {
-                                break;
-                            }
                             continue;
                         }
                     };
@@ -935,13 +955,16 @@ pub(super) async fn handle_socket(
                         other => {
                             if !authenticated {
                                 tracing::warn!(%active_player_id, "Received message before authentication");
-                                let _ = server_clone
-                                    .send_error_to_player(
-                                        &active_player_id,
-                                        "Authentication required".to_string(),
-                                        Some(ErrorCode::MissingAppId),
-                                    )
-                                    .await;
+                                // Farewell semantics: closing immediately.
+                                enqueue_farewell_message(
+                                    &tx_clone,
+                                    &active_player_id,
+                                    ServerMessage::Error {
+                                        message: "Authentication required".to_string(),
+                                        error_code: Some(ErrorCode::MissingAppId),
+                                    },
+                                    "message before authentication",
+                                );
                                 break;
                             }
 
@@ -978,13 +1001,17 @@ pub(super) async fn handle_socket(
                 Message::Binary(payload) => {
                     if !authenticated {
                         tracing::warn!(%active_player_id, "Received binary message before authentication");
-                        let _ = server_clone
-                            .send_error_to_player(
-                                &active_player_id,
-                                "Authentication required before sending binary data".to_string(),
-                                Some(ErrorCode::MissingAppId),
-                            )
-                            .await;
+                        // Farewell semantics: closing immediately.
+                        enqueue_farewell_message(
+                            &tx_clone,
+                            &active_player_id,
+                            ServerMessage::Error {
+                                message: "Authentication required before sending binary data"
+                                    .to_string(),
+                                error_code: Some(ErrorCode::MissingAppId),
+                            },
+                            "binary before authentication",
+                        );
                         break;
                     }
 

--- a/src/websocket/prometheus.rs
+++ b/src/websocket/prometheus.rs
@@ -108,7 +108,7 @@ pub(crate) fn render_prometheus_metrics(snapshot: &MetricsSnapshot) -> String {
     counter(
         &mut buf,
         "signal_fish_websocket_messages_dropped_total",
-        "Server messages abandoned together with a connection that was closed (slow consumer) or already closing",
+        "Server messages that could not be delivered: abandoned together with a slow-consumer or already-closing connection, or replaced by an error frame because a binary payload could not be converted for the recipient",
         snapshot.connections.websocket_messages_dropped,
     );
     counter(

--- a/src/websocket/prometheus.rs
+++ b/src/websocket/prometheus.rs
@@ -108,8 +108,20 @@ pub(crate) fn render_prometheus_metrics(snapshot: &MetricsSnapshot) -> String {
     counter(
         &mut buf,
         "signal_fish_websocket_messages_dropped_total",
-        "Server messages dropped because the outbound WebSocket buffer was full",
+        "Server messages abandoned together with a connection that was closed (slow consumer) or already closing",
         snapshot.connections.websocket_messages_dropped,
+    );
+    counter(
+        &mut buf,
+        "signal_fish_websocket_backpressure_events_total",
+        "Times a full outbound queue forced delivery to wait for capacity (message still delivered)",
+        snapshot.connections.websocket_backpressure_events,
+    );
+    counter(
+        &mut buf,
+        "signal_fish_websocket_slow_consumer_disconnects_total",
+        "Connections force-closed because their outbound queue stayed full past websocket.slow_consumer_timeout_ms",
+        snapshot.connections.websocket_slow_consumer_disconnects,
     );
 
     counter(

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -1,10 +1,20 @@
-use crate::protocol::{GameDataEncoding, PlayerId, ServerMessage};
+use crate::protocol::{ErrorCode, GameDataEncoding, PlayerId, ServerMessage};
 use crate::server::EnhancedGameServer;
 use axum::extract::ws::{Message, WebSocket};
 use futures_util::SinkExt;
 use rmp_serde::{from_slice, to_vec_named};
 use serde::Serialize;
 use std::sync::Arc;
+
+/// Why a binary game-data fallback could not be delivered.
+enum BinaryFallbackError {
+    /// The payload cannot be represented for this recipient (e.g. an rkyv
+    /// payload relayed to a JSON-only client). The connection is healthy; the
+    /// recipient must be told loudly instead of silently receiving nothing.
+    Undeliverable(String),
+    /// The socket write failed; the connection is closing.
+    ConnectionClosed,
+}
 
 pub(super) async fn send_immediate_server_message(
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
@@ -56,35 +66,37 @@ pub(super) async fn send_single_message(
                             error = %err,
                             "Failed to encode binary game data; attempting JSON fallback"
                         );
-                        if let Err(fallback_err) = send_binary_fallback(
+                        let fallback = send_binary_fallback(
                             sender,
                             *from_player,
                             *encoding,
                             payload,
                             player_id,
                         )
-                        .await
-                        {
-                            tracing::warn!(
-                                %player_id,
-                                %from_player,
-                                encoding = ?encoding,
-                                error = %fallback_err,
-                                "Dropping binary game data message after fallback failure"
-                            );
-                        }
+                        .await;
+                        notify_or_close_on_fallback_failure(
+                            sender,
+                            fallback,
+                            *from_player,
+                            *encoding,
+                            player_id,
+                            server,
+                        )
+                        .await?;
                     }
                 }
-            } else if let Err(err) =
-                send_binary_fallback(sender, *from_player, *encoding, payload, player_id).await
-            {
-                tracing::warn!(
-                    %player_id,
-                    %from_player,
-                    encoding = ?encoding,
-                    error = %err,
-                    "Client does not support binary payloads; message dropped"
-                );
+            } else {
+                let fallback =
+                    send_binary_fallback(sender, *from_player, *encoding, payload, player_id).await;
+                notify_or_close_on_fallback_failure(
+                    sender,
+                    fallback,
+                    *from_player,
+                    *encoding,
+                    player_id,
+                    server,
+                )
+                .await?;
             }
         }
         other => {
@@ -101,12 +113,58 @@ async fn send_binary_fallback(
     encoding: GameDataEncoding,
     payload: &[u8],
     player_id: &PlayerId,
-) -> Result<(), String> {
-    let data = decode_binary_to_json(encoding, payload)?;
+) -> Result<(), BinaryFallbackError> {
+    let data =
+        decode_binary_to_json(encoding, payload).map_err(BinaryFallbackError::Undeliverable)?;
     let fallback = ServerMessage::GameData { from_player, data };
     send_text_message(sender, &fallback, player_id)
         .await
-        .map_err(|()| "failed to write JSON fallback frame".to_string())
+        .map_err(|()| BinaryFallbackError::ConnectionClosed)
+}
+
+/// Handle a failed binary fallback without ever silently dropping game data:
+/// a dead socket closes the connection (propagated as `Err`), while a payload
+/// that genuinely cannot be represented for this recipient is counted as
+/// dropped and replaced by an explicit error frame so the recipient knows it
+/// is missing data (e.g. an rkyv-encoded room relayed to a JSON-only client).
+async fn notify_or_close_on_fallback_failure(
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    fallback: Result<(), BinaryFallbackError>,
+    from_player: PlayerId,
+    encoding: GameDataEncoding,
+    player_id: &PlayerId,
+    server: &Arc<EnhancedGameServer>,
+) -> Result<(), ()> {
+    match fallback {
+        Ok(()) => Ok(()),
+        Err(BinaryFallbackError::ConnectionClosed) => {
+            tracing::warn!(
+                %player_id,
+                %from_player,
+                "Failed to write binary game data fallback, connection closed"
+            );
+            Err(())
+        }
+        Err(BinaryFallbackError::Undeliverable(reason)) => {
+            server.metrics().increment_websocket_messages_dropped();
+            tracing::warn!(
+                %player_id,
+                %from_player,
+                encoding = ?encoding,
+                reason = %reason,
+                "Game data undeliverable to this recipient; sending an error notice instead"
+            );
+            let notice = ServerMessage::Error {
+                message: format!(
+                    "Undeliverable game data from player {from_player} \
+                     ({} payload cannot be converted for this connection): {reason}",
+                    encoding.as_wire_str()
+                ),
+                error_code: Some(ErrorCode::UnsupportedGameDataFormat),
+            };
+            send_text_message(sender, &notice, player_id).await
+        }
+    }
 }
 
 pub(super) async fn send_text_message(

--- a/tests/config_and_endpoints_tests.rs
+++ b/tests/config_and_endpoints_tests.rs
@@ -495,6 +495,16 @@ const CONFIG_REFERENCE_ROWS: &[ConfigReferenceRow] = &[
         path: "websocket.idle_timeout_secs",
         default: Some("300"),
     },
+    ConfigReferenceRow {
+        env: "SIGNAL_FISH__WEBSOCKET__SEND_QUEUE_CAPACITY",
+        path: "websocket.send_queue_capacity",
+        default: Some("1024"),
+    },
+    ConfigReferenceRow {
+        env: "SIGNAL_FISH__WEBSOCKET__SLOW_CONSUMER_TIMEOUT_MS",
+        path: "websocket.slow_consumer_timeout_ms",
+        default: Some("5000"),
+    },
 ];
 
 const README_REQUIRED_CONFIG_ROWS: &[ConfigReferenceRow] = &[

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -1574,32 +1574,21 @@ async fn collect_frames_until_closed(
 }
 
 /// An authenticated connection that sends no frames at all is closed once the
-/// idle timeout elapses, after receiving a `CONNECTION_IDLE_TIMEOUT` error.
-/// (Auth is disabled in `test_server_config`, so the connection counts as
-/// authenticated from the first frame — the idle window applies immediately.)
+/// socket-level idle timeout elapses, after receiving a
+/// `CONNECTION_IDLE_TIMEOUT` error. (Auth is disabled in `test_server_config`,
+/// so the connection counts as authenticated from the first frame — the idle
+/// window applies immediately.)
 ///
-/// `ping_timeout` is deliberately SHORTER than the idle window — the
-/// production-default ordering (30s reaper vs 300s idle). The state reaper
-/// therefore unregisters the silent client from the message coordinator well
-/// before the idle timeout fires, so this test proves the idle-timeout error
-/// is delivered on the connection's own outbound channel rather than via the
-/// coordinator (a coordinator-routed error would be silently dropped here).
+/// The maintenance reaper is deliberately NOT running here (the e2e harness
+/// does not spawn it), so the socket-level idle mechanism — the backstop for
+/// reaper-less deployments and library embedders — is what closes the
+/// connection. The reaper-driven eviction path is covered separately by
+/// `test_silent_client_is_reaped_with_activity_timeout`.
 #[tokio::test]
 async fn test_idle_client_is_disconnected_after_idle_timeout() {
     let mult = idle_timeout_test_multiplier();
-    let mut config = idle_timeout_server_config(2 * mult);
-    // Reaper window (500ms) + cleanup interval (1s, from `test_server_config`)
-    // elapse before the (2 * mult)s idle window: the client is reaped first,
-    // exactly as with production defaults. ping_timeout stays at 500ms so the
-    // reaper-before-idle ordering holds at every multiplier.
-    config.ping_timeout = tokio::time::Duration::from_millis(500);
+    let config = idle_timeout_server_config(2 * mult);
     let game_server = create_test_server_with_config(config, test_protocol_config()).await;
-    // Run the maintenance reaper (main.rs spawns it the same way); the e2e
-    // harness does not start it by default.
-    let cleanup_server = Arc::clone(&game_server);
-    tokio::spawn(async move {
-        cleanup_server.cleanup_task().await;
-    });
     let addr = start_server_with_instance(game_server).await;
     let (mut sender, mut receiver) = connect_client(addr, "/v2/ws").await;
 
@@ -1645,6 +1634,76 @@ async fn test_idle_client_is_disconnected_after_idle_timeout() {
     assert!(
         idle_error_seen,
         "expected an Error frame with CONNECTION_IDLE_TIMEOUT before close, got frames: {frames:?}"
+    );
+}
+
+/// A completely silent client is evicted by the maintenance reaper
+/// (`server.ping_timeout`) with a loud `ACTIVITY_TIMEOUT` farewell, and its
+/// socket is closed promptly — long before the (much larger) socket-level
+/// idle window. This is the production-default ordering (30s reaper vs 300s
+/// idle) scaled down, and it pins two behaviors at once: the reaper's
+/// distinct disconnect reason (not `CONNECTION_IDLE_TIMEOUT`, which is the
+/// socket-level close), and the positive socket teardown on unregistration
+/// (reaped connections must not linger half-alive until the idle window).
+#[tokio::test]
+async fn test_silent_client_is_reaped_with_activity_timeout() {
+    let mult = idle_timeout_test_multiplier();
+    // Idle window far beyond the test deadline: only the reaper can close
+    // this connection.
+    let mut config = idle_timeout_server_config(300);
+    config.ping_timeout = tokio::time::Duration::from_millis(500);
+    let game_server = create_test_server_with_config(config, test_protocol_config()).await;
+    // Run the maintenance reaper (main.rs spawns it the same way); the e2e
+    // harness does not start it by default.
+    let cleanup_server = Arc::clone(&game_server);
+    tokio::spawn(async move {
+        cleanup_server.cleanup_task().await;
+    });
+    let addr = start_server_with_instance(game_server).await;
+    let (mut sender, mut receiver) = connect_client(addr, "/v2/ws").await;
+
+    // Prove the connection works, then go silent.
+    let response = send_and_receive(
+        &mut sender,
+        &mut receiver,
+        ClientMessage::JoinRoom {
+            game_name: "reaper-eviction-game".to_string(),
+            room_code: None,
+            player_name: "Silent".to_string(),
+            max_players: Some(4),
+            supports_authority: Some(false),
+            relay_transport: None,
+        },
+    )
+    .await
+    .expect("join before going silent");
+    assert!(
+        matches!(response, ServerMessage::RoomJoined(_)),
+        "expected RoomJoined, got {response:?}"
+    );
+
+    // Reaper window (500ms) + cleanup interval (1s, from `test_server_config`)
+    // elapse well within this deadline; the idle window (300s) never can.
+    let frames = collect_frames_until_closed(
+        &mut receiver,
+        tokio::time::Duration::from_secs(15 * mult),
+        "reaped silent client",
+    )
+    .await;
+
+    let activity_timeout_seen = frames.iter().any(|frame| match frame {
+        Message::Text(text) => matches!(
+            serde_json::from_str::<ServerMessage>(text),
+            Ok(ServerMessage::Error {
+                error_code: Some(ErrorCode::ActivityTimeout),
+                ..
+            })
+        ),
+        _ => false,
+    });
+    assert!(
+        activity_timeout_seen,
+        "expected an Error frame with ACTIVITY_TIMEOUT before close, got frames: {frames:?}"
     );
 }
 

--- a/tests/relay_backpressure_e2e.rs
+++ b/tests/relay_backpressure_e2e.rs
@@ -1,0 +1,614 @@
+//! End-to-end coverage for relay delivery reliability under burst load.
+//!
+//! Regression tests for <https://github.com/Ambiguous-Interactive/signal-fish-server/issues/131>:
+//! the per-connection outbound queue used to be a small bounded channel written
+//! with `try_send`, so a `GameData` burst larger than the queue silently
+//! dropped messages with only a server-side log line. Rollback-netcode style
+//! clients (which require reliable, ordered relay of every input packet)
+//! observed a permanent sent-vs-received deficit that no amount of client-side
+//! buffering could fix.
+//!
+//! The contract under test: **the relay never silently drops a message** — a
+//! room-scoped payload is either delivered to every connected peer (with
+//! backpressure applied to the sender when a recipient's queue is full) or the
+//! unresponsive recipient is loudly disconnected as a slow consumer.
+
+mod test_helpers;
+
+use futures_util::{SinkExt, StreamExt};
+use signal_fish_server::config::ProtocolConfig;
+use signal_fish_server::protocol::{ClientMessage, ErrorCode, PlayerId, ServerMessage};
+use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
+use signal_fish_server::websocket::create_router;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use test_helpers::{create_test_server, create_test_server_with_config};
+use tokio::net::TcpListener;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+type WsSink = futures_util::stream::SplitSink<WsStream, Message>;
+type WsReceiver = futures_util::stream::SplitStream<WsStream>;
+
+/// Number of `GameData` messages the sender bursts without pacing.
+const BURST_MESSAGE_COUNT: usize = 5_000;
+
+/// Per-message payload padding. Sized so the full burst (~10 MB) cannot hide
+/// inside kernel socket buffers: the per-connection queue and the server's
+/// backpressure behavior — not TCP buffering — must absorb the burst.
+const PAYLOAD_PADDING_BYTES: usize = 2_048;
+
+/// How long the receivers wait before draining. Long enough that an unpaced
+/// sender overflows a drop-based bounded queue many times over; irrelevant to
+/// a backpressure-based server, which simply paces the sender until readers
+/// start draining.
+const READER_START_DELAY: tokio::time::Duration = tokio::time::Duration::from_millis(750);
+
+/// Generous whole-test deadline (oversubscribed CI runners included).
+const BURST_TEST_DEADLINE: tokio::time::Duration = tokio::time::Duration::from_secs(120);
+
+async fn start_server(server: Arc<EnhancedGameServer>) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("read listener address");
+
+    let router = create_router("http://localhost:3000").with_state(server);
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .expect("test server serve loop");
+    });
+
+    addr
+}
+
+async fn connect(addr: std::net::SocketAddr) -> (WsSink, WsReceiver) {
+    let url = format!("ws://{addr}/ws");
+    let (stream, _response) =
+        tokio::time::timeout(tokio::time::Duration::from_secs(10), connect_async(&url))
+            .await
+            .expect("websocket connect timed out")
+            .expect("websocket connect failed");
+    stream.split()
+}
+
+async fn join_room(sink: &mut WsSink, receiver: &mut WsReceiver, player_name: &str) {
+    let join = ClientMessage::JoinRoom {
+        game_name: "burst_game".to_string(),
+        room_code: Some("BURST1".to_string()),
+        player_name: player_name.to_string(),
+        max_players: Some(4),
+        supports_authority: Some(true),
+        relay_transport: None,
+    };
+    let json = serde_json::to_string(&join).expect("serialize JoinRoom");
+    sink.send(Message::Text(json.into()))
+        .await
+        .expect("send JoinRoom");
+
+    // Wait for the RoomJoined acknowledgement (other lobby chatter may arrive
+    // first; GameData never arrives here because no one has sent any yet).
+    loop {
+        let frame = tokio::time::timeout(tokio::time::Duration::from_secs(10), receiver.next())
+            .await
+            .expect("timed out waiting for RoomJoined")
+            .expect("connection closed while joining room")
+            .expect("websocket error while joining room");
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let message: ServerMessage = serde_json::from_str(&text).expect("valid ServerMessage");
+        match message {
+            ServerMessage::RoomJoined(_) => return,
+            ServerMessage::RoomJoinFailed { reason, .. } => {
+                panic!("room join failed for {player_name}: {reason}")
+            }
+            _ => continue,
+        }
+    }
+}
+
+/// Drain `receiver` until `expected` GameData messages arrive, returning their
+/// sequence numbers in arrival order. Panics loudly on server-sent errors or
+/// early connection close so drops can never masquerade as success.
+async fn collect_game_data_seqs(receiver: &mut WsReceiver, expected: usize) -> Vec<u64> {
+    let mut seqs = Vec::with_capacity(expected);
+    while seqs.len() < expected {
+        let Some(frame) = receiver.next().await else {
+            panic!(
+                "connection closed after {} of {expected} GameData messages",
+                seqs.len()
+            );
+        };
+        let frame = frame.expect("websocket error while draining GameData");
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let message: ServerMessage = serde_json::from_str(&text).expect("valid ServerMessage");
+        match message {
+            ServerMessage::GameData { data, .. } => {
+                let seq = data
+                    .get("seq")
+                    .and_then(serde_json::Value::as_u64)
+                    .expect("GameData payload carries a numeric seq");
+                seqs.push(seq);
+            }
+            ServerMessage::Error {
+                message,
+                error_code,
+            } => {
+                panic!(
+                    "server error while draining GameData (after {} messages): \
+                     {message} ({error_code:?})",
+                    seqs.len()
+                );
+            }
+            // Join/lobby notifications and other control chatter are expected
+            // and irrelevant to the delivery contract under test.
+            _ => continue,
+        }
+    }
+    seqs
+}
+
+fn assert_complete_and_ordered(seqs: &[u64], expected: usize, who: &str) {
+    assert_eq!(
+        seqs.len(),
+        expected,
+        "{who}: expected the full burst to be delivered"
+    );
+    for (index, seq) in seqs.iter().enumerate() {
+        assert_eq!(
+            *seq, index as u64,
+            "{who}: relay delivery must be complete and in order \
+             (message {index} arrived with seq {seq})"
+        );
+    }
+}
+
+/// A fast, unpaced `GameData` burst must reach every peer completely and in
+/// order. With the old drop-based bounded queue this fails within the first
+/// few hundred messages; with backpressure it must hold for any burst size.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn game_data_burst_is_relayed_completely_and_in_order() {
+    let server = create_test_server().await;
+    let addr = start_server(server).await;
+
+    let (mut sender_sink, mut sender_rx) = connect(addr).await;
+    let (mut receiver_a_sink, mut receiver_a_rx) = connect(addr).await;
+    let (mut receiver_b_sink, mut receiver_b_rx) = connect(addr).await;
+
+    join_room(&mut sender_sink, &mut sender_rx, "BurstSender").await;
+    join_room(&mut receiver_a_sink, &mut receiver_a_rx, "ReceiverA").await;
+    join_room(&mut receiver_b_sink, &mut receiver_b_rx, "ReceiverB").await;
+
+    // Burst the full payload set with zero pacing, exactly like a rollback
+    // netcode client catching a peer up. The writer runs on its own task so
+    // server-side backpressure (which is expected to slow this loop down once
+    // queues fill) cannot deadlock against the readers below.
+    let writer = tokio::spawn(async move {
+        let padding = "x".repeat(PAYLOAD_PADDING_BYTES);
+        for seq in 0..BURST_MESSAGE_COUNT {
+            let message = ClientMessage::GameData {
+                data: serde_json::json!({ "seq": seq as u64, "padding": padding }),
+            };
+            let json = serde_json::to_string(&message).expect("serialize GameData");
+            sender_sink
+                .send(Message::Text(json.into()))
+                .await
+                .expect("send GameData burst frame");
+        }
+        sender_sink
+    });
+
+    // Readers intentionally start late: a drop-based server has already lost
+    // most of the burst by now, while a backpressure-based server has simply
+    // paced the sender and delivers everything.
+    let reader_a = tokio::spawn(async move {
+        tokio::time::sleep(READER_START_DELAY).await;
+        let seqs = collect_game_data_seqs(&mut receiver_a_rx, BURST_MESSAGE_COUNT).await;
+        (seqs, receiver_a_rx)
+    });
+    let reader_b = tokio::spawn(async move {
+        tokio::time::sleep(READER_START_DELAY).await;
+        let seqs = collect_game_data_seqs(&mut receiver_b_rx, BURST_MESSAGE_COUNT).await;
+        (seqs, receiver_b_rx)
+    });
+
+    let (writer_result, reader_a_result, reader_b_result) =
+        tokio::time::timeout(BURST_TEST_DEADLINE, async {
+            tokio::join!(writer, reader_a, reader_b)
+        })
+        .await
+        .expect("burst relay test exceeded its deadline (deadlock or lost messages?)");
+
+    let _sender_sink = writer_result.expect("burst writer task panicked");
+    let (seqs_a, _rx_a) = reader_a_result.expect("reader A task panicked");
+    let (seqs_b, _rx_b) = reader_b_result.expect("reader B task panicked");
+
+    assert_complete_and_ordered(&seqs_a, BURST_MESSAGE_COUNT, "receiver A");
+    assert_complete_and_ordered(&seqs_b, BURST_MESSAGE_COUNT, "receiver B");
+}
+
+/// A recipient that stops draining its socket entirely must be disconnected
+/// as a slow consumer — loudly (metrics, close) — while the rest of the room
+/// keeps flowing and the sender is never wedged behind the dead connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn slow_consumer_is_disconnected_loudly_and_room_keeps_flowing() {
+    // Small queue + short grace window so the stalled recipient is evicted
+    // quickly; large payloads so the burst cannot hide in kernel TCP buffers.
+    const MESSAGE_COUNT: usize = 2_000;
+    const STALL_PADDING_BYTES: usize = 16 * 1_024;
+
+    let mut server_config = ServerConfig::default();
+    server_config.websocket_config.send_queue_capacity = 8;
+    server_config.websocket_config.slow_consumer_timeout_ms = 300;
+    let server = create_test_server_with_config(server_config, ProtocolConfig::default()).await;
+    let metrics = server.metrics();
+    let addr = start_server(server).await;
+
+    // Join order matters for the observers below: the healthy receiver joins
+    // first so it sees PlayerJoined for the stalled client (capturing its id
+    // indirectly is unnecessary — the stalled client reports its own id).
+    let (mut healthy_sink, mut healthy_rx) = connect(addr).await;
+    let (mut sender_sink, mut sender_rx) = connect(addr).await;
+    let (mut stalled_sink, mut stalled_rx) = connect(addr).await;
+
+    join_room(&mut healthy_sink, &mut healthy_rx, "HealthyReceiver").await;
+    join_room(&mut sender_sink, &mut sender_rx, "FloodSender").await;
+    let stalled_player_id =
+        join_room_returning_id(&mut stalled_sink, &mut stalled_rx, "Stalled").await;
+
+    // The stalled client now goes silent: it never polls its socket again
+    // until after the flood. Its kernel buffers will fill, then its outbound
+    // queue, then the slow-consumer timeout must evict it.
+    let writer = tokio::spawn(async move {
+        let padding = "x".repeat(STALL_PADDING_BYTES);
+        for seq in 0..MESSAGE_COUNT {
+            let message = ClientMessage::GameData {
+                data: serde_json::json!({ "seq": seq as u64, "padding": padding }),
+            };
+            let json = serde_json::to_string(&message).expect("serialize GameData");
+            sender_sink
+                .send(Message::Text(json.into()))
+                .await
+                .expect("send GameData while a peer is stalled");
+        }
+        sender_sink
+    });
+
+    // The healthy receiver must observe the complete, ordered burst AND the
+    // stalled player's eviction (PlayerLeft via the normal disconnect flow).
+    let healthy_reader = tokio::spawn(async move {
+        let mut seqs = Vec::with_capacity(MESSAGE_COUNT);
+        let mut left_players: Vec<PlayerId> = Vec::new();
+        while seqs.len() < MESSAGE_COUNT || !left_players.contains(&stalled_player_id) {
+            let Some(frame) = healthy_rx.next().await else {
+                panic!(
+                    "healthy receiver closed early ({} of {MESSAGE_COUNT} messages, left={left_players:?})",
+                    seqs.len()
+                );
+            };
+            let frame = frame.expect("healthy receiver websocket error");
+            let Message::Text(text) = frame else { continue };
+            let message: ServerMessage = serde_json::from_str(&text).expect("valid ServerMessage");
+            match message {
+                ServerMessage::GameData { data, .. } => {
+                    let seq = data
+                        .get("seq")
+                        .and_then(serde_json::Value::as_u64)
+                        .expect("GameData payload carries a numeric seq");
+                    seqs.push(seq);
+                }
+                ServerMessage::PlayerLeft { player_id } => left_players.push(player_id),
+                ServerMessage::Error {
+                    message,
+                    error_code,
+                } => panic!("healthy receiver got server error: {message} ({error_code:?})"),
+                _ => continue,
+            }
+        }
+        (seqs, left_players)
+    });
+
+    let deadline = tokio::time::Duration::from_secs(120);
+    let (writer_result, healthy_result) =
+        tokio::time::timeout(deadline, async { tokio::join!(writer, healthy_reader) })
+            .await
+            .expect("slow-consumer test exceeded its deadline (sender wedged behind dead peer?)");
+
+    let _sender_sink = writer_result.expect("flood writer task panicked");
+    let (seqs, left_players) = healthy_result.expect("healthy reader task panicked");
+    assert_complete_and_ordered(&seqs, MESSAGE_COUNT, "healthy receiver");
+    assert!(
+        left_players.contains(&stalled_player_id),
+        "stalled player must be evicted from the room (PlayerLeft), saw {left_players:?}"
+    );
+
+    // The eviction must be loud: counted as a slow-consumer disconnect with
+    // its abandoned messages recorded as drops.
+    assert!(
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed)
+            >= 1,
+        "slow-consumer disconnect must be recorded in metrics"
+    );
+    assert!(
+        metrics.websocket_messages_dropped.load(Ordering::Relaxed) >= 1,
+        "messages abandoned with the dead connection must be counted as dropped"
+    );
+
+    // The stalled client's socket must actually terminate: drain whatever was
+    // buffered and require the stream to end (server-initiated close). The
+    // best-effort SLOW_CONSUMER farewell is asserted only when it made it
+    // through the (intentionally saturated) socket.
+    let stalled_termination =
+        tokio::time::timeout(tokio::time::Duration::from_secs(30), async move {
+            let mut saw_slow_consumer_error = false;
+            while let Some(frame) = stalled_rx.next().await {
+                match frame {
+                    Ok(Message::Text(text)) => {
+                        if let Ok(ServerMessage::Error {
+                            error_code: Some(ErrorCode::SlowConsumer),
+                            ..
+                        }) = serde_json::from_str::<ServerMessage>(&text)
+                        {
+                            saw_slow_consumer_error = true;
+                        }
+                    }
+                    Ok(Message::Close(_)) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+            saw_slow_consumer_error
+        })
+        .await;
+    match stalled_termination {
+        Ok(saw_farewell) => {
+            if saw_farewell {
+                println!("stalled client received the SLOW_CONSUMER farewell before close");
+            }
+        }
+        Err(_elapsed) => panic!("stalled client's socket was never closed by the server"),
+    }
+}
+
+/// Deterministic backpressure check at the coordinator level (no sockets, no
+/// timing): with a tiny recipient queue, a burst must wait for the consumer
+/// (counted as backpressure) and still deliver every message in order.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn backpressure_delivers_every_message_in_order_without_disconnecting() {
+    const MESSAGE_COUNT: usize = 10;
+
+    let server = create_test_server().await;
+    let metrics = server.metrics();
+
+    let (tx1, mut rx1) = tokio::sync::mpsc::channel(64);
+    // Deliberately tiny: the burst below cannot fit, forcing the send().await path.
+    let (tx2, mut rx2) = tokio::sync::mpsc::channel(2);
+
+    let sender_id = server
+        .register_client(tx1, "127.0.0.1:0".parse().expect("addr"))
+        .await
+        .expect("register sender");
+    let receiver_id = server
+        .register_client(tx2, "127.0.0.1:0".parse().expect("addr"))
+        .await
+        .expect("register receiver");
+
+    join_room_direct(&server, &sender_id, "BPSender").await;
+    join_room_direct(&server, &receiver_id, "BPReceiver").await;
+
+    // Drain the join-time notifications so the tiny queue starts empty.
+    drain_join_chatter(&mut rx2, "backpressure receiver");
+    drain_join_chatter(&mut rx1, "backpressure sender");
+
+    let flood_server = Arc::clone(&server);
+    let flood = tokio::spawn(async move {
+        for seq in 0..MESSAGE_COUNT {
+            flood_server
+                .handle_client_message(
+                    &sender_id,
+                    ClientMessage::GameData {
+                        data: serde_json::json!({ "seq": seq as u64 }),
+                    },
+                )
+                .await;
+        }
+    });
+
+    // Do not drain until the sender has demonstrably hit backpressure, so this
+    // test cannot pass by racing the reader ahead of the writer.
+    let observed_backpressure = tokio::time::timeout(tokio::time::Duration::from_secs(10), async {
+        while metrics
+            .websocket_backpressure_events
+            .load(Ordering::Relaxed)
+            == 0
+        {
+            tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await;
+    assert!(
+        observed_backpressure.is_ok(),
+        "a {MESSAGE_COUNT}-message burst into a 2-slot queue must register backpressure"
+    );
+
+    let drained = tokio::time::timeout(tokio::time::Duration::from_secs(30), async {
+        let mut seqs = Vec::with_capacity(MESSAGE_COUNT);
+        while seqs.len() < MESSAGE_COUNT {
+            let Some(message) = rx2.recv().await else {
+                panic!("receiver channel closed after {} messages", seqs.len());
+            };
+            if let ServerMessage::GameData { data, .. } = message.as_ref() {
+                let seq = data
+                    .get("seq")
+                    .and_then(serde_json::Value::as_u64)
+                    .expect("numeric seq");
+                seqs.push(seq);
+            }
+        }
+        seqs
+    })
+    .await
+    .expect("backpressured delivery must complete once the consumer drains");
+
+    for (index, seq) in drained.iter().enumerate() {
+        assert_eq!(
+            *seq, index as u64,
+            "backpressured delivery must stay ordered"
+        );
+    }
+
+    flood.await.expect("flood task panicked");
+    assert_eq!(
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        0,
+        "a consumer that drains within the grace window must not be disconnected"
+    );
+}
+
+/// Deterministic slow-consumer check at the coordinator level: a recipient
+/// that never drains is pruned after the grace window, senders complete
+/// promptly afterwards, and the loss is visible in metrics.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unresponsive_recipient_is_pruned_without_blocking_senders() {
+    let mut server_config = ServerConfig::default();
+    server_config.websocket_config.slow_consumer_timeout_ms = 100;
+    let server = create_test_server_with_config(server_config, ProtocolConfig::default()).await;
+    let metrics = server.metrics();
+
+    let (tx1, mut rx1) = tokio::sync::mpsc::channel(64);
+    // Two slots and NO reader: fills immediately and never drains.
+    let (tx2, _rx2_kept_alive_but_never_read) = tokio::sync::mpsc::channel(2);
+
+    let sender_id = server
+        .register_client(tx1, "127.0.0.1:0".parse().expect("addr"))
+        .await
+        .expect("register sender");
+    let receiver_id = server
+        .register_client(tx2, "127.0.0.1:0".parse().expect("addr"))
+        .await
+        .expect("register receiver");
+
+    join_room_direct(&server, &sender_id, "PruneSender").await;
+    join_room_direct(&server, &receiver_id, "PruneReceiver").await;
+    drain_join_chatter(&mut rx1, "prune sender");
+
+    // Six sends: the receiver's queue holds its RoomJoined + one GameData at
+    // most; every subsequent send must ride the backpressure path, and the
+    // 100ms grace window must convert the dead consumer into a pruned one
+    // rather than stalling this loop forever.
+    let sends = tokio::time::timeout(tokio::time::Duration::from_secs(30), async {
+        for seq in 0..6_u64 {
+            server
+                .handle_client_message(
+                    &sender_id,
+                    ClientMessage::GameData {
+                        data: serde_json::json!({ "seq": seq }),
+                    },
+                )
+                .await;
+        }
+    })
+    .await;
+    assert!(
+        sends.is_ok(),
+        "senders must never be wedged indefinitely behind an unresponsive recipient"
+    );
+
+    assert_eq!(
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        1,
+        "exactly one slow-consumer disconnect must be recorded"
+    );
+    assert!(
+        metrics.websocket_messages_dropped.load(Ordering::Relaxed) >= 1,
+        "the message abandoned at disconnect must be counted"
+    );
+    assert!(
+        metrics
+            .websocket_backpressure_events
+            .load(Ordering::Relaxed)
+            >= 1,
+        "the full queue must have been recorded as backpressure first"
+    );
+}
+
+/// Empty a receiver of join-time notifications. `Empty` is the expected
+/// terminal state; a disconnected channel here means the client was torn down
+/// mid-setup, which must fail the test loudly.
+fn drain_join_chatter(receiver: &mut tokio::sync::mpsc::Receiver<Arc<ServerMessage>>, who: &str) {
+    loop {
+        match receiver.try_recv() {
+            Ok(_join_notification) => continue,
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => break,
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                panic!("{who}: channel disconnected while draining join chatter")
+            }
+        }
+    }
+}
+
+async fn join_room_direct(server: &Arc<EnhancedGameServer>, player_id: &PlayerId, name: &str) {
+    server
+        .handle_join_room(
+            player_id,
+            "backpressure_game".to_string(),
+            Some("BPRESS".to_string()),
+            name.to_string(),
+            Some(4),
+            Some(true),
+            None,
+        )
+        .await;
+}
+
+/// Like [`join_room`] but returns the server-assigned player id.
+async fn join_room_returning_id(
+    sink: &mut WsSink,
+    receiver: &mut WsReceiver,
+    player_name: &str,
+) -> PlayerId {
+    let join = ClientMessage::JoinRoom {
+        game_name: "burst_game".to_string(),
+        room_code: Some("BURST1".to_string()),
+        player_name: player_name.to_string(),
+        max_players: Some(4),
+        supports_authority: Some(true),
+        relay_transport: None,
+    };
+    let json = serde_json::to_string(&join).expect("serialize JoinRoom");
+    sink.send(Message::Text(json.into()))
+        .await
+        .expect("send JoinRoom");
+
+    loop {
+        let frame = tokio::time::timeout(tokio::time::Duration::from_secs(10), receiver.next())
+            .await
+            .expect("timed out waiting for RoomJoined")
+            .expect("connection closed while joining room")
+            .expect("websocket error while joining room");
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let message: ServerMessage = serde_json::from_str(&text).expect("valid ServerMessage");
+        match message {
+            ServerMessage::RoomJoined(payload) => return payload.player_id,
+            ServerMessage::RoomJoinFailed { reason, .. } => {
+                panic!("room join failed for {player_name}: {reason}")
+            }
+            _ => continue,
+        }
+    }
+}

--- a/tests/relay_backpressure_e2e.rs
+++ b/tests/relay_backpressure_e2e.rs
@@ -195,7 +195,7 @@ async fn game_data_burst_is_relayed_completely_and_in_order() {
         let padding = "x".repeat(PAYLOAD_PADDING_BYTES);
         for seq in 0..BURST_MESSAGE_COUNT {
             let message = ClientMessage::GameData {
-                data: serde_json::json!({ "seq": seq as u64, "padding": padding }),
+                data: serde_json::json!({ "seq": seq as u64, "padding": padding.as_str() }),
             };
             let json = serde_json::to_string(&message).expect("serialize GameData");
             sender_sink
@@ -271,7 +271,7 @@ async fn slow_consumer_is_disconnected_loudly_and_room_keeps_flowing() {
         let padding = "x".repeat(STALL_PADDING_BYTES);
         for seq in 0..MESSAGE_COUNT {
             let message = ClientMessage::GameData {
-                data: serde_json::json!({ "seq": seq as u64, "padding": padding }),
+                data: serde_json::json!({ "seq": seq as u64, "padding": padding.as_str() }),
             };
             let json = serde_json::to_string(&message).expect("serialize GameData");
             sender_sink

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -836,11 +836,48 @@ async fn test_concurrent_broadcast_and_register_no_deadlock() {
         let pid = Uuid::new_v4();
         let (tx, rx) = tokio::sync::mpsc::channel(16);
         coordinator
-            .register_local_client(pid, Some(room_id), tx)
+            .register_local_client(
+                pid,
+                Some(room_id),
+                signal_fish_server::coordination::ClientDeliveryHandle {
+                    sender: tx,
+                    close: signal_fish_server::coordination::ConnectionCloseSignal::detached(),
+                },
+            )
             .await
             .expect("register should succeed");
         initial_player_ids.push(pid);
         initial_receivers.push(rx);
+    }
+
+    // Healthy consumers: continuously drain the initial receivers during the
+    // storm. The delivery contract applies backpressure (and, after
+    // `slow_consumer_timeout`, a disconnect) when a recipient's queue stays
+    // full, so leaving these 16-slot queues undrained under 200 broadcasts
+    // would correctly slow the storm down — and this test would misreport
+    // that intended pacing as a lock deadlock. The property under test is
+    // unchanged: broadcast and register/unregister must interleave freely
+    // without deadlocking on the coordinator's internal locks.
+    let (stop_draining, _stop_rx) = tokio::sync::watch::channel(false);
+    let mut drain_handles = Vec::with_capacity(initial_receivers.len());
+    for mut rx in initial_receivers {
+        let mut stop = stop_draining.subscribe();
+        drain_handles.push(tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    message = rx.recv() => {
+                        assert!(
+                            message.is_some(),
+                            "initial receiver channel closed during the storm"
+                        );
+                    }
+                    changed = stop.changed() => {
+                        changed.expect("stop signal sender dropped");
+                        return rx;
+                    }
+                }
+            }
+        }));
     }
 
     let task_count = 20;
@@ -871,7 +908,15 @@ async fn test_concurrent_broadcast_and_register_no_deadlock() {
                 let pid = Uuid::new_v4();
                 let (tx, _rx) = tokio::sync::mpsc::channel(16);
                 let _ = coordinator
-                    .register_local_client(pid, Some(room_id), tx)
+                    .register_local_client(
+                        pid,
+                        Some(room_id),
+                        signal_fish_server::coordination::ClientDeliveryHandle {
+                            sender: tx,
+                            close:
+                                signal_fish_server::coordination::ConnectionCloseSignal::detached(),
+                        },
+                    )
                     .await;
                 tokio::task::yield_now().await;
                 let _ = coordinator.unregister_local_client(&pid).await;
@@ -891,6 +936,15 @@ async fn test_concurrent_broadcast_and_register_no_deadlock() {
         timeout_result.is_ok(),
         "Deadlock detected: concurrent broadcast + register/unregister did not complete within 5 seconds"
     );
+
+    // Stop the drain tasks and reclaim the receivers for verification.
+    stop_draining
+        .send(true)
+        .expect("drain tasks should still be listening for the stop signal");
+    let mut initial_receivers = Vec::with_capacity(drain_handles.len());
+    for handle in drain_handles {
+        initial_receivers.push(handle.await.expect("drain task should not panic"));
+    }
 
     // Correctness check: the initial 5 clients should still be registered.
     // Drain any buffered messages, then send a fresh broadcast and verify

--- a/tests/v2_wire_golden.rs
+++ b/tests/v2_wire_golden.rs
@@ -1156,6 +1156,7 @@ fn golden_enum_error_code_all_variants() {
         (ErrorCode::GameStartNotReady, r#""GAME_START_NOT_READY""#),
         (ErrorCode::GameStartForbidden, r#""GAME_START_FORBIDDEN""#),
         (ErrorCode::SlowConsumer, r#""SLOW_CONSUMER""#),
+        (ErrorCode::ActivityTimeout, r#""ACTIVITY_TIMEOUT""#),
     ];
     for (code, expected) in cases {
         assert_json_str(code, expected);
@@ -1213,12 +1214,13 @@ fn golden_enum_error_code_all_variants() {
         | ErrorCode::ConnectionIdleTimeout
         | ErrorCode::GameStartNotReady
         | ErrorCode::GameStartForbidden
-        | ErrorCode::SlowConsumer => (),
+        | ErrorCode::SlowConsumer
+        | ErrorCode::ActivityTimeout => (),
     };
     covered(ErrorCode::Unauthorized);
     assert_eq!(
         cases.len(),
-        49,
+        50,
         "golden table entry count must track the ErrorCode variant count \
          (update alongside the exhaustive guard above)"
     );

--- a/tests/v2_wire_golden.rs
+++ b/tests/v2_wire_golden.rs
@@ -1066,7 +1066,13 @@ fn golden_enum_spectator_state_change_reason_all_variants() {
 
 #[test]
 fn golden_enum_error_code_all_variants() {
-    // `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]` — exhaustive.
+    // `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]`.
+    //
+    // Exhaustiveness is COMPILER-ENFORCED by the `match` guard after the
+    // table: adding an `ErrorCode` variant fails compilation here until the
+    // variant is listed in the guard — and the guard's comment directs the
+    // author to freeze its wire token in this table at the same time. (The
+    // table itself was previously hand-maintained and had silently drifted.)
     let cases: &[(ErrorCode, &str)] = &[
         (ErrorCode::Unauthorized, r#""UNAUTHORIZED""#),
         (ErrorCode::InvalidToken, r#""INVALID_TOKEN""#),
@@ -1147,10 +1153,75 @@ fn golden_enum_error_code_all_variants() {
         (ErrorCode::InternalError, r#""INTERNAL_ERROR""#),
         (ErrorCode::StorageError, r#""STORAGE_ERROR""#),
         (ErrorCode::ServiceUnavailable, r#""SERVICE_UNAVAILABLE""#),
+        (ErrorCode::GameStartNotReady, r#""GAME_START_NOT_READY""#),
+        (ErrorCode::GameStartForbidden, r#""GAME_START_FORBIDDEN""#),
+        (ErrorCode::SlowConsumer, r#""SLOW_CONSUMER""#),
     ];
     for (code, expected) in cases {
         assert_json_str(code, expected);
     }
+
+    // Compile-time exhaustiveness guard: a new `ErrorCode` variant fails this
+    // match until added — ADD ITS GOLDEN WIRE TOKEN TO THE TABLE ABOVE at the
+    // same time, and keep the count assertion below in sync.
+    let covered = |code: ErrorCode| match code {
+        ErrorCode::Unauthorized
+        | ErrorCode::InvalidToken
+        | ErrorCode::AuthenticationRequired
+        | ErrorCode::InvalidAppId
+        | ErrorCode::AppIdExpired
+        | ErrorCode::AppIdRevoked
+        | ErrorCode::AppIdSuspended
+        | ErrorCode::MissingAppId
+        | ErrorCode::AuthenticationTimeout
+        | ErrorCode::SdkVersionUnsupported
+        | ErrorCode::UnsupportedGameDataFormat
+        | ErrorCode::InvalidInput
+        | ErrorCode::InvalidGameName
+        | ErrorCode::InvalidRoomCode
+        | ErrorCode::InvalidPlayerName
+        | ErrorCode::InvalidMaxPlayers
+        | ErrorCode::MessageTooLarge
+        | ErrorCode::RoomNotFound
+        | ErrorCode::RoomFull
+        | ErrorCode::AlreadyInRoom
+        | ErrorCode::NotInRoom
+        | ErrorCode::RoomCreationFailed
+        | ErrorCode::MaxRoomsPerGameExceeded
+        | ErrorCode::InvalidRoomState
+        | ErrorCode::AuthorityNotSupported
+        | ErrorCode::AuthorityConflict
+        | ErrorCode::AuthorityDenied
+        | ErrorCode::RateLimitExceeded
+        | ErrorCode::TooManyConnections
+        | ErrorCode::ReconnectionFailed
+        | ErrorCode::ReconnectionTokenInvalid
+        | ErrorCode::ReconnectionExpired
+        | ErrorCode::PlayerAlreadyConnected
+        | ErrorCode::SpectatorNotAllowed
+        | ErrorCode::TooManySpectators
+        | ErrorCode::NotASpectator
+        | ErrorCode::SpectatorJoinFailed
+        | ErrorCode::InternalError
+        | ErrorCode::StorageError
+        | ErrorCode::ServiceUnavailable
+        | ErrorCode::CrossRoomSignal
+        | ErrorCode::UnsupportedTransport
+        | ErrorCode::SignalTargetNotFound
+        | ErrorCode::SignalRateLimited
+        | ErrorCode::SignalTooLarge
+        | ErrorCode::ConnectionIdleTimeout
+        | ErrorCode::GameStartNotReady
+        | ErrorCode::GameStartForbidden
+        | ErrorCode::SlowConsumer => (),
+    };
+    covered(ErrorCode::Unauthorized);
+    assert_eq!(
+        cases.len(),
+        49,
+        "golden table entry count must track the ErrorCode variant count \
+         (update alongside the exhaustive guard above)"
+    );
 }
 
 #[test]

--- a/tests/websocket_test_helpers_tests.rs
+++ b/tests/websocket_test_helpers_tests.rs
@@ -72,10 +72,14 @@ async fn matching_server_message_skips_noise_until_match() {
 #[tokio::test]
 async fn optional_matching_server_message_uses_absolute_deadline_for_noisy_stream() {
     let mut stream = RepeatingTextFrames::new(ServerMessage::Pong);
-    let deadline = deadline_after(Duration::from_millis(10));
+    // Wide enough that a task briefly starved on an oversubscribed full-suite
+    // runner still reads several frames before the deadline (a 10ms window
+    // flaked when the task was first scheduled after the deadline had already
+    // passed); the outer timeout only guards against an unbounded loop.
+    let deadline = deadline_after(Duration::from_millis(250));
 
     let result = tokio::time::timeout(
-        Duration::from_millis(250),
+        Duration::from_secs(10),
         maybe_next_matching_server_message_with_skipped_until(
             &mut stream,
             deadline,
@@ -114,7 +118,10 @@ async fn optional_matching_server_message_reports_skipped_non_text_frames() {
 
     let (value, skipped) = maybe_next_matching_server_message_with_skipped_until(
         &mut stream,
-        deadline_after(Duration::from_millis(10)),
+        // Wide enough to survive scheduler starvation under a parallel full
+        // suite (the frames are ready instantly; the deadline only ends the
+        // wait on the pending tail).
+        deadline_after(Duration::from_millis(250)),
         "test non-text diagnostics",
         |message| match message {
             ServerMessage::SessionPlan(_) => Some(()),
@@ -142,7 +149,9 @@ async fn no_server_message_skips_non_text_frames_until_timeout() {
 
     expect_no_server_message_within(
         &mut stream,
-        Duration::from_millis(10),
+        // Wide enough that the non-text frames are actually read (exercising
+        // the skip path) even when the task starts late under suite load.
+        Duration::from_millis(100),
         "test no server message",
     )
     .await;


### PR DESCRIPTION
## Summary

Full remediation of #131 (hard-capped server buffer). Relaying high-rate `GameData` (rollback/GGPO-style input packets) silently lost messages under burst: the per-connection outbound queue was an undocumented `batch_size * 4 = 40`-slot bounded channel written with `try_send`, dropping on overflow with only a server-side `warn!` — invisible to metrics and to both peers. A client that outpaced a recipient's drain rate for a few milliseconds permanently lost packets, which rollback netcode experiences as an unrecoverable stall (the reported constant ~298-packet deficit).

This PR replaces that behavior with an explicit, server-wide **delivery contract**:

> **A message is never silently dropped.** Delivery either enqueues the message — applying real backpressure to senders while a recipient's queue is momentarily full — or, if the recipient cannot absorb a single message for the whole `websocket.slow_consumer_timeout_ms` grace window, the recipient is disconnected **loudly**: metrics, a warning log, a best-effort `SLOW_CONSUMER` error frame, and a prompt socket close. Senders in a room are paced to their slowest healthy recipient; a dead recipient costs the room at most one timeout window before eviction.

## Server changes

**Delivery layer**
- New shared primitive `coordination::deliver_or_disconnect` — fast-path `try_send`, then bounded `send().await` (counted as a backpressure event), then slow-consumer close — used by the coordinator relay/broadcast paths *and* the WebSocket layer's direct control sends (auth responses, idle-timeout errors), so there is exactly one implementation of the contract.
- `InMemoryMessageCoordinator` rewritten: delivery handles are cloned out of the routing locks before any await (a backpressured recipient can never stall registration or other rooms), broadcasts fan out concurrently (`join_all` — broadcast latency is bounded by the slowest recipient, not the sum), and slow consumers are pruned from routing immediately.
- Per-connection close signal (`ConnectionCloseSignal`, watch-based, first-reason-wins) registered alongside the outbound queue. The send/receive tasks run their work *inside* a `select!` against it, so a close request preempts even a socket write wedged against a peer that stopped reading — verified empirically (fd released, socket reaches FIN_WAIT1 within ~2s of eviction; previously such sockets lingered as zombies indefinitely).
- Every unregistration (reaper, disconnect, teardown) now positively closes the socket tasks — eliminating the pre-existing half-alive zombie-socket state — after flushing already-queued messages (bounded).

**Same-class fixes swept up**
- Undeliverable binary game data (e.g. an rkyv payload relayed to a JSON-only client) is no longer silently discarded by the send path: the recipient gets an explicit `UNSUPPORTED_GAME_DATA_FORMAT` error frame in its place and the drop is counted.
- **Every** inbound message now counts as activity for the `server.ping_timeout` reaper (previously only `Ping`): a client streaming GameData at 60 Hz without heartbeats is emphatically alive and is no longer reaped mid-session.
- Reaped (expired) clients receive a farewell `CONNECTION_IDLE_TIMEOUT` error before the close (bounded, concurrency-capped), instead of an unexplained disconnect.
- Room-operation critical sections (`authority`, `ready`, `start-game`, `lobby transition`) now release their TTL-bounded distributed lock **before** delivering notifications, so backpressured delivery can never stretch a critical section past its TTL and break mutual exclusion. A regression test pins the new invariant.
- Reconnection honesty: `missed_events` in the `Reconnected` payload is always empty today (nothing populates the buffer); this is now documented prominently (docs + rustdoc) — clients must treat reconnection as requiring app-level resync.

**Config, metrics, protocol**
- New config: `websocket.send_queue_capacity` (default **1024**, was the implicit 40) and `websocket.slow_consumer_timeout_ms` (default **5000**, validated `1..=600000`), with data-driven validation tests.
- New metrics: `signal_fish_websocket_backpressure_events_total` (full queue forced a wait; message still delivered — the congestion signal #131 asked for) and `signal_fish_websocket_slow_consumer_disconnects_total`; `websocket_messages_dropped_total` is now honest (counts messages abandoned only together with their dying connection) and its help text corrected.
- New `ErrorCode::SlowConsumer` (`SLOW_CONSUMER`), appended per rkyv discriminant-stability rules; AsyncAPI spec, error-code reference, protocol samples guards, and the native reference client updated.
- `docs/protocol.md` gains a **Delivery semantics** section covering the contract, the client driving-model requirement (continuously drive your async runtime — a merely "ticked" runtime starves the transport), and sustainable-rate guidance; configuration docs/recipes updated with tuning guidance for high-rate game data.

## Verification

- **Red → green**: `tests/relay_backpressure_e2e.rs::game_data_burst_is_relayed_completely_and_in_order` — 5000-message unpaced burst (~10 MB, sized to defeat kernel socket buffering) through real WebSockets with late readers. On the old code it times out with thousands of silent drops; now every message arrives, in order, at every peer.
- Slow-consumer e2e: a peer that stops reading entirely is evicted within the grace window (metrics + `PlayerLeft`), the room keeps flowing (healthy peer still receives the complete ordered burst), and the sender is never wedged.
- Deterministic coordinator-level tests for the backpressure wait (no drops, order preserved, no disconnect for a draining consumer) and slow-consumer pruning (senders complete promptly; exactly one disconnect counted).
- Two independent live probes against a real server instance verified socket/fd reclamation server-side (`/proc` state: ESTABLISHED zombie before the fix → FIN_WAIT1 + fd released ~2s after eviction with it).
- Full suite green locally: `cargo fmt`, `clippy --all-targets --all-features` (zero warnings), `cargo test --all-features`, `cargo deny check`, doc/spec/config drift guards. `anyhow` bumped to 1.0.103 for RUSTSEC-2026-0190 (new upstream advisory, would fail CI regardless of this change).
- Process: implemented red-green, then two adversarial review rounds (the first found a real wedge — the close signal couldn't preempt a blocked socket write — which was fixed and re-verified empirically; the second round confirmed all fixes sound with zero remaining findings).

## Compatibility

- Wire format unchanged; one additive error code. v2 goldens extended (the "exhaustive" error-code golden was missing three variants; it is now compiler-enforced exhaustive).
- Library API: `MessageCoordinator::register_local_client` now takes a `ClientDeliveryHandle` (queue + close signal); `register_client` keeps its signature (detached close signal) with a new `register_client_with_close` used by the WebSocket layer. Version bumped **0.3.0 → 0.4.0**.
- Behavioral: clients that previously *silently lost messages* under burst now experience pacing (writes momentarily slow) instead; genuinely unresponsive clients are disconnected with `SLOW_CONSUMER` after the grace window instead of accumulating invisible loss.

Fixes #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Core relay and WebSocket delivery semantics change—senders may block and slow clients disconnect after a timeout—plus distributed-lock ordering around room notifications; behavior is heavily tested but affects every connected client.
> 
> **Overview**
> **Fixes #131** by replacing fire-and-forget `try_send` on tiny per-connection outbound queues (implicit ~40 slots) with a single **no silent drop** delivery path: `try_send`, then bounded wait on a full queue, then slow-consumer disconnect with metrics, logging, and a best-effort `SLOW_CONSUMER` frame.
> 
> Adds configurable **`websocket.send_queue_capacity`** (default 1024) and **`websocket.slow_consumer_timeout_ms`** (default 5000), **`ConnectionCloseSignal`** / **`ClientDeliveryHandle`** so delivery can tear down stuck sockets, and rewrites **`InMemoryMessageCoordinator`** to backpressure-aware concurrent fan-out with immediate pruning of slow consumers. Room-operation locks are released **before** coordinator broadcasts so backpressure cannot stretch TTL-bounded critical sections.
> 
> Also adds **`ACTIVITY_TIMEOUT`** farewells on the ping reaper, treats **all inbound traffic** (not only `Ping`) as liveness, surfaces **`UNSUPPORTED_GAME_DATA_FORMAT`** instead of silently skipping undeliverable binary payloads, new Prometheus backpressure/slow-consumer counters, protocol/docs honesty on **`missed_events`**, e2e coverage in **`tests/relay_backpressure_e2e.rs`**, and bumps the crate to **0.4.0** (library registration now takes **`ClientDeliveryHandle`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2ab3cc5cfa6c3c76a38a290d43448f318c18ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->