### PR TITLE
fix(server): P10.A P0 correctness — room-GC lifetime, timeout inversion, 16-player defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contract behind the BUG-1 fix: a room whose members are active is never reaped
   (`ActiveRoomNeverReaped`) and a room holding an unexpired reconnection record
   is never reaped (`ReconnectWindowRespected`). A `StaleActivityBug` seeded
-  constant reproduces the pre-fix behaviour (both invariants violated) for
+  constant reproduces the pre-fix behavior (both invariants violated) for
   non-vacuity; the checked configs pin it `FALSE` and are green in the
   auto-globbed `scripts/run-tla-model-check.sh` suite.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -521,10 +521,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   written only at creation and never refreshed (both refresher methods had zero call sites), so a
   session over an hour old was reaped with players still in it, and a long-lived room that emptied
   was deleted immediately, collapsing the reconnection window (reconnects failed `RoomNotFound`
-  with still-valid tokens). `last_activity` is now refreshed on join, on leave/disconnect, and on
-  the throttled heartbeat/relay path; the empty-room clock keys off `last_activity` (not
-  `created_at`) so both cleanup paths agree; and room GC never deletes a room that still holds an
-  unexpired reconnection record (`ReconnectionManager::rooms_with_active_reconnections`).
+  with still-valid tokens). `last_activity` is now refreshed on join, on a real leave/disconnect,
+  and once per inbound message on the throttled liveness path — covering pings, relayed `GameData`
+  (JSON and binary), and WebRTC `Signal` traffic uniformly; the empty-room clock keys off
+  `last_activity` (not `created_at`) so both cleanup paths agree; and room GC never deletes a room
+  that still holds an unexpired reconnection record
+  (`ReconnectionManager::rooms_with_active_reconnections`). Startup validation additionally rejects
+  `server.heartbeat_throttle_secs >= server.inactive_room_timeout`, so the throttled refresh can
+  never lag the reaper and re-open the bug by misconfiguration.
 - Fixed a config timeout-inversion where a legal combination evicted a **healthy** sender: with
   `websocket.slow_consumer_timeout_ms ≥ server.ping_timeout · 1000`, a sender parked on the
   broadcast fan-out for a slow recipient could outlast the activity-reaper deadline and be closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a room-lifecycle GC bug where every room was deleted a fixed interval after **creation**
+  regardless of activity (default `inactive_room_timeout` = 1 h) — `Room.last_activity` was
+  written only at creation and never refreshed (both refresher methods had zero call sites), so a
+  session over an hour old was reaped with players still in it, and a long-lived room that emptied
+  was deleted immediately, collapsing the reconnection window (reconnects failed `RoomNotFound`
+  with still-valid tokens). `last_activity` is now refreshed on join, on leave/disconnect, and on
+  the throttled heartbeat/relay path; the empty-room clock keys off `last_activity` (not
+  `created_at`) so both cleanup paths agree; and room GC never deletes a room that still holds an
+  unexpired reconnection record (`ReconnectionManager::rooms_with_active_reconnections`).
+- Fixed a config timeout-inversion where a legal combination evicted a **healthy** sender: with
+  `websocket.slow_consumer_timeout_ms ≥ server.ping_timeout · 1000`, a sender parked on the
+  broadcast fan-out for a slow recipient could outlast the activity-reaper deadline and be closed
+  `4003` before its slow recipient was ever disconnected. Startup validation now rejects that
+  combination (cross-field check, guarded on `ping_timeout > 0`).
+- Fixed `game_data_messages` (`signal_fish_game_data_messages_total`) reading a permanent `0`: the
+  metric was exported to Prometheus but never incremented. It is now counted once per relayed
+  `GameData` message at the relay funnel.
 - Fixed an orphaned reconnection replay buffer (found by the new `fuzz_reconnect_tokens` fuzz
   target): a player re-registering a disconnect from a NEW room replaced its pending record and
   left the old room's replay ring alive forever — capturing control events and replaying ghosts
@@ -714,6 +731,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Raised `security.max_connections_per_ip` default `10` → `24`. Ten silently refused the 11th
+  concurrent connection from one IP, so a 16-player session behind a single NAT (LAN party,
+  office, venue) could not connect. `24` covers 16 players plus spectators and reconnect churn.
+  (The per-room player count is bounded separately by that room's `max_players`, default `8`.)
 - SDK platform/version enforcement (`protocol.sdk_compatibility.enforce`) now defaults to
   `false` (opt-in): with the old default the prepopulated platform list made a default-config
   server reject every client that did not claim to be a known engine — including

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `RoomLifecycleGC` TLA+ model (`formal/tla/RoomLifecycleGC.tla` +
+  `_Small.cfg` / `_WindowBoundary.cfg`) formalizing the room garbage-collection
+  contract behind the BUG-1 fix: a room whose members are active is never reaped
+  (`ActiveRoomNeverReaped`) and a room holding an unexpired reconnection record
+  is never reaped (`ReconnectWindowRespected`). A `StaleActivityBug` seeded
+  constant reproduces the pre-fix behaviour (both invariants violated) for
+  non-vacuity; the checked configs pin it `FALSE` and are green in the
+  auto-globbed `scripts/run-tla-model-check.sh` suite.
+
 - Added protocol v4 (strictly additive; clamp `protocol.max_protocol_version` back to `3` to
   disable): relayed `GameData` / `GameDataBinary` delivered to a v4 recipient carry a
   server-stamped per-`(sender, room)` `seq` starting at `1` and strictly contiguous per sender,

--- a/config.example.json
+++ b/config.example.json
@@ -42,7 +42,7 @@
     "require_metrics_auth": false,
     "max_message_size": 65536,
     "max_signal_bytes": 16384,
-    "max_connections_per_ip": 10,
+    "max_connections_per_ip": 24,
     "transport": {
       "tls": {
         "enabled": false

--- a/docs/concepts/protocol-versions.md
+++ b/docs/concepts/protocol-versions.md
@@ -39,7 +39,7 @@ The negotiated version is clamped into the server's configured range:
 `negotiated = clamp(client_max, protocol.min_protocol_version, protocol.max_protocol_version)`. A client that
 advertises a higher version than the deployment speaks is clamped **down** to `protocol.max_protocol_version`; one
 that omits `protocol_version` is negotiated from the endpoint default. Defaults: `protocol.min_protocol_version`
-is `2`, `protocol.max_protocol_version` is `3`.
+is `2`, `protocol.max_protocol_version` is `4`.
 
 ## The two invariants
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,7 +155,7 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__SECURITY__METRICS_AUTH_TOKEN` | `security.metrics_auth_token` | `null` | Bearer token for metrics endpoints |
 | `SIGNAL_FISH__SECURITY__MAX_MESSAGE_SIZE` | `security.max_message_size` | `65536` | Max WebSocket message size in bytes |
 | `SIGNAL_FISH__SECURITY__MAX_SIGNAL_BYTES` | `security.max_signal_bytes` | `16384` | Max serialized size in bytes of a v3 `Signal` payload (must be > 0 and ≤ `max_message_size`) |
-| `SIGNAL_FISH__SECURITY__MAX_CONNECTIONS_PER_IP` | `security.max_connections_per_ip` | `10` | Max concurrent connections from one IP |
+| `SIGNAL_FISH__SECURITY__MAX_CONNECTIONS_PER_IP` | `security.max_connections_per_ip` | `24` | Max concurrent connections from one IP (covers a 16-player NAT/LAN session plus spectators and reconnect churn) |
 | `SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED` | `security.transport.tls.enabled` | `false` | Enable built-in TLS listener |
 | `SIGNAL_FISH__SECURITY__TRANSPORT__TLS__CERTIFICATE_PATH` | `security.transport.tls.certificate_path` | `null` | Path to PEM certificate chain |
 | `SIGNAL_FISH__SECURITY__TRANSPORT__TLS__PRIVATE_KEY_PATH` | `security.transport.tls.private_key_path` | `null` | Path to PEM private key |
@@ -248,7 +248,7 @@ Complete reference of all configuration options with environment variable overri
   "security": {
     "cors_origins": "https://yourgame.com",
     "require_websocket_auth": true,
-    "max_connections_per_ip": 10
+    "max_connections_per_ip": 24
   }
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -122,7 +122,7 @@ self-hosted only.
     "cors_origins": "https://yourgame.com",
     "require_websocket_auth": true,
     "max_message_size": 65536,
-    "max_connections_per_ip": 10
+    "max_connections_per_ip": 24
   },
   "websocket": {
     "enable_batching": true,

--- a/docs/features.md
+++ b/docs/features.md
@@ -592,7 +592,7 @@ Limit concurrent connections per IP:
 
 {
   "security": {
-    "max_connections_per_ip": 10
+    "max_connections_per_ip": 24
   }
 }
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -662,9 +662,15 @@ Response to client `Ping`.
 ### Reconnected
 
 Reconnection successful. Includes current room state. The `missed_events`
-field is reserved for future use and is always an empty list today — messages
-sent while the player was disconnected are not buffered or replayed (see
-[Reconnection Flow](#reconnection-flow)).
+field carries the replayable **control** events (membership / lobby / authority
+transitions) broadcast to the room while the player was disconnected, oldest
+first, from a bounded per-room replay ring (`server.event_buffer_size`); it is
+NOT empty when such events occurred during the absence. High-rate data-path
+traffic (`GameData` / `Signal`) is deliberately not replayed. The companion
+`replay` field (v3+ recipients only) reports the completeness of that list —
+`complete`, `truncated` (the ring evicted an event the player needed, so
+`missed_events` is only a suffix), or `unavailable` (replay disabled,
+`event_buffer_size = 0`). See [Reconnection Flow](#reconnection-flow).
 
 ```json
 
@@ -691,7 +697,8 @@ sent while the player was disconnected are not buffered or replayed (see
     "ready_players": ["player-id-1"],
     "relay_type": "matchbox",
     "current_spectators": [],
-    "missed_events": []
+    "missed_events": [],
+    "replay": "complete"
   }
 }
 
@@ -909,11 +916,16 @@ and `room_id` (from the original `RoomJoined` response) to reconnect:
 
 On successful reconnection, the server sends a `Reconnected` message with the current room state.
 
-Note: messages sent while a player is disconnected are **not** buffered or
-replayed — the `missed_events` field in the `Reconnected` payload is always
-empty today. Clients must treat reconnection as requiring an
-application-level state resync (for example, have the authority or another
-peer re-send the current game state after `PlayerReconnected`).
+Note: replayable **control** events (membership / lobby / authority
+transitions) broadcast while the player was disconnected ARE buffered in a
+bounded per-room replay ring and returned in the `Reconnected` payload's
+`missed_events` list, with the `replay` field reporting completeness
+(`complete` / `truncated` / `unavailable`). High-rate data-path traffic
+(`GameData` / `Signal`) is **not** replayed, and a `truncated` or
+`unavailable` replay means control history is incomplete — so clients must
+still treat reconnection as requiring an application-level state resync (for
+example, have the authority or another peer re-send the current game state
+after `PlayerReconnected`).
 
 ## Protocol v3 additions
 

--- a/formal/tla/RoomLifecycleGC.tla
+++ b/formal/tla/RoomLifecycleGC.tla
@@ -1,0 +1,251 @@
+------------------------------ MODULE RoomLifecycleGC ------------------------------
+(***************************************************************************)
+(* The room garbage-collection contract (BUG-1 / P10.A1). Models the       *)
+(* maintenance sweep (`src/server/maintenance.rs cleanup_task`) against the *)
+(* room store (`src/database/mod.rs cleanup_empty_rooms /                   *)
+(* cleanup_expired_rooms`, `src/protocol/room_state.rs Room::is_expired`)   *)
+(* and the reconnection manager (`src/reconnection.rs`).                    *)
+(*                                                                          *)
+(* THE CONTRACT the fix must hold:                                          *)
+(*   (1) ActiveRoomNeverReaped — a room whose members are genuinely active  *)
+(*       (activity within `inactive_room_timeout`) is never deleted by GC.  *)
+(*   (2) ReconnectWindowRespected — a room holding an UNEXPIRED reconnection *)
+(*       record is never deleted (else a still-valid reconnection token     *)
+(*       fails `RoomNotFound`).                                             *)
+(*                                                                          *)
+(* THE BUG (pre-fix, reproduced by StaleActivityBug = TRUE): `last_activity`*)
+(* is written only at room creation and never refreshed (both refreshers    *)
+(* had zero call sites), and GC has no reconnection guard. So a room with    *)
+(* actively-communicating players is reaped `inactive_room_timeout` after    *)
+(* CREATION mid-game (violates (1)), and a room that emptied via disconnect  *)
+(* is reaped off its stale creation time before its reconnection window      *)
+(* elapses (violates (2)).                                                  *)
+(*                                                                          *)
+(* THE FIX (StaleActivityBug = FALSE): every activity (join, leave,          *)
+(* disconnect, ping/relay) refreshes `last_activity`; the empty-room clock   *)
+(* keys off `last_activity` (not `created_at`); and GC skips any room with   *)
+(* an unexpired reconnection record (the `protected` set).                  *)
+(*                                                                          *)
+(* Mapping to the implementation:                                           *)
+(*   Tick                discrete time advancing (the source of staleness); *)
+(*                       `chrono::Utc::now()` moving forward between sweeps  *)
+(*   Activity            a ping / relayed game-data refresh                  *)
+(*                       (`maybe_update_last_seen` -> `update_room_activity`)*)
+(*   JoinPlayer          `add_player_to_room` (refreshes last_activity)      *)
+(*   LeaveVoluntary      `remove_player_from_room` on a voluntary leave      *)
+(*                       (refreshes last_activity; no reconnection record)   *)
+(*   Disconnect          `unregister_client` -> `remove_player_from_room`    *)
+(*                       PLUS `register_disconnection` (leaves a record)     *)
+(*   Reconnect           a successful claim inside the window                *)
+(*   RecordExpireSweep   `ReconnectionManager::cleanup_expired`              *)
+(*   GC                  `cleanup_empty_rooms` / `cleanup_expired_rooms`     *)
+(*                       consulting the `protected` set                      *)
+(*                                                                          *)
+(* `clock` is the GC-visible `last_activity`; `trueActivity` is the ground   *)
+(* truth of when the room was last active. The fix keeps them equal (every   *)
+(* activity refreshes clock); the bug pins clock at creation (0) while       *)
+(* trueActivity still moves — that gap is exactly what makes GC reap an      *)
+(* active room.                                                             *)
+(*                                                                          *)
+(* NON-VACUITY (verified during development, keep reproducible): setting     *)
+(* StaleActivityBug = TRUE makes clock never refresh and GC ignore the       *)
+(* reconnection guard. TLC then reports BOTH ActiveRoomNeverReaped and       *)
+(* ReconnectWindowRespected violated (traces: (1) create -> Tick past        *)
+(* InactiveTimeout while Activity keeps trueActivity fresh -> GC reaps a     *)
+(* room whose clock is stuck at 0; (2) Disconnect leaving a fresh record ->  *)
+(* Tick past EmptyTimeout -> GC reaps the empty room while the record is     *)
+(* still valid). The checked configurations pin StaleActivityBug = FALSE.    *)
+(***************************************************************************)
+EXTENDS Naturals
+
+CONSTANTS
+    MaxTime,          \* time horizon (keep tiny: 6)
+    InactiveTimeout,  \* room-with-players staleness bound (inactive_room_timeout)
+    EmptyTimeout,     \* empty-room staleness bound (empty_room_timeout)
+    ReconnectWindow,  \* reconnection record validity (reconnection_window)
+    StaleActivityBug  \* TRUE: last_activity never refreshed AND no reconnection
+                      \* guard (the pre-fix code). Must violate both named
+                      \* invariants; FALSE in checked configs.
+
+ASSUME /\ MaxTime \in Nat \ {0}
+       /\ InactiveTimeout \in Nat
+       /\ EmptyTimeout \in Nat
+       /\ ReconnectWindow \in Nat
+       /\ StaleActivityBug \in BOOLEAN
+
+VARIABLES
+    time,          \* current tick, 0..MaxTime
+    exists,        \* room still in the store
+    present,       \* a player currently occupies the room
+    clock,         \* GC-visible last_activity (created_at is 0)
+    trueActivity,  \* ground-truth last activity time
+    hasRecord,     \* an (unclaimed) reconnection record exists for the room
+    recordAt,      \* tick the reconnection record was created
+    reapedActive,  \* violation flag: GC reaped a genuinely-active room
+    reapedInWindow \* violation flag: GC reaped a room inside a valid window
+
+vars == <<time, exists, present, clock, trueActivity, hasRecord, recordAt,
+          reapedActive, reapedInWindow>>
+
+(* The last_activity refresh: the fix writes `time`; the bug leaves it. *)
+Refresh == IF StaleActivityBug THEN clock ELSE time
+
+Init ==
+    /\ time = 0
+    /\ exists = TRUE
+    /\ present = TRUE       \* a room is created with its creator present
+    /\ clock = 0            \* created_at == last_activity == 0
+    /\ trueActivity = 0
+    /\ hasRecord = FALSE
+    /\ recordAt = 0
+    /\ reapedActive = FALSE
+    /\ reapedInWindow = FALSE
+
+(* Time advances between sweeps — the sole source of staleness. *)
+Tick ==
+    /\ time < MaxTime
+    /\ time' = time + 1
+    /\ UNCHANGED <<exists, present, clock, trueActivity, hasRecord, recordAt,
+                   reapedActive, reapedInWindow>>
+
+(* A ping / relayed game-data frame from a present member. Refreshes the *)
+(* ground-truth activity always, and the GC clock unless the bug is set.  *)
+Activity ==
+    /\ exists
+    /\ present
+    /\ trueActivity' = time
+    /\ clock' = Refresh
+    /\ UNCHANGED <<time, exists, present, hasRecord, recordAt, reapedActive,
+                   reapedInWindow>>
+
+(* add_player_to_room: a join is activity and refreshes last_activity. *)
+JoinPlayer ==
+    /\ exists
+    /\ ~present
+    /\ present' = TRUE
+    /\ trueActivity' = time
+    /\ clock' = Refresh
+    /\ UNCHANGED <<time, exists, hasRecord, recordAt, reapedActive,
+                   reapedInWindow>>
+
+(* remove_player_from_room on a voluntary leave: refreshes last_activity *)
+(* (starts the empty-room clock at the departure), no reconnection record. *)
+LeaveVoluntary ==
+    /\ exists
+    /\ present
+    /\ present' = FALSE
+    /\ trueActivity' = time
+    /\ clock' = Refresh
+    /\ UNCHANGED <<time, exists, hasRecord, recordAt, reapedActive,
+                   reapedInWindow>>
+
+(* unregister_client: a disconnect removes the player AND leaves a pending *)
+(* reconnection record. Also refreshes last_activity (a departure). *)
+Disconnect ==
+    /\ exists
+    /\ present
+    /\ present' = FALSE
+    /\ hasRecord' = TRUE
+    /\ recordAt' = time
+    /\ trueActivity' = time
+    /\ clock' = Refresh
+    /\ UNCHANGED <<time, exists, reapedActive, reapedInWindow>>
+
+(* A successful reconnection claim inside the window: the player returns *)
+(* and the record is consumed. *)
+Reconnect ==
+    /\ exists
+    /\ hasRecord
+    /\ time - recordAt <= ReconnectWindow
+    /\ present' = TRUE
+    /\ hasRecord' = FALSE
+    /\ trueActivity' = time
+    /\ clock' = Refresh
+    /\ UNCHANGED <<time, exists, recordAt, reapedActive, reapedInWindow>>
+
+(* ReconnectionManager::cleanup_expired drops a record whose window elapsed, *)
+(* so it stops protecting the room. *)
+RecordExpireSweep ==
+    /\ hasRecord
+    /\ time - recordAt > ReconnectWindow
+    /\ hasRecord' = FALSE
+    /\ UNCHANGED <<time, exists, present, clock, trueActivity, recordAt,
+                   reapedActive, reapedInWindow>>
+
+(* A room is expired per Room::is_expired: empty rooms off the empty-room *)
+(* clock (created_at=0 under the bug, last_activity under the fix), rooms *)
+(* with players off last_activity. *)
+EmptyClock  == IF StaleActivityBug THEN 0 ELSE clock
+EmptyExpired  == ~present /\ (time - EmptyClock > EmptyTimeout)
+ActiveExpired ==  present /\ (time - clock      > InactiveTimeout)
+IsExpired == EmptyExpired \/ ActiveExpired
+
+(* The reconnection guard (the `protected` set): only present under the fix. *)
+ProtectedByReconnect ==
+    /\ ~StaleActivityBug
+    /\ hasRecord
+    /\ time - recordAt <= ReconnectWindow
+
+(* The maintenance sweep reaps an expired, unprotected room. The two flags *)
+(* record whether that reap was WRONG: against a genuinely-active room, or *)
+(* against a room still inside a valid reconnection window. *)
+GC ==
+    /\ exists
+    /\ IsExpired
+    /\ ~ProtectedByReconnect
+    /\ exists' = FALSE
+    /\ reapedActive' =
+         (reapedActive \/ (present /\ (time - trueActivity <= InactiveTimeout)))
+    /\ reapedInWindow' =
+         (reapedInWindow \/ (hasRecord /\ (time - recordAt <= ReconnectWindow)))
+    /\ UNCHANGED <<time, present, clock, trueActivity, hasRecord, recordAt>>
+
+(* Explicit terminal stutter so TLC's deadlock check stays meaningful *)
+(* (matches the ConnectionTeardown / SignalFishSession convention). Enabled *)
+(* only at the time horizon, where Tick is disabled. *)
+Done ==
+    /\ time = MaxTime
+    /\ UNCHANGED vars
+
+Next ==
+    \/ Tick
+    \/ Activity
+    \/ JoinPlayer
+    \/ LeaveVoluntary
+    \/ Disconnect
+    \/ Reconnect
+    \/ RecordExpireSweep
+    \/ GC
+    \/ Done
+
+Spec == Init /\ [][Next]_vars
+
+----------------------------------------------------------------------------
+(* Safety *)
+
+TypeOK ==
+    /\ time \in 0..MaxTime
+    /\ exists \in BOOLEAN
+    /\ present \in BOOLEAN
+    /\ clock \in 0..MaxTime
+    /\ trueActivity \in 0..MaxTime
+    /\ hasRecord \in BOOLEAN
+    /\ recordAt \in 0..MaxTime
+    /\ reapedActive \in BOOLEAN
+    /\ reapedInWindow \in BOOLEAN
+
+(* (1) A room whose members are genuinely active (activity within the *)
+(* inactive-room timeout) is never reaped. The bug sets this by reaping a *)
+(* room whose GC clock is stuck at creation while its true activity is fresh. *)
+ActiveRoomNeverReaped == ~reapedActive
+
+(* (2) A room holding an unexpired reconnection record is never reaped. The *)
+(* bug sets this by reaping an emptied room off its stale creation time *)
+(* before the reconnection window elapses. *)
+ReconnectWindowRespected == ~reapedInWindow
+
+(* Sanity: the GC clock never runs ahead of ground-truth activity, and under *)
+(* the fix they coincide (every activity refreshes both). *)
+ClockNeverAheadOfTruth == clock <= trueActivity
+
+=============================================================================

--- a/formal/tla/RoomLifecycleGC_Small.cfg
+++ b/formal/tla/RoomLifecycleGC_Small.cfg
@@ -1,0 +1,20 @@
+\* Room-GC model at the smallest configuration that exercises every path:
+\* a time horizon that reaches past the inactive timeout (active-reap trace),
+\* an empty timeout below the reconnection window (so an emptied room's GC
+\* clock and its still-valid record race), and both departure kinds (voluntary
+\* leave vs disconnect-with-record). State space is tiny (<1s TLC). See the
+\* module header for the StaleActivityBug non-vacuity check that proves both
+\* invariants necessary (flip StaleActivityBug = TRUE locally to watch GC reap
+\* an active room and a room inside its reconnection window).
+SPECIFICATION Spec
+CONSTANTS
+    MaxTime = 6
+    InactiveTimeout = 3
+    EmptyTimeout = 1
+    ReconnectWindow = 2
+    StaleActivityBug = FALSE
+INVARIANTS
+    TypeOK
+    ActiveRoomNeverReaped
+    ReconnectWindowRespected
+    ClockNeverAheadOfTruth

--- a/formal/tla/RoomLifecycleGC_WindowBoundary.cfg
+++ b/formal/tla/RoomLifecycleGC_WindowBoundary.cfg
@@ -1,0 +1,19 @@
+\* Room-GC model tuned to the reconnection-window boundary: the empty-room
+\* timeout and the reconnection window are both tight (1), so an emptied room
+\* becomes GC-eligible on the SAME tick its record can still be claimed. This
+\* is the exact race BUG-1 corollary B lost — the fix must let the record's
+\* `protected` veto win until the window elapses, then reap on the next tick.
+\* StaleActivityBug = FALSE (checked); see the module header for the TRUE
+\* non-vacuity reproduction.
+SPECIFICATION Spec
+CONSTANTS
+    MaxTime = 5
+    InactiveTimeout = 2
+    EmptyTimeout = 1
+    ReconnectWindow = 1
+    StaleActivityBug = FALSE
+INVARIANTS
+    TypeOK
+    ActiveRoomNeverReaped
+    ReconnectWindowRespected
+    ClockNeverAheadOfTruth

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -230,8 +230,15 @@ pub const fn default_max_signal_bytes() -> usize {
     16384 // 16KB
 }
 
+/// Default cap on concurrent connections from one IP.
+///
+/// 24, not 10: a 16-player session behind one NAT (LAN party, office, venue) is
+/// a first-class use case, and 10 silently refused the 11th same-IP client
+/// (GAP-3). 24 covers 16 players plus spectators and reconnect churn with slack.
+/// (This is the connection limiter only; the number of players in a single room
+/// is bounded separately by that room's `max_players`, default 8.)
 pub const fn default_max_connections_per_ip() -> usize {
-    10
+    24
 }
 
 pub const fn default_client_auth_mode() -> ClientAuthMode {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -207,6 +207,33 @@ pub fn validate_config_security(config: &Config) -> anyhow::Result<()> {
     // WebSocket configuration validation
     config.websocket.validate()?;
 
+    // Cross-field: the slow-consumer grace period must be shorter than the
+    // activity-reaper deadline (BUG-2 / timeout inversion). A message handler
+    // records sender activity at dispatch, then parks on the broadcast
+    // `join_all` while a slow recipient drains — up to `slow_consumer_timeout_ms`.
+    // If that park can outlast `server.ping_timeout`, the reaper evicts the
+    // HEALTHY sender (close 4003) before its own slow recipient is ever
+    // disconnected: a legal config gets a healthy player kicked. Require the
+    // grace period to be strictly less than the ping deadline so the sender's
+    // recorded activity is always still fresh when its park ends. (Guarded on
+    // `ping_timeout > 0`: a zero deadline disables the reaper, so no inversion
+    // exists to prevent.)
+    if config.server.ping_timeout > 0 {
+        let ping_timeout_ms = config.server.ping_timeout.saturating_mul(1000);
+        if config.websocket.slow_consumer_timeout_ms >= ping_timeout_ms {
+            anyhow::bail!(
+                "websocket.slow_consumer_timeout_ms ({}) must be less than \
+                 server.ping_timeout ({} s = {} ms): a slow-consumer park that can \
+                 outlast the ping deadline lets the activity reaper evict the HEALTHY \
+                 sender (close 4003) before its slow recipient is disconnected \
+                 (timeout inversion)",
+                config.websocket.slow_consumer_timeout_ms,
+                config.server.ping_timeout,
+                ping_timeout_ms
+            );
+        }
+    }
+
     // Protocol version-bounds validation
     config.protocol.validate()?;
 
@@ -421,6 +448,43 @@ mod tests {
             err.to_string().contains("websocket.batch_interval_ms"),
             "error must name the offending field: {err}"
         );
+    }
+
+    /// Timeout inversion (BUG-2): the slow-consumer grace period must be
+    /// strictly less than the activity-reaper deadline. Data-driven over the
+    /// boundary. `ping_timeout` default is 30 s (30000 ms).
+    #[test]
+    fn slow_consumer_timeout_must_be_below_ping_deadline() {
+        // (slow_consumer_timeout_ms, ping_timeout_secs, expect_ok)
+        let cases = [
+            (5_000_u64, 30_u64, true), // default: well below
+            (29_999, 30, true),        // just below the 30000 ms deadline
+            (30_000, 30, false),       // equal: reaper could win → rejected
+            (60_000, 30, false),       // above: the classic inversion → rejected
+            (60_000, 0, true),         // ping_timeout 0 disables the reaper: no inversion
+            (10_000, 5, false),        // 10000 ms >= 5000 ms deadline → rejected
+        ];
+
+        for (slow_ms, ping_s, expect_ok) in cases {
+            let mut config = Config::default();
+            config.security.require_metrics_auth = false;
+            config.websocket.slow_consumer_timeout_ms = slow_ms;
+            config.server.ping_timeout = ping_s;
+
+            let result = validate_config_security(&config);
+            assert_eq!(
+                result.is_ok(),
+                expect_ok,
+                "slow_consumer_timeout_ms={slow_ms}, ping_timeout={ping_s}s"
+            );
+            if !expect_ok {
+                let err = result.unwrap_err().to_string();
+                assert!(
+                    err.contains("slow_consumer_timeout_ms") && err.contains("ping_timeout"),
+                    "rejection must name both offending fields: {err}"
+                );
+            }
+        }
     }
 
     /// With batching DISABLED the flush interval is never constructed, so a zero

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -204,6 +204,29 @@ pub fn validate_config_security(config: &Config) -> anyhow::Result<()> {
         }
     }
 
+    // Cross-field: the room-activity refresh piggybacks on the per-player
+    // heartbeat throttle (`maybe_update_last_seen`), so a room with active
+    // members has its `last_activity` refreshed at most once per
+    // `heartbeat_throttle_secs`. If that throttle is >= `inactive_room_timeout`,
+    // steady ping/GameData/Signal traffic can leave `last_activity` stale past
+    // the reaper deadline and GC an occupied room while its members are still
+    // connected (BUG-1 reintroduced by misconfiguration). Require the throttle
+    // to stay strictly below the inactive-room deadline. (`heartbeat_throttle_secs
+    // == 0` disables throttling — every heartbeat refreshes — so it is always
+    // safe and exempt.)
+    if config.server.heartbeat_throttle_secs > 0
+        && config.server.heartbeat_throttle_secs >= config.server.inactive_room_timeout
+    {
+        anyhow::bail!(
+            "server.heartbeat_throttle_secs ({}) must be less than \
+             server.inactive_room_timeout ({}): the room-activity refresh is throttled on \
+             heartbeat_throttle_secs, so a throttle at or above the inactive-room deadline \
+             lets GC reap an occupied room whose members are still active",
+            config.server.heartbeat_throttle_secs,
+            config.server.inactive_room_timeout
+        );
+    }
+
     // WebSocket configuration validation
     config.websocket.validate()?;
 
@@ -481,6 +504,43 @@ mod tests {
                 let err = result.unwrap_err().to_string();
                 assert!(
                     err.contains("slow_consumer_timeout_ms") && err.contains("ping_timeout"),
+                    "rejection must name both offending fields: {err}"
+                );
+            }
+        }
+    }
+
+    /// The heartbeat throttle must stay below the inactive-room deadline, or the
+    /// throttled room-activity refresh can let GC reap an occupied room (BUG-1
+    /// via misconfiguration). Data-driven over the boundary.
+    #[test]
+    fn heartbeat_throttle_must_be_below_inactive_room_timeout() {
+        // (heartbeat_throttle_secs, inactive_room_timeout_secs, expect_ok)
+        let cases = [
+            (30_u64, 3600_u64, true), // defaults: well below
+            (3599, 3600, true),       // just below
+            (3600, 3600, false),      // equal: refresh can lag the reaper → rejected
+            (7200, 3600, false),      // above: the misconfig bugbot flagged → rejected
+            (0, 3600, true),          // 0 disables throttling (refresh every heartbeat) → safe
+        ];
+
+        for (throttle, inactive, expect_ok) in cases {
+            let mut config = Config::default();
+            config.security.require_metrics_auth = false;
+            config.server.heartbeat_throttle_secs = throttle;
+            config.server.inactive_room_timeout = inactive;
+
+            let result = validate_config_security(&config);
+            assert_eq!(
+                result.is_ok(),
+                expect_ok,
+                "heartbeat_throttle_secs={throttle}, inactive_room_timeout={inactive}"
+            );
+            if !expect_ok {
+                let err = result.unwrap_err().to_string();
+                assert!(
+                    err.contains("heartbeat_throttle_secs")
+                        && err.contains("inactive_room_timeout"),
                     "rejection must name both offending fields: {err}"
                 );
             }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -2,7 +2,7 @@ use crate::protocol::{ConnectionInfo, PlayerId, PlayerInfo, Room, RoomId, Specta
 use anyhow::Result;
 use async_trait::async_trait;
 use std::any::Any;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 /// Summary describing how many rooms were removed by the cleanup routine.
@@ -106,14 +106,25 @@ pub trait GameDatabase: Send + Sync {
     /// Get all players in a room
     async fn get_room_players(&self, room_id: &RoomId) -> Result<Vec<PlayerInfo>>;
 
-    /// Delete empty rooms and return their IDs for relay cleanup
-    async fn cleanup_empty_rooms(&self, empty_timeout: chrono::Duration) -> Result<Vec<RoomId>>;
+    /// Delete empty rooms and return their IDs for relay cleanup.
+    ///
+    /// Rooms in `protected` are never deleted regardless of age: they hold a
+    /// still-valid reconnection record, so deleting them would strand a live
+    /// reconnection token behind a `RoomNotFound` (BUG-1 corollary B).
+    async fn cleanup_empty_rooms(
+        &self,
+        empty_timeout: chrono::Duration,
+        protected: &HashSet<RoomId>,
+    ) -> Result<Vec<RoomId>>;
 
-    /// Delete expired rooms based on timeouts and return a summary of what was removed.
+    /// Delete expired rooms based on timeouts and return a summary of what was
+    /// removed. Rooms in `protected` are never deleted (see
+    /// [`Self::cleanup_empty_rooms`]).
     async fn cleanup_expired_rooms(
         &self,
         empty_timeout: chrono::Duration,
         inactive_timeout: chrono::Duration,
+        protected: &HashSet<RoomId>,
     ) -> Result<RoomCleanupOutcome>;
 
     /// Update room activity timestamp
@@ -420,6 +431,9 @@ impl GameDatabase for InMemoryDatabase {
         if let Some(room) = rooms.get_mut(room_id) {
             if room.players.len() < room.max_players as usize {
                 room.players.insert(player.id, player);
+                // A join is activity: refresh the reaper clock so a room that
+                // fills up long after creation is not GC'd mid-game (BUG-1).
+                room.last_activity = chrono::Utc::now();
                 Ok(true)
             } else {
                 Ok(false) // Room is full
@@ -437,6 +451,13 @@ impl GameDatabase for InMemoryDatabase {
         let mut rooms = self.rooms.write().await;
         if let Some(room) = rooms.get_mut(room_id) {
             let removed_player = room.players.remove(player_id);
+
+            // A departure is activity, and it starts the empty-room clock:
+            // both cleanup paths time an empty room from `last_activity`, so
+            // refreshing it here gives a room emptied long after creation the
+            // full `empty_room_timeout` window from the LAST departure rather
+            // than deleting it immediately off a stale `created_at` (BUG-1).
+            room.last_activity = chrono::Utc::now();
 
             // Prune the departed player's ready entry so it cannot linger in
             // `RoomJoined` / `Reconnected` payloads: `finalize_room_game`
@@ -613,7 +634,11 @@ impl GameDatabase for InMemoryDatabase {
         }
     }
 
-    async fn cleanup_empty_rooms(&self, empty_timeout: chrono::Duration) -> Result<Vec<RoomId>> {
+    async fn cleanup_empty_rooms(
+        &self,
+        empty_timeout: chrono::Duration,
+        protected: &HashSet<RoomId>,
+    ) -> Result<Vec<RoomId>> {
         let mut rooms = self.rooms.write().await;
         let mut room_codes = self.room_codes.write().await;
 
@@ -626,7 +651,10 @@ impl GameDatabase for InMemoryDatabase {
 
         let mut to_remove = Vec::new();
         for (room_id, room) in rooms.iter() {
-            if room.players.is_empty() && room.last_activity <= cutoff {
+            if room.players.is_empty()
+                && room.last_activity <= cutoff
+                && !protected.contains(room_id)
+            {
                 to_remove.push((*room_id, room.game_name.clone(), room.code.clone()));
             }
         }
@@ -645,13 +673,14 @@ impl GameDatabase for InMemoryDatabase {
         &self,
         empty_timeout: chrono::Duration,
         inactive_timeout: chrono::Duration,
+        protected: &HashSet<RoomId>,
     ) -> Result<RoomCleanupOutcome> {
         let mut rooms = self.rooms.write().await;
         let mut room_codes = self.room_codes.write().await;
 
         let mut to_remove = Vec::new();
         for (room_id, room) in rooms.iter() {
-            if room.is_expired(empty_timeout, inactive_timeout) {
+            if room.is_expired(empty_timeout, inactive_timeout) && !protected.contains(room_id) {
                 let was_empty = room.players.is_empty();
                 to_remove.push((
                     *room_id,
@@ -1069,6 +1098,150 @@ mod tests {
             err_msg.contains("already exists"),
             "error message should contain 'already exists', got: {err_msg}"
         );
+    }
+
+    // --- BUG-1: room lifecycle GC (activity refresh + reconnection-aware GC) ---
+
+    fn member(name: &str) -> PlayerInfo {
+        PlayerInfo {
+            id: Uuid::new_v4(),
+            name: name.to_string(),
+            is_authority: false,
+            is_ready: false,
+            connected_at: chrono::Utc::now(),
+            connection_info: None,
+            region_id: "us-east-1".to_string(),
+        }
+    }
+
+    /// Backdate a room's timestamps so it looks stale to the GC without waiting
+    /// wall-clock time. Reaches the in-memory map directly (same module).
+    async fn age_room(db: &InMemoryDatabase, room_id: &RoomId, age: chrono::Duration) {
+        let now = chrono::Utc::now();
+        let mut rooms = db.rooms.write().await;
+        let room = rooms.get_mut(room_id).expect("room exists");
+        room.created_at = now - age;
+        room.last_activity = now - age;
+    }
+
+    fn is_fresh(ts: chrono::DateTime<chrono::Utc>) -> bool {
+        chrono::Utc::now().signed_duration_since(ts) < chrono::Duration::minutes(1)
+    }
+
+    /// A join must refresh `last_activity`: without it, a room that fills up
+    /// long after creation keeps a stale timestamp and is reaped mid-game
+    /// (`inactive_room_timeout` measured from creation, BUG-1 corollary A).
+    #[tokio::test]
+    async fn add_player_to_room_refreshes_last_activity() {
+        let db = InMemoryDatabase::new();
+        let room = create_test_room(&db, "activity_game", "ACT001")
+            .await
+            .expect("room creation should succeed");
+        age_room(&db, &room.id, chrono::Duration::hours(2)).await;
+
+        assert!(db
+            .add_player_to_room(&room.id, member("Joiner"))
+            .await
+            .expect("add_player_to_room should not error"));
+
+        let after = db
+            .get_room_by_id(&room.id)
+            .await
+            .expect("get_room_by_id should not error")
+            .expect("room exists");
+        assert!(
+            is_fresh(after.last_activity),
+            "joining must refresh last_activity so an active room is not reaped mid-game"
+        );
+    }
+
+    /// A departure must refresh `last_activity`: it is activity AND it starts
+    /// the empty-room clock, so a long-lived room that empties gets the full
+    /// `empty_room_timeout` window from the last departure (BUG-1 corollary B).
+    #[tokio::test]
+    async fn remove_player_from_room_refreshes_last_activity() {
+        let db = InMemoryDatabase::new();
+        let room = create_test_room(&db, "activity_game", "ACT002")
+            .await
+            .expect("room creation should succeed");
+        let creator = *room.players.keys().next().expect("creator present");
+        age_room(&db, &room.id, chrono::Duration::hours(2)).await;
+
+        db.remove_player_from_room(&room.id, &creator)
+            .await
+            .expect("remove_player_from_room should not error");
+
+        let after = db
+            .get_room_by_id(&room.id)
+            .await
+            .expect("get_room_by_id should not error")
+            .expect("room exists");
+        assert!(
+            is_fresh(after.last_activity),
+            "a departure must refresh last_activity (starts the empty-room clock)"
+        );
+    }
+
+    /// Both GC sweeps must spare a stale empty room whose id is `protected`
+    /// (it still holds a valid reconnection record), and must delete it when
+    /// unprotected. Data-driven over the two sweeps × {protected, not}.
+    #[tokio::test]
+    async fn cleanup_sweeps_spare_reconnection_protected_rooms() {
+        enum Sweep {
+            Empty,
+            Expired,
+        }
+        let cases = [
+            (Sweep::Empty, true, true),
+            (Sweep::Empty, false, false),
+            (Sweep::Expired, true, true),
+            (Sweep::Expired, false, false),
+        ];
+
+        for (sweep, protect, expect_survives) in cases {
+            let db = InMemoryDatabase::new();
+            let room = create_test_room(&db, "gc_game", "GC0001")
+                .await
+                .expect("room creation should succeed");
+            let creator = *room.players.keys().next().expect("creator present");
+            db.remove_player_from_room(&room.id, &creator)
+                .await
+                .expect("remove should not error");
+            // Age past both the 300s empty and 3600s inactive timeouts.
+            age_room(&db, &room.id, chrono::Duration::hours(2)).await;
+
+            let mut protected = HashSet::new();
+            if protect {
+                protected.insert(room.id);
+            }
+
+            match sweep {
+                Sweep::Empty => {
+                    db.cleanup_empty_rooms(chrono::Duration::seconds(300), &protected)
+                        .await
+                        .expect("cleanup_empty_rooms should not error");
+                }
+                Sweep::Expired => {
+                    db.cleanup_expired_rooms(
+                        chrono::Duration::seconds(300),
+                        chrono::Duration::seconds(3600),
+                        &protected,
+                    )
+                    .await
+                    .expect("cleanup_expired_rooms should not error");
+                }
+            }
+
+            let survives = db
+                .get_room_by_id(&room.id)
+                .await
+                .expect("get_room_by_id should not error")
+                .is_some();
+            assert_eq!(
+                survives, expect_survives,
+                "protect={protect}: a reconnection-protected room must survive GC"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -452,12 +452,16 @@ impl GameDatabase for InMemoryDatabase {
         if let Some(room) = rooms.get_mut(room_id) {
             let removed_player = room.players.remove(player_id);
 
-            // A departure is activity, and it starts the empty-room clock:
+            // A real departure is activity, and it starts the empty-room clock:
             // both cleanup paths time an empty room from `last_activity`, so
-            // refreshing it here gives a room emptied long after creation the
-            // full `empty_room_timeout` window from the LAST departure rather
-            // than deleting it immediately off a stale `created_at` (BUG-1).
-            room.last_activity = chrono::Utc::now();
+            // refreshing it gives a room emptied long after creation the full
+            // `empty_room_timeout` window from the LAST departure rather than
+            // deleting it immediately off a stale `created_at` (BUG-1). Guarded
+            // on an ACTUAL removal — a no-op remove (player already gone) is not
+            // activity and must not keep an otherwise-stale room alive.
+            if removed_player.is_some() {
+                room.last_activity = chrono::Utc::now();
+            }
 
             // Prune the departed player's ready entry so it cannot linger in
             // `RoomJoined` / `Reconnected` payloads: `finalize_room_game`

--- a/src/protocol/room_state.rs
+++ b/src/protocol/room_state.rs
@@ -274,8 +274,14 @@ impl Room {
         let now = chrono::Utc::now();
 
         if self.players.is_empty() {
-            // Empty room - check against creation time
-            now.signed_duration_since(self.created_at) > empty_timeout
+            // Empty room - time from the LAST activity (which `remove_player_from_room`
+            // refreshes on the final departure), not `created_at`. A long-lived room
+            // that just emptied must get the full `empty_timeout` window from when it
+            // emptied, otherwise it is deleted immediately off a stale creation time,
+            // collapsing the reconnection window (BUG-1 corollary B). This also keeps
+            // the two cleanup paths (`cleanup_empty_rooms` / `cleanup_expired_rooms`)
+            // consistent, since the former already keys off `last_activity`.
+            now.signed_duration_since(self.last_activity) > empty_timeout
         } else {
             // Room has players - check against last activity
             now.signed_duration_since(self.last_activity) > inactive_timeout
@@ -471,5 +477,77 @@ impl Room {
     #[allow(dead_code)]
     pub fn get_spectators(&self) -> Vec<SpectatorInfo> {
         self.spectators.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_room() -> Room {
+        Room::new(
+            "game".to_string(),
+            "CODE01".to_string(),
+            4,
+            true,
+            "relay".to_string(),
+        )
+    }
+
+    /// An empty room's expiry is timed from `last_activity` (refreshed on the
+    /// final departure), NOT `created_at`. A long-lived room that only just
+    /// emptied must NOT be considered expired off its stale creation time — that
+    /// would collapse the reconnection window (BUG-1 corollary B).
+    #[test]
+    fn is_expired_empty_room_keys_off_last_activity_not_created_at() {
+        let empty = chrono::Duration::seconds(300);
+        let inactive = chrono::Duration::seconds(3600);
+
+        // Created long ago but just emptied (fresh last_activity): NOT expired.
+        let mut room = empty_room();
+        room.created_at = chrono::Utc::now() - chrono::Duration::hours(2);
+        room.last_activity = chrono::Utc::now();
+        assert!(
+            !room.is_expired(empty, inactive),
+            "a freshly-emptied room must survive even if created hours ago"
+        );
+
+        // Emptied long ago (stale last_activity): expired.
+        room.last_activity = chrono::Utc::now() - chrono::Duration::hours(1);
+        assert!(
+            room.is_expired(empty, inactive),
+            "a room empty past empty_timeout must be reaped"
+        );
+    }
+
+    /// A room with players is timed from `last_activity`; refreshing it (as the
+    /// join/leave/heartbeat paths now do) keeps an active room alive past
+    /// `inactive_room_timeout` measured from creation (BUG-1 corollary A).
+    #[test]
+    fn is_expired_active_room_keys_off_last_activity() {
+        let empty = chrono::Duration::seconds(300);
+        let inactive = chrono::Duration::seconds(3600);
+
+        let mut room = empty_room();
+        let player_id = Uuid::new_v4();
+        room.players.insert(
+            player_id,
+            PlayerInfo {
+                id: player_id,
+                name: "P".to_string(),
+                is_authority: false,
+                is_ready: false,
+                connected_at: chrono::Utc::now(),
+                connection_info: None,
+                region_id: "us-east-1".to_string(),
+            },
+        );
+        // Created 2h ago but activity is fresh: NOT expired.
+        room.created_at = chrono::Utc::now() - chrono::Duration::hours(2);
+        room.last_activity = chrono::Utc::now();
+        assert!(
+            !room.is_expired(empty, inactive),
+            "an active room with fresh activity must not be reaped mid-game"
+        );
     }
 }

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -8,7 +8,7 @@
 use crate::metrics::ServerMetrics;
 use crate::protocol::{ErrorCode, PlayerId, PlayerInfo, RoomId, ServerMessage};
 use chrono::{DateTime, Duration, Utc};
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use uuid::Uuid;
@@ -861,6 +861,27 @@ impl ReconnectionManager {
             .map(|p| p.disconnected.player_id)
             .collect()
     }
+
+    /// Room IDs that currently hold at least one **unexpired** reconnection
+    /// record. Room garbage collection must not delete these rooms: a room
+    /// whose members disconnected simultaneously is empty, so it would
+    /// otherwise be reaped by the empty-room sweep before its still-valid
+    /// reconnection tokens could be redeemed — the reconnect then fails
+    /// `RoomNotFound` with a token the client was told is good (BUG-1
+    /// corollary B). Expired records are excluded (they are swept by
+    /// [`Self::cleanup_expired`] and no longer protect anything); claimed and
+    /// unclaimed records both protect, since an in-flight claim still needs
+    /// the room to exist.
+    pub async fn rooms_with_active_reconnections(&self) -> HashSet<RoomId> {
+        let window = self.reconnection_window;
+        self.disconnected_players
+            .read()
+            .await
+            .values()
+            .filter(|record| !record.disconnected.is_expired(window))
+            .map(|record| record.disconnected.room_id)
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -1012,6 +1033,41 @@ mod tests {
 
         // Should no longer have pending reconnection
         assert!(!manager.has_pending_reconnection(&player_id).await);
+    }
+
+    /// `rooms_with_active_reconnections` reports the rooms that room GC must
+    /// spare. A registered (unexpired) disconnection lists its room; an empty
+    /// manager lists nothing; completing the reconnection drops the room. Per-
+    /// record expiry is delegated to `DisconnectedPlayer::is_expired` (covered
+    /// by `reconnection_error_maps_each_variant_to_its_client_code` semantics).
+    #[tokio::test]
+    async fn rooms_with_active_reconnections_tracks_protected_rooms() {
+        let metrics = Arc::new(ServerMetrics::new());
+        let manager = ReconnectionManager::new(300, 100, metrics);
+
+        assert!(
+            manager.rooms_with_active_reconnections().await.is_empty(),
+            "a fresh manager protects no rooms"
+        );
+
+        let player_id = Uuid::new_v4();
+        let room_id = Uuid::new_v4();
+        manager
+            .register_disconnection(player_id, room_id, false, None)
+            .await;
+
+        let protected = manager.rooms_with_active_reconnections().await;
+        assert!(
+            protected.contains(&room_id),
+            "a live reconnection record must protect its room from GC"
+        );
+        assert_eq!(protected.len(), 1);
+
+        manager.complete_reconnection(&player_id).await;
+        assert!(
+            manager.rooms_with_active_reconnections().await.is_empty(),
+            "completing the reconnection releases the room"
+        );
     }
 
     #[tokio::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,7 +163,7 @@ impl Default for ServerConfig {
             inactive_room_timeout: Duration::from_secs(3600),
             max_message_size: 65536, // 64KB
             max_signal_bytes: 16384, // 16KB
-            max_connections_per_ip: 10,
+            max_connections_per_ip: 24,
             require_metrics_auth: true,
             metrics_auth_token: None,
             reconnection_window: Duration::from_secs(300), // 5 minutes

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -694,6 +694,36 @@ mod tests {
             .expect("registrations resume after slot release");
     }
 
+    /// GAP-3 regression: a 16-player session behind a single NAT must be
+    /// admissible at the DEFAULT per-IP cap. Before A3 the default was 10, so
+    /// the 11th same-IP client was refused. Builds a manager at the real
+    /// `default_max_connections_per_ip()` and registers 16 clients from one IP.
+    #[tokio::test]
+    async fn default_ip_cap_admits_a_sixteen_player_nat() {
+        let cap = crate::config::defaults::default_max_connections_per_ip();
+        assert!(
+            cap >= 16,
+            "default per-IP cap ({cap}) must admit a 16-player NAT session"
+        );
+
+        let manager = make_manager(cap);
+        let mut ids = Vec::new();
+        for i in 0..16u16 {
+            let (tx, _rx) = channel();
+            let addr: SocketAddr = format!("203.0.113.7:{}", 6000 + i).parse().unwrap();
+            let id = manager
+                .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
+                .await
+                .unwrap_or_else(|e| panic!("client {i} from one IP must be admitted: {e:?}"));
+            ids.push(id);
+        }
+        assert_eq!(
+            ids.len(),
+            16,
+            "all 16 same-IP clients admitted at default cap"
+        );
+    }
+
     #[tokio::test]
     async fn assign_client_to_room_updates_coordinator_membership() {
         let metrics = Arc::new(ServerMetrics::new());

--- a/src/server/game_data.rs
+++ b/src/server/game_data.rs
@@ -131,6 +131,13 @@ impl EnhancedGameServer {
         room_id: &RoomId,
         message: ServerMessage,
     ) {
+        // Count every GameData message accepted for relay. This is the sole
+        // increment site for the `game_data_messages` metric (both the JSON and
+        // binary handlers funnel through here); it was exported to Prometheus
+        // but never incremented before (MISC-11), so the counter read a
+        // permanent 0.
+        self.metrics.increment_game_data_messages();
+
         // Update last_seen with throttling (same mechanism as heartbeat)
         self.maybe_update_last_seen(player_id).await;
 

--- a/src/server/game_data.rs
+++ b/src/server/game_data.rs
@@ -73,8 +73,10 @@ impl EnhancedGameServer {
     ) {
         // Binary frames bypass the message router, so record liveness here
         // (mirrors `handle_client_message`): a client streaming binary game
-        // data must never be reaped as inactive.
+        // data must never be reaped as inactive, and its ROOM must not be GC'd
+        // as inactive either (throttled room + last_seen refresh, BUG-1).
         self.record_client_activity(player_id);
+        self.maybe_update_last_seen(player_id).await;
         if payload.len() > self.config.max_message_size {
             tracing::warn!(
                 %player_id,
@@ -138,8 +140,9 @@ impl EnhancedGameServer {
         // permanent 0.
         self.metrics.increment_game_data_messages();
 
-        // Update last_seen with throttling (same mechanism as heartbeat)
-        self.maybe_update_last_seen(player_id).await;
+        // (Room + last_seen liveness is refreshed once upstream per inbound
+        // message — by the router for text frames, by `handle_game_data_binary`
+        // for binary frames — so it is intentionally not repeated here.)
 
         if let Err(e) = self
             .message_coordinator

--- a/src/server/heartbeat.rs
+++ b/src/server/heartbeat.rs
@@ -37,6 +37,27 @@ impl EnhancedGameServer {
             if let Err(e) = self.database.update_player_last_seen(player_id).await {
                 tracing::warn!(%player_id, "Failed to update player last_seen: {}", e);
             }
+            // Keep the player's ROOM alive too. The activity reaper for a room
+            // with players keys off `last_activity`, which is otherwise written
+            // only at creation — so a room whose members are actively pinging or
+            // relaying would still be GC'd `inactive_room_timeout` after creation,
+            // mid-game (BUG-1). Both `handle_ping` and the game-data relay
+            // (`broadcast_game_data`) reach this path.
+            //
+            // `update_room_activity` takes the global `rooms` write lock, so this
+            // is deliberately gated behind the SAME per-player heartbeat throttle
+            // as the player update above (`should_update`, default 30 s cadence):
+            // the relay hot path (`broadcast_game_data`, potentially every frame)
+            // acquires the lock at most once per player per throttle window, not
+            // per message — a room needs only one refresh per `inactive_room_timeout`
+            // (default 1 h) to stay alive, so a 30 s cadence has enormous margin.
+            // If this ever shows up in profiling, promote `last_activity` to an
+            // atomic so it can be bumped under the shared read lock.
+            if let Some(room_id) = self.connection_manager.get_client_room(player_id) {
+                if let Err(e) = self.database.update_room_activity(&room_id).await {
+                    tracing::warn!(%player_id, %room_id, "Failed to update room activity: {}", e);
+                }
+            }
         } else {
             self.metrics.increment_heartbeat_skipped();
             tracing::trace!(%player_id, "Skipped last_seen update (throttled)");

--- a/src/server/heartbeat.rs
+++ b/src/server/heartbeat.rs
@@ -6,14 +6,13 @@ use super::EnhancedGameServer;
 impl EnhancedGameServer {
     /// Handle ping with coordination.
     ///
-    /// Updates the in-memory ping timestamp (always) and the `last_seen` timestamp
-    /// (throttled based on `heartbeat_throttle` configuration to reduce processing overhead).
+    /// Records the in-memory ping timestamp (always) for disconnect detection and
+    /// replies `Pong`. The throttled `last_seen` + room-activity refresh is done
+    /// once per inbound message by the router (`handle_client_message` →
+    /// `maybe_update_last_seen`), so `Ping` needs no separate refresh here.
     pub async fn handle_ping(&self, player_id: &PlayerId) {
         // Always record the ping in memory for disconnect detection
         self.connection_manager.record_ping(player_id);
-
-        // Only update last_seen if enough time has passed since last update (throttled)
-        self.maybe_update_last_seen(player_id).await;
 
         let _ = self
             .message_coordinator
@@ -39,20 +38,24 @@ impl EnhancedGameServer {
             }
             // Keep the player's ROOM alive too. The activity reaper for a room
             // with players keys off `last_activity`, which is otherwise written
-            // only at creation — so a room whose members are actively pinging or
-            // relaying would still be GC'd `inactive_room_timeout` after creation,
-            // mid-game (BUG-1). Both `handle_ping` and the game-data relay
-            // (`broadcast_game_data`) reach this path.
+            // only at creation — so a room whose members are actively pinging,
+            // relaying GameData, or exchanging WebRTC Signals would still be
+            // GC'd `inactive_room_timeout` after creation, mid-game (BUG-1).
+            // This method is the single throttled liveness-refresh, invoked once
+            // per inbound message by `handle_client_message` (text frames) and
+            // `handle_game_data_binary` (binary frames), so it covers every
+            // message type uniformly.
             //
             // `update_room_activity` takes the global `rooms` write lock, so this
-            // is deliberately gated behind the SAME per-player heartbeat throttle
-            // as the player update above (`should_update`, default 30 s cadence):
-            // the relay hot path (`broadcast_game_data`, potentially every frame)
-            // acquires the lock at most once per player per throttle window, not
-            // per message — a room needs only one refresh per `inactive_room_timeout`
-            // (default 1 h) to stay alive, so a 30 s cadence has enormous margin.
-            // If this ever shows up in profiling, promote `last_activity` to an
-            // atomic so it can be bumped under the shared read lock.
+            // is deliberately gated behind the per-player heartbeat throttle
+            // (`should_update`, default 30 s cadence): the relay hot path
+            // (potentially every frame) acquires the lock at most once per player
+            // per throttle window, not per message. A room needs only one refresh
+            // per `inactive_room_timeout` (default 1 h) to stay alive, and startup
+            // validation forces `heartbeat_throttle_secs < inactive_room_timeout`,
+            // so the throttled cadence can never starve the reaper. If this ever
+            // shows up in profiling, promote `last_activity` to an atomic so it can
+            // be bumped under the shared read lock.
             if let Some(room_id) = self.connection_manager.get_client_room(player_id) {
                 if let Err(e) = self.database.update_room_activity(&room_id).await {
                     tracing::warn!(%player_id, %room_id, "Failed to update room activity: {}", e);

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -1,4 +1,5 @@
 use crate::protocol::RoomId;
+use std::collections::HashSet;
 
 use super::{chrono_duration_from_std, EnhancedGameServer};
 
@@ -6,6 +7,16 @@ impl EnhancedGameServer {
     /// Log that a room has been closed during cleanup.
     pub(crate) fn publish_room_closed(&self, room_id: RoomId, reason: &str) {
         tracing::debug!(%room_id, %reason, "Room closed");
+    }
+
+    /// Rooms that room GC must not delete this tick because they still hold a
+    /// valid reconnection record. Empty when reconnection is disabled (no
+    /// manager), so the cleanup paths behave exactly as before in that case.
+    pub(crate) async fn rooms_protected_by_reconnection(&self) -> HashSet<RoomId> {
+        match &self.reconnection_manager {
+            Some(manager) => manager.rooms_with_active_reconnections().await,
+            None => HashSet::new(),
+        }
     }
 
     /// Drop the coordinator's in-memory ready-state entries for rooms that no
@@ -138,8 +149,19 @@ impl EnhancedGameServer {
                 self.unregister_client(&player_id).await;
             }
 
+            // Rooms with an unexpired reconnection record must survive both
+            // sweeps below: they are empty (their members disconnected) but a
+            // still-valid token points at them, and reaping them would fail the
+            // reconnect with `RoomNotFound` (BUG-1 corollary B). Computed once
+            // per tick, before either sweep.
+            let protected = self.rooms_protected_by_reconnection().await;
+
             // Cleanup empty rooms with idempotency
-            match self.database.cleanup_empty_rooms(empty_timeout).await {
+            match self
+                .database
+                .cleanup_empty_rooms(empty_timeout, &protected)
+                .await
+            {
                 Ok(deleted_room_ids) => {
                     let count = deleted_room_ids.len();
                     if count > 0 {
@@ -209,7 +231,7 @@ impl EnhancedGameServer {
 
             match self
                 .database
-                .cleanup_expired_rooms(empty_timeout, inactive_timeout)
+                .cleanup_expired_rooms(empty_timeout, inactive_timeout, &protected)
                 .await
             {
                 Ok(outcome) if !outcome.is_empty() => {

--- a/src/server/message_router.rs
+++ b/src/server/message_router.rs
@@ -13,6 +13,14 @@ impl EnhancedGameServer {
         // This matches the socket-level idle timeout, which already counts
         // any inbound frame as activity.
         self.record_client_activity(player_id);
+        // ...and every inbound message refreshes the sender's ROOM clock the
+        // same way (throttled), so a room stays alive as long as any member is
+        // doing ANYTHING — pinging, relaying GameData, OR exchanging WebRTC
+        // `Signal`s (a long handshake with no pings must not let GC reap an
+        // occupied room, BUG-1). This is the single room-liveness refresh site;
+        // it subsumes the former per-handler calls in `handle_ping` /
+        // `broadcast_game_data`. No-ops for a roomless sender (pre-join).
+        self.maybe_update_last_seen(player_id).await;
         match message {
             ClientMessage::Authenticate { app_id, .. } => {
                 tracing::warn!(

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -522,10 +522,11 @@ async fn test_concurrent_room_cleanup_and_activity() {
     let cleanup_handle = tokio::spawn(async move {
         barrier_clone.wait().await;
 
+        let protected = std::collections::HashSet::new();
         for _ in 0..10 {
             let _ = server_clone
                 .database()
-                .cleanup_empty_rooms(ChronoDuration::zero(), &std::collections::HashSet::new())
+                .cleanup_empty_rooms(ChronoDuration::zero(), &protected)
                 .await;
             tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
         }
@@ -614,9 +615,10 @@ async fn test_concurrent_room_cleanup_across_instances() {
         let barrier_clone = barrier.clone();
         tokio::spawn(async move {
             barrier_clone.wait().await;
+            let protected = std::collections::HashSet::new();
             server
                 .database()
-                .cleanup_empty_rooms(ChronoDuration::zero(), &std::collections::HashSet::new())
+                .cleanup_empty_rooms(ChronoDuration::zero(), &protected)
                 .await
                 .expect("cleanup should succeed")
                 .len()

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -525,7 +525,7 @@ async fn test_concurrent_room_cleanup_and_activity() {
         for _ in 0..10 {
             let _ = server_clone
                 .database()
-                .cleanup_empty_rooms(ChronoDuration::zero())
+                .cleanup_empty_rooms(ChronoDuration::zero(), &std::collections::HashSet::new())
                 .await;
             tokio::time::sleep(tokio::time::Duration::from_millis(5)).await;
         }
@@ -616,7 +616,7 @@ async fn test_concurrent_room_cleanup_across_instances() {
             barrier_clone.wait().await;
             server
                 .database()
-                .cleanup_empty_rooms(ChronoDuration::zero())
+                .cleanup_empty_rooms(ChronoDuration::zero(), &std::collections::HashSet::new())
                 .await
                 .expect("cleanup should succeed")
                 .len()

--- a/tests/config_and_endpoints_tests.rs
+++ b/tests/config_and_endpoints_tests.rs
@@ -288,7 +288,7 @@ const CONFIG_REFERENCE_ROWS: &[ConfigReferenceRow] = &[
     ConfigReferenceRow {
         env: "SIGNAL_FISH__SECURITY__MAX_CONNECTIONS_PER_IP",
         path: "security.max_connections_per_ip",
-        default: Some("10"),
+        default: Some("24"),
     },
     ConfigReferenceRow {
         env: "SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED",

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -393,9 +393,13 @@ async fn test_cleanup_rooms_atomic_with_creation() {
         let barrier = Arc::clone(&barrier);
         handles.push(tokio::spawn(async move {
             barrier.wait().await;
-            db.cleanup_expired_rooms(chrono::Duration::zero(), chrono::Duration::hours(1))
-                .await
-                .expect("cleanup should not error");
+            db.cleanup_expired_rooms(
+                chrono::Duration::zero(),
+                chrono::Duration::hours(1),
+                &std::collections::HashSet::new(),
+            )
+            .await
+            .expect("cleanup should not error");
         }));
     }
 

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -393,10 +393,11 @@ async fn test_cleanup_rooms_atomic_with_creation() {
         let barrier = Arc::clone(&barrier);
         handles.push(tokio::spawn(async move {
             barrier.wait().await;
+            let protected = std::collections::HashSet::new();
             db.cleanup_expired_rooms(
                 chrono::Duration::zero(),
                 chrono::Duration::hours(1),
-                &std::collections::HashSet::new(),
+                &protected,
             )
             .await
             .expect("cleanup should not error");


### PR DESCRIPTION
## P10.A — P0 correctness fixes + D1 formal proof (BUG-1, BUG-2, GAP-3, DOC-9, MISC-11)

Closes the "do-first" tranche of the P10 bulletproofing campaign — the two verified production bugs plus the cheap correctness/hygiene items. Every fix is red-green and general (kills the whole class, not a point patch).

### BUG-1 — rooms deleted a fixed interval after **creation**, mid-game
`Room.last_activity` was written only at creation and both refreshers had zero call sites, so any session older than `inactive_room_timeout` (default 1 h) was reaped with players still in it, and a long-lived room that emptied was deleted immediately — collapsing the 300 s reconnection window (reconnects failed `RoomNotFound` with still-valid tokens).
- `last_activity` refreshed on join, on a real leave/disconnect, and **once per inbound message on the universal liveness path** — the router (`handle_client_message`) for text frames and `handle_game_data_binary` for binary frames — so a room stays alive on ANY member activity: ping, relayed `GameData`, or WebRTC `Signal`.
- Empty-room clock keys off `last_activity` (not `created_at`) so both cleanup paths agree.
- Reconnection-aware GC: `cleanup_empty_rooms`/`cleanup_expired_rooms` take a `protected: &HashSet<RoomId>` filled from the new `ReconnectionManager::rooms_with_active_reconnections()`.
- Cross-field guard: startup rejects `heartbeat_throttle_secs >= inactive_room_timeout` so the throttled refresh can never lag the reaper by misconfiguration.
- **D1 — `formal/tla/RoomLifecycleGC.tla`**: `ActiveRoomNeverReaped` + `ReconnectWindowRespected`, both proven non-vacuous (a `StaleActivityBug` seeded constant reproduces the pre-fix behavior and violates each), 2 checked configs green in the auto-globbed TLC suite.

### BUG-2 — a legal config evicts a healthy sender (timeout inversion)
`slow_consumer_timeout_ms ≥ ping_timeout·1000` let a sender parked on the broadcast fan-out outlast the activity-reaper deadline and get evicted `4003` while healthy. Rejected at startup (cross-field validation).

### GAP-3 — 16-player NAT refused at defaults
`default_max_connections_per_ip` 10 → 24. Per-room `max_players` (8) left as a product knob, documented.

### DOC-9 — protocol doc drift
`missed_events`/`replay` ring is real (was documented "always empty"); `max_protocol_version` default 3 → 4.

### MISC-11 — dead metric + fuzz artifacts
Wired the permanently-0 `game_data_messages` metric at the relay funnel. Three `fuzz_reconnect_tokens` reproducers replayed clean against current code (stale reproducers of the #137 fix) — removed.

### Validation
`cargo fmt` · `clippy --all-targets --all-features` (zero warnings) · nextest (1403 tests + all 3 serialized process-spawning binaries green) · markdownlint · doc-consistency · full TLA+ suite (10 configs). Adversarial-review subagent: no correctness defects.

### Review round
Copilot + Cursor Bugbot findings addressed red-green: room-liveness consolidated onto the universal inbound path (Signal now refreshes), the `heartbeat_throttle < inactive_room_timeout` guard, the no-op-removal `last_activity` guard, and test-local bindings. All CI green; both reviewers clean on the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)