### PR TITLE
test(server): P10.B/C bulletproofing — verification harness, falsification experiments + client-contract docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -744,6 +744,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The activity reaper (`ConnectionManager::collect_expired_clients`) and the heartbeat-update
+  throttle (`ConnectionManager::should_update_last_seen`) now read the Tokio runtime clock
+  (`tokio::time::Instant`) instead of `std::time::Instant`. Production behavior is unchanged —
+  outside a paused runtime `tokio::time::Instant` wraps the same monotonic std clock — but tests
+  can now drive these windows deterministically with `tokio::time::advance()` under
+  `#[tokio::test(start_paused = true)]` at zero wall-clock cost. The `heartbeat.rs` reaper test
+  that previously relied on a real 25 ms sleep is now paused-clock and instant.
 - Raised `security.max_connections_per_ip` default `10` → `24`. Ten silently refused the 11th
   concurrent connection from one IP, so a 16-player session behind a single NAT (LAN party,
   office, venue) could not connect. `24` covers 16 players plus spectators and reconnect churn.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,8 +111,11 @@ tokio-test = "0.4"
 # Test-only tokio feature additions (feature-unified with the main dependency
 # for test builds only): `process` drives the spawned server binary in
 # tests/v3_multiprocess_e2e.rs; `test-util` enables the paused-clock runtime
-# (`#[tokio::test(start_paused = true)]`) used by the deterministic
-# slow-consumer timeout tests in src/coordination/mod.rs.
+# (`#[tokio::test(start_paused = true)]`) used by the deterministic delivery
+# timeout tests in src/coordination/mod.rs, the activity-reaper /
+# heartbeat-throttle window tests in src/server/{connection_manager,heartbeat}.rs,
+# and the message-batcher flush-timer tests in src/websocket/batching.rs (all
+# read `tokio::time::Instant`, so `tokio::time::advance(..)` drives them).
 tokio = { version = "1.52", features = ["process", "test-util"] }
 tempfile = "3.27"
 tokio-tungstenite = "0.29"

--- a/docs/guides/building-a-client.md
+++ b/docs/guides/building-a-client.md
@@ -182,6 +182,20 @@ Worked v3 sessions: [mesh + WebRTC](../scenarios/v3-mesh-webrtc.md),
 - **Keep the connection alive.** Send `Ping` on an interval or you will be
   dropped with `CONNECTION_IDLE_TIMEOUT`.
 - **Authenticate first.** Any other message before `Authenticate` is an error.
+- **Rejoining by code re-creates a vanished room — carry your original
+  `max_players`.** If a room no longer exists (the server restarted, or every
+  member left and its reconnection window elapsed) and your party rejoins by room
+  code, the _first_ rejoiner **re-creates** the room. Omit `max_players` and it
+  falls back to the server's per-room default (`8`), so a larger party strands
+  its overflow with `ROOM_FULL`. Always re-supply the original `max_players` on a
+  rejoin-by-code so the whole party fits.
+- **`Reconnect` is windowed and single-winner.** The reconnection `auth_token` is
+  only claimable within the reconnection window (default 300 s); after it,
+  `Reconnect` fails with `RECONNECTION_EXPIRED` / `RECONNECTION_TOKEN_INVALID`,
+  so fall back to a fresh `JoinRoom`. Exactly one of two concurrent claims on the
+  same token wins. If a reconnect races the old connection's teardown you may get
+  `PLAYER_ALREADY_CONNECTED` — the token is **not** consumed, so wait briefly and
+  retry. See [Reconnection](../concepts/reconnection.md).
 
 ## Testing checklist
 

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -1,6 +1,15 @@
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::time::Instant;
+
+// `tokio::time::Instant` (not `std::time::Instant`) so the activity reaper
+// (`collect_expired_clients`) and the heartbeat-update throttle
+// (`should_update_last_seen`) read the runtime clock. In production this wraps
+// the same monotonic std clock (identical behavior); under
+// `#[tokio::test(start_paused = true)]` it lets tests drive these windows with
+// `tokio::time::advance(..)` deterministically, at zero wall-clock cost. Every
+// `Instant::now()` here runs inside the tokio runtime (all callers are async /
+// `#[tokio::test]`), so the runtime clock is always available.
+use tokio::time::Instant;
 
 use dashmap::DashMap;
 use tokio::sync::mpsc;
@@ -721,6 +730,68 @@ mod tests {
             ids.len(),
             16,
             "all 16 same-IP clients admitted at default cap"
+        );
+    }
+
+    /// The heartbeat-update throttle (`should_update_last_seen`) is deterministic
+    /// under the paused-clock runtime: the first observation always updates, then
+    /// updates are suppressed until the threshold has *elapsed* on the runtime
+    /// clock. Driven purely by `tokio::time::advance(..)` — no wall-clock sleep,
+    /// so nothing can flake under load (this is the B4 payoff: the reaper /
+    /// throttle windows read `tokio::time::Instant`).
+    #[tokio::test(start_paused = true)]
+    async fn should_update_last_seen_throttles_until_threshold_elapses() {
+        let manager = make_manager(4);
+        let addr: SocketAddr = "127.0.0.1:7100".parse().unwrap();
+        let (tx, _rx) = channel();
+        let player_id = manager
+            .register_client(tx, ConnectionCloseSignal::detached(), addr, Uuid::new_v4())
+            .await
+            .expect("registration succeeds");
+
+        let threshold = std::time::Duration::from_secs(30);
+
+        // First observation always updates (no prior timestamp recorded).
+        assert!(
+            manager.should_update_last_seen(&player_id, threshold),
+            "first observation must update"
+        );
+        // Immediately after, the throttle suppresses another update.
+        assert!(
+            !manager.should_update_last_seen(&player_id, threshold),
+            "an update within the throttle window must be suppressed"
+        );
+
+        // Just below the threshold: still suppressed (the boundary is `>=`).
+        tokio::time::advance(threshold - std::time::Duration::from_millis(1)).await;
+        assert!(
+            !manager.should_update_last_seen(&player_id, threshold),
+            "an update just under the threshold must stay suppressed"
+        );
+
+        // Crossing the threshold releases exactly one update, then re-throttles
+        // from the new baseline.
+        tokio::time::advance(std::time::Duration::from_millis(1)).await;
+        assert!(
+            manager.should_update_last_seen(&player_id, threshold),
+            "an update at/after the threshold must fire"
+        );
+        assert!(
+            !manager.should_update_last_seen(&player_id, threshold),
+            "the update after the release is throttled from the new baseline"
+        );
+    }
+
+    /// A missing player is treated as "allow update" (the DB layer rejects it).
+    /// Clock-independent (the not-found branch never reads the clock), so this
+    /// pins the throttle's else-branch without needing a paused runtime.
+    #[tokio::test]
+    async fn should_update_last_seen_allows_unknown_player() {
+        let manager = make_manager(4);
+        let unknown = Uuid::new_v4();
+        assert!(
+            manager.should_update_last_seen(&unknown, std::time::Duration::from_secs(30)),
+            "unknown player defaults to allowing the update"
         );
     }
 

--- a/src/server/heartbeat.rs
+++ b/src/server/heartbeat.rs
@@ -81,7 +81,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration as StdDuration;
     use tokio::sync::mpsc;
-    use tokio::time::{sleep, timeout, Duration};
+    use tokio::time::{advance, timeout, Duration};
 
     async fn create_test_server() -> Arc<EnhancedGameServer> {
         EnhancedGameServer::new(
@@ -104,7 +104,10 @@ mod tests {
         .expect("failed to construct test server")
     }
 
-    #[tokio::test]
+    // Deterministic under the paused-clock runtime: the activity reaper reads
+    // `tokio::time::Instant`, so `advance(..)` drives `last_ping` staleness with
+    // no wall-clock dependence (no `sleep`, so nothing to overshoot under load).
+    #[tokio::test(start_paused = true)]
     #[cfg_attr(miri, ignore)]
     async fn handle_ping_resets_timeout_and_replies() {
         let server = create_test_server().await;
@@ -122,7 +125,7 @@ mod tests {
             .await
             .expect("client registration");
 
-        sleep(Duration::from_millis(25)).await;
+        advance(Duration::from_millis(25)).await;
         let expired_before = server
             .connection_manager
             .collect_expired_clients(StdDuration::from_millis(5));

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -157,44 +157,40 @@ mod tests {
         assert!(batcher.is_empty());
     }
 
-    #[test]
-    fn test_message_batcher_flush_on_time() {
-        use std::thread;
-        use std::time::Duration;
-
-        // The batcher's flush timer starts at `new()` and `should_flush()` reads
-        // the wall clock, so a naive "queue then immediately assert !should_flush"
-        // flakes under load: the thread can be descheduled past the interval
-        // between construction and the check. Split the two assertions into
-        // robust legs (zero-flakiness policy, .llm/context-testing.md):
-
-        // "Not enough time" leg — a LARGE (10s) interval so the immediate check
-        // cannot flip even under extreme scheduling delay.
-        let mut fresh = MessageBatcher::new(100, 10_000);
-        fresh.queue(Arc::new(ServerMessage::PlayerLeft {
+    // Deterministic under the paused-clock runtime: the flush timer reads
+    // `tokio::time::Instant`, so `advance(..)` drives the interval exactly — no
+    // `thread::sleep`, so nothing can overshoot or be descheduled. This removes
+    // the FLAKE-002 wall-clock dependence at the root rather than band-aiding it
+    // with large intervals; one batcher exercises both the "not yet" and
+    // "elapsed" edges of the `>=` boundary.
+    #[tokio::test(start_paused = true)]
+    async fn test_message_batcher_flush_on_time() {
+        let mut batcher = MessageBatcher::new(100, 50); // size 100 (unreachable), 50ms interval
+        batcher.queue(Arc::new(ServerMessage::PlayerLeft {
             player_id: uuid::Uuid::new_v4(),
         }));
-        assert_eq!(fresh.len(), 1);
+        assert_eq!(batcher.len(), 1);
         assert!(
-            !fresh.should_flush(),
-            "a fresh batch under a 10s interval must not flush on time"
+            !batcher.should_flush(),
+            "a fresh batch must not flush before its interval elapses"
         );
 
-        // "Enough time" leg — a TINY (5ms) interval and a sleep an order of
-        // magnitude larger, so the time-based flush is deterministic even if the
-        // sleep overruns (sleep only ever overshoots, never undershoots).
-        let mut timed = MessageBatcher::new(100, 5);
-        timed.queue(Arc::new(ServerMessage::PlayerLeft {
-            player_id: uuid::Uuid::new_v4(),
-        }));
-        thread::sleep(Duration::from_millis(50)); // >> 5ms interval
+        // Just under the interval: still not flushing (boundary is `>=`).
+        tokio::time::advance(Duration::from_millis(49)).await;
         assert!(
-            timed.should_flush(),
+            !batcher.should_flush(),
+            "a batch just under its interval must not flush yet"
+        );
+
+        // Crossing the interval: flushes on time.
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(
+            batcher.should_flush(),
             "the batch must flush once its interval has elapsed"
         );
-        let messages = timed.flush();
+        let messages = batcher.flush();
         assert_eq!(messages.len(), 1);
-        assert_eq!(timed.len(), 0);
+        assert_eq!(batcher.len(), 0);
     }
 
     #[test]
@@ -238,42 +234,37 @@ mod tests {
         assert_eq!(batcher.len(), 0);
     }
 
-    #[test]
-    fn test_message_batcher_partial_batch() {
-        use std::thread;
-        use std::time::Duration;
-
-        // Same split-leg shape as `test_message_batcher_flush_on_time` to keep the
-        // time-based assertions deterministic under load (zero-flakiness policy).
-
-        // "Not full, not enough time" leg — a LARGE (10s) interval makes the
-        // immediate check robust to any scheduling delay.
-        let mut fresh = MessageBatcher::new(10, 10_000);
+    // Partial-batch (below `batch_size`) time flush, deterministic under the
+    // paused clock — same `>=`-boundary pattern as
+    // `test_message_batcher_flush_on_time` (fresh → just-under → crossing).
+    #[tokio::test(start_paused = true)]
+    async fn test_message_batcher_partial_batch() {
+        let mut batcher = MessageBatcher::new(10, 50); // 3 < size 10, 50ms interval
         for _ in 0..3 {
-            fresh.queue(Arc::new(ServerMessage::PlayerLeft {
+            batcher.queue(Arc::new(ServerMessage::PlayerLeft {
                 player_id: uuid::Uuid::new_v4(),
             }));
         }
-        assert_eq!(fresh.len(), 3);
+        assert_eq!(batcher.len(), 3);
         assert!(
-            !fresh.should_flush(),
-            "a partial batch under a 10s interval must not flush yet"
+            !batcher.should_flush(),
+            "a partial batch must not flush before its interval elapses"
         );
 
-        // "Time elapsed" leg — a TINY (5ms) interval with a generous sleep, so the
-        // partial-batch time flush is deterministic.
-        let mut timed = MessageBatcher::new(10, 5);
-        for _ in 0..3 {
-            timed.queue(Arc::new(ServerMessage::PlayerLeft {
-                player_id: uuid::Uuid::new_v4(),
-            }));
-        }
-        thread::sleep(Duration::from_millis(50)); // >> 5ms interval
+        // Just under the interval: still not flushing (boundary is `>=`).
+        tokio::time::advance(Duration::from_millis(49)).await;
         assert!(
-            timed.should_flush(),
+            !batcher.should_flush(),
+            "a partial batch just under its interval must not flush yet"
+        );
+
+        // Crossing the interval: flushes on time.
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert!(
+            batcher.should_flush(),
             "a partial batch must flush once its interval has elapsed"
         );
-        let messages = timed.flush();
+        let messages = batcher.flush();
         assert_eq!(messages.len(), 3);
     }
 }

--- a/tests/multiprocess_delivery_e2e.rs
+++ b/tests/multiprocess_delivery_e2e.rs
@@ -19,11 +19,12 @@
 //!
 //! # Infrastructure
 //!
-//! The server-spawning harness is adapted from `tests/v3_multiprocess_e2e.rs`
-//! (its module doc explains the temp-config / port-reservation / readiness /
-//! kill-on-drop design; those helpers are file-private there, hence the
-//! copy), extended with per-test `websocket.send_queue_capacity` /
-//! `websocket.slow_consumer_timeout_ms` knobs. Because the server runs in a
+//! The server-spawning harness is the shared
+//! `websocket_test_helpers::server_process` (its module doc explains the
+//! temp-config / port-reservation / readiness / kill-on-drop design); this
+//! suite drives it with a config overlay carrying per-test
+//! `websocket.send_queue_capacity` / `websocket.slow_consumer_timeout_ms`
+//! knobs. Because the server runs in a
 //! separate process, delivery metrics are asserted by scraping its
 //! `/metrics/prom` endpoint (`websocket_test_helpers::prometheus_scrape`;
 //! the temp config disables metrics auth) — the same counters the in-process
@@ -74,6 +75,9 @@ use websocket_test_helpers::delivery_ledger::{extract, LedgerPayload};
 use websocket_test_helpers::prometheus_scrape::{
     assert_scraped_message_conservation, scrape_delivery_counters,
 };
+use websocket_test_helpers::server_process::{
+    spawn_server, spawn_server_on_fixed_port, CONNECT_TIMEOUT,
+};
 
 type WsStream =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
@@ -85,17 +89,13 @@ const GAME_NAME: &str = "mp-delivery";
 // Saturation-tolerant ceilings (zero-flakiness policy, .llm/context-testing.md):
 // every wait below polls real state and returns the instant it holds; these
 // only bite when something is genuinely broken, so their size never slows a
-// passing run.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+// passing run. (The server-spawn / connect / health ceilings live with the
+// harness in `websocket_test_helpers::server_process`.)
 const EVENT_DEADLINE: Duration = Duration::from_secs(30);
-const HEALTH_DEADLINE: Duration = Duration::from_secs(60);
-const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// Whole-phase ceiling for flood + drain sections.
 const PHASE_DEADLINE: Duration = Duration::from_secs(90);
 /// Ceiling for a client process to drain its JSONL stream and exit.
 const CLIENT_EXIT_DEADLINE: Duration = Duration::from_secs(60);
-const SPAWN_ATTEMPTS: usize = 5;
-const FIXED_PORT_SPAWN_ATTEMPTS: usize = 6;
 
 /// Native-client exit code for transport-level failure (socket died); see
 /// `clients/native/src/client.rs` (`EXIT_CONNECTION_ERROR`).
@@ -108,224 +108,20 @@ struct DeliveryKnobs {
     slow_consumer_timeout_ms: u64,
 }
 
-// ---------------------------------------------------------------------------
-// Server process harness (adapted from tests/v3_multiprocess_e2e.rs).
-// ---------------------------------------------------------------------------
-
-/// Guard around the spawned server binary. Dropping it kills the child
-/// (`start_kill` plus `kill_on_drop(true)` at spawn), so a panicking test
-/// never leaks an orphan server process into CI.
-struct ServerProcess {
-    child: Option<tokio::process::Child>,
-    port: u16,
-    stdout_path: PathBuf,
-    stderr_path: PathBuf,
-    /// Owns the temp config, captured output, and child working directory.
-    _workdir: tempfile::TempDir,
-}
-
-impl ServerProcess {
-    /// SIGKILL the child and reap it.
-    async fn kill_and_wait(&mut self) {
-        let mut child = self
-            .child
-            .take()
-            .expect("server process was already killed");
-        child.kill().await.expect("kill the server process");
-    }
-
-    /// The child's captured stdout/stderr, for spawn-failure diagnostics.
-    fn captured_output(&self) -> String {
-        let read = |label: &str, path: &PathBuf| {
-            let content = std::fs::read_to_string(path)
-                .unwrap_or_else(|error| format!("<failed to read {label}: {error}>"));
-            format!("--- server {label} ---\n{content}")
-        };
-        format!(
-            "{}\n{}",
-            read("stdout", &self.stdout_path),
-            read("stderr", &self.stderr_path)
-        )
-    }
-}
-
-impl Drop for ServerProcess {
-    fn drop(&mut self) {
-        if let Some(child) = self.child.as_mut() {
-            if let Err(error) = child.start_kill() {
-                eprintln!("failed to kill server process on drop: {error}");
-            }
-        }
-    }
-}
-
-/// Reserve a currently-free port by binding `0.0.0.0:0` (the address the
-/// server binds), reading the assignment, and releasing the listener.
-fn reserve_port() -> u16 {
-    let probe = std::net::TcpListener::bind(("0.0.0.0", 0)).expect("bind port probe");
-    let port = probe.local_addr().expect("port probe local_addr").port();
-    drop(probe);
-    port
-}
-
-/// Spawn the server binary on a fresh free port, retrying with a NEW port on
-/// failure (absorbs the reserve-release-spawn race).
-async fn spawn_server(knobs: DeliveryKnobs) -> ServerProcess {
-    let mut failures = Vec::new();
-    for attempt in 1..=SPAWN_ATTEMPTS {
-        let port = reserve_port();
-        match try_spawn_server(port, knobs).await {
-            Ok(server) => return server,
-            Err(failure) => failures.push(format!("attempt {attempt} (port {port}): {failure}")),
-        }
-    }
-    panic!(
-        "server binary failed to become healthy after {SPAWN_ATTEMPTS} attempts:\n{}",
-        failures.join("\n")
-    );
-}
-
-/// Spawn the server binary on a FIXED port (restart-on-same-port semantics)
-/// with exponential backoff — after a SIGKILL the kernel can briefly hold the
-/// port (see `spawn_server_on_fixed_port` in tests/v3_multiprocess_e2e.rs).
-async fn spawn_server_on_fixed_port(port: u16, knobs: DeliveryKnobs) -> ServerProcess {
-    let mut failures = Vec::new();
-    let mut backoff = Duration::from_millis(100);
-    for attempt in 1..=FIXED_PORT_SPAWN_ATTEMPTS {
-        match try_spawn_server(port, knobs).await {
-            Ok(server) => return server,
-            Err(failure) => failures.push(format!("attempt {attempt}: {failure}")),
-        }
-        if attempt < FIXED_PORT_SPAWN_ATTEMPTS {
-            tokio::time::sleep(backoff).await;
-            backoff = (backoff * 2).min(Duration::from_millis(1600));
-        }
-    }
-    panic!(
-        "server binary failed to restart on port {port} after {FIXED_PORT_SPAWN_ATTEMPTS} \
-         attempts:\n{}",
-        failures.join("\n")
-    );
-}
-
-/// One spawn attempt: write the temp config (with this suite's delivery
-/// knobs and metrics auth disabled — the tests scrape `/metrics/prom`),
-/// launch the child with a scrubbed environment, and wait for `/v2/health`.
-async fn try_spawn_server(port: u16, knobs: DeliveryKnobs) -> Result<ServerProcess, String> {
-    let workdir = tempfile::tempdir().expect("create temp workdir");
-    let config_path = workdir.path().join("server-config.json");
-    let config = json!({
-        "port": port,
-        "server": {
-            "enable_reconnection": true,
-            "reconnection_window": 300
-        },
-        "security": {
-            "require_websocket_auth": false,
-            "require_metrics_auth": false,
-            "cors_origins": "*"
-        },
-        "protocol": {
-            "sdk_compatibility": { "enforce": false }
-        },
+/// This suite's config overlay, deep-merged over the shared harness's base
+/// config (`websocket_test_helpers::server_process`): the relay default
+/// topology plus this test's websocket delivery knobs. Metrics auth stays
+/// disabled by the base config, so the tests can scrape `/metrics/prom`.
+fn config_overlay(knobs: DeliveryKnobs) -> Value {
+    json!({
         "session": {
             "default_topology": "relay"
         },
         "websocket": {
             "send_queue_capacity": knobs.send_queue_capacity,
             "slow_consumer_timeout_ms": knobs.slow_consumer_timeout_ms
-        },
-        "logging": {
-            "enable_file_logging": false
         }
-    });
-    std::fs::write(
-        &config_path,
-        serde_json::to_vec_pretty(&config).expect("serialize server config"),
-    )
-    .expect("write server config");
-
-    let stdout_path = workdir.path().join("server-stdout.log");
-    let stderr_path = workdir.path().join("server-stderr.log");
-    let stdout_file = std::fs::File::create(&stdout_path).expect("create stdout capture");
-    let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr capture");
-
-    let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_signal-fish-server"));
-    command
-        .current_dir(workdir.path())
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::from(stdout_file))
-        .stderr(std::process::Stdio::from(stderr_file))
-        .kill_on_drop(true);
-    // Scrub every inherited SIGNAL_FISH* variable: ambient config JSON, config
-    // paths, or SIGNAL_FISH__* field overrides would silently override the
-    // temp config (env overrides are applied last by the loader).
-    for (key, _) in std::env::vars_os() {
-        if key
-            .to_str()
-            .is_some_and(|key| key.starts_with("SIGNAL_FISH"))
-        {
-            command.env_remove(&key);
-        }
-    }
-    command.env("SIGNAL_FISH_CONFIG_PATH", &config_path);
-    command.env("SIGNAL_FISH__PORT", port.to_string());
-
-    let child = command.spawn().expect("spawn the server binary");
-    let mut server = ServerProcess {
-        child: Some(child),
-        port,
-        stdout_path,
-        stderr_path,
-        _workdir: workdir,
-    };
-
-    match wait_until_healthy(&mut server).await {
-        Ok(()) => Ok(server),
-        Err(reason) => Err(format!(
-            "{reason}; captured child output:\n{}",
-            server.captured_output()
-        )),
-    }
-}
-
-/// Poll `/v2/health` until it answers 200 (or the deadline passes / the child
-/// exits early).
-async fn wait_until_healthy(server: &mut ServerProcess) -> Result<(), String> {
-    let url = format!("http://127.0.0.1:{}/v2/health", server.port);
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-        .expect("build health-poll client");
-    let start = std::time::Instant::now();
-    let deadline = start + HEALTH_DEADLINE;
-
-    loop {
-        let child = server
-            .child
-            .as_mut()
-            .expect("health poll requires a live child");
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                return Err(format!("server process exited early with {status}"));
-            }
-            Ok(None) => {}
-            Err(error) => return Err(format!("failed to poll server process: {error}")),
-        }
-
-        match client.get(&url).send().await {
-            Ok(response) if response.status().is_success() => return Ok(()),
-            // Not up yet (connection refused / non-200): keep polling.
-            Ok(_) | Err(_) => {}
-        }
-
-        if std::time::Instant::now() >= deadline {
-            return Err(format!(
-                "health endpoint {url} never answered 200 within {HEALTH_DEADLINE:?}"
-            ));
-        }
-        tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
-    }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -830,7 +626,7 @@ async fn sigstop_client_process_is_evicted_and_room_flows() {
         send_queue_capacity: 64,
         slow_consumer_timeout_ms: 1_000,
     };
-    let server = spawn_server(knobs).await;
+    let server = spawn_server(config_overlay(knobs)).await;
     let port = server.port;
     let room_code = "FRZ001";
     let client_workdir = tempfile::tempdir().expect("create client workdir");
@@ -985,7 +781,7 @@ async fn sigkill_client_mid_burst_conserves() {
         send_queue_capacity: 256,
         slow_consumer_timeout_ms: 3_000,
     };
-    let server = spawn_server(knobs).await;
+    let server = spawn_server(config_overlay(knobs)).await;
     let port = server.port;
     let room_code = "KIL001";
     let client_workdir = tempfile::tempdir().expect("create client workdir");
@@ -1081,7 +877,7 @@ async fn server_sigkill_mid_relay_bounds_loss() {
         send_queue_capacity: 1_024,
         slow_consumer_timeout_ms: 5_000,
     };
-    let mut server = spawn_server(knobs).await;
+    let mut server = spawn_server(config_overlay(knobs)).await;
     let port = server.port;
     let room_code = "SRV001";
 
@@ -1201,7 +997,7 @@ async fn server_sigkill_mid_relay_bounds_loss() {
     drop(server);
 
     // A NEW process on the SAME port serves a completely fresh session.
-    let restarted = spawn_server_on_fixed_port(port, knobs).await;
+    let restarted = spawn_server_on_fixed_port(port, config_overlay(knobs)).await;
     let fresh_room = "SRV002";
     let (mut fresh_sender_sink, mut fresh_sender_rx) = connect_raw(port).await;
     let (mut fresh_receiver_sink, mut fresh_receiver_rx) = connect_raw(port).await;

--- a/tests/reconnect_window_races_e2e.rs
+++ b/tests/reconnect_window_races_e2e.rs
@@ -1,0 +1,566 @@
+//! P10.C **H6** — reconnect window / claim edge races (falsification experiment).
+//!
+//! Falsifies two DETERMINISTIC edges of the reconnection state machine through
+//! the real WebSocket stack. The third edge listed for H6 (reconnect-during-
+//! teardown) is an inherently timing-narrow race and is deliberately NOT
+//! attempted here — see "Deferred" below.
+//!
+//! # Pre-registered prediction (PLAN.md, P10.C H6)
+//!
+//! > Boundary (inside/outside window, independent of cleanup tick — prove with
+//! > cleanup interval 3600s) and duplicate-claim (exactly one winner) pass;
+//! > reconnect-during-teardown requires client retry (`PlayerAlreadyConnected`;
+//! > token NOT consumed) → F3 SDK rule.
+//!
+//! Prediction for the two facets below: **both PASS.**
+//!
+//! # Facet 1 — window boundary, independent of the cleanup tick
+//!
+//! The reconnection window is enforced by the *reconnect handler itself*
+//! (`ReconnectionManager::claim_reconnection`, which checks the token's embedded
+//! expiry and `DisconnectedPlayer::is_expired`), NOT by the background cleanup
+//! task deleting the record. To prove that, every server here runs the REAL
+//! `cleanup_task` but with `room_cleanup_interval` set to 3600s: `tokio`'s
+//! interval fires one immediate startup tick (harmless — nothing is pending
+//! yet) and then not again for an hour, so no reconnection record can be
+//! deleted during a few-second test. With the record provably still present
+//! (asserted via `has_pending_reconnection`), a post-window reconnect that is
+//! rejected can only have been rejected by the window/token check.
+//!
+//! - Inside the window: reconnect IMMEDIATELY (no sleep) ⇒ `Reconnected`.
+//! - After the window: sleep past it ⇒ `ReconnectionFailed` with a
+//!   time-expiry code (`ReconnectionExpired` or `ReconnectionTokenInvalid`),
+//!   NOT a `NoRecord`/`RoomNotFound`.
+//!
+//! # Facet 2 — duplicate claim, exactly one winner
+//!
+//! Two fresh, authenticated sockets contend for the SAME token/player
+//! concurrently (released together by a barrier on a multi-thread runtime).
+//! The claim is lock-serialized in `claim_reconnection`, so the OUTCOME COUNT
+//! is deterministic: EXACTLY ONE gets `Reconnected` and the other gets a
+//! failure. We assert the counts, never which socket wins.
+//!
+//! # Zero-flakiness design (the whole risk of H6)
+//!
+//! The window uses `chrono::Utc` wall-clock, not `tokio` time, so real time is
+//! required. That is safe here only where a sleep can merely OVERSHOOT the
+//! assertion:
+//! - Outside-window leg sleeps 2× the window, then asserts EXPIRED — more
+//!   elapsed time only makes it "more expired", so it cannot flake into "not
+//!   yet expired". (A standard `#[tokio::test]` runtime is not time-paused, so
+//!   `tokio::time::sleep` elapses real wall-clock time.)
+//! - Inside-window leg reconnects IMMEDIATELY after pre-authenticating the
+//!   replacement socket, so the only work between `disconnected_at` and the
+//!   claim is one frame send + server processing (sub-millisecond on loopback)
+//!   against a 2s window — a ~1000× margin, so "still inside" cannot flake.
+//! - No negative "not yet expired after a fixed sleep" assertion is ever made.
+//! - The duplicate-claim outcome is deterministic by construction (lock
+//!   serialization), independent of timing.
+//!
+//! Non-vacuity: the inside leg (immediate ⇒ success) and the outside leg
+//! (sleep-past ⇒ failure) share an IDENTICAL server config and both keep the
+//! record present (cleanup disabled), so the ONLY variable flipping the outcome
+//! is elapsed-time-past-window — i.e. the window check is load-bearing. This
+//! was additionally confirmed empirically during development by temporarily
+//! widening the window to 3600s, after which the very same post-sleep call
+//! returns `Reconnected` instead of `ReconnectionFailed` (reverted).
+//!
+//! # Deferred (NOT implemented here)
+//!
+//! NOTE: the reconnect-during-teardown race — a `Reconnect` arriving while
+//! `has_client(player)` is still true mid-teardown, yielding
+//! `PlayerAlreadyConnected` with the token NOT consumed (the early guard at
+//! `src/server/reconnection_service.rs:247-260`) — is an inherently
+//! timing-narrow RACE that cannot be made deterministic without flakiness. It
+//! is deferred to nightly / a future harness knob per the PLAN, and drives the
+//! F3 SDK "retry on PlayerAlreadyConnected" rule.
+//!
+//! # Result
+//!
+//! CONFIRMED — both facets pass; prediction upheld. (Observed detail: the
+//! post-window rejection surfaces as `ReconnectionTokenInvalid`, because the
+//! token's own embedded expiry — armed to `disconnect + window` — is checked a
+//! hair before the dedicated `WindowExpired` gate.)
+
+mod test_helpers;
+mod websocket_test_helpers;
+
+use futures_util::SinkExt;
+use signal_fish_server::config::AppAuthEntry;
+use signal_fish_server::protocol::{
+    ClientMessage, ErrorCode, PlayerId, ReconnectedPayload, RoomId, ServerMessage,
+};
+use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
+use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use std::sync::Arc;
+use std::time::Duration;
+use test_helpers::{test_protocol_config, test_server_config};
+use tokio::net::TcpListener;
+use tokio::sync::Barrier;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use websocket_test_helpers::{
+    assert_message_conservation, next_matching_server_message_within, next_server_message_within,
+    WsStream,
+};
+
+const APP_ID: &str = "reconnect-window-races-app";
+const SERVER_MESSAGE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Small reconnection window for the boundary tests: whole seconds, because the
+/// server passes `reconnection_window.as_secs()` to the manager (a sub-second
+/// `Duration` would truncate to 0). Small enough to keep the test fast, large
+/// enough that an immediate inside-window reconnect cannot lose the race.
+const WINDOW: Duration = Duration::from_secs(2);
+/// Overshoot the window by 2× — the robust direction (more elapsed ⇒ still
+/// expired), never a boundary-grazing "just past" sleep.
+const PAST_WINDOW_SLEEP: Duration = Duration::from_secs(4);
+/// Cleanup interval so large the `cleanup_task` never fires again after its
+/// immediate startup tick, so no reconnection record is deleted during a test.
+const HUGE_CLEANUP_INTERVAL: Duration = Duration::from_secs(3600);
+/// A comfortably large window for the duplicate-claim facet: that facet is
+/// about the lock, not timing, so both attempts must be well inside the window.
+const DUPLICATE_CLAIM_WINDOW: Duration = Duration::from_secs(300);
+
+fn app_entry() -> AppAuthEntry {
+    AppAuthEntry {
+        app_id: APP_ID.to_string(),
+        app_secret: "secret".to_string(),
+        app_name: "Reconnect Window Races App".to_string(),
+        max_rooms: Some(10),
+        max_players_per_room: Some(8),
+        rate_limit_per_minute: Some(600),
+    }
+}
+
+/// Build a v3-capable server with the given reconnection `window` and
+/// `cleanup_interval`, spawn the REAL room-cleanup task (so the window boundary
+/// is proven with a live cleanup task present, not merely absent), start
+/// serving, and return the address plus the handle for direct manager
+/// inspection (`has_pending_reconnection`).
+async fn start_server(
+    window: Duration,
+    cleanup_interval: Duration,
+) -> (std::net::SocketAddr, Arc<EnhancedGameServer>) {
+    use axum::routing::get;
+
+    let mut server_config: ServerConfig = test_server_config();
+    server_config.auth_enabled = true;
+    server_config.reconnection_window = window;
+    server_config.room_cleanup_interval = cleanup_interval;
+
+    let mut protocol_config = test_protocol_config();
+    protocol_config.sdk_compatibility.enforce = false;
+
+    let game_server = EnhancedGameServer::new(
+        server_config,
+        protocol_config,
+        signal_fish_server::config::RelayTypeConfig::default(),
+        signal_fish_server::config::SessionConfig::default(),
+        signal_fish_server::config::TurnConfig::default(),
+        signal_fish_server::database::DatabaseConfig::InMemory,
+        signal_fish_server::config::MetricsConfig::default(),
+        signal_fish_server::config::AuthMaintenanceConfig::default(),
+        signal_fish_server::config::CoordinationConfig::default(),
+        signal_fish_server::config::TransportSecurityConfig::default(),
+        vec![app_entry()],
+    )
+    .await
+    .expect("server builds");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Live cleanup task: with a 3600s interval it fires one immediate startup
+    // tick (nothing pending yet ⇒ harmless) and then not again for an hour, so
+    // any reconnection record registered during the test survives untouched —
+    // any later reconnect rejection is the handler's window check, not deletion.
+    let cleanup_server = game_server.clone();
+    tokio::spawn(async move {
+        cleanup_server.cleanup_task().await;
+    });
+
+    let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
+    let combined_router = axum::Router::new()
+        .nest("/v2", enhanced_router)
+        .route("/v3/ws", get(websocket_handler_v3))
+        .fallback(|| async { "Use /v2/ws or /v3/ws" })
+        .with_state(game_server.clone());
+
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            combined_router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    (addr, game_server)
+}
+
+async fn connect(addr: std::net::SocketAddr) -> WsStream {
+    let url = format!("ws://{addr}/v3/ws");
+    let (ws, _) = tokio::time::timeout(Duration::from_secs(10), connect_async(&url))
+        .await
+        .expect("connect timeout")
+        .expect("connect");
+    ws
+}
+
+async fn send(ws: &mut WsStream, msg: &ClientMessage) {
+    let json = serde_json::to_string(msg).unwrap();
+    ws.send(Message::Text(json.into())).await.unwrap();
+}
+
+/// Authenticate as a v3 client (mirrors `tests/reconnection_replay_e2e.rs`):
+/// `Authenticated` then `ProtocolInfo`.
+async fn authenticate_v3(ws: &mut WsStream) {
+    send(
+        ws,
+        &ClientMessage::Authenticate {
+            app_id: APP_ID.to_string(),
+            sdk_version: None,
+            platform: None,
+            game_data_format: None,
+            protocol_version: Some(3),
+            supported_transports: None,
+            supported_topologies: None,
+        },
+    )
+    .await;
+
+    let authed = next_server_message_within(ws, SERVER_MESSAGE_TIMEOUT, "Authenticated").await;
+    assert!(
+        matches!(authed, ServerMessage::Authenticated { .. }),
+        "expected Authenticated, got {authed:?}"
+    );
+    let info = next_server_message_within(ws, SERVER_MESSAGE_TIMEOUT, "ProtocolInfo").await;
+    assert!(
+        matches!(info, ServerMessage::ProtocolInfo(_)),
+        "expected ProtocolInfo, got {info:?}"
+    );
+}
+
+/// Join (or create) a 4-player room, returning the typed payload.
+async fn join_room(
+    ws: &mut WsStream,
+    game_name: &str,
+    room_code: Option<String>,
+    player_name: &str,
+) -> Box<signal_fish_server::protocol::RoomJoinedPayload> {
+    send(
+        ws,
+        &ClientMessage::JoinRoom {
+            game_name: game_name.to_string(),
+            room_code,
+            player_name: player_name.to_string(),
+            max_players: Some(4),
+            supports_authority: Some(false),
+            relay_transport: None,
+        },
+    )
+    .await;
+
+    next_matching_server_message_within(
+        ws,
+        SERVER_MESSAGE_TIMEOUT,
+        "room join response",
+        |message| match message {
+            ServerMessage::RoomJoined(payload) => Some(payload),
+            ServerMessage::RoomJoinFailed { reason, error_code } => {
+                panic!("room join failed: {reason} ({error_code:?})")
+            }
+            _ => None,
+        },
+    )
+    .await
+}
+
+/// Disconnect `player_id` server-side and mint a reconnect token for it
+/// (mirrors `tests/reconnection_replay_e2e.rs`). After this returns the
+/// server has removed the client, so `has_client(player_id)` is false and a
+/// fresh socket may immediately claim the token.
+async fn register_reconnect_token(
+    game_server: &Arc<EnhancedGameServer>,
+    player_id: PlayerId,
+    room_id: RoomId,
+) -> String {
+    let room = game_server
+        .database()
+        .get_room_by_id(&room_id)
+        .await
+        .expect("room lookup")
+        .expect("room exists");
+    let player_info = room
+        .players
+        .get(&player_id)
+        .cloned()
+        .expect("player in room before disconnect");
+
+    game_server.disconnect_client(&player_id).await;
+
+    game_server
+        .reconnection_manager()
+        .expect("reconnection enabled")
+        .register_disconnection(player_id, room_id, false, Some(player_info))
+        .await
+}
+
+/// The two terminal outcomes of a `Reconnect` attempt on the wire.
+enum ReconnectOutcome {
+    Reconnected(Box<ReconnectedPayload>),
+    Failed(ErrorCode),
+}
+
+async fn send_reconnect(
+    ws: &mut WsStream,
+    player_id: PlayerId,
+    room_id: RoomId,
+    auth_token: String,
+) {
+    send(
+        ws,
+        &ClientMessage::Reconnect {
+            player_id,
+            room_id,
+            auth_token,
+        },
+    )
+    .await;
+}
+
+/// Read the next `Reconnected` / `ReconnectionFailed` frame as a typed outcome.
+async fn next_reconnect_outcome(ws: &mut WsStream, context: &str) -> ReconnectOutcome {
+    next_matching_server_message_within(
+        ws,
+        SERVER_MESSAGE_TIMEOUT,
+        context,
+        |message| match message {
+            ServerMessage::Reconnected(payload) => Some(ReconnectOutcome::Reconnected(payload)),
+            ServerMessage::ReconnectionFailed { error_code, .. } => {
+                Some(ReconnectOutcome::Failed(error_code))
+            }
+            _ => None,
+        },
+    )
+    .await
+}
+
+/// One contender in the duplicate-claim race: park on the barrier, then send
+/// and read its own outcome, so both attempts are released together.
+async fn contended_reconnect(
+    mut ws: WsStream,
+    player_id: PlayerId,
+    room_id: RoomId,
+    token: String,
+    barrier: Arc<Barrier>,
+    context: &'static str,
+) -> ReconnectOutcome {
+    barrier.wait().await;
+    send_reconnect(&mut ws, player_id, room_id, token).await;
+    next_reconnect_outcome(&mut ws, context).await
+}
+
+// ---------------------------------------------------------------------------
+// Facet 1a — a reconnect well inside the window succeeds.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reconnect_inside_window_succeeds() {
+    let (addr, game_server) = start_server(WINDOW, HUGE_CLEANUP_INTERVAL).await;
+
+    let mut anchor = connect(addr).await;
+    authenticate_v3(&mut anchor).await;
+    let anchor_room = join_room(&mut anchor, "window-game", None, "Anchor").await;
+
+    let mut dropper = connect(addr).await;
+    authenticate_v3(&mut dropper).await;
+    let dropped = join_room(
+        &mut dropper,
+        "window-game",
+        Some(anchor_room.room_code.clone()),
+        "Dropper",
+    )
+    .await;
+
+    // Pre-authenticate the replacement BEFORE the disconnection clock starts, so
+    // the only work between `disconnected_at` and the claim is one frame send.
+    let mut replacement = connect(addr).await;
+    authenticate_v3(&mut replacement).await;
+
+    let token = register_reconnect_token(&game_server, dropped.player_id, dropped.room_id).await;
+
+    // Immediate (no sleep): microseconds into a 2s window ⇒ still inside.
+    send_reconnect(&mut replacement, dropped.player_id, dropped.room_id, token).await;
+
+    match next_reconnect_outcome(&mut replacement, "inside-window reconnect").await {
+        ReconnectOutcome::Reconnected(payload) => {
+            assert_eq!(
+                payload.player_id, dropped.player_id,
+                "the restored socket must own the original player id"
+            );
+            assert_eq!(
+                payload.room_id, dropped.room_id,
+                "the restored socket must rejoin the original room"
+            );
+        }
+        ReconnectOutcome::Failed(error_code) => {
+            panic!("a reconnect well inside the window must succeed, got ReconnectionFailed({error_code:?})")
+        }
+    }
+
+    drop(dropper);
+    assert_message_conservation(&game_server.metrics()).await;
+}
+
+// ---------------------------------------------------------------------------
+// Facet 1b — after the window elapses the reconnect is rejected by the handler,
+// NOT because the cleanup task deleted the record (cleanup is at 3600s).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn reconnect_after_window_expires_is_rejected_by_the_handler_not_cleanup() {
+    let (addr, game_server) = start_server(WINDOW, HUGE_CLEANUP_INTERVAL).await;
+
+    let mut anchor = connect(addr).await;
+    authenticate_v3(&mut anchor).await;
+    let anchor_room = join_room(&mut anchor, "window-game", None, "Anchor").await;
+
+    let mut dropper = connect(addr).await;
+    authenticate_v3(&mut dropper).await;
+    let dropped = join_room(
+        &mut dropper,
+        "window-game",
+        Some(anchor_room.room_code.clone()),
+        "Dropper",
+    )
+    .await;
+
+    let token = register_reconnect_token(&game_server, dropped.player_id, dropped.room_id).await;
+    drop(dropper);
+
+    let manager = game_server
+        .reconnection_manager()
+        .expect("reconnection enabled");
+
+    // Sleep PAST the window (2× overshoot; real wall-clock — the runtime is not
+    // time-paused). "More time elapsed ⇒ still expired", so this cannot flake.
+    tokio::time::sleep(PAST_WINDOW_SLEEP).await;
+
+    // The record is STILL present: the 3600s cleanup task has not fired again
+    // since its startup tick, so nothing deleted it during the sleep. Whatever
+    // rejects the reconnect below is therefore the handler's window/token check,
+    // never a NoRecord from deletion — the crux of the H6 boundary claim.
+    assert!(
+        manager.has_pending_reconnection(&dropped.player_id).await,
+        "with cleanup at 3600s the expired record must persist — proving the window is \
+         enforced by the reconnect handler, not by the cleanup task deleting the record"
+    );
+
+    let mut replacement = connect(addr).await;
+    authenticate_v3(&mut replacement).await;
+    send_reconnect(&mut replacement, dropped.player_id, dropped.room_id, token).await;
+
+    match next_reconnect_outcome(&mut replacement, "post-window reconnect").await {
+        ReconnectOutcome::Reconnected(_) => {
+            panic!("a reconnect after the window elapsed must be rejected")
+        }
+        ReconnectOutcome::Failed(error_code) => {
+            assert!(
+                matches!(
+                    error_code,
+                    ErrorCode::ReconnectionExpired | ErrorCode::ReconnectionTokenInvalid
+                ),
+                "the rejection must be a window/token time-expiry code (NOT a NoRecord or \
+                 RoomNotFound, which would mean the record was deleted), got {error_code:?}"
+            );
+        }
+    }
+
+    // A rejected claim never consumes the record — reconfirming the failure was
+    // a validation reject, not deletion.
+    assert!(
+        manager.has_pending_reconnection(&dropped.player_id).await,
+        "a window/token rejection must leave the pending record intact"
+    );
+
+    assert_message_conservation(&game_server.metrics()).await;
+}
+
+// ---------------------------------------------------------------------------
+// Facet 2 — two concurrent same-token claims: EXACTLY one winner.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_duplicate_reconnect_has_exactly_one_winner() {
+    let (addr, game_server) = start_server(DUPLICATE_CLAIM_WINDOW, HUGE_CLEANUP_INTERVAL).await;
+
+    let mut anchor = connect(addr).await;
+    authenticate_v3(&mut anchor).await;
+    let anchor_room = join_room(&mut anchor, "claim-game", None, "Anchor").await;
+
+    let mut dropper = connect(addr).await;
+    authenticate_v3(&mut dropper).await;
+    let dropped = join_room(
+        &mut dropper,
+        "claim-game",
+        Some(anchor_room.room_code.clone()),
+        "Dropper",
+    )
+    .await;
+
+    let token = register_reconnect_token(&game_server, dropped.player_id, dropped.room_id).await;
+    drop(dropper);
+
+    // Two fresh, authenticated sockets, released together by the barrier so the
+    // two claims genuinely contend on a multi-thread runtime.
+    let mut first = connect(addr).await;
+    authenticate_v3(&mut first).await;
+    let mut second = connect(addr).await;
+    authenticate_v3(&mut second).await;
+
+    let barrier = Arc::new(Barrier::new(2));
+    let task_first = tokio::spawn(contended_reconnect(
+        first,
+        dropped.player_id,
+        dropped.room_id,
+        token.clone(),
+        Arc::clone(&barrier),
+        "first duplicate claim",
+    ));
+    let task_second = tokio::spawn(contended_reconnect(
+        second,
+        dropped.player_id,
+        dropped.room_id,
+        token,
+        Arc::clone(&barrier),
+        "second duplicate claim",
+    ));
+
+    let outcomes = [
+        task_first.await.expect("first claim task panicked"),
+        task_second.await.expect("second claim task panicked"),
+    ];
+
+    // Assert the COUNTS, not which socket won (the claim is lock-serialized, so
+    // exactly one wins — but WHICH one is a genuine race we must not pin).
+    let winners = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, ReconnectOutcome::Reconnected(_)))
+        .count();
+    let losers = outcomes
+        .iter()
+        .filter(|outcome| matches!(outcome, ReconnectOutcome::Failed(_)))
+        .count();
+
+    assert_eq!(
+        winners, 1,
+        "exactly one concurrent same-token claim may win"
+    );
+    assert_eq!(
+        losers, 1,
+        "the other concurrent same-token claim must be rejected"
+    );
+
+    assert_message_conservation(&game_server.metrics()).await;
+}

--- a/tests/reconnection_replay_e2e.rs
+++ b/tests/reconnection_replay_e2e.rs
@@ -529,6 +529,153 @@ async fn overflowed_replay_ring_reports_truncated() {
 }
 
 // ---------------------------------------------------------------------------
+// H7 (P10.C): a truncated replay still hands the reconnector a COMPLETE room
+//    snapshot, so it can resync app state even though the event log was lost.
+//    Pre-registered prediction: "membership + authority recoverable; ready-state
+//    and spectator roster are LIKELY HOLES in ReconnectedPayload." Result:
+//    REFUTED — the snapshot already carries `current_players` (each with
+//    `is_ready`/`is_authority`), an explicit `ready_players` list, and
+//    `current_spectators`. This test pins that: with a ready peer and a live
+//    spectator established BEFORE the disconnect (so they are room state, not
+//    replay-ring events), the reconnector's TRUNCATED snapshot must still show
+//    both. Guards against a future regression that drops those fields.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn truncated_replay_still_carries_full_room_snapshot() {
+    let mut config = test_server_config();
+    config.event_buffer_size = 3;
+    let (addr, game_server) = start_server_with_config(config).await;
+
+    let mut peer_a = connect(addr).await;
+    authenticate_v3(&mut peer_a).await;
+    let joined_a = join_room(&mut peer_a, "replay-game", None, "PeerA").await;
+
+    let mut peer_b = connect(addr).await;
+    authenticate_v3(&mut peer_b).await;
+    let joined_b = join_room(
+        &mut peer_b,
+        "replay-game",
+        Some(joined_a.room_code.clone()),
+        "PeerB",
+    )
+    .await;
+
+    // Establish ready-state + a spectator BEFORE B disconnects, so both are
+    // captured in the room snapshot rather than the (truncated) replay ring.
+    // PeerA stays connected throughout, so its ready-state is unambiguous — the
+    // coordinator ready set is not cleared by membership churn
+    // (`room_service.rs`), so the later churn cannot wipe it.
+    send(&mut peer_a, &ClientMessage::PlayerReady).await;
+    next_matching_server_message_within(
+        &mut peer_a,
+        SERVER_MESSAGE_TIMEOUT,
+        "LobbyStateChanged after PeerA readies",
+        |message| matches!(message, ServerMessage::LobbyStateChanged { .. }).then_some(()),
+    )
+    .await;
+
+    let mut spectator = connect(addr).await;
+    authenticate_v3(&mut spectator).await;
+    send(
+        &mut spectator,
+        &ClientMessage::JoinAsSpectator {
+            game_name: "replay-game".to_string(),
+            room_code: joined_a.room_code.clone(),
+            spectator_name: "Spec".to_string(),
+        },
+    )
+    .await;
+    let spectator_id = next_matching_server_message_within(
+        &mut spectator,
+        SERVER_MESSAGE_TIMEOUT,
+        "SpectatorJoined ack",
+        |message| match message {
+            ServerMessage::SpectatorJoined(payload) => Some(payload.spectator_id),
+            ServerMessage::SpectatorJoinFailed { reason, error_code } => {
+                panic!("spectator join failed: {reason} ({error_code:?})")
+            }
+            _ => None,
+        },
+    )
+    .await;
+
+    // B disconnects with a valid token, then the ring overflows (3 cycles = 6+
+    // events into a 3-slot ring) so B's replay is TRUNCATED.
+    let token = register_reconnect_token(&game_server, joined_b.player_id, joined_b.room_id).await;
+    let _ = peer_b.close(None).await;
+    for i in 0..3 {
+        churn_join_leave(
+            addr,
+            &joined_a.room_code,
+            &format!("Churner{i}"),
+            &mut peer_a,
+        )
+        .await;
+    }
+
+    let mut replacement = connect(addr).await;
+    authenticate_v3(&mut replacement).await;
+    let reconnected = reconnect(
+        &mut replacement,
+        joined_b.player_id,
+        joined_b.room_id,
+        token,
+    )
+    .await;
+
+    // Precondition: the scenario really is the truncated one this test is about.
+    assert_eq!(
+        reconnected.replay,
+        Some(ReplayStatus::Truncated),
+        "the ring overflowed, so the replay must be truncated"
+    );
+
+    // Membership: both live players are in the snapshot (churners left).
+    let member_ids: Vec<PlayerId> = reconnected.current_players.iter().map(|p| p.id).collect();
+    assert!(
+        member_ids.contains(&joined_a.player_id) && member_ids.contains(&joined_b.player_id),
+        "snapshot membership must include both live players, got {member_ids:?}"
+    );
+
+    // Ready-state (the doubted field): PeerA's readiness survives in BOTH the
+    // explicit list and the per-player flag.
+    assert!(
+        reconnected.ready_players.contains(&joined_a.player_id),
+        "ready_players must list the ready peer after a truncated reconnect"
+    );
+    let peer_a_entry = reconnected
+        .current_players
+        .iter()
+        .find(|p| p.id == joined_a.player_id)
+        .expect("PeerA present in snapshot");
+    assert!(
+        peer_a_entry.is_ready,
+        "the snapshot's per-player is_ready must reflect readiness"
+    );
+
+    // Spectator roster (the other doubted field): the live spectator is present.
+    assert!(
+        reconnected
+            .current_spectators
+            .iter()
+            .any(|s| s.id == spectator_id),
+        "current_spectators must carry the live spectator after a truncated reconnect"
+    );
+
+    // The game has not started — a truncated *lobby* reconnect. `PlayerReady`
+    // (with no `StartGame`) puts the room in `Lobby`, so pin that exact state
+    // rather than merely "not Finalized".
+    assert_eq!(
+        reconnected.lobby_state,
+        signal_fish_server::protocol::LobbyState::Lobby,
+        "a readied-but-not-started room must reconnect in the Lobby state"
+    );
+
+    assert_message_conservation(&game_server.metrics()).await;
+}
+
+// ---------------------------------------------------------------------------
 // 3. v2 wire freeze: a v2 recipient's Reconnected frame must not grow a
 //    `replay` key (raw-JSON assertion; the events themselves still replay).
 // ---------------------------------------------------------------------------

--- a/tests/signal_budget_model.rs
+++ b/tests/signal_budget_model.rs
@@ -1,0 +1,90 @@
+//! P10.C H8 (model, PR lane) — a 16-player WebRTC mesh's signaling cost fits the
+//! default per-connection signal rate limit.
+//!
+//! Falsification experiment H8. Pre-registered prediction: at N=16 players in a
+//! full mesh with K=10 trickle-ICE candidates per peer, each player SENDS ~165
+//! `Signal` messages during formation, well under the default `max_signals`
+//! budget (600 per `time_window`), i.e. ≈3.6× headroom.
+//!
+//! This is a MODEL — arithmetic over the protocol's signaling rules — not a live
+//! WebRTC run; the empirical companion (`webrtc_mesh_budget_e2e.rs`) is nightly.
+//! Its job in the PR lane is a **config ↔ protocol invariant guard**: if the
+//! default `max_signals` is ever lowered below what a 16-player mesh needs (a
+//! plausible "tighten the rate limit for security" change), or the per-player
+//! mesh-formation cost grows, this fails fast rather than silently rate-limiting
+//! real P2P mesh formation at the target player count.
+
+use signal_fish_server::config::defaults;
+use signal_fish_server::rate_limit::RateLimitConfig;
+
+/// `Signal` messages a single player SENDS to form a full mesh, per the
+/// protocol's signaling rules (Appendix E glare rule + trickle ICE):
+///
+/// - exactly one offer-or-answer per peer — for each unordered pair, one side
+///   offers and the other answers (the `local_initiates` glare rule), so every
+///   player emits one SDP message toward each of its peers — plus
+/// - `k` ICE candidates per peer (trickle),
+///
+/// across its `n - 1` peers ⇒ `(n - 1) * (1 + k)`.
+fn mesh_signals_sent_per_player(n: u32, k: u32) -> u32 {
+    (n - 1) * (1 + k)
+}
+
+/// Representative trickle-ICE candidate count per peer for the model (host +
+/// server-reflexive + a relay candidate or two on a typical dual-stack client).
+const TYPICAL_ICE_CANDIDATES_PER_PEER: u32 = 10;
+
+#[test]
+fn mesh_signal_budget_model_holds_and_default_config_accommodates_sixteen_players() {
+    // Pin the model at representative points so any change to the formula (or to
+    // the glare rule's one-SDP-per-peer assumption) is caught explicitly.
+    // (n, k, expected signals sent per player)
+    for (n, k, expected) in [
+        (2, TYPICAL_ICE_CANDIDATES_PER_PEER, 11), // the two-player floor
+        (8, TYPICAL_ICE_CANDIDATES_PER_PEER, 77),
+        (16, TYPICAL_ICE_CANDIDATES_PER_PEER, 165), // the 16-player target
+        (16, 0, 15),                                // SDP-only (no trickle)
+    ] {
+        assert_eq!(
+            mesh_signals_sent_per_player(n, k),
+            expected,
+            "mesh signal model mismatch at N={n}, K={k}"
+        );
+    }
+
+    // The config ↔ protocol invariant: the default per-connection signal budget
+    // must accommodate a 16-player mesh (K=10) with real headroom, or mesh
+    // formation would rate-limit itself at the target player count.
+    //
+    // Read the DEPLOYMENT-authoritative default: `defaults::default_max_signals`
+    // is the `#[serde(default = ...)]` for `config::server::RateLimitConfig`
+    // (`src/config/server.rs`), so it is the value an operator's "tighten the
+    // rate limit" change would touch — the exact regression this guard exists to
+    // catch. (The sibling admission suite reads `defaults::*` for the same
+    // reason.) Cross-check that the in-process `rate_limit::RateLimitConfig`
+    // default agrees, so the two parallel `600` literals cannot silently drift.
+    let budget = defaults::default_max_signals();
+    assert_eq!(
+        RateLimitConfig::default().max_signals,
+        budget,
+        "the in-process and config-layer default max_signals must stay in sync"
+    );
+    let per_player = mesh_signals_sent_per_player(16, TYPICAL_ICE_CANDIDATES_PER_PEER);
+
+    assert!(
+        per_player < budget,
+        "16-player mesh formation ({per_player} signals/player) must fit the default \
+         max_signals budget ({budget}); lowering the default below this rate-limits P2P mesh"
+    );
+    assert!(
+        per_player * 2 <= budget,
+        "the default signal budget ({budget}) should keep >=2x headroom over a 16-player \
+         mesh ({per_player}/player); got {:.1}x",
+        f64::from(budget) / f64::from(per_player)
+    );
+
+    // Documented failure edge (comment, not a brittle assertion coupled to the
+    // exact default): a 16-player mesh only exceeds the budget once trickle-ICE
+    // candidates reach K≈40 — 15*(1+K) > 600 ⇒ K ≥ 40 at today's default 600. The
+    // headroom assertion above is the robust guard; this notes where it runs out.
+}

--- a/tests/sixteen_player_admission_e2e.rs
+++ b/tests/sixteen_player_admission_e2e.rs
@@ -1,0 +1,164 @@
+//! P10.C H11/H12 — sixteen-player admission regression (end-to-end).
+//!
+//! GAP-3 / fix A3 (#140): the default per-IP connection cap was `10`, so the
+//! 11th concurrent connection from one IP was refused — a 16-player session
+//! behind a single NAT (LAN party, office, venue) could not assemble. A3 raised
+//! `default_max_connections_per_ip` to `24`. This suite drives 16 real
+//! WebSocket clients from loopback (all sharing IP `127.0.0.1`, so the per-IP
+//! cap is genuinely exercised) through `Authenticate` + `JoinRoom` at the
+//! **default** cap and asserts all 16 land in one room — it would fail at the
+//! pre-A3 cap of 10, so it stands as the regression guard.
+//!
+//! A second case pins the documented room-cap trap: the per-room `max_players`
+//! default is `8` (deliberately left unchanged by A3), so a room created
+//! without an explicit `max_players` refuses the 9th join. Sixteen players in
+//! one room therefore requires the creator to raise `max_players` at join —
+//! which is exactly what the admission case does.
+
+mod test_helpers;
+mod websocket_test_helpers;
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use signal_fish_server::config::{defaults, ProtocolConfig};
+use signal_fish_server::protocol::ErrorCode;
+use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
+use signal_fish_server::websocket::create_router;
+use tokio::net::TcpListener;
+
+use test_helpers::{create_test_server_with_config, test_server_config};
+use websocket_test_helpers::room16::{authenticate, connect, join_n_players, try_join};
+
+const GAME: &str = "admission_game";
+const PROTOCOL_VERSION: u16 = 4;
+
+/// Server config at the REAL production defaults for the per-IP cap and the
+/// per-room player ceiling — `test_server_config()` uses a generous cap (100)
+/// and a small room default (4), neither of which would exercise the A3 fix or
+/// the documented room-cap trap.
+fn default_admission_config() -> ServerConfig {
+    ServerConfig {
+        max_connections_per_ip: defaults::default_max_connections_per_ip(),
+        default_max_players: defaults::default_max_players(),
+        ..test_server_config()
+    }
+}
+
+/// SDK platform enforcement off, so a bare `Authenticate` (no platform) is
+/// accepted — the reference/native clients this models do not claim an engine.
+fn admission_protocol_config() -> ProtocolConfig {
+    let mut config = ProtocolConfig::default();
+    config.sdk_compatibility.enforce = false;
+    config
+}
+
+async fn start_server(server: Arc<EnhancedGameServer>) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("read listener address");
+    let router = create_router("http://localhost:3000").with_state(server);
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .expect("test server serve loop");
+    });
+    addr
+}
+
+/// H11+H12: 16 clients from ONE IP all connect and join one room at the default
+/// per-IP cap. Regression for A3 — fails at the pre-A3 cap of 10.
+#[tokio::test]
+async fn sixteen_players_admit_at_default_ip_cap() {
+    // Premise guard: the default cap must actually admit 16 same-IP clients, or
+    // this test proves nothing. If the default is ever lowered below 16 the
+    // failure points straight at the cap rather than at a confusing refusal.
+    let cap = defaults::default_max_connections_per_ip();
+    assert!(
+        cap >= 16,
+        "default per-IP cap ({cap}) must admit a 16-player NAT session (GAP-3/A3)"
+    );
+
+    let server =
+        create_test_server_with_config(default_admission_config(), admission_protocol_config())
+            .await;
+    let addr = start_server(server).await;
+
+    // Room created (first joiner) with max_players = 16, so the per-room ceiling
+    // is not the constraint under test here — the per-IP cap is. `join_n_players`
+    // panics on any refusal, so a full return already proves all 16 were admitted
+    // at the default cap (the A3 regression). The assertions below add the
+    // non-tautological facts: distinct identities AND actual co-location in ONE
+    // room (not 16 separate rooms).
+    let players = join_n_players(addr, GAME, "LOBBYA", Some(16), 16, PROTOCOL_VERSION).await;
+
+    let unique: HashSet<_> = players.iter().map(|p| p.player_id).collect();
+    assert_eq!(
+        unique.len(),
+        16,
+        "the server must assign 16 distinct player ids"
+    );
+
+    // Co-location: the LAST joiner sees the whole room, so its
+    // `RoomJoined.current_players` (which includes itself) must be all 16 — proof
+    // that every client landed in the same room, not 16 rooms each holding one.
+    let last = players.last().expect("16 players joined");
+    assert_eq!(
+        last.room_player_count, 16,
+        "the final joiner must observe all 16 players co-located in one room"
+    );
+}
+
+/// H12: the per-room `max_players` default is 8, so a room created without an
+/// explicit ceiling refuses the 9th join. Documents why the admission case must
+/// raise `max_players` to seat 16.
+#[tokio::test]
+async fn ninth_join_fails_at_default_room_cap() {
+    let default_cap = defaults::default_max_players();
+    assert_eq!(
+        default_cap, 8,
+        "this test pins the documented default room cap of 8"
+    );
+
+    let server =
+        create_test_server_with_config(default_admission_config(), admission_protocol_config())
+            .await;
+    let addr = start_server(server).await;
+
+    // First `default_cap` joins create + fill the room (no explicit max_players,
+    // so it defaults to 8); the next join must be refused as RoomFull.
+    let mut seated = Vec::new();
+    for i in 0..default_cap {
+        let mut ws = connect(addr).await;
+        authenticate(&mut ws, PROTOCOL_VERSION).await;
+        let handle = try_join(ws, GAME, "LOBBYB", None, &format!("Seat{i}"))
+            .await
+            .unwrap_or_else(|(reason, code)| {
+                panic!("player {i} within the default cap must be seated: {reason} ({code:?})")
+            });
+        seated.push(handle);
+    }
+    assert_eq!(
+        seated.len() as u8,
+        default_cap,
+        "room fills to the default cap"
+    );
+
+    // The overflow join is refused, and specifically as RoomFull (not some other
+    // error) — the room-cap trap, not an IP-cap or auth refusal.
+    let mut overflow = connect(addr).await;
+    authenticate(&mut overflow, PROTOCOL_VERSION).await;
+    let error_code = match try_join(overflow, GAME, "LOBBYB", None, "Overflow").await {
+        Ok(_) => panic!("the 9th join into a default-cap room must be refused"),
+        Err((_reason, error_code)) => error_code,
+    };
+    assert_eq!(
+        error_code,
+        Some(ErrorCode::RoomFull),
+        "overflow join must be refused as RoomFull"
+    );
+}

--- a/tests/slow_consumer_no_cascade_e2e.rs
+++ b/tests/slow_consumer_no_cascade_e2e.rs
@@ -1,0 +1,340 @@
+//! P10.C H1+H13 — a slow consumer's eviction must NOT cascade to healthy peers.
+//!
+//! The distinctive, deterministic PR-lane claim of H1+H13 is the NO-CASCADE
+//! guarantee: when one recipient stalls hard enough to be evicted by the
+//! delivery contract, EXACTLY that one connection is torn down — the room's
+//! other healthy members are neither evicted nor starved, and each still
+//! receives the sender's complete, in-order stream.
+//!
+//! The existing delivery suite proves eviction is loud and that ONE healthy
+//! receiver keeps flowing (`relay_backpressure_e2e::
+//! slow_consumer_is_disconnected_loudly_and_room_keeps_flowing`,
+//! `wedged_socket_write_is_preempted_and_fd_released`;
+//! `v4_game_data_sequencing_e2e::evicted_recipient_observes_seq_gap_after_reconnect`).
+//! But "cascade" is inherently a MULTI-peer phenomenon, and every one of those
+//! tests uses a single healthy witness and asserts only
+//! `slow_consumer_disconnects >= 1` — none pins that the eviction did not
+//! SPREAD. This test closes that gap directly:
+//!
+//! - a room of one flooding sender, one hard-stalled recipient (never drains),
+//!   and THREE healthy recipients (all draining continuously);
+//! - each of the three healthy peers must receive every one of the sender's
+//!   messages, contiguous and in order (a cascade would show up as a healthy
+//!   peer's socket closing early or its stream losing frames);
+//! - each healthy peer must observe a `PlayerLeft` for the stalled peer ONLY —
+//!   a `PlayerLeft` for any OTHER member would be a peer being cascade-evicted;
+//! - `websocket_slow_consumer_disconnects == 1` EXACTLY (not `>= 1`): the
+//!   direct no-cascade oracle. This is sound and deterministic because the
+//!   coordinator fans a broadcast out to every recipient CONCURRENTLY
+//!   (`server.rs::deliver_to_all` via `join_all`), each recipient's
+//!   slow-consumer timeout is independent, the evicted connection is removed
+//!   before the next broadcast, and the disconnect metric is incremented once
+//!   per CLOSED CONNECTION, not per delivery
+//!   (`coordination::deliver_or_disconnect`: only the `request_close` that
+//!   returns `true` counts).
+//!
+//! Zero-flaky policy: a hard-stalled peer (never reads) is evicted regardless
+//! of timing, so the eviction is not a timing race; the healthy peers drain in
+//! tight loops and are given a generous grace window, so they never approach
+//! the slow-consumer timeout; all waits are bounded by a whole-test ceiling,
+//! never a fixed sleep used as a sync or negative oracle. The brittle facets of
+//! H1+H13 (the whole-room freeze DURATION / Pong-RTT spike, join-during-stall)
+//! are deliberately NOT asserted here — they are timing-coupled and belong to
+//! the nightly lane.
+
+mod test_helpers;
+mod websocket_test_helpers;
+
+use futures_util::{SinkExt, StreamExt};
+use signal_fish_server::config::ProtocolConfig;
+use signal_fish_server::protocol::{ClientMessage, PlayerId, ServerMessage};
+use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
+use signal_fish_server::websocket::create_router;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use test_helpers::create_test_server_with_config;
+use tokio::net::TcpListener;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use websocket_test_helpers::assert_message_conservation;
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+type WsSink = futures_util::stream::SplitSink<WsStream, Message>;
+type WsReceiver = futures_util::stream::SplitStream<WsStream>;
+
+const ROOM: &str = "NOCAS1";
+/// Healthy recipients that must all survive the one eviction. Three is enough
+/// to make "cascade" (a spreading eviction) observable while staying a fast
+/// PR-lane profile.
+const HEALTHY_PEERS: usize = 3;
+/// Fixed flood size. Large enough that (a) the stalled peer's kernel buffers +
+/// 8-slot queue overflow into an eviction well before the flood ends and (b)
+/// there is a long post-eviction tail proving the room keeps flowing; small
+/// enough to stay fast even fanned out to every healthy peer.
+const MESSAGE_COUNT: u64 = 1_000;
+/// 16 KiB per frame so the flood cannot hide inside kernel socket buffers — the
+/// stalled peer's queue must genuinely overflow into eviction.
+const STALL_PADDING_BYTES: usize = 16 * 1_024;
+/// Whole-test ceiling (oversubscribed CI runners included): a ceiling, not an
+/// expected wait — the happy path finishes far sooner.
+const TEST_DEADLINE: tokio::time::Duration = tokio::time::Duration::from_secs(120);
+
+async fn start_server(server: Arc<EnhancedGameServer>) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("read listener address");
+
+    let router = create_router("http://localhost:3000").with_state(server);
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            router.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .expect("test server serve loop");
+    });
+
+    addr
+}
+
+async fn connect(addr: std::net::SocketAddr) -> (WsSink, WsReceiver) {
+    let url = format!("ws://{addr}/ws");
+    let (stream, _response) =
+        tokio::time::timeout(tokio::time::Duration::from_secs(10), connect_async(&url))
+            .await
+            .expect("websocket connect timed out")
+            .expect("websocket connect failed");
+    stream.split()
+}
+
+/// Join the shared room (creating it with an 8-seat cap on the first join, so
+/// all five members fit) and return the server-assigned player id.
+async fn join_room_returning_id(
+    sink: &mut WsSink,
+    receiver: &mut WsReceiver,
+    player_name: &str,
+) -> PlayerId {
+    let join = ClientMessage::JoinRoom {
+        game_name: "no_cascade_game".to_string(),
+        room_code: Some(ROOM.to_string()),
+        player_name: player_name.to_string(),
+        max_players: Some(8),
+        supports_authority: Some(true),
+        relay_transport: None,
+    };
+    let json = serde_json::to_string(&join).expect("serialize JoinRoom");
+    sink.send(Message::Text(json.into()))
+        .await
+        .expect("send JoinRoom");
+
+    loop {
+        let frame = tokio::time::timeout(tokio::time::Duration::from_secs(10), receiver.next())
+            .await
+            .expect("timed out waiting for RoomJoined")
+            .expect("connection closed while joining room")
+            .expect("websocket error while joining room");
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let message: ServerMessage = serde_json::from_str(&text).expect("valid ServerMessage");
+        match message {
+            ServerMessage::RoomJoined(payload) => return payload.player_id,
+            ServerMessage::RoomJoinFailed { reason, .. } => {
+                panic!("room join failed for {player_name}: {reason}")
+            }
+            _ => continue,
+        }
+    }
+}
+
+/// One healthy recipient's drain: it must receive the sender's complete, in-order
+/// stream and observe the stalled peer's `PlayerLeft` and NOTHING else that
+/// smells of a cascade. Returns the number of GameData frames received (which
+/// the caller asserts equals the flood size).
+async fn drain_healthy_peer(mut receiver: WsReceiver, index: usize, stalled_id: PlayerId) -> u64 {
+    let mut received: u64 = 0;
+    let mut saw_stalled_left = false;
+
+    while received < MESSAGE_COUNT || !saw_stalled_left {
+        // A healthy peer's socket must never close: an early end-of-stream or a
+        // transport error here IS the cascade this test exists to forbid.
+        let Some(frame) = receiver.next().await else {
+            panic!(
+                "healthy peer {index} socket closed after {received} of {MESSAGE_COUNT} frames — \
+                 the eviction cascaded to a healthy peer"
+            );
+        };
+        let frame = frame.unwrap_or_else(|error| {
+            panic!(
+                "healthy peer {index} websocket error after {received} frames (cascade?): {error}"
+            )
+        });
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let message: ServerMessage = serde_json::from_str(&text).expect("valid ServerMessage");
+        match message {
+            ServerMessage::GameData { data, .. } => {
+                let seq = data
+                    .get("seq")
+                    .and_then(serde_json::Value::as_u64)
+                    .expect("GameData payload carries a numeric seq");
+                assert_eq!(
+                    seq, received,
+                    "healthy peer {index}: relay must stay complete and in order while a \
+                     peer is evicted (expected seq {received}, got {seq})"
+                );
+                received += 1;
+            }
+            ServerMessage::PlayerLeft { player_id } => {
+                assert_eq!(
+                    player_id, stalled_id,
+                    "healthy peer {index} observed a PlayerLeft for a NON-stalled member \
+                     ({player_id}) — the eviction cascaded to a healthy peer"
+                );
+                saw_stalled_left = true;
+            }
+            ServerMessage::Error {
+                message,
+                error_code,
+            } => panic!("healthy peer {index} got a server error: {message} ({error_code:?})"),
+            _ => continue,
+        }
+    }
+    received
+}
+
+/// H1+H13: one hard-stalled recipient is evicted while THREE healthy peers all
+/// keep the complete stream and exactly one connection is torn down — no
+/// cascade.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn slow_consumer_eviction_does_not_cascade_to_healthy_peers() {
+    // Small queue so the stalled peer overflows quickly; a grace window well
+    // above any drain a continuously-reading peer needs, so the healthy peers
+    // have generous margin against a spurious eviction (only the peer that
+    // stops reading entirely can trip it).
+    let mut server_config = ServerConfig::default();
+    server_config.websocket_config.send_queue_capacity = 8;
+    server_config.websocket_config.slow_consumer_timeout_ms = 500;
+    let server = create_test_server_with_config(server_config, ProtocolConfig::default()).await;
+    let metrics = server.metrics();
+    let addr = start_server(server).await;
+
+    // Join order: the healthy peers first (so each is an established room member
+    // that will observe the stalled peer's later join and eviction), then the
+    // sender, then the stalled peer last.
+    let mut healthy_sinks: Vec<WsSink> = Vec::with_capacity(HEALTHY_PEERS);
+    let mut healthy_receivers: Vec<WsReceiver> = Vec::with_capacity(HEALTHY_PEERS);
+    for index in 0..HEALTHY_PEERS {
+        let (mut sink, mut receiver) = connect(addr).await;
+        let _id =
+            join_room_returning_id(&mut sink, &mut receiver, &format!("Healthy{index}")).await;
+        healthy_sinks.push(sink);
+        healthy_receivers.push(receiver);
+    }
+
+    // The sender's own receive half stays alive but unread after the join
+    // handshake: during the flood it only ever queues the stalled peer's
+    // join/leave notices (two tiny control frames, well within the 8-slot
+    // queue), so the sender is never itself evicted — keeping the eviction
+    // count at exactly one. `sender_rx` is deliberately kept in scope (never
+    // moved into the writer task) so the sender connection stays open.
+    let (mut sender_sink, mut sender_rx) = connect(addr).await;
+    let _sender_id = join_room_returning_id(&mut sender_sink, &mut sender_rx, "FloodSender").await;
+
+    // The stalled peer: joins, then NEVER reads its socket again. Both halves
+    // are kept alive in scope so the connection persists (and genuinely stalls)
+    // until the server evicts it.
+    let (mut stalled_sink, mut stalled_rx) = connect(addr).await;
+    let stalled_id = join_room_returning_id(&mut stalled_sink, &mut stalled_rx, "Stalled").await;
+
+    // Flood the room. The writer runs on its own task so server-side
+    // backpressure (the broadcast that parks on the stalled peer until it is
+    // evicted) cannot deadlock against the healthy drains below.
+    let writer = tokio::spawn(async move {
+        let padding = "x".repeat(STALL_PADDING_BYTES);
+        for seq in 0..MESSAGE_COUNT {
+            let message = ClientMessage::GameData {
+                data: serde_json::json!({ "seq": seq, "padding": padding.as_str() }),
+            };
+            let json = serde_json::to_string(&message).expect("serialize GameData");
+            sender_sink
+                .send(Message::Text(json.into()))
+                .await
+                .expect("send GameData while a peer is stalled");
+        }
+        sender_sink
+    });
+
+    // Every healthy peer drains concurrently.
+    let mut healthy_readers = Vec::with_capacity(HEALTHY_PEERS);
+    for (index, receiver) in healthy_receivers.into_iter().enumerate() {
+        healthy_readers.push(tokio::spawn(drain_healthy_peer(
+            receiver, index, stalled_id,
+        )));
+    }
+
+    let (writer_result, healthy_results) = tokio::time::timeout(TEST_DEADLINE, async {
+        let writer_result = writer.await;
+        let mut healthy_results = Vec::with_capacity(HEALTHY_PEERS);
+        for reader in healthy_readers {
+            healthy_results.push(reader.await);
+        }
+        (writer_result, healthy_results)
+    })
+    .await
+    .expect("no-cascade test exceeded its deadline (eviction never happened, or a healthy peer wedged?)");
+
+    let _sender_sink = writer_result.expect("flood writer task panicked");
+    for (index, result) in healthy_results.into_iter().enumerate() {
+        let received = result.expect("healthy reader task panicked");
+        assert_eq!(
+            received, MESSAGE_COUNT,
+            "healthy peer {index} must receive the full flood despite the eviction"
+        );
+    }
+
+    // The core no-cascade oracle: EXACTLY one connection was evicted (the
+    // stalled peer), not the healthy peers alongside it.
+    assert_eq!(
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        1,
+        "exactly one slow-consumer eviction is allowed — the stalled peer; the \
+         {HEALTHY_PEERS} healthy peers must not be cascade-evicted"
+    );
+    // The eviction must be loud: the stalled peer's abandoned frames are counted
+    // as drops (non-vacuity: proves the stall really overflowed into eviction).
+    assert!(
+        metrics.websocket_messages_dropped.load(Ordering::Relaxed) >= 1,
+        "the stalled peer's abandoned frames must be counted as drops"
+    );
+
+    // The stalled peer's socket must actually be torn down by the server: drain
+    // whatever was buffered and require the stream to end. This confirms the
+    // single eviction was the stalled peer (non-vacuity for the `== 1` above).
+    let stalled_termination =
+        tokio::time::timeout(tokio::time::Duration::from_secs(30), async move {
+            while let Some(frame) = stalled_rx.next().await {
+                match frame {
+                    Ok(Message::Close(_)) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+        })
+        .await;
+    assert!(
+        stalled_termination.is_ok(),
+        "the stalled peer's socket was never closed by the server"
+    );
+    drop(stalled_sink);
+    // Keep the healthy sinks alive until here so none of the healthy
+    // connections is torn down early by a dropped write half.
+    drop(healthy_sinks);
+
+    // Everything has quiesced (flood delivered, one eviction, stalled socket
+    // closed): the conservation counters must balance.
+    assert_message_conservation(&metrics).await;
+}

--- a/tests/v3_multiprocess_e2e.rs
+++ b/tests/v3_multiprocess_e2e.rs
@@ -51,7 +51,6 @@
 mod v3_conformance_helpers;
 mod websocket_test_helpers;
 
-use std::path::PathBuf;
 use std::time::Duration;
 
 use futures_util::StreamExt;
@@ -65,253 +64,32 @@ use v3_conformance_helpers::{
     assert_full_mesh_glare_matrix, await_ready_count, expect_finalize_plan, ordered_pairs, ready,
     relay_one_signal, send, start_game, SERVER_MESSAGE_TIMEOUT,
 };
+use websocket_test_helpers::server_process::{
+    spawn_server, spawn_server_on_fixed_port, CONNECT_TIMEOUT,
+};
 use websocket_test_helpers::{deadline_after, next_matching_server_message_within, WsStream};
 
 /// Arbitrary app id: the spawned server runs with WebSocket auth disabled.
 const APP_ID: &str = "multiprocess-conformance-app";
-// These are saturation-tolerant CEILINGS, not expected waits (zero-flakiness
-// policy, .llm/context-testing.md). Each spawns/drives a REAL child server
-// process; on an oversubscribed runner the child can be CPU-starved and merely
-// slow, so the deadlines are generous enough that a starved-but-progressing
-// child still completes. They only bite under pathological load — the happy path
-// returns the instant the socket connects / the health check passes / the close
-// is observed, so large ceilings never slow a passing run. (nextest also runs
-// this binary in a bounded `process-spawning` test-group; see .config/nextest.toml.)
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 /// How long a client socket may take to observe the death of the server.
+///
+/// A saturation-tolerant CEILING, not an expected wait (zero-flakiness policy,
+/// .llm/context-testing.md): the happy path returns the instant the close is
+/// observed, so the large ceiling never slows a passing run and only bites
+/// under pathological load. (The server-spawn / connect / health ceilings live
+/// with the harness in `websocket_test_helpers::server_process`.)
 const SOCKET_CLOSE_TIMEOUT: Duration = Duration::from_secs(30);
-const HEALTH_DEADLINE: Duration = Duration::from_secs(60);
-const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
-/// Fresh-port spawn attempts. Each retry reserves a NEW port, so this absorbs
-/// the reserve-release-spawn race cheaply; a few attempts make a stolen port
-/// vanishingly unlikely to fail a run.
-const SPAWN_ATTEMPTS: usize = 5;
-/// Fixed-port (restart) spawn attempts. This path CANNOT dodge a transient race
-/// by picking a fresh port — it must reuse the SIGKILL'd port — so it gets more
-/// attempts and exponential backoff (see `spawn_server_on_fixed_port`).
-const FIXED_PORT_SPAWN_ATTEMPTS: usize = 6;
 
-/// Guard around the spawned server binary. Dropping it kills the child
-/// (`start_kill` here plus `kill_on_drop(true)` at spawn), so a panicking test
-/// never leaks an orphan server process into CI.
-struct ServerProcess {
-    child: Option<tokio::process::Child>,
-    port: u16,
-    stdout_path: PathBuf,
-    stderr_path: PathBuf,
-    /// Owns the temp config file, the captured output files, and the child's
-    /// working directory; removed from disk when the guard drops.
-    _workdir: tempfile::TempDir,
-}
-
-impl ServerProcess {
-    /// SIGKILL the child (TerminateProcess on Windows) and reap it.
-    async fn kill_and_wait(&mut self) {
-        let mut child = self
-            .child
-            .take()
-            .expect("server process was already killed");
-        child.kill().await.expect("kill the server process");
-    }
-
-    /// The child's captured stdout/stderr, for spawn-failure diagnostics.
-    fn captured_output(&self) -> String {
-        let read = |label: &str, path: &PathBuf| {
-            let content = std::fs::read_to_string(path)
-                .unwrap_or_else(|error| format!("<failed to read {label}: {error}>"));
-            format!("--- {label} ---\n{content}")
-        };
-        format!(
-            "{}\n{}",
-            read("stdout", &self.stdout_path),
-            read("stderr", &self.stderr_path)
-        )
-    }
-}
-
-impl Drop for ServerProcess {
-    fn drop(&mut self) {
-        if let Some(child) = self.child.as_mut() {
-            if let Err(error) = child.start_kill() {
-                eprintln!("failed to kill server process on drop: {error}");
-            }
-        }
-    }
-}
-
-/// Reserve a currently-free port by binding `0.0.0.0:0` (the same address the
-/// server binds), reading the assignment, and releasing the listener.
-fn reserve_port() -> u16 {
-    let probe = std::net::TcpListener::bind(("0.0.0.0", 0)).expect("bind port probe");
-    let port = probe.local_addr().expect("port probe local_addr").port();
-    drop(probe);
-    port
-}
-
-/// Spawn the server binary on a fresh free port, retrying with a NEW port on
-/// failure (absorbs the reserve-release-spawn race).
-async fn spawn_server(default_topology: &str) -> ServerProcess {
-    let mut failures = Vec::new();
-    for attempt in 1..=SPAWN_ATTEMPTS {
-        let port = reserve_port();
-        match try_spawn_server(port, default_topology).await {
-            Ok(server) => return server,
-            Err(failure) => failures.push(format!("attempt {attempt} (port {port}): {failure}")),
-        }
-    }
-    panic!(
-        "server binary failed to become healthy after {SPAWN_ATTEMPTS} attempts:\n{}",
-        failures.join("\n")
-    );
-}
-
-/// Spawn the server binary on a FIXED port (restart-on-same-port semantics),
-/// retrying the same port with exponential backoff to absorb transient
-/// socket-teardown races. After a SIGKILL the kernel may briefly hold the
-/// listening port (the dead server's accepted connections linger in TIME_WAIT;
-/// Windows' `TerminateProcess` tears the socket down more slowly than a Unix
-/// signal), so a single flat retry can expire before the port frees under load.
-/// Backoff — not a bigger fixed sleep — is the right tool: the happy path
-/// rebinds on attempt 1 and returns immediately, while a genuinely slow teardown
-/// gets progressively more time without inflating the common case.
-async fn spawn_server_on_fixed_port(port: u16, default_topology: &str) -> ServerProcess {
-    let mut failures = Vec::new();
-    let mut backoff = Duration::from_millis(100);
-    for attempt in 1..=FIXED_PORT_SPAWN_ATTEMPTS {
-        match try_spawn_server(port, default_topology).await {
-            Ok(server) => return server,
-            Err(failure) => failures.push(format!("attempt {attempt}: {failure}")),
-        }
-        if attempt < FIXED_PORT_SPAWN_ATTEMPTS {
-            tokio::time::sleep(backoff).await;
-            backoff = (backoff * 2).min(Duration::from_millis(1600));
-        }
-    }
-    panic!(
-        "server binary failed to restart on port {port} after {FIXED_PORT_SPAWN_ATTEMPTS} \
-         attempts:\n{}",
-        failures.join("\n")
-    );
-}
-
-/// One spawn attempt: write the temp config, launch the child with a scrubbed
-/// environment, and wait for `/v2/health`. On failure the guard (and its
-/// `kill_on_drop` child) is dropped and the captured output is returned.
-async fn try_spawn_server(port: u16, default_topology: &str) -> Result<ServerProcess, String> {
-    let workdir = tempfile::tempdir().expect("create temp workdir");
-    let config_path = workdir.path().join("server-config.json");
-    let config = json!({
-        "port": port,
-        "server": {
-            "enable_reconnection": true,
-            "reconnection_window": 300
-        },
-        "security": {
-            "require_websocket_auth": false,
-            "require_metrics_auth": false,
-            "cors_origins": "*"
-        },
-        "protocol": {
-            "sdk_compatibility": { "enforce": false }
-        },
+/// This suite's config overlay, deep-merged over the shared harness's base
+/// config (`websocket_test_helpers::server_process`): in-memory + webrtc, with
+/// the per-scenario default topology.
+fn config_overlay(default_topology: &str) -> serde_json::Value {
+    json!({
         "session": {
             "default_topology": default_topology,
             "enable_webrtc": true
-        },
-        "logging": {
-            "enable_file_logging": false
         }
-    });
-    std::fs::write(
-        &config_path,
-        serde_json::to_vec_pretty(&config).expect("serialize server config"),
-    )
-    .expect("write server config");
-
-    let stdout_path = workdir.path().join("server-stdout.log");
-    let stderr_path = workdir.path().join("server-stderr.log");
-    let stdout_file = std::fs::File::create(&stdout_path).expect("create stdout capture");
-    let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr capture");
-
-    let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_signal-fish-server"));
-    command
-        .current_dir(workdir.path())
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::from(stdout_file))
-        .stderr(std::process::Stdio::from(stderr_file))
-        .kill_on_drop(true);
-    // Scrub every inherited SIGNAL_FISH* variable: ambient config JSON, config
-    // paths, or SIGNAL_FISH__* field overrides would silently override the
-    // temp config (env overrides are applied last by the loader).
-    for (key, _) in std::env::vars_os() {
-        if key
-            .to_str()
-            .is_some_and(|key| key.starts_with("SIGNAL_FISH"))
-        {
-            command.env_remove(&key);
-        }
-    }
-    command.env("SIGNAL_FISH_CONFIG_PATH", &config_path);
-    command.env("SIGNAL_FISH__PORT", port.to_string());
-
-    let child = command.spawn().expect("spawn the server binary");
-    let mut server = ServerProcess {
-        child: Some(child),
-        port,
-        stdout_path,
-        stderr_path,
-        _workdir: workdir,
-    };
-
-    match wait_until_healthy(&mut server).await {
-        Ok(()) => Ok(server),
-        Err(reason) => Err(format!(
-            "{reason}; captured child output:\n{}",
-            server.captured_output()
-        )),
-    }
-}
-
-/// Poll `/v2/health` until it answers 200 (or the deadline passes / the child
-/// exits early).
-async fn wait_until_healthy(server: &mut ServerProcess) -> Result<(), String> {
-    let url = format!("http://127.0.0.1:{}/v2/health", server.port);
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-        .expect("build health-poll client");
-    let start = std::time::Instant::now();
-    let deadline = start + HEALTH_DEADLINE;
-
-    loop {
-        let child = server
-            .child
-            .as_mut()
-            .expect("health poll requires a live child");
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                return Err(format!("server process exited early with {status}"));
-            }
-            Ok(None) => {}
-            Err(error) => return Err(format!("failed to poll server process: {error}")),
-        }
-
-        match client.get(&url).send().await {
-            Ok(response) if response.status().is_success() => return Ok(()),
-            // Not up yet (connection refused / non-200): keep polling.
-            Ok(_) | Err(_) => {}
-        }
-
-        if std::time::Instant::now() >= deadline {
-            let elapsed = start.elapsed();
-            return Err(format!(
-                "health endpoint {url} (port {}) never answered 200 within {HEALTH_DEADLINE:?} \
-                 (waited {elapsed:?}); the child stayed alive but unready",
-                server.port
-            ));
-        }
-        tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
-    }
+    })
 }
 
 async fn connect_client(port: u16) -> WsStream {
@@ -425,7 +203,7 @@ async fn expect_socket_closed_within(ws: &mut WsStream, timeout: Duration, conte
 
 #[tokio::test(flavor = "multi_thread")]
 async fn multiprocess_mesh_n3_full_session_over_real_tcp() {
-    let server = spawn_server("mesh").await;
+    let server = spawn_server(config_overlay("mesh")).await;
     let game = "mp-mesh3";
 
     // Three v3+webrtc clients connect to the real binary over real TCP.
@@ -502,7 +280,7 @@ async fn multiprocess_mesh_n3_full_session_over_real_tcp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn multiprocess_server_restart_invalidates_reconnect_tokens() {
-    let mut server = spawn_server("mesh").await;
+    let mut server = spawn_server(config_overlay("mesh")).await;
     let port = server.port;
     let game = "mp-restart";
 
@@ -558,7 +336,7 @@ async fn multiprocess_server_restart_invalidates_reconnect_tokens() {
     drop(server);
 
     // Restart a NEW server process on the SAME port.
-    let restarted = spawn_server_on_fixed_port(port, "mesh").await;
+    let restarted = spawn_server_on_fixed_port(port, config_overlay("mesh")).await;
 
     // The previous reconnect flow must be rejected: the registry died with the
     // old process, so the identity is unknown (well-formed token or not).

--- a/tests/websocket_test_helpers/mod.rs
+++ b/tests/websocket_test_helpers/mod.rs
@@ -3,6 +3,8 @@
 pub mod chaos_proxy;
 pub mod delivery_ledger;
 pub mod prometheus_scrape;
+pub mod room16;
+pub mod server_process;
 
 use std::collections::VecDeque;
 use std::time::Duration;

--- a/tests/websocket_test_helpers/room16.rs
+++ b/tests/websocket_test_helpers/room16.rs
@@ -1,0 +1,157 @@
+//! 16-player room test harness (PLAN P10.B1).
+//!
+//! Shared helpers for the sixteen-player suites: bring up N real WebSocket
+//! clients from loopback (all sharing IP `127.0.0.1`, so the per-IP admission
+//! cap is genuinely exercised) and drive them through `Authenticate` +
+//! `JoinRoom`.
+//!
+//! Built incrementally alongside its consumers (red-green, so every helper is
+//! exercised by a test the same PR): the connect / authenticate / join
+//! primitives land with the admission suite
+//! (`tests/sixteen_player_admission_e2e.rs`). The per-client `ChaosProxy`
+//! option and the fault-tuned `sixteen_player_server_config()` (raised send
+//! queue / slow-consumer timeout) land with the slow-consumer / matrix suites
+//! that actually inject faults — added when those tests exist rather than as
+//! unexercised scaffolding.
+
+use futures_util::SinkExt;
+use signal_fish_server::protocol::{ClientMessage, ErrorCode, PlayerId, ServerMessage};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+
+use super::{next_matching_server_message_within, WsStream};
+
+/// Ceiling for one connect / auth / join step — generous (only a genuine wedge
+/// spends it), never an expected wait.
+const STEP_DEADLINE: tokio::time::Duration = tokio::time::Duration::from_secs(30);
+
+/// A connected, authenticated, room-joined player: its server-assigned id and
+/// the live socket. The socket is retained so the player stays in the room for
+/// the lifetime of the handle (dropping it disconnects the player).
+pub struct PlayerHandle {
+    pub player_id: PlayerId,
+    /// Players the server reported in the room at this player's join
+    /// (`RoomJoined.current_players`, which includes this player). Lets a caller
+    /// assert co-location — that N joiners share ONE room — without a second
+    /// round-trip or draining every socket's `PlayerJoined` stream.
+    pub room_player_count: usize,
+    pub ws: WsStream,
+}
+
+/// Open a WebSocket to `addr`'s `/ws` endpoint.
+pub async fn connect(addr: std::net::SocketAddr) -> WsStream {
+    let url = format!("ws://{addr}/ws");
+    let (ws, _) = tokio::time::timeout(STEP_DEADLINE, connect_async(&url))
+        .await
+        .expect("websocket connect timed out")
+        .expect("websocket connect failed");
+    ws
+}
+
+async fn send(ws: &mut WsStream, msg: &ClientMessage) {
+    let json = serde_json::to_string(msg).expect("serialize client message");
+    ws.send(Message::Text(json.into()))
+        .await
+        .expect("send client message");
+}
+
+/// Authenticate advertising `protocol_version`, then drain the handshake up to
+/// the `ProtocolInfo` that follows `Authenticated`.
+pub async fn authenticate(ws: &mut WsStream, protocol_version: u16) {
+    send(
+        ws,
+        &ClientMessage::Authenticate {
+            app_id: "room16".to_string(),
+            sdk_version: None,
+            platform: None,
+            game_data_format: None,
+            protocol_version: Some(protocol_version),
+            supported_transports: None,
+            supported_topologies: None,
+        },
+    )
+    .await;
+    next_matching_server_message_within(ws, STEP_DEADLINE, "ProtocolInfo after auth", |message| {
+        matches!(message, ServerMessage::ProtocolInfo(_)).then_some(())
+    })
+    .await;
+}
+
+/// Attempt to join `room_code` as `player_name` on an already-authenticated
+/// socket. Returns the joined handle, or the server's `(reason, error_code)`
+/// on refusal — so a caller can assert admission (the A3 regression) OR the
+/// documented room-cap refusal without a panic in either direction.
+pub async fn try_join(
+    mut ws: WsStream,
+    game_name: &str,
+    room_code: &str,
+    max_players: Option<u8>,
+    player_name: &str,
+) -> Result<PlayerHandle, (String, Option<ErrorCode>)> {
+    send(
+        &mut ws,
+        &ClientMessage::JoinRoom {
+            game_name: game_name.to_string(),
+            room_code: Some(room_code.to_string()),
+            player_name: player_name.to_string(),
+            max_players,
+            supports_authority: Some(false),
+            relay_transport: None,
+        },
+    )
+    .await;
+
+    let outcome = next_matching_server_message_within(
+        &mut ws,
+        STEP_DEADLINE,
+        "room join outcome",
+        |message| match message {
+            ServerMessage::RoomJoined(payload) => {
+                Some(Ok((payload.player_id, payload.current_players.len())))
+            }
+            ServerMessage::RoomJoinFailed { reason, error_code } => Some(Err((reason, error_code))),
+            _ => None,
+        },
+    )
+    .await;
+
+    outcome.map(|(player_id, room_player_count)| PlayerHandle {
+        player_id,
+        room_player_count,
+        ws,
+    })
+}
+
+/// Connect + authenticate + join `n` players from loopback into one room,
+/// creating it on the first join at `max_players`. Every player shares IP
+/// `127.0.0.1`, so the per-IP admission cap is exercised. Panics on any refusal
+/// — use it for the success path; drive [`connect`] / [`try_join`] directly to
+/// assert a refusal.
+///
+/// The returned sockets are NOT drained afterward. That is safe as long as the
+/// caller uses a server started via `create_router` + `axum::serve` (no
+/// `cleanup_task`, so no activity reaper) and the default `send_queue_capacity`
+/// (1024) — each retained socket then accumulates only a handful of small
+/// `PlayerJoined` frames, far below any slow-consumer threshold. A caller that
+/// starts the maintenance loop or shrinks the queue must drain instead.
+pub async fn join_n_players(
+    addr: std::net::SocketAddr,
+    game_name: &str,
+    room_code: &str,
+    max_players: Option<u8>,
+    n: usize,
+    protocol_version: u16,
+) -> Vec<PlayerHandle> {
+    let mut handles = Vec::with_capacity(n);
+    for i in 0..n {
+        let name = format!("P{i}");
+        let mut ws = connect(addr).await;
+        authenticate(&mut ws, protocol_version).await;
+        match try_join(ws, game_name, room_code, max_players, &name).await {
+            Ok(handle) => handles.push(handle),
+            Err((reason, code)) => {
+                panic!("player {name} failed to join room {room_code}: {reason} ({code:?})")
+            }
+        }
+    }
+    handles
+}

--- a/tests/websocket_test_helpers/room16.rs
+++ b/tests/websocket_test_helpers/room16.rs
@@ -54,8 +54,11 @@ async fn send(ws: &mut WsStream, msg: &ClientMessage) {
         .expect("send client message");
 }
 
-/// Authenticate advertising `protocol_version`, then drain the handshake up to
-/// the `ProtocolInfo` that follows `Authenticated`.
+/// Authenticate advertising `protocol_version`, asserting the full handshake:
+/// `Authenticated` THEN `ProtocolInfo`. Both frames are required — a regression
+/// that dropped or reordered `Authenticated` must fail here rather than pass
+/// silently on the later `ProtocolInfo` (matching the auth helpers in the other
+/// e2e suites).
 pub async fn authenticate(ws: &mut WsStream, protocol_version: u16) {
     send(
         ws,
@@ -69,6 +72,10 @@ pub async fn authenticate(ws: &mut WsStream, protocol_version: u16) {
             supported_topologies: None,
         },
     )
+    .await;
+    next_matching_server_message_within(ws, STEP_DEADLINE, "Authenticated ack", |message| {
+        matches!(message, ServerMessage::Authenticated { .. }).then_some(())
+    })
     .await;
     next_matching_server_message_within(ws, STEP_DEADLINE, "ProtocolInfo after auth", |message| {
         matches!(message, ServerMessage::ProtocolInfo(_)).then_some(())

--- a/tests/websocket_test_helpers/server_process.rs
+++ b/tests/websocket_test_helpers/server_process.rs
@@ -1,0 +1,332 @@
+//! Shared real-binary server harness for the true multi-process suites.
+//!
+//! `tests/v3_multiprocess_e2e.rs` and `tests/multiprocess_delivery_e2e.rs` both
+//! spawn the compiled `signal-fish-server` binary
+//! (`env!("CARGO_BIN_EXE_signal-fish-server")`) as a REAL child OS process and
+//! drive it over real TCP — a genuine process boundary, unlike the in-process
+//! suites. They used to carry byte-identical copies of this harness (a
+//! maintenance bug: a fix to one silently skipped the other); this module is
+//! the single copy.
+//!
+//! # Infrastructure
+//!
+//! - **Configuration**: the binary has no config-file CLI flag (`-c` is
+//!   `--validate-config`); it discovers configuration through the environment
+//!   (`src/config/loader.rs`). Each spawn writes a per-test temp config file
+//!   (tempfile) and points the child at it via `SIGNAL_FISH_CONFIG_PATH`, with
+//!   the child's working directory set to the same temp dir so no stray
+//!   `config.json` in the repo can interfere. Because later config sources
+//!   merge over earlier ones and `SIGNAL_FISH__*` env overrides always win,
+//!   the port is ALSO pinned via `SIGNAL_FISH__PORT` (belt and braces), and
+//!   every inherited `SIGNAL_FISH*` variable is scrubbed from the child env.
+//!   The base config keeps the binary zero-dependency: in-memory storage (the
+//!   only backend), `require_websocket_auth: false`, `require_metrics_auth:
+//!   false` (the delivery suite scrapes `/metrics/prom`), SDK enforcement off,
+//!   reconnection enabled, and file logging off.
+//! - **Per-suite config overlay**: the two suites need DIFFERENT config
+//!   (v3 sets `session.default_topology` + `session.enable_webrtc`; the
+//!   delivery suite sets `session.default_topology` + `websocket.*` knobs), so
+//!   [`spawn_server`] / [`spawn_server_on_fixed_port`] take a
+//!   [`serde_json::Value`] overlay that is DEEP-merged over [`base_config`]
+//!   (see [`merge_config`]): any test can set any key — nested keys merge with
+//!   their base siblings rather than replacing the whole subtree — without this
+//!   harness knowing the schema.
+//! - **Ports**: a `std::net::TcpListener` bound to `0.0.0.0:0` (matching the
+//!   server's bind address) reserves a free port which is then released and
+//!   passed to the child. The reserve-release-spawn race is absorbed by up to
+//!   [`SPAWN_ATTEMPTS`] spawns with fresh ports ([`spawn_server`]); the restart
+//!   scenario retries on its FIXED port instead
+//!   ([`spawn_server_on_fixed_port`]).
+//! - **Readiness**: the spawned process is polled on `/v2/health` (reqwest)
+//!   until it answers 200, with a hard deadline; early child exit is detected
+//!   via `try_wait`. Failures report the child's captured stdout/stderr
+//!   (piped to files in the temp dir).
+//! - **Cleanup**: [`ServerProcess`] is a child guard — `Drop` issues
+//!   `start_kill()` and the spawn sets `kill_on_drop(true)`, so the server
+//!   process dies even when a test panics; no orphans survive CI. Tests that
+//!   need a deterministic kill call [`ServerProcess::kill_and_wait`] (SIGKILL +
+//!   reap).
+//!
+//! The parent module (`tests/websocket_test_helpers/mod.rs`) carries
+//! `#![allow(dead_code)]`, which covers this child module: a helper only one
+//! suite uses is not a dead-code warning in the other.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+/// How long a client socket may take to connect to the spawned binary.
+///
+/// A saturation-tolerant CEILING, not an expected wait (zero-flakiness policy,
+/// .llm/context-testing.md). Each test spawns/drives a REAL child server
+/// process; on an oversubscribed runner the child can be CPU-starved and merely
+/// slow, so the deadline is generous enough that a starved-but-progressing
+/// child still completes. It only bites under pathological load — the happy
+/// path returns the instant the socket connects — so a large ceiling never
+/// slows a passing run. (nextest also runs these binaries in a bounded
+/// `process-spawning` test-group; see .config/nextest.toml.)
+pub const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Hard ceiling for the child to answer `/v2/health` (same rationale as
+/// [`CONNECT_TIMEOUT`]).
+const HEALTH_DEADLINE: Duration = Duration::from_secs(60);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Fresh-port spawn attempts. Each retry reserves a NEW port, so this absorbs
+/// the reserve-release-spawn race cheaply; a few attempts make a stolen port
+/// vanishingly unlikely to fail a run.
+const SPAWN_ATTEMPTS: usize = 5;
+/// Fixed-port (restart) spawn attempts. This path CANNOT dodge a transient race
+/// by picking a fresh port — it must reuse the SIGKILL'd port — so it gets more
+/// attempts and exponential backoff (see [`spawn_server_on_fixed_port`]).
+const FIXED_PORT_SPAWN_ATTEMPTS: usize = 6;
+
+/// Guard around the spawned server binary. Dropping it kills the child
+/// (`start_kill` here plus `kill_on_drop(true)` at spawn), so a panicking test
+/// never leaks an orphan server process into CI.
+pub struct ServerProcess {
+    child: Option<tokio::process::Child>,
+    /// The port the child is listening on (the reserved fresh port, or the
+    /// fixed restart port).
+    pub port: u16,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+    /// Owns the temp config file, the captured output files, and the child's
+    /// working directory; removed from disk when the guard drops.
+    _workdir: tempfile::TempDir,
+}
+
+impl ServerProcess {
+    /// SIGKILL the child (TerminateProcess on Windows) and reap it.
+    pub async fn kill_and_wait(&mut self) {
+        let mut child = self
+            .child
+            .take()
+            .expect("server process was already killed");
+        child.kill().await.expect("kill the server process");
+    }
+
+    /// The child's captured stdout/stderr, for spawn-failure diagnostics.
+    fn captured_output(&self) -> String {
+        let read = |label: &str, path: &PathBuf| {
+            let content = std::fs::read_to_string(path)
+                .unwrap_or_else(|error| format!("<failed to read {label}: {error}>"));
+            format!("--- server {label} ---\n{content}")
+        };
+        format!(
+            "{}\n{}",
+            read("stdout", &self.stdout_path),
+            read("stderr", &self.stderr_path)
+        )
+    }
+}
+
+impl Drop for ServerProcess {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            if let Err(error) = child.start_kill() {
+                eprintln!("failed to kill server process on drop: {error}");
+            }
+        }
+    }
+}
+
+/// Reserve a currently-free port by binding `0.0.0.0:0` (the same address the
+/// server binds), reading the assignment, and releasing the listener.
+fn reserve_port() -> u16 {
+    let probe = std::net::TcpListener::bind(("0.0.0.0", 0)).expect("bind port probe");
+    let port = probe.local_addr().expect("port probe local_addr").port();
+    drop(probe);
+    port
+}
+
+/// The suite-independent base config: in-memory, auth-off, zero-dependency. Each
+/// suite's per-scenario config is layered on top via a [`merge_config`] overlay
+/// (`session.default_topology`, `websocket.*`, `server.*`, …).
+fn base_config(port: u16) -> Value {
+    json!({
+        "port": port,
+        "server": {
+            "enable_reconnection": true,
+            "reconnection_window": 300
+        },
+        "security": {
+            "require_websocket_auth": false,
+            "require_metrics_auth": false,
+            "cors_origins": "*"
+        },
+        "protocol": {
+            "sdk_compatibility": { "enforce": false }
+        },
+        "logging": {
+            "enable_file_logging": false
+        }
+    })
+}
+
+/// Recursively merge `overlay` into `base`: when both sides are JSON objects the
+/// keys are merged (so an overlay can set a single nested key — e.g.
+/// `server.ping_timeout` — without dropping its base siblings); otherwise the
+/// overlay value replaces the base value.
+fn merge_config(base: &mut Value, overlay: &Value) {
+    match (base, overlay) {
+        (Value::Object(base_map), Value::Object(overlay_map)) => {
+            for (key, overlay_value) in overlay_map {
+                merge_config(
+                    base_map.entry(key.clone()).or_insert(Value::Null),
+                    overlay_value,
+                );
+            }
+        }
+        (base_slot, overlay_value) => {
+            *base_slot = overlay_value.clone();
+        }
+    }
+}
+
+/// Spawn the server binary on a fresh free port, retrying with a NEW port on
+/// failure (absorbs the reserve-release-spawn race). `overlay` is deep-merged
+/// over [`base_config`] to produce this test's effective config.
+pub async fn spawn_server(overlay: Value) -> ServerProcess {
+    let mut failures = Vec::new();
+    for attempt in 1..=SPAWN_ATTEMPTS {
+        let port = reserve_port();
+        match try_spawn_server(port, &overlay).await {
+            Ok(server) => return server,
+            Err(failure) => failures.push(format!("attempt {attempt} (port {port}): {failure}")),
+        }
+    }
+    panic!(
+        "server binary failed to become healthy after {SPAWN_ATTEMPTS} attempts:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Spawn the server binary on a FIXED port (restart-on-same-port semantics),
+/// retrying the same port with exponential backoff to absorb transient
+/// socket-teardown races. After a SIGKILL the kernel may briefly hold the
+/// listening port (the dead server's accepted connections linger in TIME_WAIT;
+/// Windows' `TerminateProcess` tears the socket down more slowly than a Unix
+/// signal), so a single flat retry can expire before the port frees under load.
+/// Backoff — not a bigger fixed sleep — is the right tool: the happy path
+/// rebinds on attempt 1 and returns immediately, while a genuinely slow teardown
+/// gets progressively more time without inflating the common case.
+pub async fn spawn_server_on_fixed_port(port: u16, overlay: Value) -> ServerProcess {
+    let mut failures = Vec::new();
+    let mut backoff = Duration::from_millis(100);
+    for attempt in 1..=FIXED_PORT_SPAWN_ATTEMPTS {
+        match try_spawn_server(port, &overlay).await {
+            Ok(server) => return server,
+            Err(failure) => failures.push(format!("attempt {attempt}: {failure}")),
+        }
+        if attempt < FIXED_PORT_SPAWN_ATTEMPTS {
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(Duration::from_millis(1600));
+        }
+    }
+    panic!(
+        "server binary failed to restart on port {port} after {FIXED_PORT_SPAWN_ATTEMPTS} \
+         attempts:\n{}",
+        failures.join("\n")
+    );
+}
+
+/// One spawn attempt: write the temp config (base merged with `overlay`),
+/// launch the child with a scrubbed environment, and wait for `/v2/health`. On
+/// failure the guard (and its `kill_on_drop` child) is dropped and the captured
+/// output is returned.
+async fn try_spawn_server(port: u16, overlay: &Value) -> Result<ServerProcess, String> {
+    let workdir = tempfile::tempdir().expect("create temp workdir");
+    let config_path = workdir.path().join("server-config.json");
+    let mut config = base_config(port);
+    merge_config(&mut config, overlay);
+    std::fs::write(
+        &config_path,
+        serde_json::to_vec_pretty(&config).expect("serialize server config"),
+    )
+    .expect("write server config");
+
+    let stdout_path = workdir.path().join("server-stdout.log");
+    let stderr_path = workdir.path().join("server-stderr.log");
+    let stdout_file = std::fs::File::create(&stdout_path).expect("create stdout capture");
+    let stderr_file = std::fs::File::create(&stderr_path).expect("create stderr capture");
+
+    let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_signal-fish-server"));
+    command
+        .current_dir(workdir.path())
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(stdout_file))
+        .stderr(std::process::Stdio::from(stderr_file))
+        .kill_on_drop(true);
+    // Scrub every inherited SIGNAL_FISH* variable: ambient config JSON, config
+    // paths, or SIGNAL_FISH__* field overrides would silently override the
+    // temp config (env overrides are applied last by the loader).
+    for (key, _) in std::env::vars_os() {
+        if key
+            .to_str()
+            .is_some_and(|key| key.starts_with("SIGNAL_FISH"))
+        {
+            command.env_remove(&key);
+        }
+    }
+    command.env("SIGNAL_FISH_CONFIG_PATH", &config_path);
+    command.env("SIGNAL_FISH__PORT", port.to_string());
+
+    let child = command.spawn().expect("spawn the server binary");
+    let mut server = ServerProcess {
+        child: Some(child),
+        port,
+        stdout_path,
+        stderr_path,
+        _workdir: workdir,
+    };
+
+    match wait_until_healthy(&mut server).await {
+        Ok(()) => Ok(server),
+        Err(reason) => Err(format!(
+            "{reason}; captured child output:\n{}",
+            server.captured_output()
+        )),
+    }
+}
+
+/// Poll `/v2/health` until it answers 200 (or the deadline passes / the child
+/// exits early).
+async fn wait_until_healthy(server: &mut ServerProcess) -> Result<(), String> {
+    let url = format!("http://127.0.0.1:{}/v2/health", server.port);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .expect("build health-poll client");
+    let start = std::time::Instant::now();
+    let deadline = start + HEALTH_DEADLINE;
+
+    loop {
+        let child = server
+            .child
+            .as_mut()
+            .expect("health poll requires a live child");
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Err(format!("server process exited early with {status}"));
+            }
+            Ok(None) => {}
+            Err(error) => return Err(format!("failed to poll server process: {error}")),
+        }
+
+        match client.get(&url).send().await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            // Not up yet (connection refused / non-200): keep polling.
+            Ok(_) | Err(_) => {}
+        }
+
+        if std::time::Instant::now() >= deadline {
+            let elapsed = start.elapsed();
+            return Err(format!(
+                "health endpoint {url} (port {}) never answered 200 within {HEALTH_DEADLINE:?} \
+                 (waited {elapsed:?}); the child stayed alive but unready",
+                server.port
+            ));
+        }
+        tokio::time::sleep(HEALTH_POLL_INTERVAL).await;
+    }
+}


### PR DESCRIPTION
Advances the **P10 bulletproofing campaign** (after P10.A landed in #140) with the
shared verification infrastructure, the deterministic falsification experiments,
and the client-facing contract docs those experiments produced. Almost entirely
test/doc; the one production-adjacent change (B4) is behavior-preserving.

## Commits

**P10.B4 — reaper + heartbeat throttle read the Tokio runtime clock.**
`connection_manager.rs` uses `tokio::time::Instant`; outside a paused runtime it
wraps the same monotonic std clock (production behavior unchanged), but tests can
now drive the reaper/throttle windows with `tokio::time::advance()`. The
`heartbeat.rs` reaper test dropped its real 25 ms sleep; two throttle-boundary
tests added.

**FLAKE-002 root-cause (same class).** `batching.rs` flush-timer tests →
`start_paused` + `advance()` (was large-interval + `thread::sleep`); fully
deterministic now.

**P10.B1 — 16-player harness.** New `tests/websocket_test_helpers/room16.rs`
(connect / authenticate / try_join / join_n_players): N real loopback clients
sharing one IP so the per-IP admission cap is genuinely exercised.

**P10.B2 — real-binary harness dedupe.** The `ServerProcess`/spawn/health-poll
machinery duplicated across the two multiprocess suites is now a single
`server_process.rs` with a `serde_json` deep-merge config overlay (v3
620→398, delivery 1253→1049 lines). Pure refactor; same effective config.

**P10.C H11/H12 — 16-player admission regression.** 16 same-IP clients connect +
co-locate in one room at the default cap (the A3 fix, #140); the 9th join into a
default (8-cap) room is `ROOM_FULL`. Red-green proven (fails at the pre-A3 cap 10).

**P10.C H8 — mesh signal-budget model.** Config↔protocol invariant guard: a
16-player mesh's `(N-1)·(1+K)` = 165 signals/player fits the deployment default
`max_signals` (600) with ≥2× headroom.

**P10.C H7 — truncated-reconnect snapshot completeness.** Falsification: the
predicted "ready-state/spectator holes" in `ReconnectedPayload` are **refuted** —
a truncated replay still carries the full snapshot; new test pins it.

**P10.C H6 — reconnect window + duplicate-claim.** Window boundary is enforced by
the reconnect handler (proven independent of the cleanup tick via a 3600 s
interval); two concurrent same-token claims yield exactly one winner. Zero-flaky
(overshoot-only timing; lock-serialized outcome).

**P10.C H1+H13 — no-cascade.** One hard-stalled recipient is evicted while THREE
healthy peers each keep the complete in-order stream and exactly one connection
is torn down (`slow_consumer_disconnects == 1`) — the multi-peer no-cascade
guarantee prior single-witness tests never pinned.

**P10.F3 — SDK client-contract docs.** `building-a-client.md` gains two grounded
pitfalls from the findings above: rejoin-by-code must carry the original
`max_players` (or a vanished room re-creates at cap 8 → `ROOM_FULL`); `Reconnect`
is windowed + single-winner, and a teardown race yields
`PLAYER_ALREADY_CONNECTED` (token not consumed → retry).

## Audited, already covered (no new tests — non-bloating)

- **H4** (half-open loss visibility) — covered by
  `v4_game_data_sequencing_e2e::evicted_recipient_observes_seq_gap_after_reconnect`.
- **H9 (phases 1–3)** (seq-gap accountability) — covered by the v4 sequencing +
  relay-chaos + reconnection-replay suites.
- **H3** (restart + capacity trap) — covered by
  `multiprocess_server_restart_invalidates_reconnect_tokens` +
  `ninth_join_fails_at_default_room_cap` (composition).

## Verification

- `cargo nextest run --profile ci --all-features` — **1472/1472 passing**
  (repeatedly, incl. under full-suite load); zero flaky.
- `cargo fmt --check` · `cargo clippy --all-targets --all-features` (0 warnings)
  · `--locked` clean · all doc tests + `check-doc-consistency.sh` green.
- v2/v3 golden wire snapshots byte-identical (no protocol/wire change; v4 untouched).
- Every increment adversarially reviewed (sub-agents + main-thread); all findings addressed.

## Scope notes

No protocol/wire change. `PLAN.md` / `progress/` are gitignored working docs and
are not part of this PR. Deferred (out of PR lane): nightly timing experiments
(H2/H5/H10/H14 + nightly facets), the ConformanceAuditor (B3), and the v4
revision (E, owner-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production clock swap is documented as behavior-preserving; scope is tests, docs, and refactors with no protocol or wire changes.
> 
> **Overview**
> **P10.B4 / FLAKE-002:** The activity reaper and `should_update_last_seen` throttle in `ConnectionManager` now use **`tokio::time::Instant`** instead of `std::time::Instant` (production behavior unchanged). Tests drive those windows with **`tokio::time::advance()`** under `start_paused`; the heartbeat reaper test drops real sleep, and batcher flush tests move from `thread::sleep` to paused-clock boundary checks.
> 
> **Harness:** Duplicated multi-process server spawn logic is consolidated into **`websocket_test_helpers::server_process`** (JSON config overlay); **`room16`** helpers support 16 loopback clients on one IP. `v3_multiprocess_e2e` and `multiprocess_delivery_e2e` call the shared module.
> 
> **New e2e / model tests:** 16-player admission at default per-IP cap and 9th join `ROOM_FULL`; reconnect window vs cleanup tick and duplicate-claim winner; truncated reconnect still carries full room snapshot; mesh signal-budget vs default `max_signals`; slow-consumer eviction with **exactly one** disconnect and three healthy peers unaffected.
> 
> **Docs:** `building-a-client.md` adds rejoin-by-code **`max_players`** and **`Reconnect`** window / retry guidance. **CHANGELOG** and **Cargo.toml** dev-deps note **`test-util`** for paused-clock tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6072aa9284a13fbf7c7327776022ed9876f8bbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->