### PR TITLE
feat: Formal Verification Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `DeliveryClasses` TLA+ model (`formal/tla/DeliveryClasses.tla` +
+  `_Small.cfg`) — spec-first for the protocol-v4 P10.E2 delivery classes
+  (reliable / latest / volatile). It pins the per-class accounting contract:
+  `ReliableConservation` (reliable never coalesced), `LatestConservation` /
+  `VolatileConservation` (each class only in its legitimate buckets),
+  `AccountedSupersession` (every coalesced-away id is ledgered — held always,
+  since the ledger write is atomic with the supersession), `LatestValueLastWrite`
+  (≤1 queued latest per key; the queued rep is newest), and `ReportHonest` (the
+  out-of-band `DeliveryReport` never overstates). Four seeded bugs prove
+  non-vacuity — `SilentSupersedeBug`, `CoalesceReliableBug`, `MisdropLatestBug`,
+  `ReportOverstateBug` (each violating its intended invariant) — all pinned
+  `FALSE` in the checked config (green in the auto-globbed suite). `latest` never
+  backpressures (a new-key send on a full queue drop-oldest-volatile or drops the
+  arrival); the per-successor `supersedes_from` scalar is documented as the
+  D4/E5 watermark concern, out of scope here.
+
 - Added the `ControlPriorityDelivery` TLA+ model
   (`formal/tla/ControlPriorityDelivery.tla` + `_Small.cfg`) — spec-first for the
   protocol-v4 P10.E2 delivery revision (merged before the code). It pins the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `SenderPacingReaper` TLA+ model
+  (`formal/tla/SenderPacingReaper.tla` + `_Small.cfg` / `_Boundary.cfg`) — the
+  repo's first discrete-time (`now` + `Tick`) spec — formalizing BUG-2, the
+  timeout inversion the config
+  cross-field check prevents: a healthy sender parked on the broadcast
+  `join_all` while a slow recipient drains must never be evicted by the activity
+  reaper (`HealthySenderNeverReaped`). A `TimeoutInversionBug` seeded constant
+  (effective grace = `ping_timeout`, the `slow = ping` boundary) reproduces the
+  healthy-sender eviction for non-vacuity; the checked configs pin it `FALSE`
+  and are green in the auto-globbed `scripts/run-tla-model-check.sh` suite. By
+  modeling the pre-park delay (the `maybe_update_last_seen` DB write + `rooms`
+  lock between the activity record and the park), the model derives that
+  `slow_consumer_timeout_ms >= ping_timeout` is unsafe — exactly the region
+  `validate_config_security` rejects — so the strict `<` is the necessary floor
+  (documented in `formal/README.md` and the check's comment, with the
+  not-proven-sufficient margin caveat). No behavior change to the A2 check.
+
 - Added the `RoomLifecycleGC` TLA+ model (`formal/tla/RoomLifecycleGC.tla` +
   `_Small.cfg` / `_WindowBoundary.cfg`) formalizing the room garbage-collection
   contract behind the BUG-1 fix: a room whose members are active is never reaped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the `ControlPriorityDelivery` TLA+ model
+  (`formal/tla/ControlPriorityDelivery.tla` + `_Small.cfg`) — spec-first for the
+  protocol-v4 P10.E2 delivery revision (merged before the code). It pins the two
+  properties the queue split must satisfy, composing with the #131
+  `DeliveryContract` substrate: `ControlAgeBounded` (control rides a separate
+  queue drained strictly before data — never starved behind a data backlog) and
+  the `DeliveryEventuallyResolves` liveness (a frame that sits too long triggers
+  a sojourn close, so `enqueued ~> written ∨ closed` holds even against a peer
+  that pings but never reads — resting only on `WF(Tick, SojournEvict,
+  CloseFinish)`, never on writer fairness). Two seeded bugs prove non-vacuity:
+  `SingleQueueBug` (control misrouted onto the data FIFO) violates
+  `ControlAgeBounded`, and `NoSojournEvictionBug` violates the liveness. Both are
+  pinned `FALSE` in the checked config (green in the auto-globbed suite);
+  `PerClassConservation`, `CtrlDropsAreLoud`, and `StalenessBounded` are also
+  checked.
+
 - Added the `SenderPacingReaper` TLA+ model
   (`formal/tla/SenderPacingReaper.tla` + `_Small.cfg` / `_Boundary.cfg`) — the
   repo's first discrete-time (`now` + `Tick`) spec — formalizing BUG-2, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,8 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and are green in the auto-globbed `scripts/run-tla-model-check.sh` suite. By
   modeling the pre-park delay (the `maybe_update_last_seen` DB write + `rooms`
   lock between the activity record and the park), the model derives that
-  `slow_consumer_timeout_ms >= ping_timeout` is unsafe — exactly the region
-  `validate_config_security` rejects — so the strict `<` is the necessary floor
+  `slow_consumer_timeout_ms >= ping_timeout * 1000` is unsafe (same units — ms;
+  `ping_timeout` is seconds) — exactly the region `validate_config_security`
+  rejects — so the strict `<` is the necessary floor
   (documented in `formal/README.md` and the check's comment, with the
   not-proven-sufficient margin caveat). No behavior change to the A2 check.
 

--- a/formal/README.md
+++ b/formal/README.md
@@ -19,14 +19,20 @@ path filters in `.github/workflows/formal-verification.yml`.
 
 ## Layout
 
-| Path                                  | Purpose                                                              |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| `tla/SignalFishSession.tla`           | The specification: actions, invariants, action properties            |
-| `tla/SignalFishSession_Mesh.cfg`      | Model: `desired = mesh`, both upgrade transports enabled             |
-| `tla/SignalFishSession_Host.cfg`      | Model: `desired = host`, both upgrade transports enabled, a v2 member |
-| `tla/SignalFishSession_HostDirect.cfg` | Model: `desired = host`, WebRTC transport disabled (host+direct rung) |
-| `tla/SignalFishSession_Floor.cfg`     | Model: `desired = mesh`, BOTH upgrade transports disabled (relay-floor denial)  |
-| `z3/protocol_invariants.py`           | Z3 SMT proofs of the pure decision functions (selector, glare, host election)   |
+Each `.tla` module carries one or more `<Module>_<Scenario>.cfg` configurations;
+the runner auto-globs **every** `formal/tla/*.cfg` (12 today), so a new spec or
+scenario is picked up with zero CI plumbing.
+
+| Path                          | Purpose                                                                            |
+| ----------------------------- | --------------------------------------------------------------------------------- |
+| `tla/SignalFishSession.tla`   | Per-room session lifecycle: negotiation, finalize, replan, late-join, reconnect (`_Mesh` / `_Host` / `_HostDirect` / `_Floor`) |
+| `tla/DeliveryContract.tla`    | The #131 deliver-or-disconnect queue contract: bounded queue, backpressure, grace expiry, conservation |
+| `tla/ConnectionTeardown.tla`  | Per-connection task teardown: no zombie sockets, exact drop accounting             |
+| `tla/SequencedRelay.tla`      | v4 per-(sender, room) sequence contract: gap accountability + the split-brain theorem |
+| `tla/ReconnectReplay.tla`     | v4 reconnect replay: faithful replay, honest status + the split-brain theorem      |
+| `tla/RoomLifecycleGC.tla`     | Room GC vs activity refresh + the reconnection-window guard (BUG-1)                |
+| `tla/SenderPacingReaper.tla`  | Sender-pacing vs the activity reaper: the timeout inversion, discrete-time (BUG-2) |
+| `z3/protocol_invariants.py`   | Z3 SMT proofs of the pure decision functions (selector, glare, host election)     |
 
 This directory holds **two complementary** formal checks:
 
@@ -42,7 +48,7 @@ This directory holds **two complementary** formal checks:
 ## How to run
 
 ```bash
-# TLA+: all four configurations (downloads + verifies the pinned tla2tools.jar once):
+# TLA+: every configuration in formal/tla/ (downloads + verifies the pinned tla2tools.jar once):
 bash scripts/run-tla-model-check.sh
 
 # One configuration / full TLC output:

--- a/formal/README.md
+++ b/formal/README.md
@@ -261,6 +261,28 @@ spurious deadlocks, so the spec adds an explicit `Done` self-loop action once th
 is exhausted; any remaining deadlock TLC reports is then a real modeling bug (a reachable
 mid-protocol state with no enabled action).
 
+### Tooling decisions (P10.D8)
+
+- **TLC-first (explicit-state), not Apalache-first.** Every model here is small and
+  finite by construction (tiny budgets/caps), so exhaustive state enumeration is fast and
+  gives concrete, minimal counterexample traces — which is what the seeded-bug non-vacuity
+  discipline needs. Apalache (symbolic, SMT-backed) is kept **dev-side only** (a future
+  `scripts/run-apalache.sh` could discharge, e.g., `SenderPacingReaper`'s inequality
+  symbolically for _all_ constant valuations rather than the pinned ones) and is **not
+  CI-gating** until it catches something TLC missed — adding an SMT dependency to CI earns
+  its keep only then.
+- **Discrete-tick integer time, not dense/real time.** Every timed property in these
+  models is a _relation between timeout constants_ (grace vs ping deadline, age vs sojourn
+  bound), never a dense-time reachability question. An integer `now`/`Tick` (or per-frame
+  `age`) with absolute-deadline guards captures them exactly, keeps the state space finite,
+  and avoids a real-time model checker. See `SenderPacingReaper` and
+  `ControlPriorityDelivery`.
+- **The action↔code correspondence style, not PlusCal.** Each action bundles one external
+  event with all its side effects and maps to one code function (the correspondence tables
+  and mapping comments). PlusCal's generated control-flow variable (`pc`) would break that
+  one-action-per-function readability, so it is deliberately **not** used — the specs are
+  written directly in TLA+.
+
 ## Single-instance theorems (split brain / ARCH-10)
 
 Several of the v4 relay/reconnect invariants are **theorems of a single relay

--- a/formal/README.md
+++ b/formal/README.md
@@ -20,8 +20,8 @@ path filters in `.github/workflows/formal-verification.yml`.
 ## Layout
 
 Each `.tla` module carries one or more `<Module>_<Scenario>.cfg` configurations;
-the runner auto-globs **every** `formal/tla/*.cfg` (13 today), so a new spec or
-scenario is picked up with zero CI plumbing.
+the runner auto-globs **every** `formal/tla/*.cfg`, so a new spec or scenario is
+picked up with zero CI plumbing.
 
 | Path                          | Purpose                                                                            |
 | ----------------------------- | --------------------------------------------------------------------------------- |

--- a/formal/README.md
+++ b/formal/README.md
@@ -295,6 +295,46 @@ single-instance by the same construction. The multi-instance seams
 dead stubs today; the deliberate single-node CP stance and the LB room-affinity
 requirement are the subject of the `F1` doctrine page in `PLAN.md`.
 
+## Timing theorem (sender pacing vs the activity reaper)
+
+`SenderPacingReaper.tla` (P10.D3) is the repo's first **discrete-time** model
+(Appendix-O house rule: an integer `now` + a `Tick` action, timers as
+absolute-deadline guards). It pins **BUG-2**, the timeout inversion the P10.A2
+config cross-field check prevents: a message handler records a sender's activity
+at dispatch, then — still on the same task — does a throttled room refresh
+(`maybe_update_last_seen`, a DB write + `rooms` write-lock) and parks on the
+broadcast `join_all` while a slow recipient drains (up to
+`websocket.slow_consumer_timeout_ms`). The receive loop is that same task, so a
+long enough park freezes its recorded activity past `server.ping_timeout` and the
+activity reaper evicts the **healthy** sender (close 4003) before its slow
+recipient is ever disconnected. Time advances only in the two waiting states: while
+parked (capped at the grace deadline) and **once while broadcasting** — the
+pre-park delay `d` (the `maybe_update_last_seen` lock/DB await), so the
+reaper-visible gap peaks at `d + SLOW`. `HealthySenderNeverReaped == ~sndEvicted`
+is the contract, with the stronger `GapWithinPingDeadline` (the reaper never sees a
+healthy gap over the deadline) pinning the boundary it rests on.
+
+| Spec (invariant)                                    | Seeded constant (checked `FALSE`) | What TRUE models | Result |
+| --------------------------------------------------- | --------------------------------- | ---------------- | ------ |
+| `SenderPacingReaper.tla` (`HealthySenderNeverReaped` / `GapWithinPingDeadline`) | `TimeoutInversionBug` | the effective grace period forced to exactly `PING_TIMEOUT` — the `slow = ping` boundary the check rejects (legal per-field, forbidden cross-field; legal system-wide before A2) | via the `d = 1` pre-park path the peak gap reaches `PING + 1 > PING` and the reaper evicts the healthy parked sender → both invariants violated (`GapWithinPingDeadline` trips one step earlier) |
+
+**Derived deliverable (the A2 inequality).** With the pre-park delay `d` (0 or 1
+tick) modeled, TLC derives that `slow >= ping` is unsafe — **exactly** the region
+`validate_config_security` rejects (`slow_consumer_timeout_ms >= ping_timeout *
+1000`): at the boundary (effective grace `= PING`, exhibited via the
+`TimeoutInversionBug` flag since the checked configs pin `SLOW < PING`) the
+`d = 1` path pushes the peak gap to `PING + 1 > PING` and the reaper (strict `>`)
+evicts. Two checked configs are green — `_Small`
+(`SLOW = 2 < PING = 4`) and `_Boundary` (`SLOW = 3 = PING − 1`, the tightest safe:
+peak gap `SLOW + 1 = PING`, never `> PING`). So the strict `<` is the **necessary
+floor** the model derives — it eliminates every `SLOW >= PING` inversion, gross
+(60 s vs 30 s) and boundary alike. It is **not proven sufficient**: the model
+bounds `d` to one tick, but the lock/DB pre-park delay is unbounded under
+contention, so a thin-margin config can still invert if `d` exceeds `PING − SLOW`.
+True safety is an operator sizing concern (keep the margin above the worst-case
+pre-park delay; the default 25 s dwarfs it) — the check is the derived guardrail
+against the provable inversion region, not a liveness proof under unbounded load.
+
 ## Intentionally not modeled (and why)
 
 - **Rate limits / relay backpressure** — quantitative throttling and queue dynamics,

--- a/formal/README.md
+++ b/formal/README.md
@@ -20,7 +20,7 @@ path filters in `.github/workflows/formal-verification.yml`.
 ## Layout
 
 Each `.tla` module carries one or more `<Module>_<Scenario>.cfg` configurations;
-the runner auto-globs **every** `formal/tla/*.cfg` (12 today), so a new spec or
+the runner auto-globs **every** `formal/tla/*.cfg` (13 today), so a new spec or
 scenario is picked up with zero CI plumbing.
 
 | Path                          | Purpose                                                                            |
@@ -32,6 +32,7 @@ scenario is picked up with zero CI plumbing.
 | `tla/ReconnectReplay.tla`     | v4 reconnect replay: faithful replay, honest status + the split-brain theorem      |
 | `tla/RoomLifecycleGC.tla`     | Room GC vs activity refresh + the reconnection-window guard (BUG-1)                |
 | `tla/SenderPacingReaper.tla`  | Sender-pacing vs the activity reaper: the timeout inversion, discrete-time (BUG-2) |
+| `tla/ControlPriorityDelivery.tla` | Spec-first for v4/P10.E2: control-priority queue split + sojourn eviction (liveness) |
 | `z3/protocol_invariants.py`   | Z3 SMT proofs of the pure decision functions (selector, glare, host election)     |
 
 This directory holds **two complementary** formal checks:
@@ -340,6 +341,26 @@ contention, so a thin-margin config can still invert if `d` exceeds `PING − SL
 True safety is an operator sizing concern (keep the margin above the worst-case
 pre-park delay; the default 25 s dwarfs it) — the check is the derived guardrail
 against the provable inversion region, not a liveness proof under unbounded load.
+
+## Delivery-revision spec-first (control priority + sojourn)
+
+`ControlPriorityDelivery.tla` is **spec-first** for the protocol-v4 P10.E2
+delivery revision — it is merged BEFORE the code and pins the two properties the
+queue split must satisfy, composing with the #131 `DeliveryContract.tla`
+substrate rather than re-deriving it. Frames are modeled by CLASS (data | ctrl)
+and carry a discrete AGE (the Appendix-O `now`/`Tick` convention, sojourn as an
+absolute-age guard). The writer (the peer draining) is deliberately UNFAIR.
+
+| Property | What it pins | Seeded bug (checked `FALSE`) → result |
+| --- | --- | --- |
+| `ControlAgeBounded` | control frames ride a separate queue drained **strictly before** data — never starved behind a data backlog | `SingleQueueBug` (control misrouted onto the data FIFO) → a data frame is written while a control frame waits behind it → **violated** |
+| `DeliveryEventuallyResolves` (liveness) | a frame that sits too long triggers a **sojourn** close, so `enqueued ~> written ∨ closed` holds even against a peer that pings but never reads | `NoSojournEvictionBug` (no sojourn close) → the frame parks forever behind the unfair writer → **violated** |
+
+Also checked: `PerClassConservation` (each class independently queued ∨ written ∨
+dropped-with-close), `CtrlDropsAreLoud`, `StalenessBounded` (no head ages past
+the bound while open — safety, given the Tick cap), and `ReasonStable`. The
+liveness rests only on `WF(Tick, SojournEvict, CloseFinish)` — **never** on writer
+fairness, which is exactly what makes the sojourn close load-bearing.
 
 ## Intentionally not modeled (and why)
 

--- a/formal/README.md
+++ b/formal/README.md
@@ -33,6 +33,7 @@ picked up with zero CI plumbing.
 | `tla/RoomLifecycleGC.tla`     | Room GC vs activity refresh + the reconnection-window guard (BUG-1)                |
 | `tla/SenderPacingReaper.tla`  | Sender-pacing vs the activity reaper: the timeout inversion, discrete-time (BUG-2) |
 | `tla/ControlPriorityDelivery.tla` | Spec-first for v4/P10.E2: control-priority queue split + sojourn eviction (liveness) |
+| `tla/DeliveryClasses.tla`     | Spec-first for v4/P10.E2: reliable/latest/volatile delivery classes + supersession accounting |
 | `z3/protocol_invariants.py`   | Z3 SMT proofs of the pure decision functions (selector, glare, host election)     |
 
 This directory holds **two complementary** formal checks:
@@ -383,6 +384,36 @@ dropped-with-close), `CtrlDropsAreLoud`, `StalenessBounded` (no head ages past
 the bound while open — safety, given the Tick cap), and `ReasonStable`. The
 liveness rests only on `WF(Tick, SojournEvict, CloseFinish)` — **never** on writer
 fairness, which is exactly what makes the sojourn close load-bearing.
+
+## Delivery classes (reliable / latest / volatile)
+
+`DeliveryClasses.tla` is the second **spec-first** module for P10.E2 (with
+`ControlPriorityDelivery.tla`), pinning the per-class delivery contract before the
+code. A single recipient's data queue carries three classes, modeled by
+`[class, key, id]` frames with globally-unique ids; the writer is UNFAIR.
+
+- **reliable** — backpressures while the queue is full (enablement); conserved,
+  never coalesced.
+- **latest** (keyed) — a same-key send SUPERSEDES the queued predecessor in place
+  (old id → the `superseded` ledger, counted); a new-key send on a full queue
+  drop-oldest-volatile or drops the arrival (`latDropped`) — it **never parks**.
+- **volatile** — enqueue if space, else drop-oldest-volatile (`volDropped`).
+
+| Invariant | Pins | Seeded bug (checked `FALSE`) → result |
+| --- | --- | --- |
+| `ReliableConservation` | reliable is queued ∨ written ∨ dropped-with-close — never coalesced | `CoalesceReliableBug` → a reliable Head evicted into `volDropped` → **violated** |
+| `LatestConservation` / `VolatileConservation` | each class lands only in its legitimate buckets | `MisdropLatestBug` → a latest misdropped into `volDropped` → **violated** |
+| `AccountedSupersession` | every superseded id is in the ledger (coalescing is never silent) — held ALWAYS, since the ledger write is atomic with the coalesce | `SilentSupersedeBug` → supersede without ledgering → **violated** |
+| `LatestValueLastWrite` | ≤1 queued latest per key; the queued rep is the newest vs superseded ∪ written | — |
+| `ReportHonest` | the out-of-band `DeliveryReport` snapshot never overstates the true counts | `ReportOverstateBug` → published count above truth → **violated** |
+
+Also checked: `TypeOK`, `UniqueIds`, `CoalesceNeverTouchesReliable`, `ReasonStable`.
+Deliberately scoped OUT (documented in the header): the per-successor
+`supersedes_from` scalar and client-side range classification — the D4/E5
+watermark concern, not this module. This module verifies **ledger completeness**,
+not scalar arithmetic. It is consistent with (not a formal refinement of) the #131
+`DeliveryContract.tla` — its counted per-class drops replace that model's single
+conservation law.
 
 ## Intentionally not modeled (and why)
 

--- a/formal/tla/ControlPriorityDelivery.tla
+++ b/formal/tla/ControlPriorityDelivery.tla
@@ -8,8 +8,8 @@
 (*      SessionPlan, errors) ride a SEPARATE per-connection queue drained   *)
 (*      STRICTLY BEFORE the data queue, so a control frame is never stuck   *)
 (*      behind a data backlog. (`websocket.control_queue_capacity`.)        *)
-(*   2. SOJOURN EVICTION. A frame that sits at the head of a queue longer   *)
-(*      than `websocket.max_sojourn_ms` closes the connection ("Stale"),    *)
+(*   2. SOJOURN EVICTION. A frame whose AGE (time since enqueue) exceeds    *)
+(*      `websocket.max_sojourn_ms` closes the connection ("Stale"),         *)
 (*      which is what makes "enqueued ~> written or closed" TRUE even       *)
 (*      against a peer that pings (so the activity reaper is happy) but      *)
 (*      never READS (so the writer never drains) — the limbo a plain        *)
@@ -211,8 +211,10 @@ SojournEvict ==
     /\ UNCHANGED <<dataQ, ctrlQ, sentD, sentC, writtenD, writtenC,
                    droppedD, droppedC, ctrlDelayedByData>>
 
-(* Any other eviction (activity reaper, idle timeout) requesting the close.    *)
-(* Exercises first-reason-wins against SojournEvict. *)
+(* A distinct non-sojourn close path (activity reaper, idle timeout). First-   *)
+(* reason-wins is preserved by RequestClose (the house pattern), though in this *)
+(* abstraction the two close actions cannot actually contest it — both require  *)
+(* connState = "Open", which is left one-way, so the reason is set exactly once.*)
 LifecycleClose ==
     /\ connState = "Open"
     /\ connState' = "CloseRequested"

--- a/formal/tla/ControlPriorityDelivery.tla
+++ b/formal/tla/ControlPriorityDelivery.tla
@@ -1,0 +1,337 @@
+--------------------------- MODULE ControlPriorityDelivery ---------------------------
+(***************************************************************************)
+(* Spec-FIRST for the protocol-v4 P10.E2 delivery revision (the design is   *)
+(* not yet implemented — this module is merged BEFORE the code and pins the *)
+(* two properties the queue split must satisfy):                            *)
+(*                                                                         *)
+(*   1. CONTROL PRIORITY. Control frames (PlayerJoined/Left/Reconnected,    *)
+(*      SessionPlan, errors) ride a SEPARATE per-connection queue drained   *)
+(*      STRICTLY BEFORE the data queue, so a control frame is never stuck   *)
+(*      behind a data backlog. (`websocket.control_queue_capacity`.)        *)
+(*   2. SOJOURN EVICTION. A frame that sits at the head of a queue longer   *)
+(*      than `websocket.max_sojourn_ms` closes the connection ("Stale"),    *)
+(*      which is what makes "enqueued ~> written or closed" TRUE even       *)
+(*      against a peer that pings (so the activity reaper is happy) but      *)
+(*      never READS (so the writer never drains) — the limbo a plain        *)
+(*      backpressure queue cannot escape.                                   *)
+(*                                                                         *)
+(* This COMPOSES WITH DeliveryContract.tla (the #131 deliver-or-disconnect  *)
+(* substrate: bounded queue, backpressure, grace expiry, conservation). It  *)
+(* does NOT re-derive the data slow-consumer grace close (that is           *)
+(* DeliveryContract's subject); it adds the control/data split and the      *)
+(* sojourn clock on top. The consumer (the socket writer) is deliberately   *)
+(* UNFAIR — the contract must hold against a peer that never reads.         *)
+(*                                                                         *)
+(* TIME is discrete and tracked as per-frame AGE (ticks since enqueue),     *)
+(* the Appendix-O house convention with sojourn as an absolute-age guard.   *)
+(* There is no separate wall clock: ages are bounded by SojournBound and    *)
+(* sends by the budgets, so the state space is finite without one, and a    *)
+(* frame can always age to the bound (a wall-clock horizon would falsely    *)
+(* strand a late-enqueued frame below the bound and break the liveness).    *)
+(* `Tick` ages every queued frame one step, capped so no head exceeds the   *)
+(* bound.                                                                   *)
+(*                                                                         *)
+(* Messages are modeled by CLASS (data | ctrl) rather than by sender: the   *)
+(* recipient's two queues do not distinguish senders, and per-class         *)
+(* conservation is the contract.                                            *)
+(*                                                                         *)
+(* Mapping to the (planned) implementation:                                 *)
+(*   SendData          a `reliable` data frame enqueued on the data queue    *)
+(*                     (backpressure = the send waits while the queue is     *)
+(*                     full — the DeliveryContract park, abstracted)         *)
+(*   SendCtrl          a control frame enqueued on the control queue         *)
+(*                     (SingleQueueBug misroutes it onto the DATA queue —    *)
+(*                     the pre-split behavior)                               *)
+(*   WriterDrainCtrl   the send task draining the CONTROL queue head — done  *)
+(*   First             strictly before any data (UNFAIR: a stalled peer      *)
+(*                     means TLC never schedules it)                         *)
+(*   Tick              one unit of wall time; every queued frame ages one    *)
+(*                     tick (capped at SojournBound)                         *)
+(*   SojournEvict      the oldest head aged to `max_sojourn_ms`: close       *)
+(*                     "Stale" (WF — this is the liveness guarantee;         *)
+(*                     NoSojournEvictionBug disables it)                     *)
+(*   LifecycleClose    any other eviction requesting the close (reaper /     *)
+(*                     idle timeout) — exercises first-reason-wins           *)
+(*   CloseFinish       teardown: every still-queued frame is counted         *)
+(*                     dropped against the closing connection (per class)    *)
+(*                                                                         *)
+(* NON-VACUITY (verified during development, keep reproducible), two seeded  *)
+(* bugs, each pinned FALSE in the checked config:                           *)
+(*                                                                         *)
+(*   - SingleQueueBug = TRUE routes control onto the DATA FIFO (no priority  *)
+(*     queue). A control frame enqueued behind data is then written after    *)
+(*     it, so TLC latches the `ctrlDelayedByData` ghost and reports a        *)
+(*     `ControlAgeBounded` violation. Minimal shape: SendData -> SendCtrl    *)
+(*     (both onto dataQ) -> WriterDrainCtrlFirst writes the data head while  *)
+(*     the ctrl frame waits behind it -> ControlAgeBounded FALSE.           *)
+(*   - NoSojournEvictionBug = TRUE disables SojournEvict. A frame enqueued   *)
+(*     for a peer that never drains (WriterDrain is unfair) then ages to the *)
+(*     bound and STAYS — no writer, no sojourn close — so TLC reports a      *)
+(*     `DeliveryEventuallyResolves` (temporal) violation: the non-empty      *)
+(*     queue never empties.                                                  *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences
+
+CONSTANTS
+    DataBudget,          \* data frames offered over the run (keep tiny: 2)
+    CtrlBudget,          \* control frames offered over the run (keep tiny: 1)
+    DataCap,             \* data-queue capacity (keep tiny: 2)
+    CtrlCap,             \* control-queue capacity (keep tiny: 1)
+    SojournBound,        \* max head age before a Stale close (keep tiny: 2)
+    SingleQueueBug,      \* TRUE misroutes control onto the data FIFO (must
+                         \* violate ControlAgeBounded; FALSE in checked cfgs)
+    NoSojournEvictionBug \* TRUE disables sojourn eviction (must violate the
+                         \* DeliveryEventuallyResolves liveness; FALSE checked)
+
+ASSUME /\ DataBudget \in Nat \ {0}
+       /\ CtrlBudget \in Nat \ {0}
+       /\ DataCap \in Nat \ {0}
+       /\ CtrlCap \in Nat \ {0}
+       /\ SojournBound \in Nat \ {0}
+       /\ SingleQueueBug \in BOOLEAN
+       /\ NoSojournEvictionBug \in BOOLEAN
+
+Class == {"data", "ctrl"}
+Entry == [class : Class, age : 0..SojournBound]
+
+VARIABLES
+    dataQ,          \* Seq(Entry): the data queue (holds ctrl too under the bug)
+    ctrlQ,          \* Seq(Entry): the priority control queue
+    sentD,          \* data frames offered
+    sentC,          \* control frames offered
+    writtenD,       \* data frames written to the socket
+    writtenC,       \* control frames written to the socket
+    droppedD,       \* data frames abandoned with a closing connection
+    droppedC,       \* control frames abandoned with a closing connection
+    connState,      \* "Open" | "CloseRequested" | "Closed"
+    closeReason,    \* "None" | "Stale" | "Lifecycle" (first wins)
+    ctrlDelayedByData \* ghost: latches TRUE if data is written while a control
+                      \* frame is pending — the starvation ControlAgeBounded forbids
+
+vars == <<dataQ, ctrlQ, sentD, sentC, writtenD, writtenC, droppedD,
+          droppedC, connState, closeReason, ctrlDelayedByData>>
+
+(* Count queued frames of a class across both queues (ctrlQ never holds data). *)
+CountClass(q, c) == Len(SelectSeq(q, LAMBDA e: e.class = c))
+DataInQueues == CountClass(dataQ, "data") + CountClass(ctrlQ, "data")
+CtrlInQueues == CountClass(dataQ, "ctrl") + CountClass(ctrlQ, "ctrl")
+
+(* Every age currently held, and the oldest of them (0 when both empty). The  *)
+(* head of each FIFO queue is its oldest frame; the max over all frames is    *)
+(* the global oldest. *)
+AllAges == {dataQ[i].age : i \in DOMAIN dataQ} \cup {ctrlQ[i].age : i \in DOMAIN ctrlQ}
+MaxAge == IF AllAges = {} THEN 0 ELSE CHOOSE a \in AllAges : \A b \in AllAges : b <= a
+
+(* A control frame is pending anywhere OTHER than the data-queue head (the     *)
+(* frame WriterDrainCtrlFirst is about to write): used to detect data written  *)
+(* while control waits. *)
+CtrlPendingBehindDataHead ==
+    \/ ctrlQ # <<>>
+    \/ \E i \in DOMAIN dataQ : i > 1 /\ dataQ[i].class = "ctrl"
+
+(* First close reason wins. *)
+RequestClose(reason) ==
+    closeReason' = IF closeReason = "None" THEN reason ELSE closeReason
+
+Init ==
+    /\ dataQ = <<>>
+    /\ ctrlQ = <<>>
+    /\ sentD = 0
+    /\ sentC = 0
+    /\ writtenD = 0
+    /\ writtenC = 0
+    /\ droppedD = 0
+    /\ droppedC = 0
+    /\ connState = "Open"
+    /\ closeReason = "None"
+    /\ ctrlDelayedByData = FALSE
+
+(* A reliable data frame is enqueued on the data queue. Backpressure is        *)
+(* modeled by enablement: while the queue is full the send simply waits (the   *)
+(* DeliveryContract park). Frames keep landing after a close is REQUESTED —    *)
+(* CloseFinish accounts whatever never reaches the socket. *)
+SendData ==
+    /\ sentD < DataBudget
+    /\ connState \in {"Open", "CloseRequested"}
+    /\ Len(dataQ) < DataCap
+    /\ dataQ' = Append(dataQ, [class |-> "data", age |-> 0])
+    /\ sentD' = sentD + 1
+    /\ UNCHANGED <<ctrlQ, sentC, writtenD, writtenC, droppedD, droppedC,
+                   connState, closeReason, ctrlDelayedByData>>
+
+(* A control frame is enqueued. Normally onto the priority control queue;      *)
+(* under SingleQueueBug onto the data FIFO instead (the pre-split behavior     *)
+(* that lets control starve behind data). *)
+SendCtrl ==
+    /\ sentC < CtrlBudget
+    /\ connState \in {"Open", "CloseRequested"}
+    /\ IF SingleQueueBug
+           THEN /\ Len(dataQ) < DataCap
+                /\ dataQ' = Append(dataQ, [class |-> "ctrl", age |-> 0])
+                /\ UNCHANGED ctrlQ
+           ELSE /\ Len(ctrlQ) < CtrlCap
+                /\ ctrlQ' = Append(ctrlQ, [class |-> "ctrl", age |-> 0])
+                /\ UNCHANGED dataQ
+    /\ sentC' = sentC + 1
+    /\ UNCHANGED <<sentD, writtenD, writtenC, droppedD, droppedC,
+                   connState, closeReason, ctrlDelayedByData>>
+
+(* The send task writes ONE frame, control queue strictly first. Deliberately  *)
+(* UNFAIR (no fairness): a stalled peer means TLC may never schedule it. When  *)
+(* it does drain a DATA-class frame while a control frame is still pending      *)
+(* (only reachable under SingleQueueBug, where control shares the data FIFO),   *)
+(* the ctrlDelayedByData ghost latches — the starvation the split prevents. *)
+WriterDrainCtrlFirst ==
+    /\ connState = "Open"
+    /\ ctrlQ # <<>> \/ dataQ # <<>>
+    /\ IF ctrlQ # <<>>
+           THEN /\ writtenC' = writtenC + 1
+                /\ ctrlQ' = Tail(ctrlQ)
+                /\ UNCHANGED <<dataQ, writtenD, ctrlDelayedByData>>
+           ELSE LET h == Head(dataQ)
+                IN /\ dataQ' = Tail(dataQ)
+                   /\ UNCHANGED ctrlQ
+                   /\ IF h.class = "ctrl"
+                          THEN /\ writtenC' = writtenC + 1
+                               /\ UNCHANGED <<writtenD, ctrlDelayedByData>>
+                          ELSE /\ writtenD' = writtenD + 1
+                               /\ UNCHANGED writtenC
+                               /\ ctrlDelayedByData' =
+                                      (ctrlDelayedByData \/ CtrlPendingBehindDataHead)
+    /\ UNCHANGED <<sentD, sentC, droppedD, droppedC, connState, closeReason>>
+
+(* The oldest head has aged to the sojourn bound: close "Stale" (the liveness  *)
+(* guarantee). Disabled by NoSojournEvictionBug. *)
+SojournEvict ==
+    /\ ~NoSojournEvictionBug
+    /\ connState = "Open"
+    /\ MaxAge >= SojournBound
+    /\ connState' = "CloseRequested"
+    /\ RequestClose("Stale")
+    /\ UNCHANGED <<dataQ, ctrlQ, sentD, sentC, writtenD, writtenC,
+                   droppedD, droppedC, ctrlDelayedByData>>
+
+(* Any other eviction (activity reaper, idle timeout) requesting the close.    *)
+(* Exercises first-reason-wins against SojournEvict. *)
+LifecycleClose ==
+    /\ connState = "Open"
+    /\ connState' = "CloseRequested"
+    /\ RequestClose("Lifecycle")
+    /\ UNCHANGED <<dataQ, ctrlQ, sentD, sentC, writtenD, writtenC,
+                   droppedD, droppedC, ctrlDelayedByData>>
+
+(* Teardown completes: every still-queued frame is counted dropped against     *)
+(* the closing connection, per class, and the queues are emptied.             *)
+CloseFinish ==
+    /\ connState = "CloseRequested"
+    /\ connState' = "Closed"
+    /\ droppedD' = droppedD + DataInQueues
+    /\ droppedC' = droppedC + CtrlInQueues
+    /\ dataQ' = <<>>
+    /\ ctrlQ' = <<>>
+    /\ UNCHANGED <<sentD, sentC, writtenD, writtenC, closeReason,
+                   ctrlDelayedByData>>
+
+(* One unit of wall time; every queued frame ages one tick. Enabled only with  *)
+(* a frame to age and while open, and capped so the oldest head never exceeds  *)
+(* SojournBound (SojournEvict becomes enabled AT the bound, before any frame   *)
+(* ages past it — so StalenessBounded is a safety invariant, not merely        *)
+(* eventual). *)
+AgeOne(q) == [i \in DOMAIN q |-> [q[i] EXCEPT !.age = @ + 1]]
+Tick ==
+    /\ connState = "Open"
+    /\ dataQ # <<>> \/ ctrlQ # <<>>
+    /\ MaxAge < SojournBound
+    /\ dataQ' = AgeOne(dataQ)
+    /\ ctrlQ' = AgeOne(ctrlQ)
+    /\ UNCHANGED <<sentD, sentC, writtenD, writtenC, droppedD, droppedC,
+                   connState, closeReason, ctrlDelayedByData>>
+
+(* Explicit terminal stutter so TLC's deadlock check stays meaningful: every   *)
+(* budget spent and either both queues drained or the connection closed. Under *)
+(* NoSojournEvictionBug the liveness violation is a fair STUTTER at a stuck     *)
+(* non-empty-queue state (WriterDrain is enabled but UNFAIR, so a behavior may  *)
+(* never take it, and Tick/SojournEvict are then disabled so their WF is        *)
+(* vacuous); Done covers the resolved terminal only, so that stuck state is not *)
+(* masked here. *)
+AllResolved ==
+    \/ connState = "Closed"   \* a closed connection accepts no more sends — terminal
+    \/ (sentD = DataBudget /\ sentC = CtrlBudget /\ dataQ = <<>> /\ ctrlQ = <<>>)
+
+Done ==
+    /\ AllResolved
+    /\ UNCHANGED vars
+
+Next ==
+    \/ SendData
+    \/ SendCtrl
+    \/ WriterDrainCtrlFirst
+    \/ SojournEvict
+    \/ LifecycleClose
+    \/ CloseFinish
+    \/ Tick
+    \/ Done
+
+(* Fairness: ONLY the contract's own guarantees — sojourn eviction always       *)
+(* eventually fires for an aged head, a requested close always completes, and   *)
+(* frames actually age (Tick). The WRITER (the peer draining) gets NO fairness: *)
+(* the whole point is that delivery still resolves against a peer that never     *)
+(* reads. *)
+Fairness ==
+    /\ WF_vars(Tick)
+    /\ WF_vars(SojournEvict)
+    /\ WF_vars(CloseFinish)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------
+(* Safety *)
+
+TypeOK ==
+    /\ dataQ \in Seq(Entry)
+    /\ ctrlQ \in Seq(Entry)
+    /\ Len(dataQ) <= DataCap
+    /\ Len(ctrlQ) <= CtrlCap
+    /\ sentD \in 0..DataBudget
+    /\ sentC \in 0..CtrlBudget
+    /\ connState \in {"Open", "CloseRequested", "Closed"}
+    /\ closeReason \in {"None", "Stale", "Lifecycle"}
+    /\ ctrlDelayedByData \in BOOLEAN
+
+(* PER-CLASS CONSERVATION: every offered frame of each class is, at every       *)
+(* reachable state, queued, written, or dropped with a closing connection —      *)
+(* never silently lost, and the two classes are accounted independently.        *)
+PerClassConservation ==
+    /\ sentD = DataInQueues + writtenD + droppedD
+    /\ sentC = CtrlInQueues + writtenC + droppedC
+
+(* Control drops are LOUD: control is abandoned only on the close path.          *)
+CtrlDropsAreLoud ==
+    droppedC > 0 => (connState \in {"CloseRequested", "Closed"} /\ closeReason # "None")
+
+(* CONTROL PRIORITY: control is never starved behind a data backlog — no data   *)
+(* frame is ever written while a control frame is still pending. A theorem of    *)
+(* the two-queue split; SingleQueueBug (control on the data FIFO) breaks it.     *)
+ControlAgeBounded ==
+    ~ctrlDelayedByData
+
+(* STALENESS BOUNDED: while the connection is open, no queued frame has aged     *)
+(* past the sojourn bound — the sojourn close fires AT the bound (safety, given  *)
+(* the Tick cap), not merely eventually.                                        *)
+StalenessBounded ==
+    connState = "Open" => MaxAge <= SojournBound
+
+----------------------------------------------------------------------------
+(* Temporal *)
+
+(* First reason wins: once recorded, the close reason never changes.            *)
+ReasonStable == [][closeReason # "None" => closeReason' = closeReason]_vars
+
+(* THE sojourn liveness: a non-empty queue never stays non-empty forever — it    *)
+(* drains, or (against a peer that never reads) the sojourn close fires and       *)
+(* teardown empties it. Holds WITHOUT any writer fairness; NoSojournEvictionBug   *)
+(* is exactly what makes it FALSE.                                              *)
+DeliveryEventuallyResolves ==
+    (dataQ # <<>> \/ ctrlQ # <<>>) ~> (dataQ = <<>> /\ ctrlQ = <<>>)
+
+=============================================================================

--- a/formal/tla/ControlPriorityDelivery_Small.cfg
+++ b/formal/tla/ControlPriorityDelivery_Small.cfg
@@ -1,0 +1,25 @@
+\* Control-priority + sojourn model at the smallest configuration that exercises
+\* both properties: a 2-slot data queue and a 1-slot control queue (so control
+\* can be enqueued while data is backlogged), a 2-data + 1-control budget, and a
+\* sojourn bound of 2 ticks. Both seeded bugs pinned FALSE (safe). See the module
+\* header for the SingleQueueBug (violates ControlAgeBounded) and
+\* NoSojournEvictionBug (violates the DeliveryEventuallyResolves liveness)
+\* non-vacuity checks. Liveness checking is on (PROPERTIES), so keep it tiny.
+SPECIFICATION Spec
+CONSTANTS
+    DataBudget = 2
+    CtrlBudget = 1
+    DataCap = 2
+    CtrlCap = 1
+    SojournBound = 2
+    SingleQueueBug = FALSE
+    NoSojournEvictionBug = FALSE
+INVARIANTS
+    TypeOK
+    PerClassConservation
+    CtrlDropsAreLoud
+    ControlAgeBounded
+    StalenessBounded
+PROPERTIES
+    ReasonStable
+    DeliveryEventuallyResolves

--- a/formal/tla/DeliveryClasses.tla
+++ b/formal/tla/DeliveryClasses.tla
@@ -1,0 +1,541 @@
+------------------------------ MODULE DeliveryClasses ------------------------------
+(***************************************************************************)
+(* Spec-FIRST for the protocol-v4 P10.E2 delivery-classes revision (the     *)
+(* design is NOT yet implemented — this module is merged BEFORE the code and *)
+(* pins the class-accounting contract the queue split must satisfy). It is   *)
+(* the wire-contract twin of `ServerMessage::DeliveryReport`. It is a         *)
+(* STANDALONE module — CONSISTENT WITH / analogous to the #131                *)
+(* `DeliveryContract.tla` substrate (bounded queue, backpressure,             *)
+(* deliver-or-disconnect) and the `ControlPriorityDelivery.tla` control/data  *)
+(* split, but with NO formal refinement mapping to them; it re-uses their     *)
+(* conventions rather than importing their state.                            *)
+(*                                                                         *)
+(* A single recipient's per-connection outbound DATA queue carrying three    *)
+(* delivery CLASSES. Messages are modeled by [class, key, id] (NO senders —  *)
+(* the recipient's one queue does not distinguish them); ids are GLOBALLY     *)
+(* UNIQUE and issued monotonically (checked by `UniqueIds`), so a frame can   *)
+(* be tracked through every disposition and the cardinality-based             *)
+(* conservation laws are sound. Control frames ride a SEPARATE queue (that    *)
+(* split, and its sojourn liveness, are `ControlPriorityDelivery.tla`'s       *)
+(* subject) and are therefore OUT of this data-queue model —                 *)
+(* `CoalesceNeverTouchesReliable` is the reliable-side half of E2's           *)
+(* "coalescing never touches control OR reliable" (control being             *)
+(* structurally unreachable here, on its own queue).                         *)
+(*                                                                         *)
+(* CLASS semantics (PLAN.md E2 / Appendix O.5):                             *)
+(*   reliable  today's semantics. BACKPRESSURES while the queue is full      *)
+(*             (modeled as ENABLEMENT: the send simply waits — the #131      *)
+(*             park/grace/4002 escalation is DeliveryContract's subject and  *)
+(*             is abstracted away here). It is the ONLY class that parks the *)
+(*             sender. Leaves the queue ONLY by being written or             *)
+(*             dropped-with-a-closing-connection. NEVER coalesced (never     *)
+(*             superseded, volatile-dropped, or latest-dropped). Conserves.  *)
+(*   latest    keyed current-value. NEVER parks the sender. Sending a latest *)
+(*             frame for key k SUPERSEDES the undelivered same-key latest     *)
+(*             already queued: the old id moves to `superseded` (counted) and *)
+(*             the successor replaces it IN PLACE (same slot, no growth — a   *)
+(*             hot key never grows the queue). The supersession is accounted  *)
+(*             INLINE into the ledger `reported`, atomically with the         *)
+(*             coalesce. At most ONE queued latest per key. A brand-new key   *)
+(*             enqueues on free space; on a FULL queue it still never parks — *)
+(*             it drops the oldest VOLATILE to make room (best-effort), or if *)
+(*             none exists drops the ARRIVING latest into `latDropped`        *)
+(*             (reliable and other-key latest are never displaced).          *)
+(*   volatile  best-effort. NEVER parks. Enqueue if space, else              *)
+(*             DROP-OLDEST-VOLATILE (counted); if the full queue holds no     *)
+(*             volatile to evict, the ARRIVING volatile is dropped (reliable  *)
+(*             and latest are never displaced).                              *)
+(*                                                                         *)
+(* ACCOUNTING — `reported` is the supersession LEDGER, not a scalar:          *)
+(*   `reported` is the server's global SET of superseded ids it has accounted *)
+(*   (the coalesce records the predecessor's id into it, in place, at         *)
+(*   supersede time). `AccountedSupersession` (superseded \subseteq reported) *)
+(*   is the property it pins — coalescing is NEVER SILENT. Because the ledger *)
+(*   write is atomic with the coalesce, there is NO window, so this is an     *)
+(*   ALWAYS invariant (stronger than O.5's at-quiescence phrasing — the "or   *)
+(*   always, if you can" it invites).                                        *)
+(*                                                                         *)
+(*   DELIBERATELY OUT OF SCOPE: the per-successor `supersedes_from` SCALAR    *)
+(*   (the lowest superseded id a single successor frame carries, so a client  *)
+(*   accepts the range [supersedes_from, seq)) and the client-side gap        *)
+(*   RANGE-classification it drives. That is the per-sender WATERMARK concern  *)
+(*   (E5 `sender_watermarks` / E6 accountability-rules rewrite), to be modeled  *)
+(*   by the D4 flagship `EndToEndGapAccountability.tla` (Appendix O.4, not yet   *)
+(*   built) — NOT here. This module verifies LEDGER COMPLETENESS only —        *)
+(*   that every coalesced-away id is accounted somewhere — NOT the per-frame  *)
+(*   scalar arithmetic. `reported` is a SET; `supersedes_from` is a scalar;   *)
+(*   they are different objects and only the former is checked here.          *)
+(*                                                                         *)
+(*   `lastReport` is the separate OUT-OF-BAND `ServerMessage::DeliveryReport`  *)
+(*   cumulative per-class counter snapshot; `ReportHonest` pins that it never  *)
+(*   overstates the true monotone counts.                                    *)
+(*                                                                         *)
+(* Mapping to the (planned) implementation:                                 *)
+(*   SendReliable      the `reliable` arm of `deliver_or_disconnect`          *)
+(*                     (`src/coordination/mod.rs`); backpressure = the send   *)
+(*                     waits while the data queue is full (the #131 park,     *)
+(*                     abstracted to enablement)                             *)
+(*   SendLatest(k)     the `latest` keyed arm: in-queue same-key replace, old *)
+(*                     id -> superseded, ledgered into `reported`; new-key    *)
+(*                     never parks (drop-oldest-volatile or drop the arrival) *)
+(*                     (`src/coordination/mod.rs` + `src/websocket/connection`*)
+(*                     `.rs` send task)                                       *)
+(*   SendBestEffort    the `volatile` arm: enqueue-or-drop-oldest-volatile    *)
+(*   WriterDrain       the send task writing one queued data frame to the     *)
+(*                     socket — deliberately UNFAIR (a stalled peer means TLC *)
+(*                     may never schedule it)                                 *)
+(*   EmitDeliveryReport  `ServerMessage::DeliveryReport` — the out-of-band    *)
+(*                     per-class CUMULATIVE counter snapshot (`src/metrics.rs`*)
+(*                     + connection)                                          *)
+(*   CloseStale       sojourn eviction (`websocket.max_sojourn_ms`) — the     *)
+(*                     pings-but-never-reads close (D2/E2 liveness path)      *)
+(*   CloseLifecycle   any other eviction requesting the close (reaper / idle  *)
+(*                     timeout)                                               *)
+(*   CloseFinish      teardown: every still-queued frame counted dropped      *)
+(*                     against the closing connection, per class              *)
+(*                     (`finalize_closed_connection`)                        *)
+(*   Done             explicit terminal stutter (deadlock checking stays ON)  *)
+(*                                                                         *)
+(* The consumer (the socket writer) is deliberately UNFAIR and no fairness   *)
+(* is asserted: these are SAFETY (accounting) contracts, checked over every  *)
+(* reachable state, plus the `ReasonStable` first-reason-wins action property.*)
+(* Time / sojourn duration is NOT modeled here (that is                      *)
+(* `ControlPriorityDelivery.tla`'s subject); `CloseStale` abstracts the        *)
+(* sojourn-close trigger as a nondeterministic action.                       *)
+(*                                                                         *)
+(* NON-VACUITY (verified during development, keep reproducible), FOUR seeded  *)
+(* bugs, each pinned FALSE in the checked config:                            *)
+(*                                                                         *)
+(*   - SilentSupersedeBug = TRUE makes the `latest` coalesce record the old   *)
+(*     id into `superseded` WITHOUT ledgering it into `reported`. Minimal     *)
+(*     trace:                                                                 *)
+(*       SendLatest(k1)  [enqueue latest id 0]                                *)
+(*       SendLatest(k1)  [supersede id 0 -> superseded = {id 0}, reported {}] *)
+(*     -> `AccountedSupersession` violated at step 2.                        *)
+(*   - CoalesceReliableBug = TRUE makes the volatile drop-oldest evict the    *)
+(*     queue Head regardless of class, so a RELIABLE frame can be coalesced   *)
+(*     away. Minimal trace (QCAP = 2):                                        *)
+(*       SendReliable    [queue = <<r id 0>>]                                 *)
+(*       Send*           [fill the queue: <<r id 0, x id 1>>]                 *)
+(*       SendBestEffort  [full; the bug evicts Head (r id 0) into volDropped] *)
+(*     -> `ReliableConservation` violated at step 3.                         *)
+(*   - MisdropLatestBug = TRUE makes the volatile drop-oldest evict the       *)
+(*     oldest LATEST frame into the VOLATILE bucket (a class misroute).       *)
+(*     Minimal trace (QCAP = 2):                                             *)
+(*       SendLatest(k1)  [queue = <<l id 0>>]                                 *)
+(*       SendLatest(k2)  [queue = <<l id 0, l id 1>> — full]                  *)
+(*       SendBestEffort  [full; the bug misdrops latest id 0 into volDropped] *)
+(*     -> `LatestConservation` violated at step 3.                           *)
+(*   - ReportOverstateBug = TRUE makes EmitDeliveryReport publish a supersede *)
+(*     count ABOVE the true one. Minimal trace:                              *)
+(*       SendLatest(k1)  [enqueue latest id 0]                                *)
+(*       SendLatest(k1)  [supersede -> superseded count 1]                    *)
+(*       EmitDeliveryReport [publishes sup = 2 > true 1]                      *)
+(*     -> `ReportHonest` violated at step 3.                                 *)
+(*                                                                         *)
+(* All four constants are pinned FALSE in `DeliveryClasses_Small.cfg`; flip   *)
+(* any one locally to watch TLC exhibit the counterexample.                  *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    Keys,               \* nonempty set of latest-value keys (keep tiny: 2)
+    RelBudget,          \* reliable frames offered over the run (keep tiny: 1)
+    LatBudget,          \* latest frames offered over the run   (keep tiny: 3 —
+                        \* so a 2-level same-key chain id0->id1->id2 is reachable)
+    BeBudget,           \* volatile frames offered over the run (keep tiny: 2)
+    QCAP,               \* bounded data-queue capacity          (keep tiny: 2)
+    SilentSupersedeBug, \* TRUE coalesces without ledgering (must violate
+                        \* AccountedSupersession; FALSE in checked cfgs)
+    CoalesceReliableBug,\* TRUE lets the volatile drop evict a reliable frame
+                        \* (must violate ReliableConservation; FALSE checked)
+    MisdropLatestBug,   \* TRUE misdrops a latest into the volatile bucket
+                        \* (must violate LatestConservation; FALSE checked)
+    ReportOverstateBug  \* TRUE publishes a report above the true counts
+                        \* (must violate ReportHonest; FALSE checked)
+
+ASSUME /\ Keys # {}
+       /\ "nokey" \notin Keys
+       /\ RelBudget \in Nat \ {0}
+       /\ LatBudget \in Nat \ {0}
+       /\ BeBudget  \in Nat \ {0}
+       /\ QCAP      \in Nat \ {0}
+       /\ SilentSupersedeBug  \in BOOLEAN
+       /\ CoalesceReliableBug \in BOOLEAN
+       /\ MisdropLatestBug    \in BOOLEAN
+       /\ ReportOverstateBug  \in BOOLEAN
+
+Class == {"reliable", "latest", "volatile"}
+MaxId == RelBudget + LatBudget + BeBudget          \* total frames offered; ids 0..MaxId-1
+KeyDom == Keys \cup {"nokey"}                       \* "nokey" tags non-latest frames
+Entry == [class : Class, key : KeyDom, id : 0..(MaxId - 1)]
+
+VARIABLES
+    queue,            \* Seq(Entry): the recipient's bounded outbound data queue
+    written,          \* SUBSET Entry: frames drained to the socket
+    superseded,       \* SUBSET Entry: latest frames coalesced away by a same-key successor
+    volDropped,       \* SUBSET Entry: volatile frames dropped best-effort (drop-oldest)
+    latDropped,       \* SUBSET Entry: latest frames dropped best-effort (full, no volatile)
+    droppedWithClose, \* SUBSET Entry: frames abandoned with a closing connection (per class)
+    reported,         \* SUBSET (0..MaxId-1): supersession LEDGER (accounted superseded ids)
+    relSent,          \* Nat: reliable frames offered
+    latSent,          \* Nat: latest frames offered
+    volSent,          \* Nat: volatile frames offered
+    connState,        \* "Open" | "CloseRequested" | "Closed"
+    closeReason,      \* "None" | "Stale" | "Lifecycle" (first wins)
+    lastReport        \* [sup, vol, lat, closed]: last emitted DeliveryReport snapshot
+
+vars == <<queue, written, superseded, volDropped, latDropped, droppedWithClose,
+          reported, relSent, latSent, volSent, connState, closeReason, lastReport>>
+
+(* The set of frames currently sitting in the queue (ids are unique, so the   *)
+(* set loses nothing). *)
+QueueSet == {queue[i] : i \in DOMAIN queue}
+
+(* Every frame the run has ever admitted lives in exactly one of these. *)
+AllEntries ==
+    QueueSet \cup written \cup superseded \cup volDropped \cup latDropped
+             \cup droppedWithClose
+
+(* Class projections of a set of entries. *)
+RelIn(S) == {e \in S : e.class = "reliable"}
+LatIn(S) == {e \in S : e.class = "latest"}
+VolIn(S) == {e \in S : e.class = "volatile"}
+
+(* The id assigned to the next admitted frame — the running total of offers,  *)
+(* so ids are unique and monotone. *)
+NextId == relSent + latSent + volSent
+
+(* Cumulative per-class coalesce/drop counters the DeliveryReport publishes. *)
+CurSup    == Cardinality(superseded)
+CurVol    == Cardinality(volDropped)
+CurLat    == Cardinality(latDropped)
+CurClosed == Cardinality(droppedWithClose)
+
+(* Is a latest frame for key k currently queued? (At most one — an invariant.) *)
+HasLatest(k) == \E i \in DOMAIN queue : queue[i].class = "latest" /\ queue[i].key = k
+LatestIdx(k) == CHOOSE i \in DOMAIN queue : queue[i].class = "latest" /\ queue[i].key = k
+
+(* Is any volatile queued, and the index of the oldest (lowest) one? *)
+HasVol == \E i \in DOMAIN queue : queue[i].class = "volatile"
+OldestVolIdx ==
+    CHOOSE i \in DOMAIN queue :
+        /\ queue[i].class = "volatile"
+        /\ \A j \in DOMAIN queue : queue[j].class = "volatile" => i <= j
+
+(* Is any latest queued, and the index of the oldest (lowest) one? *)
+HasLat == \E i \in DOMAIN queue : queue[i].class = "latest"
+OldestLatIdx ==
+    CHOOSE i \in DOMAIN queue :
+        /\ queue[i].class = "latest"
+        /\ \A j \in DOMAIN queue : queue[j].class = "latest" => i <= j
+
+(* Drop the element at index i from a sequence (order-preserving). *)
+Remove(seq, i) == SubSeq(seq, 1, i - 1) \o SubSeq(seq, i + 1, Len(seq))
+
+(* First close reason wins — later requests must not overwrite it. *)
+RequestClose(reason) ==
+    closeReason' = (IF closeReason = "None" THEN reason ELSE closeReason)
+
+Init ==
+    /\ queue = <<>>
+    /\ written = {}
+    /\ superseded = {}
+    /\ volDropped = {}
+    /\ latDropped = {}
+    /\ droppedWithClose = {}
+    /\ reported = {}
+    /\ relSent = 0
+    /\ latSent = 0
+    /\ volSent = 0
+    /\ connState = "Open"
+    /\ closeReason = "None"
+    /\ lastReport = [sup |-> 0, vol |-> 0, lat |-> 0, closed |-> 0]
+
+(* A reliable frame is admitted. BACKPRESSURE is modeled by enablement: while *)
+(* the queue is full the send simply waits (the #131 park, abstracted).       *)
+(* Reliable is the ONLY class that parks. Frames keep landing after a close is *)
+(* REQUESTED — CloseFinish accounts whatever never reaches the socket. *)
+SendReliable ==
+    /\ relSent < RelBudget
+    /\ connState \in {"Open", "CloseRequested"}
+    /\ Len(queue) < QCAP
+    /\ queue' = Append(queue, [class |-> "reliable", key |-> "nokey", id |-> NextId])
+    /\ relSent' = relSent + 1
+    /\ UNCHANGED <<written, superseded, volDropped, latDropped, droppedWithClose,
+                   reported, latSent, volSent, connState, closeReason, lastReport>>
+
+(* A latest frame for key k. If a same-key latest is queued, SUPERSEDE it in  *)
+(* place (no growth — never parks for a hot key): the old id moves to          *)
+(* `superseded` and is LEDGERED into `reported` (SilentSupersedeBug drops the  *)
+(* ledger write). A brand-new key NEVER parks either: enqueue on free space,   *)
+(* else drop the oldest volatile to make room, else drop the ARRIVING latest   *)
+(* into `latDropped` — reliable and other-key latest are never displaced. *)
+SendLatest(k) ==
+    /\ latSent < LatBudget
+    /\ connState \in {"Open", "CloseRequested"}
+    /\ latSent' = latSent + 1
+    /\ UNCHANGED <<written, droppedWithClose, relSent, volSent, connState,
+                   closeReason, lastReport>>
+    /\ LET new == [class |-> "latest", key |-> k, id |-> NextId] IN
+         IF HasLatest(k)
+           THEN LET i == LatestIdx(k)
+                    old == queue[i]
+                IN /\ queue' = [queue EXCEPT ![i] = new]
+                   /\ superseded' = (superseded \cup {old})
+                   /\ reported' = (IF SilentSupersedeBug
+                                     THEN reported
+                                     ELSE (reported \cup {old.id}))
+                   /\ UNCHANGED <<volDropped, latDropped>>
+           ELSE IF Len(queue) < QCAP
+                  THEN /\ queue' = Append(queue, new)
+                       /\ UNCHANGED <<superseded, reported, volDropped, latDropped>>
+                  ELSE IF HasVol
+                         THEN LET j == OldestVolIdx IN
+                                /\ queue' = Append(Remove(queue, j), new)
+                                /\ volDropped' = (volDropped \cup {queue[j]})
+                                /\ UNCHANGED <<superseded, reported, latDropped>>
+                         ELSE /\ queue' = queue
+                              /\ latDropped' = (latDropped \cup {new})
+                              /\ UNCHANGED <<superseded, reported, volDropped>>
+
+(* A volatile frame. Enqueue if space; else drop-oldest-VOLATILE and enqueue   *)
+(* (or, if the full queue holds no volatile, drop the ARRIVING one — reliable  *)
+(* and latest are never displaced). CoalesceReliableBug instead evicts the     *)
+(* queue Head regardless of class (so a reliable can be dropped); MisdropLatest*)
+(* Bug instead evicts the oldest LATEST into the volatile bucket. *)
+SendBestEffort ==
+    /\ volSent < BeBudget
+    /\ connState \in {"Open", "CloseRequested"}
+    /\ volSent' = volSent + 1
+    /\ UNCHANGED <<written, superseded, reported, latDropped, droppedWithClose,
+                   relSent, latSent, connState, closeReason, lastReport>>
+    /\ LET new == [class |-> "volatile", key |-> "nokey", id |-> NextId] IN
+         IF Len(queue) < QCAP
+           THEN /\ queue' = Append(queue, new)
+                /\ UNCHANGED volDropped
+           ELSE IF CoalesceReliableBug
+                  THEN /\ queue' = Append(Tail(queue), new)
+                       /\ volDropped' = (volDropped \cup {Head(queue)})
+                  ELSE IF (MisdropLatestBug /\ HasLat)
+                         THEN LET j == OldestLatIdx IN
+                                /\ queue' = Append(Remove(queue, j), new)
+                                /\ volDropped' = (volDropped \cup {queue[j]})
+                         ELSE IF HasVol
+                                THEN LET j == OldestVolIdx IN
+                                       /\ queue' = Append(Remove(queue, j), new)
+                                       /\ volDropped' = (volDropped \cup {queue[j]})
+                                ELSE /\ queue' = queue
+                                     /\ volDropped' = (volDropped \cup {new})
+
+(* The send task writes one queued frame to the socket. Deliberately UNFAIR:  *)
+(* a stalled peer means TLC never schedules this. *)
+WriterDrain ==
+    /\ connState = "Open"
+    /\ queue # <<>>
+    /\ written' = (written \cup {Head(queue)})
+    /\ queue' = Tail(queue)
+    /\ UNCHANGED <<superseded, volDropped, latDropped, droppedWithClose, reported,
+                   relSent, latSent, volSent, connState, closeReason, lastReport>>
+
+(* ServerMessage::DeliveryReport: publish the CUMULATIVE per-class counters.   *)
+(* Out-of-band and observational (the in-band ledger `reported` already        *)
+(* accounts every coalesce). Enabled only when a counter has advanced beyond   *)
+(* the last snapshot, so it always makes progress — never a self-loop.         *)
+(* ReportOverstateBug inflates the published supersede count above the truth.  *)
+EmitDeliveryReport ==
+    /\ connState \in {"Open", "CloseRequested"}
+    /\ CurSup + CurVol + CurLat + CurClosed
+         > lastReport.sup + lastReport.vol + lastReport.lat + lastReport.closed
+    /\ lastReport' = (IF ReportOverstateBug
+                        THEN [sup |-> CurSup + 1, vol |-> CurVol,
+                              lat |-> CurLat, closed |-> CurClosed]
+                        ELSE [sup |-> CurSup, vol |-> CurVol,
+                              lat |-> CurLat, closed |-> CurClosed])
+    /\ UNCHANGED <<queue, written, superseded, volDropped, latDropped,
+                   droppedWithClose, reported, relSent, latSent, volSent,
+                   connState, closeReason>>
+
+(* Sojourn eviction (`websocket.max_sojourn_ms`): close "Stale". The trigger   *)
+(* time is abstracted — this nondeterministic action stands in for the         *)
+(* pings-but-never-reads sojourn close (whose clock is ControlPriorityDelivery's*)
+(* subject). *)
+CloseStale ==
+    /\ connState = "Open"
+    /\ connState' = "CloseRequested"
+    /\ RequestClose("Stale")
+    /\ UNCHANGED <<queue, written, superseded, volDropped, latDropped,
+                   droppedWithClose, reported, relSent, latSent, volSent, lastReport>>
+
+(* A distinct non-sojourn close path (activity reaper, idle timeout). First-   *)
+(* reason-wins is preserved by RequestClose (the house pattern), though in     *)
+(* this abstraction the two close actions cannot actually contest it — both    *)
+(* require connState = "Open", which is left one-way, so the reason is set     *)
+(* exactly once. *)
+CloseLifecycle ==
+    /\ connState = "Open"
+    /\ connState' = "CloseRequested"
+    /\ RequestClose("Lifecycle")
+    /\ UNCHANGED <<queue, written, superseded, volDropped, latDropped,
+                   droppedWithClose, reported, relSent, latSent, volSent, lastReport>>
+
+(* Teardown completes: every still-queued frame is counted dropped against the *)
+(* closing connection (per class — reliable lands in the legal droppedWithClose*)
+(* bucket), and the queue is emptied. *)
+CloseFinish ==
+    /\ connState = "CloseRequested"
+    /\ connState' = "Closed"
+    /\ droppedWithClose' = (droppedWithClose \cup QueueSet)
+    /\ queue' = <<>>
+    /\ UNCHANGED <<written, superseded, volDropped, latDropped, reported,
+                   relSent, latSent, volSent, closeReason, lastReport>>
+
+(* Explicit terminal stutter so TLC's deadlock check stays ON without flagging *)
+(* the natural terminals. Deadlock-freedom is otherwise STRUCTURAL here: while *)
+(* "Open" the two close actions are always enabled, and while "CloseRequested" *)
+(* CloseFinish is — only the "Closed" terminal (which accepts no more sends)   *)
+(* needs this stutter, so any OTHER deadlock TLC reports is a real modeling    *)
+(* bug. *)
+AllResolved ==
+    \/ connState = "Closed"
+    \/ (relSent = RelBudget /\ latSent = LatBudget /\ volSent = BeBudget /\ queue = <<>>)
+
+Done ==
+    /\ AllResolved
+    /\ UNCHANGED vars
+
+Next ==
+    \/ SendReliable
+    \/ \E k \in Keys : SendLatest(k)
+    \/ SendBestEffort
+    \/ WriterDrain
+    \/ EmitDeliveryReport
+    \/ CloseStale
+    \/ CloseLifecycle
+    \/ CloseFinish
+    \/ Done
+
+(* No fairness: these are SAFETY (accounting) contracts, checked over every    *)
+(* reachable state. The writer gets no fairness — the contract must hold        *)
+(* against a peer that never reads. *)
+Spec == Init /\ [][Next]_vars
+
+----------------------------------------------------------------------------
+(* Safety *)
+
+TypeOK ==
+    /\ queue \in Seq(Entry)
+    /\ Len(queue) <= QCAP
+    /\ written \subseteq Entry
+    /\ superseded \subseteq Entry
+    /\ volDropped \subseteq Entry
+    /\ latDropped \subseteq Entry
+    /\ droppedWithClose \subseteq Entry
+    /\ reported \subseteq (0..(MaxId - 1))
+    /\ relSent \in 0..RelBudget
+    /\ latSent \in 0..LatBudget
+    /\ volSent \in 0..BeBudget
+    /\ connState \in {"Open", "CloseRequested", "Closed"}
+    /\ closeReason \in {"None", "Stale", "Lifecycle"}
+    /\ lastReport \in [sup : 0..LatBudget, vol : 0..BeBudget,
+                       lat : 0..LatBudget, closed : 0..MaxId]
+    \* only latest frames carry a real key; everything else is tagged "nokey"
+    /\ \A e \in AllEntries : (e.class = "latest") <=> (e.key \in Keys)
+
+(* Ids are GLOBALLY UNIQUE: no two distinct admitted frames share an id. This  *)
+(* is what makes the cardinality-based conservation laws sound (a set built    *)
+(* from the queue or a disposition bucket never collapses two frames). *)
+UniqueIds ==
+    \A e1 \in AllEntries : \A e2 \in AllEntries : (e1.id = e2.id) => (e1 = e2)
+
+(* RELIABLE CONSERVATION: every reliable frame offered is, at every reachable  *)
+(* state, queued OR written OR dropped-with-a-closing-connection — and NEVER   *)
+(* coalesced (superseded, volatile-dropped, or latest-dropped). The count      *)
+(* equation catches a reliable frame that leaked into a coalescing bucket (the *)
+(* legal-bucket total falls short of relSent); the emptiness clauses name the  *)
+(* illegal buckets directly. CoalesceReliableBug breaks it. *)
+ReliableConservation ==
+    /\ relSent = Cardinality(RelIn(QueueSet))
+                 + Cardinality(RelIn(written))
+                 + Cardinality(RelIn(droppedWithClose))
+    /\ RelIn(superseded) = {}
+    /\ RelIn(volDropped) = {}
+    /\ RelIn(latDropped) = {}
+
+(* The reliable-side half of E2's "coalescing never touches control OR         *)
+(* reliable" (control rides its own queue — structurally unreachable here). A   *)
+(* dedicated restatement of the illegal-bucket clauses; CoalesceReliableBug     *)
+(* breaks it too. *)
+CoalesceNeverTouchesReliable ==
+    /\ RelIn(superseded) = {}
+    /\ RelIn(volDropped) = {}
+    /\ RelIn(latDropped) = {}
+
+(* LATEST CONSERVATION: every latest frame offered is queued OR written OR      *)
+(* superseded OR latest-dropped OR dropped-with-close — and NEVER misrouted     *)
+(* into the volatile bucket. MisdropLatestBug (a latest evicted into volDropped)*)
+(* breaks it. *)
+LatestConservation ==
+    /\ latSent = Cardinality(LatIn(QueueSet))
+                 + Cardinality(LatIn(written))
+                 + Cardinality(LatIn(superseded))
+                 + Cardinality(LatIn(latDropped))
+                 + Cardinality(LatIn(droppedWithClose))
+    /\ LatIn(volDropped) = {}
+
+(* VOLATILE CONSERVATION: every volatile frame offered is queued OR written OR  *)
+(* volatile-dropped OR dropped-with-close — and NEVER superseded or            *)
+(* latest-dropped (those coalescing buckets belong to the latest class). *)
+VolatileConservation ==
+    /\ volSent = Cardinality(VolIn(QueueSet))
+                 + Cardinality(VolIn(written))
+                 + Cardinality(VolIn(volDropped))
+                 + Cardinality(VolIn(droppedWithClose))
+    /\ VolIn(superseded) = {}
+    /\ VolIn(latDropped) = {}
+
+(* LATEST = LAST WRITE WINS (among the QUEUED representative vs superseded ∪     *)
+(* written): at most one queued latest per key, and that queued frame's id is    *)
+(* the maximum among all latest frames for the key seen so far (every            *)
+(* superseded/written same-key latest has a strictly lower id — coalescing is    *)
+(* monotone, an older value never displaces a newer one, across a chain). This   *)
+(* is deliberately NOT an end-to-end "newest value always delivered" guarantee:   *)
+(* it excludes `latDropped`, so a NEWER same-key latest dropped under queue       *)
+(* pressure (latest never parks / never displaces reliable) can leave an OLDER    *)
+(* written value the last delivered — accounted in `latDropped`, by design. *)
+LatestValueLastWrite ==
+    /\ \A k \in Keys :
+         Cardinality({i \in DOMAIN queue :
+                        queue[i].class = "latest" /\ queue[i].key = k}) <= 1
+    /\ \A qi \in DOMAIN queue :
+         queue[qi].class = "latest" =>
+           \A e \in (superseded \cup written) :
+             (e.class = "latest" /\ e.key = queue[qi].key) => e.id < queue[qi].id
+
+(* ACCOUNTED SUPERSESSION: coalescing is never silent — every superseded id is  *)
+(* in the ledger `reported`. Held ALWAYS (not merely at quiescence) because the *)
+(* ledger write is atomic with the coalesce. SilentSupersedeBug breaks it. *)
+AccountedSupersession ==
+    \A e \in superseded : e.id \in reported
+
+(* REPORT HONESTY: the published DeliveryReport never OVERSTATES the true        *)
+(* cumulative counts (it is a snapshot of monotonically growing counters).      *)
+(* ReportOverstateBug breaks it (via the `sup` conjunct). NOTE the `closed`      *)
+(* conjunct is structurally INERT in this single-connection model: droppedWith   *)
+(* Close is populated only at CloseFinish (-> Closed), after which no            *)
+(* EmitDeliveryReport can fire (it is gated to {Open, CloseRequested}), so       *)
+(* lastReport.closed is always 0. It is kept for contract symmetry; a            *)
+(* terminal/multi-report abstraction would give it teeth. *)
+ReportHonest ==
+    /\ lastReport.sup    <= CurSup
+    /\ lastReport.vol    <= CurVol
+    /\ lastReport.lat    <= CurLat
+    /\ lastReport.closed <= CurClosed
+
+----------------------------------------------------------------------------
+(* Temporal *)
+
+(* First reason wins: once recorded, the close reason never changes. *)
+ReasonStable == [][closeReason # "None" => closeReason' = closeReason]_vars
+
+=============================================================================

--- a/formal/tla/DeliveryClasses_Small.cfg
+++ b/formal/tla/DeliveryClasses_Small.cfg
@@ -1,0 +1,35 @@
+\* Delivery-classes model at the smallest configuration that exercises every
+\* class interaction: a 2-slot data queue, a single reliable frame (so it can
+\* be the oldest Head a buggy drop would evict), THREE latest frames (so a
+\* 2-level same-key supersession chain id0->id1->id2 is reachable, exercising
+\* the ledger and LatestValueLastWrite across a chain) over two keys (so both
+\* keys can be queued at once, ≤1 each), and two volatile frames (so
+\* drop-oldest-volatile fires, as well as the drop-the-arrival path and the
+\* new-key-latest-evicts-a-volatile path). All four seeded bugs pinned FALSE
+\* (safe). See the module header for the SilentSupersedeBug (violates
+\* AccountedSupersession), CoalesceReliableBug (violates ReliableConservation),
+\* MisdropLatestBug (violates LatestConservation) and ReportOverstateBug
+\* (violates ReportHonest) non-vacuity checks. State space stays tiny (<2s TLC).
+SPECIFICATION Spec
+CONSTANTS
+    Keys = {"k1", "k2"}
+    RelBudget = 1
+    LatBudget = 3
+    BeBudget = 2
+    QCAP = 2
+    SilentSupersedeBug = FALSE
+    CoalesceReliableBug = FALSE
+    MisdropLatestBug = FALSE
+    ReportOverstateBug = FALSE
+INVARIANTS
+    TypeOK
+    UniqueIds
+    ReliableConservation
+    CoalesceNeverTouchesReliable
+    LatestConservation
+    VolatileConservation
+    LatestValueLastWrite
+    AccountedSupersession
+    ReportHonest
+PROPERTIES
+    ReasonStable

--- a/formal/tla/SenderPacingReaper.tla
+++ b/formal/tla/SenderPacingReaper.tla
@@ -1,0 +1,404 @@
+----------------------------- MODULE SenderPacingReaper -----------------------------
+(***************************************************************************)
+(* The sender-pacing vs activity-reaper TIMING contract (BUG-2 / the       *)
+(* timeout-inversion hazard the P10.A2 config cross-field check prevents):  *)
+(*                                                                         *)
+(*   A healthy, actively-sending player is NEVER evicted by the activity    *)
+(*   reaper for having its own recorded activity go stale while it is       *)
+(*   PARKED broadcasting to a slow recipient — PROVIDED the slow-consumer   *)
+(*   grace period cannot outlast the reaper's ping deadline.                *)
+(*                                                                         *)
+(* The hazard is a race between two independent server clocks measured      *)
+(* against the SAME frozen timestamp:                                       *)
+(*                                                                         *)
+(*   1. A player's message handler records its activity at DISPATCH         *)
+(*      (`record_client_activity`, src/server/message_router.rs:15), then   *)
+(*      — still on the same task, BEFORE relaying — does a throttled room   *)
+(*      refresh `maybe_update_last_seen(...).await` (message_router.rs:23),  *)
+(*      which on the throttle boundary performs a DB write and takes the    *)
+(*      global `rooms` write lock (src/server/heartbeat.rs). It then relays *)
+(*      the frame: `deliver_to_all` awaits `join_all` over every recipient  *)
+(*      (src/server.rs:675-716). A slow recipient PARKS that await for up   *)
+(*      to `websocket.slow_consumer_timeout_ms` (`deliver_or_disconnect`    *)
+(*      grace, src/coordination/mod.rs). The player's receive loop is the   *)
+(*      SAME task (connection.rs inline-awaits `handle_client_message`), so *)
+(*      while parked it processes NO further inbound frames — its recorded  *)
+(*      activity stays frozen at the dispatch instant even as the client    *)
+(*      keeps sending (pings pile up unread at the socket).                  *)
+(*   2. The activity reaper (`collect_expired_clients`,                     *)
+(*      src/server/connection_manager.rs) evicts any client whose recorded  *)
+(*      activity is older than `server.ping_timeout`                        *)
+(*      (`now.duration_since(last_ping) > ping_timeout`, close 4003), swept *)
+(*      each `room_cleanup_interval` tick (src/server/maintenance.rs).      *)
+(*                                                                         *)
+(* If a park (bounded by SLOW_TIMEOUT) plus the pre-park delay can push the  *)
+(* frozen-activity gap past PING_TIMEOUT, the reaper evicts the HEALTHY      *)
+(* parked SENDER (4003) before its slow RECIPIENT is ever disconnected —     *)
+(* the timeout inversion.                                                   *)
+(*                                                                         *)
+(* TIME MODEL (Appendix-O house rule: discrete integer `now` + `Tick`,      *)
+(* timers as absolute-deadline guards). `Tick` advances time in exactly two *)
+(* situations, the only two where the sender waits and cannot refresh its   *)
+(* activity: (a) while PARKED on the slow recipient (capped at the grace    *)
+(* deadline — the recipient's grace timer WILL fire at EffectiveSlow, so    *)
+(* the park never outlasts it), and (b) ONCE while BROADCASTING, modeling   *)
+(* the PRE-PARK delay `d` above (the `maybe_update_last_seen` DB-write +     *)
+(* `rooms`-lock await that runs after the activity record and before the    *)
+(* park). Bounding `d` to a single tick is a deliberate floor: in wall time *)
+(* it is usually sub-tick, but under `rooms`-lock contention it is nonzero  *)
+(* and unbounded, and even one tick is enough to make the exact boundary    *)
+(* `SLOW = PING` unsafe (see the derivation). Processing, enqueuing, and    *)
+(* the client sending are otherwise instantaneous at this time scale.       *)
+(*                                                                         *)
+(* Mapping to the implementation:                                           *)
+(*   ClientSend        a client frame (ping / game-data) ARRIVING at the    *)
+(*                     socket — the client's liveness, independent of        *)
+(*                     whether the server task is free to process it        *)
+(*   SenderProcess     the receive loop dispatching one inbound frame:       *)
+(*                     record_client_activity (activity := now) then begin   *)
+(*                     the relay (message_router.rs -> broadcast)            *)
+(*   Tick (broadcast)  the `maybe_update_last_seen` DB-write + `rooms`-lock  *)
+(*                     await between the activity record and the park (the   *)
+(*                     pre-park delay `d`, at most one tick)                 *)
+(*   BroadcastFast     deliver_to_all enqueuing to a recipient that has room *)
+(*                     (or is already gone) — the relay completes, no park   *)
+(*   BroadcastPark     the join_all await blocking on a FULL recipient queue *)
+(*                     (deliver_or_disconnect entering its grace wait)       *)
+(*   RecipientDrain    the recipient's socket writer draining one frame —     *)
+(*                     scheduled nondeterministically; a recipient that       *)
+(*                     stopped reading stalls the whole park (this spec has   *)
+(*                     no fairness on any action — see Spec)                  *)
+(*   ParkResolve       a drained slot lets the parked broadcast enqueue and   *)
+(*                     the handler return (the delivery succeeded in time)    *)
+(*   ParkGraceExpire   grace expiry: the recipient is the slow consumer and   *)
+(*                     is disconnected (CloseReason::SlowConsumer, close      *)
+(*                     4002); the handler returns. Activity is NOT refreshed  *)
+(*                     here — only the NEXT dispatched frame refreshes it     *)
+(*   RecipientReconnect a fresh recipient takes the seat, so the sender can   *)
+(*                     be made to park again (the refill loop)                *)
+(*   ReaperSweep       collect_expired_clients evicting a client whose        *)
+(*                     recorded activity exceeds ping_timeout (close 4003).   *)
+(*                     Reachable ONLY under the inversion (bug arm); in the   *)
+(*                     checked safe cfgs the gap never exceeds PING, so this  *)
+(*                     action is never enabled — that IS the contract         *)
+(*   Tick (parked)     one unit of wall time passing while the sender is      *)
+(*                     parked (room_cleanup_interval granularity abstracted   *)
+(*                     to the worst case: the reaper may sample every tick,   *)
+(*                     which over-approximates the real 60 s sweep, so        *)
+(*                     safety here implies safety there)                      *)
+(*                                                                         *)
+(* THE VERDICT (safety). `sndEvicted` is a ghost that latches TRUE the       *)
+(* instant the reaper evicts the sender. Because the sender is healthy by    *)
+(* construction (its client never stops sending — ClientSend is always       *)
+(* enabled — and the only staleness source is a park, which by construction  *)
+(* follows a recent dispatch), ANY reaper eviction is a false positive.      *)
+(* HealthySenderNeverReaped == ~sndEvicted is the contract; the stronger     *)
+(* GapWithinPingDeadline pins the reaper-visible gap it rests on.            *)
+(*                                                                         *)
+(* NON-VACUITY (verified during development, keep reproducible): the         *)
+(* `TimeoutInversionBug` constant forces the EFFECTIVE grace period to       *)
+(* exactly PING_TIMEOUT — the `slow = ping` boundary the cross-field check   *)
+(* rejects (legal per-field, forbidden cross-field; legal system-wide before *)
+(* A2). TLC then violates `HealthySenderNeverReaped` via the pre-park-delay  *)
+(* path: SenderProcess (activity := t) -> a one-tick pre-park Tick (d = 1)   *)
+(* -> BroadcastPark (parkedAt := t + 1) -> the grace-region Ticks push the   *)
+(* gap to (t + 1 + PING) - t = PING + 1 > PING while the grace (>= PING) is  *)
+(* only now satisfiable -> ReaperSweep wins that race and evicts the healthy *)
+(* sender. (`slow > ping` is a fortiori unsafe — it evicts even with d = 0.) *)
+(* The checked configurations pin `TimeoutInversionBug = FALSE`; flip it     *)
+(* locally to watch the invariant catch the inversion.                      *)
+(*                                                                         *)
+(* THE DERIVED INEQUALITY (the P10.A2 deliverable). With the pre-park delay  *)
+(* `d` (0 or 1 tick) modeled, the reaper-visible gap of a parked healthy     *)
+(* sender peaks at `d + SLOW`. TLC then derives that `SLOW >= PING` is        *)
+(* unsafe — EXACTLY the region `validate_config_security` rejects            *)
+(* (`slow_consumer_timeout_ms >= ping_timeout * 1000`): at `SLOW = PING` the *)
+(* `d = 1` path pushes the peak to `PING + 1 > PING` and the reaper (strict  *)
+(* `>`) evicts. The two checked cfgs pin `SLOW < PING` and are green —       *)
+(* `_Small` (SLOW = 2 < PING = 4) and `_Boundary` (SLOW = 3 = PING - 1, the  *)
+(* tightest safe: peak gap SLOW + 1 = PING, never `> PING`).                 *)
+(*                                                                         *)
+(* So the strict `<` the check enforces is the NECESSARY floor the model     *)
+(* derives — it eliminates every `SLOW >= PING` inversion, the gross         *)
+(* misconfiguration (e.g. 60 s vs 30 s) and the exact boundary alike. It is  *)
+(* NOT proven SUFFICIENT: the model bounds `d` to one tick, but the          *)
+(* `rooms`-lock/DB-write pre-park delay is unbounded under contention, so a  *)
+(* config with a thin margin (`SLOW` just under `PING`) can still invert if  *)
+(* `d` exceeds `PING - SLOW`. True safety requires the operator to size the  *)
+(* margin `(ping_timeout - slow_consumer_timeout_ms)` above their worst-case *)
+(* pre-park delay; the default 25 s margin dwarfs any realistic `d`. The     *)
+(* check is the derived guardrail against the provable inversion region, not *)
+(* a liveness proof under unbounded contention. (When ping_timeout = 0 the   *)
+(* reaper is disabled — no deadline, no inversion — so the A2 check is        *)
+(* guarded on ping_timeout > 0, matching this module's ASSUME.)              *)
+(***************************************************************************)
+EXTENDS Naturals
+
+CONSTANTS
+    PING_TIMEOUT,       \* activity-reaper deadline in ticks (keep tiny: 4)
+    SLOW_TIMEOUT,       \* slow-consumer grace period in ticks (keep tiny; the
+                        \* checked cfgs pin SLOW_TIMEOUT < PING_TIMEOUT)
+    HORIZON,            \* wall-clock bound so `now` (and the state space) is
+                        \* finite (keep tiny: 6)
+    QueueCapacity,      \* bounded recipient outbound queue slots (keep tiny: 1)
+    InboxCap,           \* bounded unread client frames at the socket (keep
+                        \* tiny: 1) — the client's liveness the reaper ignores
+    ReconnectBudget,    \* recipient disconnect+reconnect refills (keep tiny: 1)
+    TimeoutInversionBug \* TRUE forces the effective grace to PING_TIMEOUT (the
+                        \* `slow = ping` boundary the check rejects); must
+                        \* violate HealthySenderNeverReaped; FALSE in checked cfgs
+
+ASSUME /\ PING_TIMEOUT \in Nat \ {0}
+       /\ SLOW_TIMEOUT \in Nat \ {0}
+       \* The checked configs are safe by construction; the seeded bug, not a
+       \* bad SLOW_TIMEOUT, exhibits the inversion.
+       /\ SLOW_TIMEOUT < PING_TIMEOUT
+       /\ HORIZON \in Nat \ {0}
+       /\ QueueCapacity \in Nat \ {0}
+       /\ InboxCap \in Nat \ {0}
+       /\ ReconnectBudget \in Nat
+       /\ TimeoutInversionBug \in BOOLEAN
+       \* The horizon must let a full grace period elapse plus the pre-park
+       \* tick and one reaper over-run tick, or the inversion could never be
+       \* exhibited.
+       /\ HORIZON >= PING_TIMEOUT + 2
+
+\* The grace period the park actually waits out. The seeded bug forces the
+\* exact `slow = ping` boundary the A2 check rejects; otherwise it is the
+\* configured SLOW_TIMEOUT.
+EffectiveSlow == IF TimeoutInversionBug THEN PING_TIMEOUT ELSE SLOW_TIMEOUT
+
+VARIABLES
+    now,               \* discrete wall time (advances while Parked, or once
+                       \* while Broadcasting for the pre-park delay)
+    sndPhase,          \* "Reading" | "Broadcasting" | "Parked"
+    sndParkedAt,       \* the `now` at which the current park began
+    sndLastActivityAt, \* the `now` of the sender's last DISPATCHED frame — the
+                       \* timestamp the reaper measures (refreshed only by
+                       \* SenderProcess, NOT by a park ending)
+    sndInbox,          \* unread client frames sitting at the socket (>0 proves
+                       \* the client is alive while the sender is parked)
+    sndEvicted,        \* ghost: the reaper false-positive verdict (the bug)
+    rcpConn,           \* "Connected" | "Dropped": the slow recipient
+    rcpQueue,          \* recipient outbound queue depth (a full queue parks)
+    rcpReconnects      \* recipient disconnect+reconnect refills consumed
+
+vars == <<now, sndPhase, sndParkedAt, sndLastActivityAt, sndInbox, sndEvicted,
+          rcpConn, rcpQueue, rcpReconnects>>
+
+Init ==
+    /\ now = 0
+    /\ sndPhase = "Reading"
+    /\ sndParkedAt = 0
+    /\ sndLastActivityAt = 0
+    /\ sndInbox = 0
+    /\ sndEvicted = FALSE
+    /\ rcpConn = "Connected"
+    /\ rcpQueue = 0
+    /\ rcpReconnects = 0
+
+(* A client frame arrives at the socket. The client is healthy and keeps     *)
+(* sending regardless of whether the server task is free to process it —      *)
+(* while the sender is parked these pile up UNREAD, which is precisely the    *)
+(* liveness the activity reaper fails to credit.                             *)
+ClientSend ==
+    /\ ~sndEvicted
+    /\ sndInbox < InboxCap
+    /\ sndInbox' = sndInbox + 1
+    /\ UNCHANGED <<now, sndPhase, sndParkedAt, sndLastActivityAt, sndEvicted,
+                   rcpConn, rcpQueue, rcpReconnects>>
+
+(* The receive loop dispatches one inbound frame: it records the sender's     *)
+(* activity at dispatch (activity := now) and begins the relay broadcast.     *)
+(* This is the ONLY action that refreshes the reaper's timestamp.            *)
+SenderProcess ==
+    /\ ~sndEvicted
+    /\ sndPhase = "Reading"
+    /\ sndInbox > 0
+    /\ sndInbox' = sndInbox - 1
+    /\ sndLastActivityAt' = now
+    /\ sndPhase' = "Broadcasting"
+    /\ UNCHANGED <<now, sndParkedAt, sndEvicted, rcpConn, rcpQueue,
+                   rcpReconnects>>
+
+(* deliver_to_all enqueues the relayed frame to the recipient. Fast path:     *)
+(* the recipient has a free slot (enqueue) or is already gone (nothing to     *)
+(* enqueue). Either way the broadcast completes without parking.             *)
+BroadcastFast ==
+    /\ ~sndEvicted
+    /\ sndPhase = "Broadcasting"
+    /\ (rcpConn = "Dropped" \/ rcpQueue < QueueCapacity)
+    /\ rcpQueue' = IF rcpConn = "Connected" THEN rcpQueue + 1 ELSE rcpQueue
+    /\ sndPhase' = "Reading"
+    /\ UNCHANGED <<now, sndParkedAt, sndLastActivityAt, sndInbox, sndEvicted,
+                   rcpConn, rcpReconnects>>
+
+(* The join_all await blocks on a FULL recipient queue: the sender parks,     *)
+(* recording when the grace clock starts. `sndParkedAt` may be one tick after *)
+(* `sndLastActivityAt` (the pre-park delay `d` above), so the reaper-visible  *)
+(* gap during the park is `d + (now - sndParkedAt)`.                          *)
+BroadcastPark ==
+    /\ ~sndEvicted
+    /\ sndPhase = "Broadcasting"
+    /\ rcpConn = "Connected"
+    /\ rcpQueue = QueueCapacity
+    /\ sndPhase' = "Parked"
+    /\ sndParkedAt' = now
+    /\ UNCHANGED <<now, sndLastActivityAt, sndInbox, sndEvicted, rcpConn,
+                   rcpQueue, rcpReconnects>>
+
+(* The recipient's socket writer draining one queued frame. This spec has no  *)
+(* fairness on any action (Spec is INVARIANTS-only), so TLC also explores the *)
+(* behavior where this is never scheduled — the recipient that stopped        *)
+(* reading and stalls the park to its grace limit (the slow consumer).        *)
+RecipientDrain ==
+    /\ ~sndEvicted
+    /\ rcpConn = "Connected"
+    /\ rcpQueue > 0
+    /\ rcpQueue' = rcpQueue - 1
+    /\ UNCHANGED <<now, sndPhase, sndParkedAt, sndLastActivityAt, sndInbox,
+                   sndEvicted, rcpConn, rcpReconnects>>
+
+(* A drained slot lets the parked broadcast enqueue and the handler return:   *)
+(* the delivery succeeded within grace. Activity is NOT refreshed — the       *)
+(* handler returning is not a dispatch; only the next frame refreshes it.     *)
+ParkResolve ==
+    /\ ~sndEvicted
+    /\ sndPhase = "Parked"
+    /\ rcpConn = "Connected"
+    /\ rcpQueue < QueueCapacity
+    /\ rcpQueue' = rcpQueue + 1
+    /\ sndPhase' = "Reading"
+    /\ UNCHANGED <<now, sndParkedAt, sndLastActivityAt, sndInbox, sndEvicted,
+                   rcpConn, rcpReconnects>>
+
+(* Grace expiry: the park has waited EffectiveSlow ticks, so the recipient is *)
+(* the slow consumer and is disconnected (CloseReason::SlowConsumer, 4002);   *)
+(* the handler returns and the sender is free. Activity is NOT refreshed here *)
+(* (see the header): the sender's timestamp is still the pre-park dispatch,   *)
+(* so the reaper can still be racing this exact tick.                        *)
+ParkGraceExpire ==
+    /\ ~sndEvicted
+    /\ sndPhase = "Parked"
+    /\ now - sndParkedAt >= EffectiveSlow
+    /\ rcpConn' = "Dropped"
+    /\ rcpQueue' = 0
+    /\ sndPhase' = "Reading"
+    /\ UNCHANGED <<now, sndParkedAt, sndLastActivityAt, sndInbox, sndEvicted,
+                   rcpReconnects>>
+
+(* A fresh recipient takes the disconnected seat (a reconnect / a new joiner) *)
+(* so the sender can be driven to park again — the refill loop that lets the  *)
+(* model exhibit repeated park cycles within one horizon.                    *)
+RecipientReconnect ==
+    /\ ~sndEvicted
+    /\ rcpConn = "Dropped"
+    /\ rcpReconnects < ReconnectBudget
+    /\ rcpConn' = "Connected"
+    /\ rcpQueue' = 0
+    /\ rcpReconnects' = rcpReconnects + 1
+    /\ UNCHANGED <<now, sndPhase, sndParkedAt, sndLastActivityAt, sndInbox,
+                   sndEvicted>>
+
+(* collect_expired_clients: the reaper evicts a client whose recorded         *)
+(* activity is STRICTLY older than the ping deadline (close 4003). In this    *)
+(* model the sender is healthy throughout, so a firing here is always a false *)
+(* positive — the timeout inversion made observable. Enabled only when the    *)
+(* gap has been pushed past PING_TIMEOUT, i.e. only under the inversion.      *)
+ReaperSweep ==
+    /\ ~sndEvicted
+    /\ now - sndLastActivityAt > PING_TIMEOUT
+    /\ sndEvicted' = TRUE
+    /\ UNCHANGED <<now, sndPhase, sndParkedAt, sndLastActivityAt, sndInbox,
+                   rcpConn, rcpQueue, rcpReconnects>>
+
+(* One unit of wall time passes, in the only two waiting states:              *)
+(*   - Parked, before the grace deadline: the slow recipient has not drained  *)
+(*     and the grace timer has not yet fired (it WILL at EffectiveSlow, so the *)
+(*     park never outlasts it — Tick can no longer advance once                *)
+(*     now - sndParkedAt = EffectiveSlow, forcing ParkGraceExpire/ParkResolve).*)
+(*   - Broadcasting, exactly ONCE (guarded now = sndLastActivityAt, which     *)
+(*     holds only until this tick advances it): the pre-park delay `d` — the  *)
+(*     `maybe_update_last_seen` DB-write + `rooms`-lock await between the      *)
+(*     activity record and the park. Bounded to one tick (see the header).    *)
+(* All other phases make instantaneous progress at this time scale.           *)
+Tick ==
+    /\ ~sndEvicted
+    /\ now < HORIZON
+    /\ \/ (sndPhase = "Parked" /\ now - sndParkedAt < EffectiveSlow)
+       \/ (sndPhase = "Broadcasting" /\ now = sndLastActivityAt)
+    /\ now' = now + 1
+    /\ UNCHANGED <<sndPhase, sndParkedAt, sndLastActivityAt, sndInbox,
+                   sndEvicted, rcpConn, rcpQueue, rcpReconnects>>
+
+(* Explicit terminal stutter for the evicted (bug-arm) state — the only       *)
+(* genuinely terminal state, since every other action guards on ~sndEvicted.  *)
+(* The checked safe configs never evict; they make perpetual progress         *)
+(* (ClientSend / SenderProcess / park cycles) and so have no terminal, relying *)
+(* on that progress — not Done — for deadlock-freedom. Done deliberately does *)
+(* NOT cover the Broadcasting/Parked phases, so a missing transition there     *)
+(* would still surface as a deadlock rather than be masked.                   *)
+Done ==
+    /\ sndEvicted
+    /\ UNCHANGED vars
+
+Next ==
+    \/ ClientSend
+    \/ SenderProcess
+    \/ BroadcastFast
+    \/ BroadcastPark
+    \/ RecipientDrain
+    \/ ParkResolve
+    \/ ParkGraceExpire
+    \/ RecipientReconnect
+    \/ ReaperSweep
+    \/ Tick
+    \/ Done
+
+Spec == Init /\ [][Next]_vars
+
+----------------------------------------------------------------------------
+(* Safety *)
+
+TypeOK ==
+    /\ now \in 0..HORIZON
+    /\ sndPhase \in {"Reading", "Broadcasting", "Parked"}
+    /\ sndParkedAt \in 0..HORIZON
+    /\ sndLastActivityAt \in 0..HORIZON
+    /\ sndInbox \in 0..InboxCap
+    /\ sndEvicted \in BOOLEAN
+    /\ rcpConn \in {"Connected", "Dropped"}
+    /\ rcpQueue \in 0..QueueCapacity
+    /\ rcpReconnects \in 0..ReconnectBudget
+
+(* THE contract: a healthy, actively-sending sender is never evicted by the   *)
+(* activity reaper. Holds in every reachable state exactly when the grace     *)
+(* period cannot outlast the ping deadline (SLOW_TIMEOUT < PING_TIMEOUT once   *)
+(* the one-tick pre-park delay is counted); the seeded TimeoutInversionBug     *)
+(* (grace = ping) violates it.                                               *)
+HealthySenderNeverReaped ==
+    ~sndEvicted
+
+(* The reaper-relevant boundary, and the actual safe-region characterization: *)
+(* while the sender is healthy the reaper never SEES a gap over the ping       *)
+(* deadline. This is strictly stronger than HealthySenderNeverReaped (it       *)
+(* fails one step BEFORE the eviction) and, unlike ActivityGapBounded, it      *)
+(* DISTINGUISHES the safe configs from the bug arm: it holds iff              *)
+(* EffectiveSlow + (pre-park delay) <= PING_TIMEOUT, i.e. iff SLOW < PING.     *)
+GapWithinPingDeadline ==
+    ~sndEvicted => now - sndLastActivityAt <= PING_TIMEOUT
+
+(* Dynamics sanity bound (a lemma, NOT the safe-region boundary): the gap of  *)
+(* a healthy sender never exceeds the grace period plus the one-tick pre-park *)
+(* delay. Reaches equality (tight), and holds in BOTH the safe and bug arms   *)
+(* — which is exactly why it does not by itself certify safety; that is       *)
+(* GapWithinPingDeadline's job.                                              *)
+ActivityGapBounded ==
+    ~sndEvicted => now - sndLastActivityAt <= EffectiveSlow + 1
+
+(* The park clock never runs backwards or beyond wall time: a parked sender's *)
+(* grace timer is a real elapsed-time guard.                                 *)
+ParkClockSound ==
+    sndPhase = "Parked" => sndParkedAt <= now
+
+=============================================================================

--- a/formal/tla/SenderPacingReaper_Boundary.cfg
+++ b/formal/tla/SenderPacingReaper_Boundary.cfg
@@ -1,0 +1,24 @@
+\* The tightest SAFE config: SLOW_TIMEOUT = 3 = PING_TIMEOUT - 1. With the
+\* one-tick pre-park delay counted, the reaper-visible gap peaks at
+\* SLOW + 1 = 4 = PING_TIMEOUT while the reaper needs gap > 4 — so `ping - 1`
+\* is the last safe grace period, and `SLOW = PING` is the first unsafe one
+\* (the boundary the seeded TimeoutInversionBug exhibits and the production
+\* check rejects). This cfg proves the model genuinely derives the STRICT
+\* `slow < ping` boundary the P10.A2 check enforces (not merely `slow <= ping`):
+\* the modeled pre-park delay is what makes equality unsafe. See the module
+\* header for the necessary-floor-vs-sufficiency framing.
+SPECIFICATION Spec
+CONSTANTS
+    PING_TIMEOUT = 4
+    SLOW_TIMEOUT = 3
+    HORIZON = 6
+    QueueCapacity = 1
+    InboxCap = 1
+    ReconnectBudget = 1
+    TimeoutInversionBug = FALSE
+INVARIANTS
+    TypeOK
+    HealthySenderNeverReaped
+    GapWithinPingDeadline
+    ActivityGapBounded
+    ParkClockSound

--- a/formal/tla/SenderPacingReaper_Small.cfg
+++ b/formal/tla/SenderPacingReaper_Small.cfg
@@ -1,0 +1,24 @@
+\* Sender-pacing vs activity-reaper model at the smallest configuration that
+\* still exercises the timeout inversion: a 1-slot recipient queue (so a
+\* second relayed frame parks the sender), a 1-frame inbox (the client stays
+\* alive during the park), and one recipient reconnect (a second park cycle).
+\* SLOW_TIMEOUT = 2 < PING_TIMEOUT = 4 is safe with margin — the reaper-visible
+\* gap peaks at SLOW + pre-park-delay = 3, never reaching the strict `> 4` the
+\* reaper needs. See the module header for the TimeoutInversionBug non-vacuity
+\* check (grace = ping evicts the healthy sender) and the derivation of the A2
+\* config inequality. HORIZON = 6 >= PING_TIMEOUT + 2. Tiny (<5s TLC).
+SPECIFICATION Spec
+CONSTANTS
+    PING_TIMEOUT = 4
+    SLOW_TIMEOUT = 2
+    HORIZON = 6
+    QueueCapacity = 1
+    InboxCap = 1
+    ReconnectBudget = 1
+    TimeoutInversionBug = FALSE
+INVARIANTS
+    TypeOK
+    HealthySenderNeverReaped
+    GapWithinPingDeadline
+    ActivityGapBounded
+    ParkClockSound

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -241,6 +241,20 @@ pub fn validate_config_security(config: &Config) -> anyhow::Result<()> {
     // recorded activity is always still fresh when its park ends. (Guarded on
     // `ping_timeout > 0`: a zero deadline disables the reaper, so no inversion
     // exists to prevent.)
+    //
+    // `formal/tla/SenderPacingReaper.tla` (P10.D3) derives this strict `<` as
+    // the NECESSARY floor. It models the pre-park delay `d` — the
+    // `maybe_update_last_seen` throttle-boundary DB write + `rooms` write-lock
+    // that runs after the activity record and before the park — and TLC shows
+    // that `slow >= ping` is unsafe (the peak reaper-visible gap `d + slow`
+    // exceeds the deadline), which is EXACTLY the region rejected here. The
+    // `<` is not, however, proven SUFFICIENT: the model bounds `d` to one
+    // tick, but the lock/DB delay is unbounded under contention, so a config
+    // with a thin margin can still invert if `d` exceeds `ping - slow`. Full
+    // safety is an operator sizing concern — keep `ping_timeout -
+    // slow_consumer_timeout_ms` above the worst-case pre-park delay (the
+    // default 25 s margin dwarfs it). This check is the guardrail against the
+    // provable inversion region, not a liveness proof under unbounded load.
     if config.server.ping_timeout > 0 {
         let ping_timeout_ms = config.server.ping_timeout.saturating_mul(1000);
         if config.websocket.slow_consumer_timeout_ms >= ping_timeout_ms {
@@ -475,7 +489,12 @@ mod tests {
 
     /// Timeout inversion (BUG-2): the slow-consumer grace period must be
     /// strictly less than the activity-reaper deadline. Data-driven over the
-    /// boundary. `ping_timeout` default is 30 s (30000 ms).
+    /// boundary. `ping_timeout` default is 30 s (30000 ms). This asserts the
+    /// check's NECESSARY floor — it rejects `slow >= ping` (the provable
+    /// inversion region derived by `formal/tla/SenderPacingReaper.tla`, P10.D3)
+    /// and accepts `slow < ping`. Passing the floor is not a safety
+    /// certificate: a thin margin can still invert under load, which is an
+    /// operator sizing concern (see `validate_config_security`).
     #[test]
     fn slow_consumer_timeout_must_be_below_ping_deadline() {
         // (slow_consumer_timeout_ms, ping_timeout_secs, expect_ok)

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -250,11 +250,13 @@ pub fn validate_config_security(config: &Config) -> anyhow::Result<()> {
     // exceeds the deadline), which is EXACTLY the region rejected here. The
     // `<` is not, however, proven SUFFICIENT: the model bounds `d` to one
     // tick, but the lock/DB delay is unbounded under contention, so a config
-    // with a thin margin can still invert if `d` exceeds `ping - slow`. Full
-    // safety is an operator sizing concern — keep `ping_timeout -
-    // slow_consumer_timeout_ms` above the worst-case pre-park delay (the
-    // default 25 s margin dwarfs it). This check is the guardrail against the
-    // provable inversion region, not a liveness proof under unbounded load.
+    // with a thin margin can still invert if `d` exceeds that margin. Full
+    // safety is an operator sizing concern — keep the margin
+    // `ping_timeout * 1000 - slow_consumer_timeout_ms` (both in ms; note
+    // `ping_timeout` is seconds, `slow_consumer_timeout_ms` is milliseconds)
+    // above the worst-case pre-park delay (the default 30000 - 5000 = 25000 ms
+    // dwarfs it). This check is the guardrail against the provable inversion
+    // region, not a liveness proof under unbounded load.
     if config.server.ping_timeout > 0 {
         let ping_timeout_ms = config.server.ping_timeout.saturating_mul(1000);
         if config.websocket.slow_consumer_timeout_ms >= ping_timeout_ms {


### PR DESCRIPTION
# Formal verification expansion for delivery timing and control priority

## Summary

This PR adds two new TLA+ models and supporting docs to formalize delivery-time
edge cases, then aligns changelog and validation comments with those results.

## What changed

- Added a new `ControlPriorityDelivery` TLA+ model and config
  (`formal/tla/ControlPriorityDelivery.tla`, `formal/tla/ControlPriorityDelivery_Small.cfg`)
  to validate control-priority delivery and sojourn-based resolution behavior.
- Added a new `SenderPacingReaper` TLA+ model and configs
  (`formal/tla/SenderPacingReaper.tla`, `formal/tla/SenderPacingReaper_Small.cfg`,
  `formal/tla/SenderPacingReaper_Boundary.cfg`) to cover timeout inversion and
  the sender/reaper timing boundary.
- Updated formal docs (`formal/README.md`) to:
  - include the new models in the catalog,
  - document tooling choices (TLC-first, discrete tick time, direct TLA+ style),
  - add timing/control-priority theorem context for maintainers.
- Updated `CHANGELOG.md` with entries for both new formal models and their
  derived guarantees.
- Clarified comments in `src/config/validation.rs` and its related test docs to
  explain why `slow_consumer_timeout_ms < ping_timeout * 1000` is enforced and
  how the formal model motivates that floor.

## User impact

- No API or wire-format changes in this branch.
- No intended runtime behavior changes.
- Improves confidence and maintainability by documenting and model-checking
  critical timeout and delivery-priority assumptions.

## Validation

- New TLA+ modules/configs are added to the existing auto-discovered formal
  model-check suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and formal verification only; config validation behavior is unchanged aside from expanded comments.
> 
> **Overview**
> **Spec-first formal models for protocol-v4 P10.E2 delivery and BUG-2 timing**, merged ahead of implementation. No server runtime or wire changes.
> 
> Adds **`DeliveryClasses.tla`** (+ `_Small.cfg`) for reliable / latest / volatile per-class accounting (conservation, supersession ledger, honest `DeliveryReport`), with four seeded bugs pinned `FALSE`. Adds **`ControlPriorityDelivery.tla`** (+ `_Small.cfg`) for a separate control queue drained before data and sojourn eviction liveness against an unfair writer, with two seeded bugs. Adds **`SenderPacingReaper.tla`** (+ `_Small` / `_Boundary.cfg`) as the repo’s first discrete-time spec for healthy-sender eviction during slow-consumer parks and the **`slow < ping`** config floor.
> 
> **Docs:** `CHANGELOG.md` and `formal/README.md` catalog the new modules, tooling choices (TLC-first, discrete ticks), and theorem write-ups; **`src/config/validation.rs`** comments and test notes now cite `SenderPacingReaper` for the necessary-but-not-sufficient A2 inequality (logic unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724c85b2dacea9fecf814623b5d3e131296b7f2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->