### PR TITLE
feat(protocol): P10.E1 incarnation epoch — self-describing v3 seq reset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,15 @@ jobs:
       # the expensive matrix spends minutes rediscovering it on every lane.
       - name: Check compilation
         run: cargo check --locked --all-targets --all-features
+      # The fuzz crate is a SEPARATE workspace (fuzz/, out-of-tree per ADR-0003),
+      # so the check above never sees it — which let an E1 `register_disconnection`
+      # signature change break `fuzz_reconnect_tokens` undetected (fuzz.yml only
+      # runs on narrow paths and builds two other targets). Type-check every fuzz
+      # target here against current library code on every PR. This is a no-codegen
+      # `check` (no libFuzzer/sanitizer), so the pinned stable toolchain suffices;
+      # the nightly build/run stays in fuzz.yml. No --locked (matches fuzz.yml).
+      - name: Check fuzz crate compiles
+        run: cargo check --manifest-path fuzz/Cargo.toml --bins
 
   lint:
     name: Lint (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added the protocol-v4 incarnation `epoch` (P10.E1) beside the relay `seq`.
-  Every relayed `GameData` / `GameDataBinary` to a v4 recipient now carries an
+- Added the protocol-v3 incarnation `epoch` (P10.E1) beside the relay `seq`.
+  Every relayed `GameData` / `GameDataBinary` to a v3 recipient now carries an
   `epoch: u32` — a per-`(sender, room)` counter that increments once per
   incarnation of the sender's membership (first join is 1; each join-after-leave
   or reconnect increments it) while `seq` restarts at 1 within each epoch. The
@@ -21,14 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PlayerLeft`/`PlayerJoined`/`PlayerReconnected` control message. Each member's
   current epoch is also carried on the room snapshots
   (`RoomJoined.current_players[].epoch`, `PlayerJoined.player.epoch`,
-  `PlayerReconnected.epoch`, and the `Reconnected` member snapshot) so a v4
+  `PlayerReconnected.epoch`, and the `Reconnected` member snapshot) so a v3
   recipient can baseline a sender before its first relayed frame. The epoch is
   captured into the reconnection record at disconnect and resumed at
   `last_epoch + 1` on reconnect, so it stays strictly increasing across a
   sender's absence for a recipient that never left. Like `seq`, `epoch` is
-  stripped for pre-v4 recipients — the v2/v3 wire stays byte-identical (golden
-  snapshots unchanged). Covered by `tests/v4_wire_golden.rs`,
-  `tests/v4_game_data_sequencing_e2e.rs`, and the `src/websocket/sending.rs` unit
+  stripped for pre-v3 recipients — the v2 wire stays byte-identical (golden
+  snapshots unchanged). Covered by `tests/v3_reliability_wire_golden.rs`,
+  `tests/v3_game_data_sequencing_e2e.rs`, and the `src/websocket/sending.rs` unit
   tests; documented in `docs/protocol.md` and
   `spec/signal-fish-protocol.asyncapi.yaml`.
 - Added the flagship `EndToEndGapAccountability` TLA+ model
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`ClientCanClassify`), no evicted frame ever resurfaces out of order
   (`DroppedNeverObserved`), and the reconnection snapshot heals the tail dropped
   at eviction (`MembershipEventuallyHonest`). It is the executable proof that
-  the protocol-v4 P10.E5 per-sender `(epoch, seq)` watermarks
+  the protocol-v3 P10.E5 per-sender `(epoch, seq)` watermarks
   (`Reconnected.sender_watermarks`) are necessary — a reconnecting client
   cannot otherwise tell its own outage gap from relay loss. Three seeded bugs
   prove non-vacuity (`SingleFlagBug` and `NoBaselineResetBug` violate
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   everything else stays exhaustive and CI-gating.
 
 - Added the `DeliveryClasses` TLA+ model (`formal/tla/DeliveryClasses.tla` +
-  `_Small.cfg`) — spec-first for the protocol-v4 P10.E2 delivery classes
+  `_Small.cfg`) — spec-first for the protocol-v3 P10.E2 delivery classes
   (reliable / latest / volatile). It pins the per-class accounting contract:
   `ReliableConservation` (reliable never coalesced), `LatestConservation` /
   `VolatileConservation` (each class only in its legitimate buckets),
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the `ControlPriorityDelivery` TLA+ model
   (`formal/tla/ControlPriorityDelivery.tla` + `_Small.cfg`) — spec-first for the
-  protocol-v4 P10.E2 delivery revision (merged before the code). It pins the two
+  protocol-v3 P10.E2 delivery revision (merged before the code). It pins the two
   properties the queue split must satisfy, composing with the #131
   `DeliveryContract` substrate: `ControlAgeBounded` (control rides a separate
   queue drained strictly before data — never starved behind a data backlog) and
@@ -113,7 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-vacuity; the checked configs pin it `FALSE` and are green in the
   auto-globbed `scripts/run-tla-model-check.sh` suite.
 
-- Added split-brain seeded-bug constants to two v4 TLA+ models, making the
+- Added split-brain seeded-bug constants to two v3 TLA+ models, making the
   single-instance boundary of the relay/reconnect contracts (ARCH-10)
   executable: `SplitBrainStampBug` in `formal/tla/SequencedRelay.tla` (a second
   instance stamps the same sender's stream from an independent counter →
@@ -126,13 +126,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section in `formal/README.md` catalogs which invariants are single-instance
   theorems and states the LB room-affinity requirement.
 
-- Added protocol v4 (strictly additive; clamp `protocol.max_protocol_version` back to `3` to
-  disable): relayed `GameData` / `GameDataBinary` delivered to a v4 recipient carry a
+- Added protocol v3 (strictly additive; clamp `protocol.max_protocol_version` back to `3` to
+  disable): relayed `GameData` / `GameDataBinary` delivered to a v3 recipient carry a
   server-stamped per-`(sender, room)` `seq` starting at `1` and strictly contiguous per sender,
-  so any recipient can detect any relay gap end-to-end; pre-v4 recipients receive byte-identical
-  frames with no `seq` key. Documented in `docs/protocol.md` ("Protocol v4 additions") and the
-  AsyncAPI spec; pinned by `tests/v4_wire_golden.rs` and `tests/v4_game_data_sequencing_e2e.rs`.
-- Added the v4-only `RelayStats` server message (config-gated by
+  so any recipient can detect any relay gap end-to-end; pre-v3 recipients receive byte-identical
+  frames with no `seq` key. Documented in `docs/protocol.md` ("Protocol v3 delivery reliability") and the
+  AsyncAPI spec; pinned by `tests/v3_reliability_wire_golden.rs` and `tests/v3_game_data_sequencing_e2e.rs`.
+- Added the v3-only `RelayStats` server message (config-gated by
   `websocket.delivery_stats_interval_secs`, default `0` = disabled, must be ≤ 3600): periodic
   per-connection cumulative delivery accounting (`sent_to_you`, `dropped_for_you`,
   `backpressure_events`) so clients can attribute loss without server log access.
@@ -852,6 +852,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Consolidated the pre-release protocol into a single v3.** The
+  delivery-reliability features that were briefly developed behind a separate
+  `protocol_version: 4` (server-stamped `GameData.seq` + incarnation `epoch`, and
+  the opt-in `RelayStats` frame) now negotiate under **v3** — there is no v4. v3
+  is the single unshipped/mutable "current" version (WebRTC signaling AND
+  delivery reliability), additive over the frozen v2 floor.
+  `SERVER_MAX_PROTOCOL_VERSION` and the `protocol.max_protocol_version` default
+  are now **3**; a client that still advertises `4`/`5` is clamped to 3. v2
+  remains byte-frozen (the pre-v3 forms are unchanged). Net effect for consumers:
+  a client obtains the reliability surface by negotiating v3 rather than v4. The
+  `[Unreleased]` entries that referenced "v4" describe these same features as
+  they now ship — under v3.
 - The activity reaper (`ConnectionManager::collect_expired_clients`) and the heartbeat-update
   throttle (`ConnectionManager::should_update_last_seen`) now read the Tokio runtime clock
   (`tokio::time::Instant`) instead of `std::time::Instant`. Production behavior is unchanged —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the protocol-v4 incarnation `epoch` (P10.E1) beside the relay `seq`.
+  Every relayed `GameData` / `GameDataBinary` to a v4 recipient now carries an
+  `epoch: u32` — a per-`(sender, room)` counter that increments once per
+  incarnation of the sender's membership (first join is 1; each join-after-leave
+  or reconnect increments it) while `seq` restarts at 1 within each epoch. The
+  pair `(epoch, seq)` is therefore strictly lexicographically increasing per
+  sender as observed by any single recipient, making a `seq` reset
+  **self-describing** (GAP-8): a recipient attributes the backwards `seq` jump to
+  the epoch bump directly instead of correlating a separately-ordered
+  `PlayerLeft`/`PlayerJoined`/`PlayerReconnected` control message. Each member's
+  current epoch is also carried on the room snapshots
+  (`RoomJoined.current_players[].epoch`, `PlayerJoined.player.epoch`,
+  `PlayerReconnected.epoch`, and the `Reconnected` member snapshot) so a v4
+  recipient can baseline a sender before its first relayed frame. The epoch is
+  captured into the reconnection record at disconnect and resumed at
+  `last_epoch + 1` on reconnect, so it stays strictly increasing across a
+  sender's absence for a recipient that never left. Like `seq`, `epoch` is
+  stripped for pre-v4 recipients — the v2/v3 wire stays byte-identical (golden
+  snapshots unchanged). Covered by `tests/v4_wire_golden.rs`,
+  `tests/v4_game_data_sequencing_e2e.rs`, and the `src/websocket/sending.rs` unit
+  tests; documented in `docs/protocol.md` and
+  `spec/signal-fish-protocol.asyncapi.yaml`.
 - Added the flagship `EndToEndGapAccountability` TLA+ model
   (`formal/tla/EndToEndGapAccountability.tla` + `_Small.cfg` + `_Sim.cfg`) —
   P10.D4. It composes three previously separate contracts (`SequencedRelay`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,8 +126,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section in `formal/README.md` catalogs which invariants are single-instance
   theorems and states the LB room-affinity requirement.
 
-- Added protocol v3 (strictly additive; clamp `protocol.max_protocol_version` back to `3` to
-  disable): relayed `GameData` / `GameDataBinary` delivered to a v3 recipient carry a
+- Added protocol v3 (strictly additive; clamp `protocol.max_protocol_version` back to `2` —
+  pure v2 — to disable, since v3 is now the current version): relayed `GameData` /
+  `GameDataBinary` delivered to a v3 recipient carry a
   server-stamped per-`(sender, room)` `seq` starting at `1` and strictly contiguous per sender,
   so any recipient can detect any relay gap end-to-end; pre-v3 recipients receive byte-identical
   frames with no `seq` key. Documented in `docs/protocol.md` ("Protocol v3 delivery reliability") and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the protocol-v3 incarnation `epoch` (P10.E1) beside the relay `seq`.
   Every relayed `GameData` / `GameDataBinary` to a v3 recipient now carries an
-  `epoch: u32` — a per-`(sender, room)` counter that increments once per
-  incarnation of the sender's membership (first join is 1; each join-after-leave
-  or reconnect increments it) while `seq` restarts at 1 within each epoch. The
-  pair `(epoch, seq)` is therefore strictly lexicographically increasing per
-  sender as observed by any single recipient, making a `seq` reset
+  `epoch: u32` — a monotonic per-sender counter (tracked per connection, not
+  reset on a room switch) that increments once per incarnation of the sender's
+  membership (its first-ever incarnation is 1; each join-after-leave or reconnect
+  increments it) while `seq` restarts at 1 within each epoch. The pair
+  `(epoch, seq)` is therefore strictly lexicographically increasing per
+  `(sender, room)` as observed by any single recipient, making a `seq` reset
   **self-describing** (GAP-8): a recipient attributes the backwards `seq` jump to
   the epoch bump directly instead of correlating a separately-ordered
   `PlayerLeft`/`PlayerJoined`/`PlayerReconnected` control message. Each member's

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ complete reference.
 | `SIGNAL_FISH__PROTOCOL__MAX_PLAYERS_LIMIT`        | `protocol.max_players_limit`       | `100`     | Hard ceiling on players per room                    |
 | `SIGNAL_FISH__PROTOCOL__ENABLE_MESSAGE_PACK_GAME_DATA` | `protocol.enable_message_pack_game_data` | `true` | Enable MessagePack game-data frames                 |
 | `SIGNAL_FISH__PROTOCOL__MIN_PROTOCOL_VERSION`     | `protocol.min_protocol_version`    | `2`       | Lowest accepted protocol version                    |
-| `SIGNAL_FISH__PROTOCOL__MAX_PROTOCOL_VERSION`     | `protocol.max_protocol_version`    | `4`       | Highest negotiated protocol version                 |
+| `SIGNAL_FISH__PROTOCOL__MAX_PROTOCOL_VERSION`     | `protocol.max_protocol_version`    | `3`       | Highest negotiated protocol version                 |
 | `SIGNAL_FISH__LOGGING__LEVEL`                     | `logging.level`                    | `null`    | Log level override (`trace`, `debug`, `info`, `warn`, `error`) |
 | `SIGNAL_FISH__LOGGING__ENABLE_FILE_LOGGING`       | `logging.enable_file_logging`      | `true`    | Enable rolling file logs                            |
 | `SIGNAL_FISH__LOGGING__FORMAT`                    | `logging.format`                   | `json`    | Log output format (`json` or `text`)                |

--- a/docs/concepts/protocol-versions.md
+++ b/docs/concepts/protocol-versions.md
@@ -39,7 +39,7 @@ The negotiated version is clamped into the server's configured range:
 `negotiated = clamp(client_max, protocol.min_protocol_version, protocol.max_protocol_version)`. A client that
 advertises a higher version than the deployment speaks is clamped **down** to `protocol.max_protocol_version`; one
 that omits `protocol_version` is negotiated from the endpoint default. Defaults: `protocol.min_protocol_version`
-is `2`, `protocol.max_protocol_version` is `4`.
+is `2`, `protocol.max_protocol_version` is `3`.
 
 ## The two invariants
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -132,7 +132,7 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__PROTOCOL__MAX_PLAYERS_LIMIT` | `protocol.max_players_limit` | `100` | Hard ceiling on players per room |
 | `SIGNAL_FISH__PROTOCOL__ENABLE_MESSAGE_PACK_GAME_DATA` | `protocol.enable_message_pack_game_data` | `true` | Enable MessagePack game-data frames |
 | `SIGNAL_FISH__PROTOCOL__MIN_PROTOCOL_VERSION` | `protocol.min_protocol_version` | `2` | Lowest accepted protocol version |
-| `SIGNAL_FISH__PROTOCOL__MAX_PROTOCOL_VERSION` | `protocol.max_protocol_version` | `4` | Highest negotiated protocol version (clamp back to `3` to disable v4 features) |
+| `SIGNAL_FISH__PROTOCOL__MAX_PROTOCOL_VERSION` | `protocol.max_protocol_version` | `3` | Highest negotiated protocol version (clamp back to `2` to disable v3 features) |
 | `SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE` | `protocol.sdk_compatibility.enforce` | `false` | Enforce SDK platform/version checks (opt-in: the default platform list would otherwise reject unregistered/custom clients) |
 | `SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__MINIMUM_VERSIONS` | `protocol.sdk_compatibility.minimum_versions` | `platform defaults` | JSON object of minimum SDK versions |
 | `SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__RECOMMENDED_VERSIONS` | `protocol.sdk_compatibility.recommended_versions` | `platform defaults` | JSON object of recommended SDK versions |
@@ -198,7 +198,7 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__WEBSOCKET__IDLE_TIMEOUT_SECS` | `websocket.idle_timeout_secs` | `300` | Seconds without any inbound frame before an authenticated connection is closed (`0` disables) |
 | `SIGNAL_FISH__WEBSOCKET__SEND_QUEUE_CAPACITY` | `websocket.send_queue_capacity` | `1024` | Per-connection outbound message queue capacity in messages (must be ≥ 1); a full queue applies backpressure to senders |
 | `SIGNAL_FISH__WEBSOCKET__SLOW_CONSUMER_TIMEOUT_MS` | `websocket.slow_consumer_timeout_ms` | `5000` | Milliseconds delivery may wait on a full outbound queue before the recipient is disconnected as a slow consumer (must be > 0 and ≤ `600000`) |
-| `SIGNAL_FISH__WEBSOCKET__DELIVERY_STATS_INTERVAL_SECS` | `websocket.delivery_stats_interval_secs` | `0` | Seconds between per-connection `RelayStats` frames for v4 clients (`0` disables; must be ≤ `3600`) |
+| `SIGNAL_FISH__WEBSOCKET__DELIVERY_STATS_INTERVAL_SECS` | `websocket.delivery_stats_interval_secs` | `0` | Seconds between per-connection `RelayStats` frames for v3 clients (`0` disables; must be ≤ `3600`) |
 | `RUST_LOG` | -- | `info` | Standard `tracing` log filter used when `logging.level` is `null` |
 
 ## Common Configurations

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1383,6 +1383,15 @@ baseline a sender's stream before its first relayed frame arrives. Like `seq`,
 `epoch` is stripped for pre-v4 recipients (their bytes stay byte-identical), so
 its absence and its presence are both part of the frozen wire contract.
 
+The `epoch` value is only meaningful **relatively**: baseline each sender from
+the `epoch` you first observe for it (on a snapshot or its first frame) and
+compare subsequent values against that — do NOT assume a newly observed sender
+starts at `epoch` 1. The server tracks epoch as a single monotonic counter per
+connection, so a sender that reached your room after being in another room (on
+the same connection) may first appear at `epoch` 2 or higher. The only
+guarantee — and the only one you need — is that, for a given sender in your
+room, `(epoch, seq)` never goes backwards while you stay connected.
+
 ### RelayStats
 
 Periodic per-connection delivery accounting, emitted only to v4 connections

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1328,21 +1328,23 @@ C1                        server                          H (host)            C2
 |  (on failure: each client falls back to GameData over the relay floor)      |
 ```
 
-## Protocol v4 additions
+## Protocol v3 delivery reliability
 
-Protocol v4 is a strictly additive negotiation step over v3: every v2/v3
-message and byte stays identical, and a deployment can clamp
-`protocol.max_protocol_version` back to `3` to disable everything below.
-v4 exists so clients can _detect_ relay loss end-to-end instead of trusting
-the delivery contract blindly.
+The v3 additions above cover WebRTC signaling. v3 ALSO adds a delivery
+reliability surface (there is no separate v4: v3 is the single unshipped
+"current" version, so everything additive over the frozen v2 floor negotiates
+under `protocol_version: 3`). A deployment can clamp
+`protocol.max_protocol_version` back to `2` to disable all of it (pure v2).
+This surface exists so clients can _detect_ relay loss end-to-end instead of
+trusting the delivery contract blindly.
 
 ### Sequenced relay (`seq`)
 
 Relayed `GameData` (JSON) and `GameDataBinary` / bare MessagePack frames
-delivered to a v4 recipient carry an additional server-stamped `seq` field:
+delivered to a v3 recipient carry an additional server-stamped `seq` field:
 a per-(sender, room) counter that starts at `1` and increases by exactly one
-for every message the server relays from that sender to the room. Pre-v4
-recipients in the same room receive byte-identical frames with no `seq` key.
+for every message the server relays from that sender to the room. Pre-v3
+(v2) recipients in the same room receive byte-identical frames with no `seq` key.
 
 Recipient rules:
 
@@ -1363,7 +1365,7 @@ Recipient rules:
 
 ### Incarnation epoch (`epoch`)
 
-Alongside `seq`, every relayed `GameData` / `GameDataBinary` to a v4 recipient
+Alongside `seq`, every relayed `GameData` / `GameDataBinary` to a v3 recipient
 also carries an `epoch`: a per-`(sender, room)` counter that increments once
 per **incarnation** of that sender's membership — the first join is `epoch` 1,
 and each join-after-leave or reconnect increments it. `seq` restarts at `1`
@@ -1380,7 +1382,7 @@ control message. Each member's current epoch is also carried on the room
 snapshots — `RoomJoined.current_players[].epoch`, `PlayerJoined.player.epoch`,
 `PlayerReconnected.epoch`, and the `Reconnected` member snapshot — so you can
 baseline a sender's stream before its first relayed frame arrives. Like `seq`,
-`epoch` is stripped for pre-v4 recipients (their bytes stay byte-identical), so
+`epoch` is stripped for pre-v3 (v2) recipients (their bytes stay byte-identical), so
 its absence and its presence are both part of the frozen wire contract.
 
 The `epoch` value is only meaningful **relatively**: baseline each sender from
@@ -1394,7 +1396,7 @@ room, `(epoch, seq)` never goes backwards while you stay connected.
 
 ### RelayStats
 
-Periodic per-connection delivery accounting, emitted only to v4 connections
+Periodic per-connection delivery accounting, emitted only to v3 connections
 and only when `websocket.delivery_stats_interval_secs` is nonzero (default
 `0`, disabled):
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1349,8 +1349,10 @@ Recipient rules:
 - Per sender, `seq` is strictly contiguous while you stay connected. A gap
   can only mean (a) the server abandoned messages together with _your_
   slow-consumer disconnect (you were told: `SLOW_CONSUMER` + close), or
-  (b) the sender left and rejoined (you were told: `PlayerLeft` /
-  `PlayerJoined` / `PlayerReconnected`), which resets its counter to `1`, or
+  (b) the sender left and rejoined, which resets its counter to `1` — and the
+  `epoch` bumps at the same time (see below), so the reset is self-describing;
+  you are also told out of band (`PlayerLeft` / `PlayerJoined` /
+  `PlayerReconnected`), or
   (c) a single binary payload that could not be converted for your
   negotiated format was replaced in-stream by an `Error` with code
   `UNSUPPORTED_GAME_DATA_FORMAT` (you were told, and the connection stayed
@@ -1358,6 +1360,28 @@ Recipient rules:
 - An unexplained gap — one with none of the above notifications — is a
   server bug; report it. That is exactly the condition the sequence numbers
   exist to make observable.
+
+### Incarnation epoch (`epoch`)
+
+Alongside `seq`, every relayed `GameData` / `GameDataBinary` to a v4 recipient
+also carries an `epoch`: a per-`(sender, room)` counter that increments once
+per **incarnation** of that sender's membership — the first join is `epoch` 1,
+and each join-after-leave or reconnect increments it. `seq` restarts at `1`
+within every epoch, so the pair `(epoch, seq)` is strictly
+**lexicographically increasing** per sender as observed by any single recipient:
+
+- `(1, 1), (1, 2), (1, 3)` — the sender's first incarnation, and then
+- `(2, 1), (2, 2), …` — after the sender left+rejoined or reconnected.
+
+This makes the `seq` reset in rule (b) above **self-describing**: you attribute
+the backwards `seq` jump to the `epoch` bump directly, rather than having to
+correlate a separately-ordered `PlayerLeft`/`PlayerJoined`/`PlayerReconnected`
+control message. Each member's current epoch is also carried on the room
+snapshots — `RoomJoined.current_players[].epoch`, `PlayerJoined.player.epoch`,
+`PlayerReconnected.epoch`, and the `Reconnected` member snapshot — so you can
+baseline a sender's stream before its first relayed frame arrives. Like `seq`,
+`epoch` is stripped for pre-v4 recipients (their bytes stay byte-identical), so
+its absence and its presence are both part of the frozen wire contract.
 
 ### RelayStats
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1366,11 +1366,16 @@ Recipient rules:
 ### Incarnation epoch (`epoch`)
 
 Alongside `seq`, every relayed `GameData` / `GameDataBinary` to a v3 recipient
-also carries an `epoch`: a per-`(sender, room)` counter that increments once
-per **incarnation** of that sender's membership — the first join is `epoch` 1,
-and each join-after-leave or reconnect increments it. `seq` restarts at `1`
-within every epoch, so the pair `(epoch, seq)` is strictly
-**lexicographically increasing** per sender as observed by any single recipient:
+also carries an `epoch`: a **monotonic per-sender** counter that increments once
+per **incarnation** of that sender's membership — its first-ever incarnation is
+`epoch` 1, and each join-after-leave or reconnect increments it. The server
+tracks it per sender connection and never resets it on a room switch, so a
+sender's first frame in a given room may begin at `epoch` 2 or higher if that
+sender was previously in another room — do not assume a room's first observed
+epoch is 1. What the contract guarantees is per `(sender, room)`: because `seq`
+restarts at `1` within every epoch, the pair `(epoch, seq)` is strictly
+**lexicographically increasing** per `(sender, room)` as observed by any single
+recipient:
 
 - `(1, 1), (1, 2), (1, 3)` — the sender's first incarnation, and then
 - `(2, 1), (2, 2), …` — after the sender left+rejoined or reconnected.

--- a/fuzz/fuzz_targets/fuzz_reconnect_tokens.rs
+++ b/fuzz/fuzz_targets/fuzz_reconnect_tokens.rs
@@ -160,7 +160,10 @@ async fn run(plan: Plan) {
                 let player = player_id(player);
                 let room = room_id(room);
                 let token = manager
-                    .register_disconnection(player, room, was_authority, None)
+                    // `last_epoch = 0`: this fuzzer exercises token accept/reject
+                    // paths, not the v3 incarnation-epoch stream, so "no prior v3
+                    // stream to preserve" is the correct provisional value.
+                    .register_disconnection(player, room, was_authority, None, 0)
                     .await;
                 // Re-registration replaces the record (and any active claim).
                 reference.pending.insert(player, (room, token, false));

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -913,12 +913,16 @@ components:
               type: integer
               minimum: 1
               description: >-
-                v4 only: server-tracked incarnation epoch, per (sender, room).
-                Increments once per incarnation (the first join is 1; each
-                join-after-leave or reconnect increments it), and seq restarts at
-                1 within each epoch, so (epoch, seq) is strictly lexicographically
-                increasing per sender as observed by any single recipient. This
-                makes the seq restart of case (b) SELF-DESCRIBING. Stamped
+                v4 only: server-tracked incarnation epoch. A single monotonic
+                per-connection counter that increments once per incarnation (the
+                first join is 1; each join-after-leave or reconnect increments
+                it; NOT reset when the same connection switches rooms), while seq
+                restarts at 1 within each epoch, so (epoch, seq) is strictly
+                lexicographically increasing per (sender, room) as observed by
+                any single recipient. This makes the seq restart of case (b)
+                SELF-DESCRIBING. The absolute value is not meaningful: baseline
+                each sender from the epoch you first observe for it (a newly
+                observed sender may start above 1) and compare relatively. Stamped
                 together with seq; absent for pre-v4 recipients (byte-identical
                 wire). Also carried on room snapshots (see PlayerInfo.epoch,
                 PlayerReconnected.epoch).

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -45,14 +45,16 @@
 #   TransportStatus, PeerTransportStatus. v3 messages are tagged `x-protocol: v3`
 #   below. A relay-only room never emits SessionPlan, so a v2 client never sees
 #   v3 messages.
-# * v4 is an OPTIONAL relay-observability upgrade: the server stamps relayed
-#   GameData / GameDataBinary with a per-(sender, room) `seq` (v4 recipients
-#   only — pre-v4 recipients' bytes are unchanged) so any server-side loss is
-#   detectable end-to-end as a gap, and can emit the opt-in periodic RelayStats
-#   frame for attribution. The delivery contract itself (deliver-or-disconnect,
-#   SLOW_CONSUMER) is version-independent; see the ServerGameData and
-#   RelayStats schema descriptions for the normative wording. The server's
-#   default negotiation ceiling is 4 (`protocol.max_protocol_version`).
+# * v3 ALSO adds a relay-observability surface (there is no separate v4 — v3 is
+#   the single unshipped "current" version): the server stamps relayed
+#   GameData / GameDataBinary with a per-(sender, room) `seq` + incarnation
+#   `epoch` (v3 recipients only — pre-v3 (v2) recipients' bytes are unchanged)
+#   so any server-side loss is detectable end-to-end as a gap, and can emit the
+#   opt-in periodic RelayStats frame for attribution. The delivery contract
+#   itself (deliver-or-disconnect, SLOW_CONSUMER) is version-independent; see
+#   the ServerGameData and RelayStats schema descriptions for the normative
+#   wording. The server's default negotiation ceiling is 3
+#   (`protocol.max_protocol_version`).
 # See docs/concepts/protocol-versions.md and docs/guides/building-a-client.md.
 
 asyncapi: 3.0.0
@@ -63,7 +65,7 @@ info:
   description: |
     JSON-over-WebSocket signaling protocol for peer-to-peer game networking.
     v2 relay floor + optional v3 capability negotiation / WebRTC signaling +
-    optional v4 relay sequencing (GameData.seq) and delivery statistics
+    optional v3 relay sequencing (GameData.seq) and delivery statistics
     (RelayStats).
   license:
     name: MIT
@@ -364,8 +366,8 @@ components:
     RelayStats:
       title: RelayStats
       summary: >-
-        v4: periodic per-connection relay-delivery statistics (opt-in via
-        websocket.delivery_stats_interval_secs; never sent to pre-v4 clients).
+        v3: periodic per-connection relay-delivery statistics (opt-in via
+        websocket.delivery_stats_interval_secs; never sent to pre-v3 clients).
       payload: { $ref: '#/components/schemas/RelayStats' }
 
   schemas:
@@ -504,10 +506,10 @@ components:
           type: integer
           minimum: 1
           description: >-
-            v4 only: this player's current incarnation epoch (see
+            v3 only: this player's current incarnation epoch (see
             ServerGameData.epoch), carried on room snapshots (RoomJoined,
-            PlayerJoined, Reconnected) so a v4 recipient learns each member's
-            epoch before that member's first relayed frame. Absent for pre-v4
+            PlayerJoined, Reconnected) so a v3 recipient learns each member's
+            epoch before that member's first relayed frame. Absent for pre-v3
             recipients (byte-identical wire).
     SpectatorInfo:
       type: object
@@ -898,14 +900,14 @@ components:
               type: integer
               minimum: 1
               description: >-
-                v4 only: server-stamped relay sequence number, per (sender,
+                v3 only: server-stamped relay sequence number, per (sender,
                 room). Starts at 1 and is strictly contiguous per sender while
                 the recipient stays connected, so a gap can only mean (a) the
                 recipient's own SLOW_CONSUMER eviction (messages abandoned with
                 the disconnect it was told about), (b) the sender leaving and
                 rejoining (correlate with PlayerLeft + PlayerJoined) or
                 reconnecting (PlayerReconnected) — both RESTART the counter at
-                1 — or (c) the recipient's own reconnect. Absent for pre-v4
+                1 — or (c) the recipient's own reconnect. Absent for pre-v3
                 recipients (their bytes are byte-identical to v3 and earlier).
                 Client-to-server GameData carries no seq; stamping is purely
                 server-side.
@@ -913,7 +915,7 @@ components:
               type: integer
               minimum: 1
               description: >-
-                v4 only: server-tracked incarnation epoch. A single monotonic
+                v3 only: server-tracked incarnation epoch. A single monotonic
                 per-connection counter that increments once per incarnation (the
                 first join is 1; each join-after-leave or reconnect increments
                 it; NOT reset when the same connection switches rooms), while seq
@@ -923,14 +925,14 @@ components:
                 SELF-DESCRIBING. The absolute value is not meaningful: baseline
                 each sender from the epoch you first observe for it (a newly
                 observed sender may start above 1) and compare relatively. Stamped
-                together with seq; absent for pre-v4 recipients (byte-identical
+                together with seq; absent for pre-v3 recipients (byte-identical
                 wire). Also carried on room snapshots (see PlayerInfo.epoch,
                 PlayerReconnected.epoch).
       required: [type, data]
     GameDataBinary:
       type: object
       description: >-
-        Same delivery contract and v4 seq semantics as GameData (text and
+        Same delivery contract and v3 seq semantics as GameData (text and
         binary relay share one per-(sender, room) counter). On the bare binary
         MessagePack frame actually sent to negotiated-MessagePack clients, the
         stamp is the optional trailing `seq` map key; the json/rkyv binary
@@ -947,11 +949,11 @@ components:
             seq:
               type: integer
               minimum: 1
-              description: 'v4 only: see ServerGameData seq (identical semantics).'
+              description: 'v3 only: see ServerGameData seq (identical semantics).'
             epoch:
               type: integer
               minimum: 1
-              description: 'v4 only: see ServerGameData epoch (identical semantics).'
+              description: 'v3 only: see ServerGameData epoch (identical semantics).'
       required: [type, data]
     AuthorityChanged:
       type: object
@@ -1152,10 +1154,10 @@ components:
               type: integer
               minimum: 1
               description: >-
-                v4 only: the reconnector's new incarnation epoch (see
+                v3 only: the reconnector's new incarnation epoch (see
                 ServerGameData.epoch) — the same value now stamped on its relayed
                 GameData — so recipients re-baseline the per-sender (epoch, seq)
-                stream immediately. Absent for pre-v4 recipients (byte-identical
+                stream immediately. Absent for pre-v3 recipients (byte-identical
                 wire).
       required: [type, data]
     SpectatorJoined:
@@ -1267,9 +1269,9 @@ components:
     RelayStats:
       type: object
       description: >-
-        v4 only, config-gated (websocket.delivery_stats_interval_secs > 0;
+        v3 only, config-gated (websocket.delivery_stats_interval_secs > 0;
         default 0 = disabled) and never emitted to a connection that
-        negotiated below v4 (enforced at emission). Counters are CUMULATIVE
+        negotiated below v3 (enforced at emission). Counters are CUMULATIVE
         since the connection registered and survive a reconnection's
         player-id reassignment, so a frame skipped while the connection's
         queue is full (the frame is advisory and never waits) loses nothing.

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -500,6 +500,15 @@ components:
         is_ready: { type: boolean }
         connected_at: { type: string, format: date-time }
         connection_info: { $ref: '#/components/schemas/ConnectionInfo' }
+        epoch:
+          type: integer
+          minimum: 1
+          description: >-
+            v4 only: this player's current incarnation epoch (see
+            ServerGameData.epoch), carried on room snapshots (RoomJoined,
+            PlayerJoined, Reconnected) so a v4 recipient learns each member's
+            epoch before that member's first relayed frame. Absent for pre-v4
+            recipients (byte-identical wire).
     SpectatorInfo:
       type: object
       required: [id, name, connected_at]
@@ -900,6 +909,19 @@ components:
                 recipients (their bytes are byte-identical to v3 and earlier).
                 Client-to-server GameData carries no seq; stamping is purely
                 server-side.
+            epoch:
+              type: integer
+              minimum: 1
+              description: >-
+                v4 only: server-tracked incarnation epoch, per (sender, room).
+                Increments once per incarnation (the first join is 1; each
+                join-after-leave or reconnect increments it), and seq restarts at
+                1 within each epoch, so (epoch, seq) is strictly lexicographically
+                increasing per sender as observed by any single recipient. This
+                makes the seq restart of case (b) SELF-DESCRIBING. Stamped
+                together with seq; absent for pre-v4 recipients (byte-identical
+                wire). Also carried on room snapshots (see PlayerInfo.epoch,
+                PlayerReconnected.epoch).
       required: [type, data]
     GameDataBinary:
       type: object
@@ -922,6 +944,10 @@ components:
               type: integer
               minimum: 1
               description: 'v4 only: see ServerGameData seq (identical semantics).'
+            epoch:
+              type: integer
+              minimum: 1
+              description: 'v4 only: see ServerGameData epoch (identical semantics).'
       required: [type, data]
     AuthorityChanged:
       type: object
@@ -1118,6 +1144,15 @@ components:
           required: [player_id]
           properties:
             player_id: { $ref: '#/components/schemas/PlayerId' }
+            epoch:
+              type: integer
+              minimum: 1
+              description: >-
+                v4 only: the reconnector's new incarnation epoch (see
+                ServerGameData.epoch) — the same value now stamped on its relayed
+                GameData — so recipients re-baseline the per-sender (epoch, seq)
+                stream immediately. Absent for pre-v4 recipients (byte-identical
+                wire).
       required: [type, data]
     SpectatorJoined:
       type: object

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -446,7 +446,7 @@ pub const fn default_slow_consumer_timeout_ms() -> u64 {
 /// Default per-connection `RelayStats` emission interval in seconds
 /// (`0` disables — the default posture).
 ///
-/// The frame is protocol v4-only and purely diagnostic, so it is opt-in:
+/// The frame is protocol v3-only and purely diagnostic, so it is opt-in:
 /// deployments that want delivery attribution (pairing `GameData.seq` gap
 /// detection with `dropped_for_you` / `backpressure_events`) enable it
 /// explicitly. Validated to at most 3600 (one hour) — a longer period is

--- a/src/config/protocol.rs
+++ b/src/config/protocol.rs
@@ -12,10 +12,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Highest protocol version this server build implements. Single source of truth
-/// for the `max_protocol_version` default and validation ceiling. v4 adds the
-/// server-stamped `GameData.seq` relay sequence and the opt-in `RelayStats`
-/// frame; deployments can clamp back to 3 via `protocol.max_protocol_version`.
-pub const SERVER_MAX_PROTOCOL_VERSION: u16 = 4;
+/// for the `max_protocol_version` default and validation ceiling. v3 is the
+/// single unshipped/mutable "current" protocol: it adds the WebRTC signaling
+/// surface (`Signal`/`NewPeer`/`SessionPlan`/`TransportStatus`) AND the delivery
+/// reliability surface (server-stamped `GameData.seq` + incarnation `epoch` and
+/// the opt-in `RelayStats` frame) over the frozen v2 floor. Deployments can clamp
+/// back to 2 (pure v2) via `protocol.max_protocol_version`.
+pub const SERVER_MAX_PROTOCOL_VERSION: u16 = 3;
 /// Lowest protocol version this server build still accepts (the v2 floor).
 pub const SERVER_MIN_PROTOCOL_VERSION: u16 = 2;
 
@@ -40,7 +43,7 @@ pub struct ProtocolConfig {
     /// Lowest protocol version this deployment accepts (the v2 floor; default 2).
     #[serde(default = "default_min_protocol_version")]
     pub min_protocol_version: u16,
-    /// Highest protocol version this deployment will negotiate (default 4).
+    /// Highest protocol version this deployment will negotiate (default 3).
     #[serde(default = "default_max_protocol_version")]
     pub max_protocol_version: u16,
     /// SDK compatibility manifest
@@ -384,7 +387,7 @@ mod protocol_version_tests {
     fn default_protocol_version_bounds() {
         let cfg = ProtocolConfig::default();
         assert_eq!(cfg.min_protocol_version, 2);
-        assert_eq!(cfg.max_protocol_version, 4);
+        assert_eq!(cfg.max_protocol_version, 3);
         assert_eq!(cfg.min_protocol_version, SERVER_MIN_PROTOCOL_VERSION);
         assert_eq!(cfg.max_protocol_version, SERVER_MAX_PROTOCOL_VERSION);
         assert!(cfg.validate().is_ok());
@@ -392,14 +395,14 @@ mod protocol_version_tests {
 
     #[test]
     fn negotiate_clamps_into_range() {
-        let cfg = ProtocolConfig::default(); // [2, 4]
+        let cfg = ProtocolConfig::default(); // [2, 3]
 
-        // v4 client + v4 server => 4
-        assert_eq!(cfg.negotiate_protocol_version(Some(4)), 4);
-        // v3 client stays v3 (never upgraded)
+        // v3 client + v3 server => 3
         assert_eq!(cfg.negotiate_protocol_version(Some(3)), 3);
+        // a stale v4-era (or future) client is clamped down to the ceiling (3)
+        assert_eq!(cfg.negotiate_protocol_version(Some(4)), 3);
         // client beyond server max => clamped to max
-        assert_eq!(cfg.negotiate_protocol_version(Some(9)), 4);
+        assert_eq!(cfg.negotiate_protocol_version(Some(9)), 3);
         // v2 client (None) => floor
         assert_eq!(cfg.negotiate_protocol_version(None), 2);
         // client below floor => raised to min

--- a/src/config/websocket.rs
+++ b/src/config/websocket.rs
@@ -49,12 +49,12 @@ pub struct WebSocketConfig {
     /// notified through the normal disconnect flow.
     #[serde(default = "default_slow_consumer_timeout_ms")]
     pub slow_consumer_timeout_ms: u64,
-    /// How often (seconds) each connection that negotiated protocol v4+ is
+    /// How often (seconds) each connection that negotiated protocol v3+ is
     /// sent a `RelayStats` frame with its cumulative delivery statistics
     /// (`sent_to_you` / `dropped_for_you` / `backpressure_events`); `0`
     /// (the default) disables emission entirely.
     ///
-    /// Pre-v4 recipients never receive the frame regardless of this setting
+    /// Pre-v3 recipients never receive the frame regardless of this setting
     /// (the version gate is enforced at emission). Must be at most `3600`.
     #[serde(default = "default_delivery_stats_interval_secs")]
     pub delivery_stats_interval_secs: u64,

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -223,7 +223,7 @@ pub async fn deliver_or_disconnect(
     // one of enqueued / channel-closed / slow-consumer drop, so the exported
     // counters can prove no delivery outcome went unrecorded.
     metrics.increment_websocket_delivery_attempts();
-    // Per-connection ledger for the v4 RelayStats frame. `None` (registry
+    // Per-connection ledger for the v3 RelayStats frame. `None` (registry
     // empty) unless `websocket.delivery_stats_interval_secs` enabled tracking,
     // so the default deployment pays one cheap map miss here. Relaxed: these
     // are monotonic diagnostics, never synchronization.

--- a/src/coordination/room_coordinator.rs
+++ b/src/coordination/room_coordinator.rs
@@ -1167,6 +1167,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info,
+            epoch: None,
             region_id: "test-region".to_string(),
         }
     }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -347,6 +347,9 @@ impl GameDatabase for InMemoryDatabase {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            // Room-state record, not a wire snapshot: the v4 incarnation epoch
+            // is filled at snapshot-send time, so this stays `None`.
+            epoch: None,
             region_id: region_id.clone(),
         };
 
@@ -1114,6 +1117,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: "us-east-1".to_string(),
         }
     }
@@ -1529,6 +1533,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: "us-east-1".to_string(),
         };
         assert!(db

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -347,7 +347,7 @@ impl GameDatabase for InMemoryDatabase {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
-            // Room-state record, not a wire snapshot: the v4 incarnation epoch
+            // Room-state record, not a wire snapshot: the v3 incarnation epoch
             // is filled at snapshot-send time, so this stays `None`.
             epoch: None,
             region_id: region_id.clone(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
-/// Per-connection delivery bookkeeping backing the protocol v4 `RelayStats`
+/// Per-connection delivery bookkeeping backing the protocol v3 `RelayStats`
 /// frame (`ServerMessage::RelayStats`).
 ///
 /// Counters are cumulative for the lifetime of one logical connection
@@ -637,7 +637,7 @@ impl ServerMetrics {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    // Per-connection delivery statistics (protocol v4 RelayStats)
+    // Per-connection delivery statistics (protocol v3 RelayStats)
 
     /// Start tracking per-connection delivery statistics for `player_id`,
     /// returning the (fresh) ledger. Called at connection registration only

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -299,7 +299,7 @@ pub enum ServerMessage {
     GameData {
         from_player: PlayerId,
         data: serde_json::Value,
-        /// Server-stamped relay sequence number (v4 only). Per-(sender, room),
+        /// Server-stamped relay sequence number (v3 only). Per-(sender, room),
         /// starts at 1, and is strictly contiguous per sender for as long as
         /// the recipient stays connected. A gap therefore always has an
         /// EXPLICIT, observable cause — the recipient was told — and never an
@@ -319,12 +319,12 @@ pub enum ServerMessage {
         /// reconnects, so recipients must treat `PlayerLeft`+`PlayerJoined` /
         /// `PlayerReconnected` for the sender as a seq reset. Stamped at relay
         /// time in `server::game_data`; stripped per recipient in
-        /// `websocket::sending` — `None` and absent from the wire for pre-v4
+        /// `websocket::sending` — `None` and absent from the wire for pre-v3
         /// recipients, keeping their bytes byte-identical. Client→server
         /// `GameData` is unchanged (stamping is purely server-side).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
-        /// Server-tracked incarnation epoch (v4 only), stamped beside `seq`. It
+        /// Server-tracked incarnation epoch (v3 only), stamped beside `seq`. It
         /// increments once per `(sender, room)` incarnation — a join-after-leave
         /// or a reconnect — and `seq` restarts at 1 within each epoch, so
         /// `(epoch, seq)` is strictly lexicographically increasing per sender as
@@ -334,7 +334,7 @@ pub enum ServerMessage {
         /// ordered `PlayerLeft`/`PlayerJoined`/`PlayerReconnected` (which a
         /// future control-plane/data split may reorder relative to data). Gated
         /// exactly like `seq`: stamped from the sender's counter, present only
-        /// for v4 recipients, absent (bytes byte-identical to pre-v4) below.
+        /// for v3 recipients, absent (bytes byte-identical to pre-v3) below.
         /// Precedent: Aeron image sessionId, Kafka producer epoch (KIP-98).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         epoch: Option<u32>,
@@ -350,20 +350,20 @@ pub enum ServerMessage {
         encoding: GameDataEncoding,
         #[serde(with = "bytes_serde")]
         payload: Bytes,
-        /// Server-stamped relay sequence number (v4 only): the same counter,
+        /// Server-stamped relay sequence number (v3 only): the same counter,
         /// semantics, and per-recipient gating as [`ServerMessage::GameData::seq`]
         /// — text and binary relay share one per-(sender, room) stream. On the
         /// bare binary wire frame the stamp is carried as the optional `seq`
         /// map key of `BinaryGameDataFrame` (see `websocket::sending`), present
-        /// only for v4 recipients.
+        /// only for v3 recipients.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
-        /// Server-tracked incarnation epoch (v4 only): the same per-(sender,
+        /// Server-tracked incarnation epoch (v3 only): the same per-(sender,
         /// room) counter, semantics, and per-recipient gating as
         /// [`ServerMessage::GameData::epoch`] — text and binary relay share the
         /// one epoch on the sender's `ClientConnection`. On the bare binary wire
         /// frame it rides beside `seq` as an optional `epoch` map key of
-        /// `BinaryGameDataFrame` (see `websocket::sending`), present only for v4
+        /// `BinaryGameDataFrame` (see `websocket::sending`), present only for v3
         /// recipients.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         epoch: Option<u32>,
@@ -436,12 +436,12 @@ pub enum ServerMessage {
     },
     /// Another player reconnected to the room.
     ///
-    /// `epoch` (v4 only) is the reconnector's new incarnation epoch — the same
+    /// `epoch` (v3 only) is the reconnector's new incarnation epoch — the same
     /// value now stamped on that player's relayed [`ServerMessage::GameData`] —
     /// so a recipient can re-baseline the per-sender `(epoch, seq)` stream
     /// immediately, before the first post-reconnect frame arrives. Stripped for
-    /// pre-v4 recipients, keeping their bytes byte-identical to the frozen
-    /// v2/v3 wire.
+    /// pre-v3 recipients, keeping their bytes byte-identical to the frozen
+    /// v2 wire.
     PlayerReconnected {
         player_id: PlayerId,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -510,11 +510,11 @@ pub enum ServerMessage {
         transport: Transport,
         connected: bool,
     },
-    /// Periodic per-connection relay-delivery statistics (v4 only).
+    /// Periodic per-connection relay-delivery statistics (v3 only).
     ///
-    /// Emitted to a connection only when it negotiated protocol v4+ AND the
+    /// Emitted to a connection only when it negotiated protocol v3+ AND the
     /// deployment enabled `websocket.delivery_stats_interval_secs` (> 0;
-    /// default 0 = disabled — enforcement happens at emission, so a pre-v4
+    /// default 0 = disabled — enforcement happens at emission, so a pre-v3
     /// recipient can never observe this message). Counters are CUMULATIVE
     /// since the connection registered, so a frame skipped under load loses
     /// nothing — the next one carries the totals. Pairs with the

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -324,6 +324,20 @@ pub enum ServerMessage {
         /// `GameData` is unchanged (stamping is purely server-side).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
+        /// Server-tracked incarnation epoch (v4 only), stamped beside `seq`. It
+        /// increments once per `(sender, room)` incarnation — a join-after-leave
+        /// or a reconnect — and `seq` restarts at 1 within each epoch, so
+        /// `(epoch, seq)` is strictly lexicographically increasing per sender as
+        /// observed by any single recipient. This makes the `seq` restart
+        /// SELF-DESCRIBING: a recipient attributes a backwards `seq` jump to the
+        /// epoch bump directly, rather than inferring it from a separately
+        /// ordered `PlayerLeft`/`PlayerJoined`/`PlayerReconnected` (which a
+        /// future control-plane/data split may reorder relative to data). Gated
+        /// exactly like `seq`: stamped from the sender's counter, present only
+        /// for v4 recipients, absent (bytes byte-identical to pre-v4) below.
+        /// Precedent: Aeron image sessionId, Kafka producer epoch (KIP-98).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        epoch: Option<u32>,
     },
     /// Binary game data payload from another player.
     ///
@@ -344,6 +358,15 @@ pub enum ServerMessage {
         /// only for v4 recipients.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         seq: Option<u64>,
+        /// Server-tracked incarnation epoch (v4 only): the same per-(sender,
+        /// room) counter, semantics, and per-recipient gating as
+        /// [`ServerMessage::GameData::epoch`] — text and binary relay share the
+        /// one epoch on the sender's `ClientConnection`. On the bare binary wire
+        /// frame it rides beside `seq` as an optional `epoch` map key of
+        /// `BinaryGameDataFrame` (see `websocket::sending`), present only for v4
+        /// recipients.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        epoch: Option<u32>,
     },
     /// Authority status changed
     AuthorityChanged {
@@ -411,8 +434,19 @@ pub enum ServerMessage {
         reason: String,
         error_code: ErrorCode,
     },
-    /// Another player reconnected to the room
-    PlayerReconnected { player_id: PlayerId },
+    /// Another player reconnected to the room.
+    ///
+    /// `epoch` (v4 only) is the reconnector's new incarnation epoch — the same
+    /// value now stamped on that player's relayed [`ServerMessage::GameData`] —
+    /// so a recipient can re-baseline the per-sender `(epoch, seq)` stream
+    /// immediately, before the first post-reconnect frame arrives. Stripped for
+    /// pre-v4 recipients, keeping their bytes byte-identical to the frozen
+    /// v2/v3 wire.
+    PlayerReconnected {
+        player_id: PlayerId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        epoch: Option<u32>,
+    },
     /// Successfully joined a room as spectator (boxed to reduce enum size)
     SpectatorJoined(Box<SpectatorJoinedPayload>),
     /// Failed to join as spectator

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -77,6 +77,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -87,6 +88,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -101,6 +103,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -125,6 +128,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -152,6 +156,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -223,6 +228,7 @@ mod tests {
                 is_ready: false,
                 connected_at: chrono::Utc::now(),
                 connection_info: None,
+                epoch: None,
                 region_id: types::DEFAULT_REGION_ID.to_string(),
             },
         );
@@ -285,6 +291,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -303,6 +310,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -334,6 +342,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
         let player2 = PlayerInfo {
@@ -343,6 +352,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -389,6 +399,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
         let player2 = PlayerInfo {
@@ -398,6 +409,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -435,6 +447,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -462,6 +475,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
 
@@ -498,6 +512,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
         room.add_player(player1);
@@ -525,6 +540,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         };
         room.add_player(player2);
@@ -568,6 +584,7 @@ mod tests {
                 is_ready: false,
                 connected_at: chrono::Utc::now(),
                 connection_info: None,
+                epoch: None,
                 region_id: types::DEFAULT_REGION_ID.to_string(),
             });
         }
@@ -612,6 +629,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         });
 
@@ -622,6 +640,7 @@ mod tests {
             is_ready: false,
             connected_at: chrono::Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: types::DEFAULT_REGION_ID.to_string(),
         });
 
@@ -660,6 +679,7 @@ mod tests {
                 is_ready: false,
                 connected_at: chrono::Utc::now(),
                 connection_info: None,
+                epoch: None,
                 region_id: types::DEFAULT_REGION_ID.to_string(),
             });
         }

--- a/src/protocol/room_state.rs
+++ b/src/protocol/room_state.rs
@@ -539,6 +539,7 @@ mod tests {
                 is_ready: false,
                 connected_at: chrono::Utc::now(),
                 connection_info: None,
+                epoch: None,
                 region_id: "us-east-1".to_string(),
             },
         );

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -260,6 +260,14 @@ pub struct PlayerInfo {
     /// Legacy self-declared peer metadata for `GameStarting`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_info: Option<ConnectionInfo>,
+    /// Server-tracked incarnation epoch (v4 only): this player's current
+    /// `(player, room)` epoch behind [`ServerMessage::GameData::epoch`], carried
+    /// on room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v4
+    /// recipient learns each member's epoch before their first relayed frame.
+    /// `None` — and absent from the wire — for pre-v4 recipients and in every
+    /// non-snapshot use, keeping v2/v3 bytes byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub epoch: Option<u32>,
     /// Deployment region that currently hosts this player (internal only).
     #[serde(skip_serializing, skip_deserializing, default)]
     pub region_id: String,
@@ -432,6 +440,7 @@ mod tests {
             is_ready: true,
             connected_at: Utc.timestamp_opt(1_700_000_000, 0).unwrap(),
             connection_info,
+            epoch: None,
             region_id: "test-region".to_string(),
         }
     }

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -261,9 +261,10 @@ pub struct PlayerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_info: Option<ConnectionInfo>,
     /// Server-tracked incarnation epoch (v3 only): this player's current
-    /// `(player, room)` epoch behind
-    /// [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage),
-    /// carried on room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v3
+    /// incarnation epoch behind
+    /// [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage) — a
+    /// monotonic per-sender counter (not reset on a room switch), carried on
+    /// room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v3
     /// recipient learns each member's epoch before their first relayed frame.
     /// `None` — and absent from the wire — for pre-v3 recipients and in every
     /// non-snapshot use, keeping v2 bytes byte-identical.

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -260,13 +260,13 @@ pub struct PlayerInfo {
     /// Legacy self-declared peer metadata for `GameStarting`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_info: Option<ConnectionInfo>,
-    /// Server-tracked incarnation epoch (v4 only): this player's current
+    /// Server-tracked incarnation epoch (v3 only): this player's current
     /// `(player, room)` epoch behind
     /// [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage),
-    /// carried on room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v4
+    /// carried on room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v3
     /// recipient learns each member's epoch before their first relayed frame.
-    /// `None` — and absent from the wire — for pre-v4 recipients and in every
-    /// non-snapshot use, keeping v2/v3 bytes byte-identical.
+    /// `None` — and absent from the wire — for pre-v3 recipients and in every
+    /// non-snapshot use, keeping v2 bytes byte-identical.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch: Option<u32>,
     /// Deployment region that currently hosts this player (internal only).

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -261,8 +261,9 @@ pub struct PlayerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connection_info: Option<ConnectionInfo>,
     /// Server-tracked incarnation epoch (v4 only): this player's current
-    /// `(player, room)` epoch behind [`ServerMessage::GameData::epoch`], carried
-    /// on room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v4
+    /// `(player, room)` epoch behind
+    /// [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage),
+    /// carried on room snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a v4
     /// recipient learns each member's epoch before their first relayed frame.
     /// `None` — and absent from the wire — for pre-v4 recipients and in every
     /// non-snapshot use, keeping v2/v3 bytes byte-identical.

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -207,6 +207,14 @@ pub struct DisconnectedPlayer {
     pub was_authority: bool,
     /// Room membership snapshot used to restore the player on reconnect.
     pub player_info: Option<PlayerInfo>,
+    /// The disconnecting connection's game-data incarnation epoch (protocol
+    /// v4). Captured here so it SURVIVES the connection removal: on reconnect
+    /// the restored connection resumes at `last_epoch + 1`, keeping the
+    /// per-(sender, room) `(epoch, seq)` stream strictly increasing for a
+    /// recipient that stayed connected across the sender's absence (a fresh
+    /// reconnect socket would otherwise reset the epoch to 1, colliding with
+    /// the first incarnation). `0` when the sender never relayed under v4.
+    pub last_epoch: u32,
 }
 
 impl DisconnectedPlayer {
@@ -360,13 +368,20 @@ impl ReconnectionManager {
         self.pre_issued.write().await.remove(player_id);
     }
 
-    /// Register a player disconnection
+    /// Register a player disconnection.
+    ///
+    /// `last_epoch` is the disconnecting connection's game-data incarnation
+    /// epoch (protocol v4), captured by the caller from the still-live
+    /// connection so it survives into [`DisconnectedPlayer::last_epoch`] and the
+    /// reconnect can resume at `last_epoch + 1` (see that field). Pass `0` when
+    /// there is no v4 stream to preserve.
     pub async fn register_disconnection(
         &self,
         player_id: PlayerId,
         room_id: RoomId,
         was_authority: bool,
         player_info: Option<PlayerInfo>,
+        last_epoch: u32,
     ) -> String {
         // Reuse the token STRING pre-issued at join (the client already holds
         // it — issue #136, F4), re-stamping its expiry so the reconnect gate
@@ -417,6 +432,17 @@ impl ReconnectionManager {
             _ => fresh_last_sequence,
         };
 
+        // Same-room re-registration keeps the ORIGINAL incarnation epoch: the
+        // player has not reconnected, so its epoch has not advanced, and a
+        // second capture reads `0` from the already-removed connection — `.max`
+        // ensures that can never clobber the real value.
+        let last_epoch = match players.get(&player_id) {
+            Some(existing) if existing.disconnected.room_id == room_id => {
+                existing.disconnected.last_epoch.max(last_epoch)
+            }
+            _ => last_epoch,
+        };
+
         let record = ReconnectionRecord {
             disconnected: DisconnectedPlayer {
                 player_id,
@@ -426,6 +452,7 @@ impl ReconnectionManager {
                 last_sequence,
                 was_authority,
                 player_info,
+                last_epoch,
             },
             claim: None,
         };
@@ -1019,7 +1046,7 @@ mod tests {
 
         // Register disconnection
         let token = manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
 
         // Validate reconnection
@@ -1053,7 +1080,7 @@ mod tests {
         let player_id = Uuid::new_v4();
         let room_id = Uuid::new_v4();
         manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
 
         let protected = manager.rooms_with_active_reconnections().await;
@@ -1077,7 +1104,7 @@ mod tests {
         let player_id = Uuid::new_v4();
         let room_id = Uuid::new_v4();
         let token = manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
         let current_a = Uuid::new_v4();
         let current_b = Uuid::new_v4();
@@ -1131,7 +1158,7 @@ mod tests {
         let player_id = Uuid::new_v4();
         let room_id = Uuid::new_v4();
         let token = manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
 
         let first_claim = manager
@@ -1159,7 +1186,7 @@ mod tests {
         let player_id = Uuid::new_v4();
         let room_id = Uuid::new_v4();
         let _token = manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
         {
             let mut players = manager.disconnected_players.write().await;
@@ -1213,7 +1240,7 @@ mod tests {
         let player_id = Uuid::new_v4();
         let room_id = Uuid::new_v4();
         manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
 
         // 5 events into a 3-slot ring: 2 evictions.
@@ -1245,10 +1272,10 @@ mod tests {
         let room_a = Uuid::new_v4();
         let room_b = Uuid::new_v4();
         manager
-            .register_disconnection(Uuid::new_v4(), room_a, false, None)
+            .register_disconnection(Uuid::new_v4(), room_a, false, None, 0)
             .await;
         manager
-            .register_disconnection(Uuid::new_v4(), room_b, false, None)
+            .register_disconnection(Uuid::new_v4(), room_b, false, None, 0)
             .await;
 
         // Interleave: room B consumes global sequence numbers between room
@@ -1290,7 +1317,7 @@ mod tests {
 
         // Pending: the gate is open.
         manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
         manager.record_room_event(&room_id, &control_event()).await;
         assert_eq!(manager.get_missed_events(&room_id, 0).await.events.len(), 1);
@@ -1330,7 +1357,7 @@ mod tests {
         );
 
         let armed_token = manager
-            .register_disconnection(player, room, false, None)
+            .register_disconnection(player, room, false, None, 0)
             .await;
         assert_eq!(
             armed_token, wire_token,
@@ -1345,7 +1372,7 @@ mod tests {
         );
         // Consumed: a second disconnect (no new join in between) mints fresh.
         let fresh = manager
-            .register_disconnection(player, room, false, None)
+            .register_disconnection(player, room, false, None, 0)
             .await;
         assert_ne!(fresh, wire_token, "a consumed token is never re-armed");
     }
@@ -1360,7 +1387,7 @@ mod tests {
 
         let stale = manager.pre_issue_token(player, Uuid::new_v4()).await;
         let armed = manager
-            .register_disconnection(player, Uuid::new_v4(), false, None)
+            .register_disconnection(player, Uuid::new_v4(), false, None, 0)
             .await;
         assert_ne!(armed, stale, "a wrong-room pre-issue must not be armed");
     }
@@ -1377,7 +1404,7 @@ mod tests {
         let wire_token = manager.pre_issue_token(player, room).await;
         manager.discard_pre_issued(&player).await;
         let armed = manager
-            .register_disconnection(player, room, false, None)
+            .register_disconnection(player, room, false, None, 0)
             .await;
         assert_ne!(armed, wire_token, "a discarded token must never be armed");
     }
@@ -1397,7 +1424,7 @@ mod tests {
         // First disconnect: snapshot taken here. Then a control event is
         // buffered (the player is pending and never sees it).
         manager
-            .register_disconnection(player, room, false, None)
+            .register_disconnection(player, room, false, None, 0)
             .await;
         manager.record_room_event(&room, &control_event()).await;
 
@@ -1405,7 +1432,7 @@ mod tests {
         // replaced/racing connection): the snapshot must not jump past the
         // buffered event.
         manager
-            .register_disconnection(player, room, false, None)
+            .register_disconnection(player, room, false, None, 0)
             .await;
         manager.record_room_event(&room, &control_event()).await;
 
@@ -1443,14 +1470,14 @@ mod tests {
 
         // P pends in room A; the gate opens and captures events there.
         manager
-            .register_disconnection(player, room_a, false, None)
+            .register_disconnection(player, room_a, false, None, 0)
             .await;
         manager.record_room_event(&room_a, &control_event()).await;
 
         // P disconnects again from room B: the re-registration REPLACES its
         // record. Nobody pends in room A anymore, so its buffer must go.
         manager
-            .register_disconnection(player, room_b, false, None)
+            .register_disconnection(player, room_b, false, None, 0)
             .await;
         assert!(
             !manager.event_buffers.read().await.contains_key(&room_a),
@@ -1466,14 +1493,14 @@ mod tests {
         // But while ANOTHER player still pends in the old room, a sibling's
         // re-registration must leave that room's buffer untouched.
         manager
-            .register_disconnection(other_player, room_a, false, None)
+            .register_disconnection(other_player, room_a, false, None, 0)
             .await;
         manager.record_room_event(&room_a, &control_event()).await;
         manager
-            .register_disconnection(player, room_a, false, None)
+            .register_disconnection(player, room_a, false, None, 0)
             .await;
         manager
-            .register_disconnection(player, room_b, false, None)
+            .register_disconnection(player, room_b, false, None, 0)
             .await;
         assert!(
             manager.event_buffers.read().await.contains_key(&room_a),
@@ -1489,7 +1516,7 @@ mod tests {
         let player_id = Uuid::new_v4();
         let room_id = Uuid::new_v4();
         manager
-            .register_disconnection(player_id, room_id, false, None)
+            .register_disconnection(player_id, room_id, false, None, 0)
             .await;
         assert!(
             manager.event_buffers.read().await.contains_key(&room_id),
@@ -1529,7 +1556,7 @@ mod tests {
         let room_id = Uuid::new_v4();
         let player_id = Uuid::new_v4();
         manager
-            .register_disconnection(Uuid::new_v4(), room_id, false, None)
+            .register_disconnection(Uuid::new_v4(), room_id, false, None, 0)
             .await;
 
         let player_info = PlayerInfo {
@@ -1539,6 +1566,7 @@ mod tests {
             is_ready: false,
             connected_at: Utc::now(),
             connection_info: None,
+            epoch: None,
             region_id: "test".to_string(),
         };
         let spectator = SpectatorInfo {
@@ -1553,7 +1581,10 @@ mod tests {
                 player: player_info,
             },
             ServerMessage::PlayerLeft { player_id },
-            ServerMessage::PlayerReconnected { player_id },
+            ServerMessage::PlayerReconnected {
+                player_id,
+                epoch: None,
+            },
             ServerMessage::NewSpectatorJoined {
                 spectator: spectator.clone(),
                 current_spectators: vec![spectator.clone()],
@@ -1589,6 +1620,7 @@ mod tests {
                 from_player: player_id,
                 data: serde_json::json!({ "tick": 1 }),
                 seq: None,
+                epoch: None,
             },
             ServerMessage::GameStarting {
                 peer_connections: Vec::new(),

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -213,7 +213,9 @@ pub struct DisconnectedPlayer {
     /// per-(sender, room) `(epoch, seq)` stream strictly increasing for a
     /// recipient that stayed connected across the sender's absence (a fresh
     /// reconnect socket would otherwise reset the epoch to 1, colliding with
-    /// the first incarnation). `0` when the sender never relayed under v3.
+    /// the first incarnation). The epoch is tracked for every sender regardless
+    /// of protocol version (it bumps on each room join), so this is `0` only
+    /// when the sender disconnected before ever joining a room.
     pub last_epoch: u32,
 }
 

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -373,10 +373,15 @@ impl ReconnectionManager {
     /// Register a player disconnection.
     ///
     /// `last_epoch` is the disconnecting connection's game-data incarnation
-    /// epoch (protocol v3), captured by the caller from the still-live
-    /// connection so it survives into [`DisconnectedPlayer::last_epoch`] and the
-    /// reconnect can resume at `last_epoch + 1` (see that field). Pass `0` when
-    /// there is no v3 stream to preserve.
+    /// epoch, captured by the caller from the still-live connection (via
+    /// `ConnectionManager::game_data_epoch`) so it survives into
+    /// [`DisconnectedPlayer::last_epoch`] and the reconnect can resume at
+    /// `last_epoch + 1` (see that field). The epoch is tracked for every sender
+    /// regardless of negotiated version — it bumps on each room join — so
+    /// whenever the still-live connection's epoch is reachable, pass it. `0`
+    /// (resume at epoch 1) is the fallback for when there is no incarnation to
+    /// preserve: the connection never joined a room, or it was already removed
+    /// (`game_data_epoch` returns `None`) before this call.
     pub async fn register_disconnection(
         &self,
         player_id: PlayerId,

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -397,10 +397,52 @@ impl ReconnectionManager {
         // pre-issue keep the old disconnect-time semantics; such a token is
         // unclaimable by an honest client, exactly as before).
         let pre_issued = self.pre_issued.write().await.remove(&player_id);
-        let (token, minted_fresh) = match pre_issued {
-            Some(pre_issued) if pre_issued.room_id == room_id => {
-                let now = Utc::now();
+
+        let fresh_last_sequence = *self.next_sequence.read().await;
+
+        let mut players = self.disconnected_players.write().await;
+
+        // A same-room re-registration — the player registered a SECOND
+        // disconnection for the same room while still pending, so it has NOT
+        // reconnected — must preserve what the client already holds/expects from
+        // its first pending record. Snapshot those values up front (owned, so
+        // the later `players.insert` is unencumbered): the client-held token
+        // string and its mint time, the original replay snapshot point, and the
+        // original incarnation epoch. A record from a DIFFERENT room, or a
+        // genuinely new one, takes fresh values instead.
+        let existing_same_room = players
+            .get(&player_id)
+            .filter(|existing| existing.disconnected.room_id == room_id)
+            .map(|existing| {
                 (
+                    existing.disconnected.token.token.clone(),
+                    existing.disconnected.token.created_at,
+                    existing.disconnected.last_sequence,
+                    existing.disconnected.last_epoch,
+                )
+            });
+
+        let now = Utc::now();
+        // Token, in preference order: (1) the token from an existing same-room
+        // pending record — the FIRST registration already consumed the
+        // pre-issued entry, so minting fresh here would overwrite the record
+        // with a token the client never received (issue #136, F4: the client
+        // holds the join-time token); (2) the pre-issued join token; (3) a fresh
+        // fallback mint (embedders that never pre-issue). Only (3) is a NEW
+        // token, so only it counts toward the issued-token metric.
+        let (token, minted_fresh) = match &existing_same_room {
+            Some((existing_token, created_at, _, _)) => (
+                ReconnectionToken {
+                    token: existing_token.clone(),
+                    player_id,
+                    room_id,
+                    created_at: *created_at,
+                    expires_at: now + Duration::seconds(self.reconnection_window),
+                },
+                false,
+            ),
+            None => match pre_issued {
+                Some(pre_issued) if pre_issued.room_id == room_id => (
                     ReconnectionToken {
                         token: pre_issued.token,
                         player_id,
@@ -409,46 +451,34 @@ impl ReconnectionManager {
                         expires_at: now + Duration::seconds(self.reconnection_window),
                     },
                     false,
-                )
-            }
-            _ => (
-                ReconnectionToken::new(player_id, room_id, self.reconnection_window),
-                true,
-            ),
+                ),
+                _ => (
+                    ReconnectionToken::new(player_id, room_id, self.reconnection_window),
+                    true,
+                ),
+            },
         };
         let token_string = token.token.clone();
 
-        let fresh_last_sequence = *self.next_sequence.read().await;
-
-        let mut players = self.disconnected_players.write().await;
-
         // Preserve the ORIGINAL replay snapshot point across a same-room
-        // re-registration. A player registering a second disconnection for the
-        // same room while still pending has NOT reconnected, so it has still
-        // not seen anything after its FIRST disconnect. Advancing
-        // `last_sequence` to the current counter would silently exclude the
-        // control events buffered in `(original, now]` from a later
-        // `get_missed_events`, dropping events the client never saw while
-        // `replay` still reported `complete`. Only a genuinely new pending
-        // record (different player state, or a different room) takes the fresh
-        // snapshot.
-        let last_sequence = match players.get(&player_id) {
-            Some(existing) if existing.disconnected.room_id == room_id => {
-                existing.disconnected.last_sequence
-            }
-            _ => fresh_last_sequence,
-        };
+        // re-registration: the player has not seen anything after its FIRST
+        // disconnect, so advancing `last_sequence` to the current counter would
+        // silently exclude the control events buffered in `(original, now]` from
+        // a later `get_missed_events`, dropping events the client never saw
+        // while `replay` still reported `complete`.
+        let last_sequence = existing_same_room
+            .as_ref()
+            .map(|(_, _, last_sequence, _)| *last_sequence)
+            .unwrap_or(fresh_last_sequence);
 
         // Same-room re-registration keeps the ORIGINAL incarnation epoch: the
         // player has not reconnected, so its epoch has not advanced, and a
         // second capture reads `0` from the already-removed connection — `.max`
         // ensures that can never clobber the real value.
-        let last_epoch = match players.get(&player_id) {
-            Some(existing) if existing.disconnected.room_id == room_id => {
-                existing.disconnected.last_epoch.max(last_epoch)
-            }
-            _ => last_epoch,
-        };
+        let last_epoch = existing_same_room
+            .as_ref()
+            .map(|(_, _, _, existing_epoch)| (*existing_epoch).max(last_epoch))
+            .unwrap_or(last_epoch);
 
         let record = ReconnectionRecord {
             disconnected: DisconnectedPlayer {
@@ -1377,11 +1407,57 @@ mod tests {
                 .load(std::sync::atomic::Ordering::Relaxed),
             1
         );
-        // Consumed: a second disconnect (no new join in between) mints fresh.
-        let fresh = manager
+        // A SECOND same-room disconnect while STILL PENDING (no reconnect in
+        // between) must PRESERVE the client-held token: the first registration
+        // already consumed the pre-issued entry, so re-minting here would
+        // overwrite the record with a token the client never received (delivered
+        // at join) and silently break its reconnect. No new mint is counted.
+        let re_armed = manager
             .register_disconnection(player, room, false, None, 0)
             .await;
-        assert_ne!(fresh, wire_token, "a consumed token is never re-armed");
+        assert_eq!(
+            re_armed, wire_token,
+            "a still-pending same-room re-registration keeps the client's token"
+        );
+        assert_eq!(
+            metrics
+                .reconnection_tokens_issued
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "preserving the token must not count a new mint"
+        );
+    }
+
+    /// Regression: a same-room re-registration while still pending must keep the
+    /// client's pre-issued token CLAIMABLE. Before the fix, the second
+    /// registration found the pre-issued entry already consumed, minted a fresh
+    /// token, and overwrote the record — so a client reconnecting with the token
+    /// it received at join (the only token it ever held) was rejected.
+    #[tokio::test]
+    async fn same_room_reregistration_keeps_pre_issued_token_claimable() {
+        let metrics = Arc::new(ServerMetrics::new());
+        let manager = ReconnectionManager::new(300, 100, metrics);
+        let player = Uuid::new_v4();
+        let room = Uuid::new_v4();
+
+        let wire_token = manager.pre_issue_token(player, room).await;
+        manager
+            .register_disconnection(player, room, false, None, 0)
+            .await;
+        // A benign second registration for the same still-pending room (e.g. a
+        // concurrent teardown path re-invoking the disconnect handler).
+        manager
+            .register_disconnection(player, room, false, None, 0)
+            .await;
+
+        // The client only ever held `wire_token`; it must still reconnect.
+        let claim = manager
+            .claim_reconnection(&Uuid::new_v4(), &player, &room, &wire_token)
+            .await;
+        assert!(
+            claim.is_ok(),
+            "the join-time token must stay claimable after re-registration: {claim:?}"
+        );
     }
 
     /// A pre-issued token bound to a DIFFERENT room is not reused (the player

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -208,7 +208,7 @@ pub struct DisconnectedPlayer {
     /// Room membership snapshot used to restore the player on reconnect.
     pub player_info: Option<PlayerInfo>,
     /// The disconnecting connection's game-data incarnation epoch (protocol
-    /// v4). Captured here so it SURVIVES the connection removal: on reconnect
+    /// v3). Captured here so it SURVIVES the connection removal: on reconnect
     /// the restored connection resumes at `last_epoch + 1`, keeping the
     /// per-(sender, room) `(epoch, seq)` stream strictly increasing for a
     /// recipient that stayed connected across the sender's absence (a fresh
@@ -371,10 +371,10 @@ impl ReconnectionManager {
     /// Register a player disconnection.
     ///
     /// `last_epoch` is the disconnecting connection's game-data incarnation
-    /// epoch (protocol v4), captured by the caller from the still-live
+    /// epoch (protocol v3), captured by the caller from the still-live
     /// connection so it survives into [`DisconnectedPlayer::last_epoch`] and the
     /// reconnect can resume at `last_epoch + 1` (see that field). Pass `0` when
-    /// there is no v4 stream to preserve.
+    /// there is no v3 stream to preserve.
     pub async fn register_disconnection(
         &self,
         player_id: PlayerId,

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -404,12 +404,14 @@ impl ReconnectionManager {
 
         // A same-room re-registration — the player registered a SECOND
         // disconnection for the same room while still pending, so it has NOT
-        // reconnected — must preserve what the client already holds/expects from
-        // its first pending record. Snapshot those values up front (owned, so
-        // the later `players.insert` is unencumbered): the client-held token
-        // string and its mint time, the original replay snapshot point, and the
-        // original incarnation epoch. A record from a DIFFERENT room, or a
-        // genuinely new one, takes fresh values instead.
+        // reconnected — must preserve everything the client already
+        // holds/expects from its first pending record. Snapshot the original
+        // record's preserved fields up front (owned, so the later
+        // `players.insert` is unencumbered). Field order:
+        //   (token string, token mint time, last_sequence, last_epoch,
+        //    was_authority, player_info).
+        // A record from a DIFFERENT room, or a genuinely new one, takes fresh
+        // values instead.
         let existing_same_room = players
             .get(&player_id)
             .filter(|existing| existing.disconnected.room_id == room_id)
@@ -419,6 +421,8 @@ impl ReconnectionManager {
                     existing.disconnected.token.created_at,
                     existing.disconnected.last_sequence,
                     existing.disconnected.last_epoch,
+                    existing.disconnected.was_authority,
+                    existing.disconnected.player_info.clone(),
                 )
             });
 
@@ -431,7 +435,7 @@ impl ReconnectionManager {
         // fallback mint (embedders that never pre-issue). Only (3) is a NEW
         // token, so only it counts toward the issued-token metric.
         let (token, minted_fresh) = match &existing_same_room {
-            Some((existing_token, created_at, _, _)) => (
+            Some((existing_token, created_at, ..)) => (
                 ReconnectionToken {
                     token: existing_token.clone(),
                     player_id,
@@ -468,7 +472,7 @@ impl ReconnectionManager {
         // while `replay` still reported `complete`.
         let last_sequence = existing_same_room
             .as_ref()
-            .map(|(_, _, last_sequence, _)| *last_sequence)
+            .map(|(_, _, last_sequence, ..)| *last_sequence)
             .unwrap_or(fresh_last_sequence);
 
         // Same-room re-registration keeps the ORIGINAL incarnation epoch: the
@@ -477,8 +481,26 @@ impl ReconnectionManager {
         // ensures that can never clobber the real value.
         let last_epoch = existing_same_room
             .as_ref()
-            .map(|(_, _, _, existing_epoch)| (*existing_epoch).max(last_epoch))
+            .map(|(_, _, _, existing_epoch, ..)| (*existing_epoch).max(last_epoch))
             .unwrap_or(last_epoch);
+
+        // Likewise keep the ORIGINAL disconnect snapshot — the authority flag
+        // and room-membership `player_info` captured at the FIRST disconnect. A
+        // racing second registration carrying `player_info: None` (or a stale
+        // `was_authority`) must NOT clobber them: `reconnection_service` REJECTS
+        // a reconnect whose stored `player_info` is `None`. Fall back to the new
+        // call's values only when there is no original to preserve (or the
+        // original itself never captured `player_info`).
+        let was_authority = existing_same_room
+            .as_ref()
+            .map(|(_, _, _, _, was_authority, _)| *was_authority)
+            .unwrap_or(was_authority);
+        let player_info = match &existing_same_room {
+            Some((_, _, _, _, _, existing_info)) if existing_info.is_some() => {
+                existing_info.clone()
+            }
+            _ => player_info,
+        };
 
         let record = ReconnectionRecord {
             disconnected: DisconnectedPlayer {
@@ -1457,6 +1479,56 @@ mod tests {
         assert!(
             claim.is_ok(),
             "the join-time token must stay claimable after re-registration: {claim:?}"
+        );
+    }
+
+    /// Regression: a same-room re-registration must NOT clobber the disconnect
+    /// snapshot captured at the FIRST disconnect. A racing second call with
+    /// `player_info: None` (and a stale `was_authority`) would otherwise erase
+    /// the membership snapshot — and `reconnection_service` rejects a reconnect
+    /// whose stored `player_info` is `None`.
+    #[tokio::test]
+    async fn same_room_reregistration_preserves_disconnect_snapshot() {
+        let metrics = Arc::new(ServerMetrics::new());
+        let manager = ReconnectionManager::new(300, 100, metrics);
+        let player = Uuid::new_v4();
+        let room = Uuid::new_v4();
+        let info = PlayerInfo {
+            id: player,
+            name: "Player".to_string(),
+            is_authority: true,
+            is_ready: false,
+            connected_at: Utc::now(),
+            connection_info: None,
+            epoch: None,
+            region_id: "test".to_string(),
+        };
+
+        let token = manager.pre_issue_token(player, room).await;
+        // First disconnect captures the real snapshot: authority + membership.
+        manager
+            .register_disconnection(player, room, true, Some(info), 5)
+            .await;
+        // A racing second registration carries None + a stale authority flag.
+        manager
+            .register_disconnection(player, room, false, None, 0)
+            .await;
+
+        let claim = manager
+            .claim_reconnection(&Uuid::new_v4(), &player, &room, &token)
+            .await
+            .expect("claim succeeds with the preserved token");
+        assert!(
+            claim.disconnected.player_info.is_some(),
+            "the first disconnect's player_info snapshot must survive re-registration"
+        );
+        assert!(
+            claim.disconnected.was_authority,
+            "the first disconnect's was_authority must survive re-registration"
+        );
+        assert_eq!(
+            claim.disconnected.last_epoch, 5,
+            "last_epoch preserved (max) across re-registration"
         );
     }
 

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -219,6 +219,20 @@ pub struct DisconnectedPlayer {
     pub last_epoch: u32,
 }
 
+/// The subset of a still-pending disconnect record that a same-room
+/// re-registration must PRESERVE — the player has not reconnected, so this
+/// state is unchanged and re-deriving it from a (possibly racing, possibly
+/// `None`) second `register_disconnection` call would clobber the real capture.
+/// See [`ReconnectionManager::register_disconnection`].
+struct PreservedPending {
+    token: String,
+    token_created_at: DateTime<Utc>,
+    last_sequence: u64,
+    last_epoch: u32,
+    was_authority: bool,
+    player_info: Option<PlayerInfo>,
+}
+
 impl DisconnectedPlayer {
     /// Check if reconnection window has expired
     pub fn is_expired(&self, window_seconds: i64) -> bool {
@@ -405,25 +419,20 @@ impl ReconnectionManager {
         // A same-room re-registration — the player registered a SECOND
         // disconnection for the same room while still pending, so it has NOT
         // reconnected — must preserve everything the client already
-        // holds/expects from its first pending record. Snapshot the original
-        // record's preserved fields up front (owned, so the later
-        // `players.insert` is unencumbered). Field order:
-        //   (token string, token mint time, last_sequence, last_epoch,
-        //    was_authority, player_info).
-        // A record from a DIFFERENT room, or a genuinely new one, takes fresh
-        // values instead.
+        // holds/expects from its first pending record. Snapshot those preserved
+        // fields up front (owned, so the later `players.insert` is
+        // unencumbered). A record from a DIFFERENT room, or a genuinely new one,
+        // takes fresh values instead.
         let existing_same_room = players
             .get(&player_id)
             .filter(|existing| existing.disconnected.room_id == room_id)
-            .map(|existing| {
-                (
-                    existing.disconnected.token.token.clone(),
-                    existing.disconnected.token.created_at,
-                    existing.disconnected.last_sequence,
-                    existing.disconnected.last_epoch,
-                    existing.disconnected.was_authority,
-                    existing.disconnected.player_info.clone(),
-                )
+            .map(|existing| PreservedPending {
+                token: existing.disconnected.token.token.clone(),
+                token_created_at: existing.disconnected.token.created_at,
+                last_sequence: existing.disconnected.last_sequence,
+                last_epoch: existing.disconnected.last_epoch,
+                was_authority: existing.disconnected.was_authority,
+                player_info: existing.disconnected.player_info.clone(),
             });
 
         let now = Utc::now();
@@ -435,12 +444,12 @@ impl ReconnectionManager {
         // fallback mint (embedders that never pre-issue). Only (3) is a NEW
         // token, so only it counts toward the issued-token metric.
         let (token, minted_fresh) = match &existing_same_room {
-            Some((existing_token, created_at, ..)) => (
+            Some(existing) => (
                 ReconnectionToken {
-                    token: existing_token.clone(),
+                    token: existing.token.clone(),
                     player_id,
                     room_id,
-                    created_at: *created_at,
+                    created_at: existing.token_created_at,
                     expires_at: now + Duration::seconds(self.reconnection_window),
                 },
                 false,
@@ -472,7 +481,7 @@ impl ReconnectionManager {
         // while `replay` still reported `complete`.
         let last_sequence = existing_same_room
             .as_ref()
-            .map(|(_, _, last_sequence, ..)| *last_sequence)
+            .map(|existing| existing.last_sequence)
             .unwrap_or(fresh_last_sequence);
 
         // Same-room re-registration keeps the ORIGINAL incarnation epoch: the
@@ -481,7 +490,7 @@ impl ReconnectionManager {
         // ensures that can never clobber the real value.
         let last_epoch = existing_same_room
             .as_ref()
-            .map(|(_, _, _, existing_epoch, ..)| (*existing_epoch).max(last_epoch))
+            .map(|existing| existing.last_epoch.max(last_epoch))
             .unwrap_or(last_epoch);
 
         // Likewise keep the ORIGINAL disconnect snapshot — the authority flag
@@ -493,12 +502,10 @@ impl ReconnectionManager {
         // original itself never captured `player_info`).
         let was_authority = existing_same_room
             .as_ref()
-            .map(|(_, _, _, _, was_authority, _)| *was_authority)
+            .map(|existing| existing.was_authority)
             .unwrap_or(was_authority);
         let player_info = match &existing_same_room {
-            Some((_, _, _, _, _, existing_info)) if existing_info.is_some() => {
-                existing_info.clone()
-            }
+            Some(existing) if existing.player_info.is_some() => existing.player_info.clone(),
             _ => player_info,
         };
 

--- a/src/reconnection.rs
+++ b/src/reconnection.rs
@@ -213,7 +213,7 @@ pub struct DisconnectedPlayer {
     /// per-(sender, room) `(epoch, seq)` stream strictly increasing for a
     /// recipient that stayed connected across the sender's absence (a fresh
     /// reconnect socket would otherwise reset the epoch to 1, colliding with
-    /// the first incarnation). `0` when the sender never relayed under v4.
+    /// the first incarnation). `0` when the sender never relayed under v3.
     pub last_epoch: u32,
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -419,16 +419,12 @@ impl EnhancedGameServer {
         self.connection_manager.transport_status(player_id)
     }
 
-    /// Whether the client negotiated protocol v3 or higher (gates all v3 emission).
+    /// Whether the client negotiated protocol v3+ (the single unshipped
+    /// "current" version). Gates ALL additive emission over the frozen v2 floor:
+    /// the WebRTC signaling surface AND the delivery reliability surface
+    /// (`GameData.seq`/`epoch` stamps + `RelayStats`).
     pub fn client_supports_v3(&self, player_id: &PlayerId) -> bool {
         self.connection_manager.supports_v3(player_id)
-    }
-
-    /// Whether the client negotiated protocol v4 or higher (gates the relayed
-    /// `GameData.seq` stamp and `RelayStats` emission; mirrors
-    /// [`client_supports_v3`](Self::client_supports_v3)).
-    pub fn client_supports_v4(&self, player_id: &PlayerId) -> bool {
-        self.connection_manager.supports_v4(player_id)
     }
 
     /// Whether the client negotiated support for the given transport.

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -80,6 +80,28 @@ pub(crate) struct ClientConnection {
     /// rejoin: recipients treat a sender's rejoin/reconnect as a seq reset) —
     /// and it is cleaned up with the connection, with no separate map to leak.
     pub game_data_seq: u64,
+    /// Incarnation epoch for this client's outbound game-data stream (protocol
+    /// v4): the per-`(player, room)` counter behind
+    /// [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage). It
+    /// increments once each time a NEW incarnation of the membership begins —
+    /// [`ConnectionManager::assign_client_to_room`] (join / seat-fill join) and
+    /// [`ConnectionManager::reassign_connection`] (reconnect) — so `0` means
+    /// "never joined a room" and the first incarnation is epoch `1`. Leaving a
+    /// room ([`ConnectionManager::clear_room_assignment`]) resets `seq` but does
+    /// NOT bump the epoch: the NEXT join does. Paired with `game_data_seq`
+    /// (which restarts at 1 per epoch) it makes a `seq` restart self-describing.
+    pub game_data_epoch: u32,
+}
+
+/// One relay stamp read atomically from a sender's `ClientConnection`: the
+/// per-`(sender, room)` [`game_data_seq`](ClientConnection::game_data_seq) and
+/// its [`game_data_epoch`](ClientConnection::game_data_epoch). Read together
+/// under one map lock so a recipient always observes a consistent `(epoch,
+/// seq)` pair even if the sender is reassigned concurrently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelayStamp {
+    pub seq: u64,
+    pub epoch: u32,
 }
 
 impl ClientConnection {
@@ -166,6 +188,7 @@ impl ConnectionManager {
             protocol: NegotiatedProtocol::default(),
             transport_status: None,
             game_data_seq: 0,
+            game_data_epoch: 0,
         };
 
         self.clients.insert(player_id, connection);
@@ -205,6 +228,7 @@ impl ConnectionManager {
             protocol: NegotiatedProtocol::default(),
             transport_status: None,
             game_data_seq: 0,
+            game_data_epoch: 0,
         };
 
         self.increment_ip_slot_unbounded(client_addr.ip());
@@ -229,6 +253,10 @@ impl ConnectionManager {
             // Fresh room membership => fresh per-(sender, room) relay stamp
             // stream (restart-on-rejoin; see the `game_data_seq` field doc).
             client.game_data_seq = 0;
+            // A new incarnation of the membership begins here (first join or a
+            // join-after-leave), so its epoch advances; recipients pair it with
+            // the reset `seq` to attribute the restart (see `game_data_epoch`).
+            client.game_data_epoch = client.game_data_epoch.wrapping_add(1);
             let delivery = client.delivery_handle();
             drop(client);
             if let Err(err) = self
@@ -371,15 +399,44 @@ impl ConnectionManager {
         })
     }
 
-    /// Advance and return the relay sequence stamp for `player_id`'s next
-    /// relayed game-data message (protocol v4; first stamp is 1). `None` when
-    /// the connection no longer exists (a disconnect race — the relay then
-    /// simply stamps nothing).
-    pub fn next_game_data_seq(&self, player_id: &PlayerId) -> Option<u64> {
+    /// Advance the relay sequence and return the full relay stamp — the next
+    /// `seq` (protocol v4; first stamp is 1) together with the current
+    /// incarnation `epoch` — for `player_id`'s next relayed game-data message.
+    /// Both are read under one `get_mut` so the `(epoch, seq)` pair a recipient
+    /// observes is always internally consistent. `None` when the connection no
+    /// longer exists (a disconnect race — the relay then simply stamps nothing).
+    pub fn next_relay_stamp(&self, player_id: &PlayerId) -> Option<RelayStamp> {
         self.clients.get_mut(player_id).map(|mut client| {
             client.game_data_seq += 1;
-            client.game_data_seq
+            RelayStamp {
+                seq: client.game_data_seq,
+                epoch: client.game_data_epoch,
+            }
         })
+    }
+
+    /// Read the current incarnation [`epoch`](ClientConnection::game_data_epoch)
+    /// for `player_id` without advancing anything. Used when building v4 room
+    /// snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a recipient
+    /// learns each member's epoch before that member's first relayed frame.
+    /// `None` when the connection no longer exists.
+    pub fn game_data_epoch(&self, player_id: &PlayerId) -> Option<u32> {
+        self.clients
+            .get(player_id)
+            .map(|client| client.game_data_epoch)
+    }
+
+    /// Override the incarnation [`epoch`](ClientConnection::game_data_epoch) for
+    /// a reconnected connection. [`Self::reassign_connection`] derives the epoch
+    /// from the transient reconnect socket (which never joined a room, so it
+    /// would reset to 1); the reconnect path calls this with `last_epoch + 1`
+    /// from the surviving [`DisconnectedPlayer`](crate::reconnection::DisconnectedPlayer)
+    /// record so the sender's `(epoch, seq)` stream stays strictly increasing
+    /// for a recipient that never left. No-op if the connection is gone.
+    pub fn set_game_data_epoch(&self, player_id: &PlayerId, epoch: u32) {
+        if let Some(mut client) = self.clients.get_mut(player_id) {
+            client.game_data_epoch = epoch;
+        }
     }
 
     pub fn record_ping(&self, player_id: &PlayerId) {
@@ -455,6 +512,15 @@ impl ConnectionManager {
                 // stream starts over at 1; recipients treat its
                 // `PlayerReconnected` as a seq reset (field doc above).
                 game_data_seq: 0,
+                // PROVISIONAL epoch. `old_connection` is the transient reconnect
+                // socket (never joined a room ⇒ epoch 0), so this alone would
+                // reset the incarnation to 1 and collide with the sender's first
+                // incarnation. The reconnect path in `reconnection_service`
+                // OVERRIDES this via `set_game_data_epoch` with the surviving
+                // record's `last_epoch + 1` (see `DisconnectedPlayer::last_epoch`);
+                // the `+1` here is only a non-zero fallback for a standalone
+                // reassign that never calls the override.
+                game_data_epoch: old_connection.game_data_epoch.wrapping_add(1),
             };
 
             // IP slot is already reserved from the old entry -- no need to

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -70,7 +70,7 @@ pub(crate) struct ClientConnection {
     /// default and never closes regardless of what is (or is not) reported.
     pub transport_status: Option<(Transport, bool)>,
     /// Last relay sequence number stamped on this client's outbound game data
-    /// (protocol v4): the per-(sender, room) counter behind
+    /// (protocol v3): the per-(sender, room) counter behind
     /// [`ServerMessage::GameData::seq`](crate::protocol::ServerMessage). `0`
     /// means "nothing stamped yet" (the first stamp is 1). Owned here because
     /// its lifecycle is exactly the connection's room membership: it RESETS
@@ -81,7 +81,7 @@ pub(crate) struct ClientConnection {
     /// and it is cleaned up with the connection, with no separate map to leak.
     pub game_data_seq: u64,
     /// Incarnation epoch for this client's outbound game-data stream (protocol
-    /// v4), behind [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage).
+    /// v3), behind [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage).
     ///
     /// It is a single **monotonic per-connection** counter that increments once
     /// each time a NEW incarnation of a room membership begins —
@@ -142,7 +142,7 @@ pub(crate) struct ConnectionManager {
     metrics: Arc<ServerMetrics>,
     message_coordinator: Arc<dyn MessageCoordinator>,
     max_connections_per_ip: usize,
-    /// Whether per-connection delivery statistics (the v4 `RelayStats`
+    /// Whether per-connection delivery statistics (the v3 `RelayStats`
     /// ledger) are registered with the metrics sink for each connection.
     /// Mirrors `websocket.delivery_stats_interval_secs > 0` so a disabled
     /// deployment keeps the per-delivery bookkeeping at a single map miss.
@@ -361,20 +361,16 @@ impl ConnectionManager {
             .and_then(|conn| conn.transport_status)
     }
 
+    /// Whether the client negotiated protocol v3+ (the single unshipped
+    /// "current" version). v3 is the ONE gate for every additive feature over
+    /// the frozen v2 floor: the WebRTC signaling surface
+    /// (`Signal`/`NewPeer`/`SessionPlan`/`TransportStatus`) AND the delivery
+    /// reliability surface (relayed `GameData.seq` + incarnation `epoch`, and
+    /// `RelayStats` emission). A v2 client gets none of it (byte-identical wire).
     pub fn supports_v3(&self, player_id: &PlayerId) -> bool {
         self.clients
             .get(player_id)
             .map(|conn| conn.protocol.version >= 3)
-            .unwrap_or(false)
-    }
-
-    /// Whether the client negotiated protocol v4 or higher (gates the relayed
-    /// `GameData.seq` stamp and `RelayStats` emission; mirrors
-    /// [`Self::supports_v3`]).
-    pub fn supports_v4(&self, player_id: &PlayerId) -> bool {
-        self.clients
-            .get(player_id)
-            .map(|conn| conn.protocol.version >= 4)
             .unwrap_or(false)
     }
 
@@ -412,7 +408,7 @@ impl ConnectionManager {
     }
 
     /// Advance the relay sequence and return the full relay stamp — the next
-    /// `seq` (protocol v4; first stamp is 1) together with the current
+    /// `seq` (protocol v3; first stamp is 1) together with the current
     /// incarnation `epoch` — for `player_id`'s next relayed game-data message.
     /// Both are read under one `get_mut` so the `(epoch, seq)` pair a recipient
     /// observes is always internally consistent. `None` when the connection no
@@ -428,7 +424,7 @@ impl ConnectionManager {
     }
 
     /// Read the current incarnation [`epoch`](ClientConnection::game_data_epoch)
-    /// for `player_id` without advancing anything. Used when building v4 room
+    /// for `player_id` without advancing anything. Used when building v3 room
     /// snapshots (`RoomJoined`/`PlayerJoined`/`Reconnected`) so a recipient
     /// learns each member's epoch before that member's first relayed frame.
     /// `None` when the connection no longer exists.

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -256,7 +256,7 @@ impl ConnectionManager {
             // A new incarnation of the membership begins here (first join or a
             // join-after-leave), so its epoch advances; recipients pair it with
             // the reset `seq` to attribute the restart (see `game_data_epoch`).
-            client.game_data_epoch = client.game_data_epoch.wrapping_add(1);
+            client.game_data_epoch = client.game_data_epoch.saturating_add(1);
             let delivery = client.delivery_handle();
             drop(client);
             if let Err(err) = self
@@ -520,7 +520,7 @@ impl ConnectionManager {
                 // record's `last_epoch + 1` (see `DisconnectedPlayer::last_epoch`);
                 // the `+1` here is only a non-zero fallback for a standalone
                 // reassign that never calls the override.
-                game_data_epoch: old_connection.game_data_epoch.wrapping_add(1),
+                game_data_epoch: old_connection.game_data_epoch.saturating_add(1),
             };
 
             // IP slot is already reserved from the old entry -- no need to

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -93,11 +93,14 @@ pub(crate) struct ClientConnection {
     /// the same connection switches rooms — a room-B membership entered after a
     /// room-A one carries a higher epoch, not a fresh `1`. This is what upholds
     /// the client-facing contract: `(epoch, seq)` is strictly increasing per
-    /// `(sender, room)` as observed by ANY single recipient. A per-room-reset
-    /// counter would instead REPLAY a lower epoch when a sender leaves and
-    /// rejoins the SAME room (a recipient that stayed would see the epoch go
-    /// backwards), unless the server kept unbounded per-`(player, room)` epoch
-    /// state; a monotonic counter guarantees the invariant for free. The
+    /// `(sender, room)` as observed by ANY single recipient. A counter reset per
+    /// room membership would instead REPEAT an epoch it already used when a
+    /// sender leaves and rejoins the SAME room — a recipient that stayed would
+    /// see `(epoch, seq)` collide (the same `epoch`, with `seq` restarting at
+    /// 1), the very ambiguity `epoch` exists to remove. Keeping a distinct
+    /// per-`(player, room)` epoch across leave/rejoin would instead require
+    /// unbounded server state; a single monotonic counter guarantees the
+    /// strictly-increasing invariant for free. The
     /// absolute value is not meaningful to clients — they baseline each sender
     /// from the epoch on its snapshot / first frame and only compare relatively.
     /// Paired with `game_data_seq` (which restarts at 1 per epoch) it makes a

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -81,15 +81,27 @@ pub(crate) struct ClientConnection {
     /// and it is cleaned up with the connection, with no separate map to leak.
     pub game_data_seq: u64,
     /// Incarnation epoch for this client's outbound game-data stream (protocol
-    /// v4): the per-`(player, room)` counter behind
-    /// [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage). It
-    /// increments once each time a NEW incarnation of the membership begins —
+    /// v4), behind [`ServerMessage::GameData::epoch`](crate::protocol::ServerMessage).
+    ///
+    /// It is a single **monotonic per-connection** counter that increments once
+    /// each time a NEW incarnation of a room membership begins —
     /// [`ConnectionManager::assign_client_to_room`] (join / seat-fill join) and
     /// [`ConnectionManager::reassign_connection`] (reconnect) — so `0` means
     /// "never joined a room" and the first incarnation is epoch `1`. Leaving a
     /// room ([`ConnectionManager::clear_room_assignment`]) resets `seq` but does
-    /// NOT bump the epoch: the NEXT join does. Paired with `game_data_seq`
-    /// (which restarts at 1 per epoch) it makes a `seq` restart self-describing.
+    /// NOT bump the epoch: the NEXT join does. It is deliberately NOT reset when
+    /// the same connection switches rooms — a room-B membership entered after a
+    /// room-A one carries a higher epoch, not a fresh `1`. This is what upholds
+    /// the client-facing contract: `(epoch, seq)` is strictly increasing per
+    /// `(sender, room)` as observed by ANY single recipient. A per-room-reset
+    /// counter would instead REPLAY a lower epoch when a sender leaves and
+    /// rejoins the SAME room (a recipient that stayed would see the epoch go
+    /// backwards), unless the server kept unbounded per-`(player, room)` epoch
+    /// state; a monotonic counter guarantees the invariant for free. The
+    /// absolute value is not meaningful to clients — they baseline each sender
+    /// from the epoch on its snapshot / first frame and only compare relatively.
+    /// Paired with `game_data_seq` (which restarts at 1 per epoch) it makes a
+    /// `seq` restart self-describing.
     pub game_data_epoch: u32,
 }
 

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -268,6 +268,11 @@ impl ConnectionManager {
             // A new incarnation of the membership begins here (first join or a
             // join-after-leave), so its epoch advances; recipients pair it with
             // the reset `seq` to attribute the restart (see `game_data_epoch`).
+            // `saturating_add` is deliberate: the u32 epoch space (~4.3B
+            // incarnations on a single connection lineage) is unreachable in
+            // practice, and saturating is the only overflow behavior that never
+            // regresses to a LOWER value — unlike `wrapping_add`, which would
+            // reset to 0 and break the strictly-increasing `(epoch, seq)` view.
             client.game_data_epoch = client.game_data_epoch.saturating_add(1);
             let delivery = client.delivery_handle();
             drop(client);

--- a/src/server/game_data.rs
+++ b/src/server/game_data.rs
@@ -122,7 +122,7 @@ impl EnhancedGameServer {
     /// The stamp is carried INSIDE the shared `Arc<ServerMessage>`, so this
     /// layer — and the [`MessageCoordinator`](crate::coordination::MessageCoordinator)
     /// below it — stays protocol-version-agnostic: per-recipient gating
-    /// (stripping `seq` for pre-v4 recipients) happens at serialization time
+    /// (stripping `seq` for pre-v3 recipients) happens at serialization time
     /// in `websocket::sending`, where every other per-recipient wire decision
     /// (binary vs JSON-fallback encoding) already lives. Because the stamp is
     /// an ordinary serde field of `ServerMessage`, it also survives the

--- a/src/server/game_data.rs
+++ b/src/server/game_data.rs
@@ -49,14 +49,15 @@ impl EnhancedGameServer {
     /// Handle JSON game data fan-out with coordination.
     pub async fn handle_game_data(&self, player_id: &PlayerId, data: serde_json::Value) {
         if let Some(room_id) = self.get_client_room(player_id).await {
-            let seq = self.connection_manager.next_game_data_seq(player_id);
+            let stamp = self.connection_manager.next_relay_stamp(player_id);
             self.broadcast_game_data(
                 player_id,
                 &room_id,
                 ServerMessage::GameData {
                     from_player: *player_id,
                     data,
-                    seq,
+                    seq: stamp.map(|s| s.seq),
+                    epoch: stamp.map(|s| s.epoch),
                 },
             )
             .await;
@@ -98,7 +99,7 @@ impl EnhancedGameServer {
         }
 
         if let Some(room_id) = self.get_client_room(player_id).await {
-            let seq = self.connection_manager.next_game_data_seq(player_id);
+            let stamp = self.connection_manager.next_relay_stamp(player_id);
             self.broadcast_game_data(
                 player_id,
                 &room_id,
@@ -106,7 +107,8 @@ impl EnhancedGameServer {
                     from_player: *player_id,
                     encoding,
                     payload,
-                    seq,
+                    seq: stamp.map(|s| s.seq),
+                    epoch: stamp.map(|s| s.epoch),
                 },
             )
             .await;

--- a/src/server/ready_state_tests.rs
+++ b/src/server/ready_state_tests.rs
@@ -90,6 +90,7 @@ fn player_info(id: PlayerId, name: &str) -> PlayerInfo {
         is_ready: false,
         connected_at: chrono::Utc::now(),
         connection_info: None,
+        epoch: None,
         region_id: "region-a".to_string(),
     }
 }

--- a/src/server/reconnection_service.rs
+++ b/src/server/reconnection_service.rs
@@ -543,7 +543,11 @@ impl EnhancedGameServer {
         // epoch survived in the reconnection record), so a recipient that stayed
         // connected sees the per-(sender, room) `(epoch, seq)` stream strictly
         // INCREASE across the reconnect instead of an ambiguous reset to (1, 1).
-        // (v3; a pre-v3 sender's `last_epoch` is 0 ⇒ epoch 1 here, harmless.)
+        // (Epoch is tracked server-side for EVERY sender — it bumps on each join
+        // regardless of the sender's own protocol version — so `last_epoch` is
+        // the sender's true pre-disconnect value, not necessarily 0 for a v2
+        // sender. It is still stripped per-recipient, so a v2 recipient never
+        // sees it while a v3 recipient gets a correct monotonic stamp.)
         self.connection_manager.set_game_data_epoch(
             reconnect_player_id,
             disconnected.last_epoch.saturating_add(1),

--- a/src/server/reconnection_service.rs
+++ b/src/server/reconnection_service.rs
@@ -394,6 +394,25 @@ impl EnhancedGameServer {
             _ => true,
         });
 
+        // v4 wire gate for REPLAYED snapshots. The replay ring stores
+        // `PlayerJoined` / `PlayerReconnected` in their live-broadcast form —
+        // carrying the v4 incarnation `epoch` — but `missed_events` is embedded
+        // in the `Reconnected` payload and so BYPASSES the per-recipient strip in
+        // `websocket::sending` (which only rewrites the top-level frame). Strip
+        // `epoch` for a pre-v4 reconnector so its `Reconnected` stays
+        // byte-identical to the frozen v2/v3 wire. The reconnecting socket's
+        // negotiated version lives on `current_player_id` here (the reassignment
+        // to `reconnect_player_id` happens below), and the protocol survives it.
+        if self.client_protocol(current_player_id).version < 4 {
+            for event in &mut missed_events.events {
+                match event {
+                    ServerMessage::PlayerJoined { player } => player.epoch = None,
+                    ServerMessage::PlayerReconnected { epoch, .. } => *epoch = None,
+                    _ => {}
+                }
+            }
+        }
+
         if !room.players.contains_key(reconnect_player_id) {
             let Some(player_info) = disconnected.player_info.clone() else {
                 return self
@@ -521,8 +540,10 @@ impl EnhancedGameServer {
         // connected sees the per-(sender, room) `(epoch, seq)` stream strictly
         // INCREASE across the reconnect instead of an ambiguous reset to (1, 1).
         // (v4; a pre-v4 sender's `last_epoch` is 0 ⇒ epoch 1 here, harmless.)
-        self.connection_manager
-            .set_game_data_epoch(reconnect_player_id, disconnected.last_epoch.wrapping_add(1));
+        self.connection_manager.set_game_data_epoch(
+            reconnect_player_id,
+            disconnected.last_epoch.saturating_add(1),
+        );
 
         // Complete once the fallible connection reassignment succeeds. The
         // remaining coordinator/message operations are best-effort updates.

--- a/src/server/reconnection_service.rs
+++ b/src/server/reconnection_service.rs
@@ -144,8 +144,17 @@ impl EnhancedGameServer {
             }
         };
 
+        // Capture the connection's current game-data incarnation epoch WHILE it
+        // is still registered (unregister removes it right after this call), so
+        // the reconnect can resume at `last_epoch + 1` and keep the recipient's
+        // (epoch, seq) view strictly increasing (v4). `None` ⇒ no v4 stream ⇒ 0.
+        let last_epoch = self
+            .connection_manager
+            .game_data_epoch(player_id)
+            .unwrap_or(0);
+
         let token = reconnection_manager
-            .register_disconnection(*player_id, room_id, was_authority, player_info)
+            .register_disconnection(*player_id, room_id, was_authority, player_info, last_epoch)
             .await;
 
         tracing::info!(
@@ -378,7 +387,9 @@ impl EnhancedGameServer {
         // times the player's disconnect was registered before it reconnected.)
         missed_events.events.retain(|event| match event {
             ServerMessage::PlayerLeft { player_id }
-            | ServerMessage::PlayerReconnected { player_id } => player_id != reconnect_player_id,
+            | ServerMessage::PlayerReconnected { player_id, .. } => {
+                player_id != reconnect_player_id
+            }
             ServerMessage::PlayerJoined { player } => player.id != *reconnect_player_id,
             _ => true,
         });
@@ -503,6 +514,16 @@ impl EnhancedGameServer {
                 .await;
         };
 
+        // `reassign_connection` rebuilt the connection from the transient
+        // reconnect socket, whose epoch resets to 1. Restore the sender's real
+        // incarnation lineage: resume at `last_epoch + 1` (the pre-disconnect
+        // epoch survived in the reconnection record), so a recipient that stayed
+        // connected sees the per-(sender, room) `(epoch, seq)` stream strictly
+        // INCREASE across the reconnect instead of an ambiguous reset to (1, 1).
+        // (v4; a pre-v4 sender's `last_epoch` is 0 ⇒ epoch 1 here, harmless.)
+        self.connection_manager
+            .set_game_data_epoch(reconnect_player_id, disconnected.last_epoch.wrapping_add(1));
+
         // Complete once the fallible connection reassignment succeeds. The
         // remaining coordinator/message operations are best-effort updates.
         if !claim_guard.complete().await {
@@ -549,8 +570,19 @@ impl EnhancedGameServer {
         // reflect it on each player's `is_ready`.
         let ready_players = self.room_coordinator.current_ready_players(room_id).await;
         let mut current_players: Vec<PlayerInfo> = room.players.values().cloned().collect();
+        // v4 room snapshot: give a v4 reconnector each member's current
+        // incarnation epoch (including its own freshly bumped epoch) so it can
+        // re-baseline every per-sender (epoch, seq) stream. Single recipient, so
+        // gate on its version at construction — a pre-v4 reconnector keeps every
+        // epoch `None` and byte-identical v2/v3 bytes.
+        let recipient_is_v4 = self.connection_manager.supports_v4(reconnect_player_id);
         for player in current_players.iter_mut() {
             player.is_ready = ready_players.contains(&player.id);
+            player.epoch = if recipient_is_v4 {
+                self.connection_manager.game_data_epoch(&player.id)
+            } else {
+                None
+            };
         }
         let is_authority = room.authority_player == Some(*reconnect_player_id);
 
@@ -613,8 +645,14 @@ impl EnhancedGameServer {
         // room's ring persists when other players are still pending): a
         // reconnector must learn this player came back exactly like a
         // connected member would have.
+        // v4 wire snapshot: carry the reconnector's new incarnation epoch (Some
+        // after the `reassign_connection` above bumped it) — the same value now
+        // stamped on its relayed GameData, so recipients re-baseline the
+        // per-sender (epoch, seq) stream immediately. Stripped per-recipient for
+        // pre-v4 members in `websocket::sending`.
         let notification = Arc::new(ServerMessage::PlayerReconnected {
             player_id: *reconnect_player_id,
+            epoch: self.connection_manager.game_data_epoch(reconnect_player_id),
         });
         self.record_replayable_room_event(room_id, notification.as_ref())
             .await;

--- a/src/server/reconnection_service.rs
+++ b/src/server/reconnection_service.rs
@@ -147,7 +147,11 @@ impl EnhancedGameServer {
         // Capture the connection's current game-data incarnation epoch WHILE it
         // is still registered (unregister removes it right after this call), so
         // the reconnect can resume at `last_epoch + 1` and keep the recipient's
-        // (epoch, seq) view strictly increasing (v4). `None` ⇒ no v4 stream ⇒ 0.
+        // (epoch, seq) view strictly increasing (v3 reliability surface).
+        // `game_data_epoch` returns `None` only if the connection already
+        // vanished (a disconnect race) — never merely because the client is v2;
+        // that case falls back to `0` here (equivalent to "never stamped", so
+        // the reconnect just resumes at epoch 1).
         let last_epoch = self
             .connection_manager
             .game_data_epoch(player_id)
@@ -394,16 +398,16 @@ impl EnhancedGameServer {
             _ => true,
         });
 
-        // v4 wire gate for REPLAYED snapshots. The replay ring stores
+        // v3 wire gate for REPLAYED snapshots. The replay ring stores
         // `PlayerJoined` / `PlayerReconnected` in their live-broadcast form —
-        // carrying the v4 incarnation `epoch` — but `missed_events` is embedded
+        // carrying the v3 incarnation `epoch` — but `missed_events` is embedded
         // in the `Reconnected` payload and so BYPASSES the per-recipient strip in
         // `websocket::sending` (which only rewrites the top-level frame). Strip
-        // `epoch` for a pre-v4 reconnector so its `Reconnected` stays
-        // byte-identical to the frozen v2/v3 wire. The reconnecting socket's
+        // `epoch` for a pre-v3 (v2) reconnector so its `Reconnected` stays
+        // byte-identical to the frozen v2 wire. The reconnecting socket's
         // negotiated version lives on `current_player_id` here (the reassignment
         // to `reconnect_player_id` happens below), and the protocol survives it.
-        if self.client_protocol(current_player_id).version < 4 {
+        if self.client_protocol(current_player_id).version < 3 {
             for event in &mut missed_events.events {
                 match event {
                     ServerMessage::PlayerJoined { player } => player.epoch = None,
@@ -539,7 +543,7 @@ impl EnhancedGameServer {
         // epoch survived in the reconnection record), so a recipient that stayed
         // connected sees the per-(sender, room) `(epoch, seq)` stream strictly
         // INCREASE across the reconnect instead of an ambiguous reset to (1, 1).
-        // (v4; a pre-v4 sender's `last_epoch` is 0 ⇒ epoch 1 here, harmless.)
+        // (v3; a pre-v3 sender's `last_epoch` is 0 ⇒ epoch 1 here, harmless.)
         self.connection_manager.set_game_data_epoch(
             reconnect_player_id,
             disconnected.last_epoch.saturating_add(1),
@@ -591,15 +595,15 @@ impl EnhancedGameServer {
         // reflect it on each player's `is_ready`.
         let ready_players = self.room_coordinator.current_ready_players(room_id).await;
         let mut current_players: Vec<PlayerInfo> = room.players.values().cloned().collect();
-        // v4 room snapshot: give a v4 reconnector each member's current
+        // v3 room snapshot: give a v3 reconnector each member's current
         // incarnation epoch (including its own freshly bumped epoch) so it can
         // re-baseline every per-sender (epoch, seq) stream. Single recipient, so
-        // gate on its version at construction — a pre-v4 reconnector keeps every
-        // epoch `None` and byte-identical v2/v3 bytes.
-        let recipient_is_v4 = self.connection_manager.supports_v4(reconnect_player_id);
+        // gate on its version at construction — a pre-v3 (v2) reconnector keeps
+        // every epoch `None` and byte-identical v2 bytes.
+        let recipient_is_v3 = self.connection_manager.supports_v3(reconnect_player_id);
         for player in current_players.iter_mut() {
             player.is_ready = ready_players.contains(&player.id);
-            player.epoch = if recipient_is_v4 {
+            player.epoch = if recipient_is_v3 {
                 self.connection_manager.game_data_epoch(&player.id)
             } else {
                 None
@@ -666,11 +670,11 @@ impl EnhancedGameServer {
         // room's ring persists when other players are still pending): a
         // reconnector must learn this player came back exactly like a
         // connected member would have.
-        // v4 wire snapshot: carry the reconnector's new incarnation epoch (Some
+        // v3 wire snapshot: carry the reconnector's new incarnation epoch (Some
         // after the `reassign_connection` above bumped it) — the same value now
         // stamped on its relayed GameData, so recipients re-baseline the
         // per-sender (epoch, seq) stream immediately. Stripped per-recipient for
-        // pre-v4 members in `websocket::sending`.
+        // pre-v3 members in `websocket::sending`.
         let notification = Arc::new(ServerMessage::PlayerReconnected {
             player_id: *reconnect_player_id,
             epoch: self.connection_manager.game_data_epoch(reconnect_player_id),

--- a/src/server/room_service.rs
+++ b/src/server/room_service.rs
@@ -229,15 +229,15 @@ impl EnhancedGameServer {
                 // lobby that already has ready members; reflect it on each player's
                 // `is_ready` too.
                 let ready_players = self.room_coordinator.current_ready_players(&room.id).await;
-                // v4 room snapshot: give a v4 joiner each member's current
+                // v3 room snapshot: give a v3 joiner each member's current
                 // incarnation epoch so it can baseline the per-sender (epoch,
                 // seq) stream before the first relayed frame. Single recipient
-                // (the joiner), so gate on its version at construction — a pre-v4
-                // joiner keeps every epoch `None` and byte-identical v2/v3 bytes.
-                let recipient_is_v4 = self.connection_manager.supports_v4(player_id);
+                // (the joiner), so gate on its version at construction — a pre-v3
+                // (v2) joiner keeps every epoch `None` and byte-identical v2 bytes.
+                let recipient_is_v3 = self.connection_manager.supports_v3(player_id);
                 for player in current_players.iter_mut() {
                     player.is_ready = ready_players.contains(&player.id);
-                    player.epoch = if recipient_is_v4 {
+                    player.epoch = if recipient_is_v3 {
                         self.connection_manager.game_data_epoch(&player.id)
                     } else {
                         None
@@ -280,10 +280,10 @@ impl EnhancedGameServer {
                     )
                     .await;
 
-                // Notify other players. This is a v4 wire snapshot, so it
+                // Notify other players. This is a v3 wire snapshot, so it
                 // carries the joiner's current incarnation epoch (Some after the
-                // `assign_client_to_room` above bumped it); pre-v4 recipients
-                // have it stripped per-recipient in `websocket::sending`.
+                // `assign_client_to_room` above bumped it); pre-v3 (v2)
+                // recipients have it stripped per-recipient in `websocket::sending`.
                 let player_info = PlayerInfo {
                     id: *player_id,
                     name: player_name,
@@ -506,7 +506,7 @@ impl EnhancedGameServer {
                         connected_at: chrono::Utc::now(),
                         connection_info: None,
                         // Room-state record (stored in the DB + `room.players`),
-                        // not a wire snapshot: the v4 epoch is filled at
+                        // not a wire snapshot: the v3 epoch is filled at
                         // snapshot-send time, so this stays `None`.
                         epoch: None,
                         region_id: room.region_id.clone(),

--- a/src/server/room_service.rs
+++ b/src/server/room_service.rs
@@ -229,8 +229,19 @@ impl EnhancedGameServer {
                 // lobby that already has ready members; reflect it on each player's
                 // `is_ready` too.
                 let ready_players = self.room_coordinator.current_ready_players(&room.id).await;
+                // v4 room snapshot: give a v4 joiner each member's current
+                // incarnation epoch so it can baseline the per-sender (epoch,
+                // seq) stream before the first relayed frame. Single recipient
+                // (the joiner), so gate on its version at construction — a pre-v4
+                // joiner keeps every epoch `None` and byte-identical v2/v3 bytes.
+                let recipient_is_v4 = self.connection_manager.supports_v4(player_id);
                 for player in current_players.iter_mut() {
                     player.is_ready = ready_players.contains(&player.id);
+                    player.epoch = if recipient_is_v4 {
+                        self.connection_manager.game_data_epoch(&player.id)
+                    } else {
+                        None
+                    };
                 }
 
                 // Send success response
@@ -269,7 +280,10 @@ impl EnhancedGameServer {
                     )
                     .await;
 
-                // Notify other players
+                // Notify other players. This is a v4 wire snapshot, so it
+                // carries the joiner's current incarnation epoch (Some after the
+                // `assign_client_to_room` above bumped it); pre-v4 recipients
+                // have it stripped per-recipient in `websocket::sending`.
                 let player_info = PlayerInfo {
                     id: *player_id,
                     name: player_name,
@@ -277,6 +291,7 @@ impl EnhancedGameServer {
                     is_ready: false,
                     connected_at: chrono::Utc::now(),
                     connection_info: None,
+                    epoch: self.connection_manager.game_data_epoch(player_id),
                     region_id: self.region_id().to_string(),
                 };
                 // Recorded for reconnection replay BEFORE delivery (buffered
@@ -490,6 +505,10 @@ impl EnhancedGameServer {
                         is_ready: false,
                         connected_at: chrono::Utc::now(),
                         connection_info: None,
+                        // Room-state record (stored in the DB + `room.players`),
+                        // not a wire snapshot: the v4 epoch is filled at
+                        // snapshot-send time, so this stays `None`.
+                        epoch: None,
                         region_id: room.region_id.clone(),
                     };
 

--- a/src/server/room_service_tests.rs
+++ b/src/server/room_service_tests.rs
@@ -257,7 +257,7 @@ async fn maintenance_cleanup_removes_expired_reconnections() {
         .expect("reconnection enabled for test server");
 
     let _token = reconnection_manager
-        .register_disconnection(player_id, room_id, false, None)
+        .register_disconnection(player_id, room_id, false, None, 0)
         .await;
     assert!(
         reconnection_manager

--- a/src/server/session_policy_tests.rs
+++ b/src/server/session_policy_tests.rs
@@ -1286,6 +1286,7 @@ fn player_info(id: PlayerId, name: &str, is_authority: bool) -> PlayerInfo {
         is_ready: true,
         connected_at: base_time(),
         connection_info: None,
+        epoch: None,
         region_id: "region-a".to_string(),
     }
 }

--- a/src/server/signaling_tests.rs
+++ b/src/server/signaling_tests.rs
@@ -2621,7 +2621,19 @@ async fn reconnect_restores_room_membership_plan_and_webrtc_pairing() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
+        .register_disconnection(
+            reconnecting,
+            room_id,
+            false,
+            Some(reconnecting_info),
+            // Mirror production: capture the connection's real pre-disconnect
+            // incarnation epoch (non-zero once it has joined a room), so the
+            // reconnect resumes at `epoch + 1` instead of colliding at 1.
+            server
+                .connection_manager
+                .game_data_epoch(&reconnecting)
+                .unwrap_or(0),
+        )
         .await;
     server
         .database
@@ -2728,7 +2740,19 @@ async fn reconnect_room_full_failure_releases_claim_for_retry() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
+        .register_disconnection(
+            reconnecting,
+            room_id,
+            false,
+            Some(reconnecting_info),
+            // Mirror production: capture the connection's real pre-disconnect
+            // incarnation epoch (non-zero once it has joined a room), so the
+            // reconnect resumes at `epoch + 1` instead of colliding at 1.
+            server
+                .connection_manager
+                .game_data_epoch(&reconnecting)
+                .unwrap_or(0),
+        )
         .await;
     server
         .database
@@ -2817,7 +2841,19 @@ async fn reconnect_reassign_failure_rolls_back_membership_and_releases_claim() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
+        .register_disconnection(
+            reconnecting,
+            room_id,
+            false,
+            Some(reconnecting_info),
+            // Mirror production: capture the connection's real pre-disconnect
+            // incarnation epoch (non-zero once it has joined a room), so the
+            // reconnect resumes at `epoch + 1` instead of colliding at 1.
+            server
+                .connection_manager
+                .game_data_epoch(&reconnecting)
+                .unwrap_or(0),
+        )
         .await;
     server
         .database
@@ -2896,7 +2932,12 @@ async fn reconnect_from_roomed_temporary_connection_is_rejected_without_ghost_me
             target_room_id,
             false,
             Some(reconnecting_info),
-            0,
+            // Mirror production: pass the real pre-disconnect incarnation epoch
+            // (non-zero after the room assignment above), not 0.
+            server
+                .connection_manager
+                .game_data_epoch(&reconnecting)
+                .unwrap_or(0),
         )
         .await;
     server
@@ -2976,7 +3017,19 @@ async fn concurrent_reconnect_attempts_with_same_token_allow_exactly_one_winner(
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
+        .register_disconnection(
+            reconnecting,
+            room_id,
+            false,
+            Some(reconnecting_info),
+            // Mirror production: capture the connection's real pre-disconnect
+            // incarnation epoch (non-zero once it has joined a room), so the
+            // reconnect resumes at `epoch + 1` instead of colliding at 1.
+            server
+                .connection_manager
+                .game_data_epoch(&reconnecting)
+                .unwrap_or(0),
+        )
         .await;
     server
         .database

--- a/src/server/signaling_tests.rs
+++ b/src/server/signaling_tests.rs
@@ -983,6 +983,7 @@ fn player_info(id: PlayerId, name: &str) -> PlayerInfo {
         is_ready: false,
         connected_at: chrono::Utc::now(),
         connection_info: None,
+        epoch: None,
         region_id: "region-a".to_string(),
     }
 }
@@ -2620,7 +2621,7 @@ async fn reconnect_restores_room_membership_plan_and_webrtc_pairing() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info))
+        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
         .await;
     server
         .database
@@ -2653,7 +2654,7 @@ async fn reconnect_restores_room_membership_plan_and_webrtc_pairing() {
     }
 
     match recv(&mut existing_rx).await.as_ref() {
-        ServerMessage::PlayerReconnected { player_id } => assert_eq!(*player_id, reconnecting),
+        ServerMessage::PlayerReconnected { player_id, .. } => assert_eq!(*player_id, reconnecting),
         other => panic!("expected PlayerReconnected, got {other:?}"),
     }
 
@@ -2727,7 +2728,7 @@ async fn reconnect_room_full_failure_releases_claim_for_retry() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info))
+        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
         .await;
     server
         .database
@@ -2816,7 +2817,7 @@ async fn reconnect_reassign_failure_rolls_back_membership_and_releases_claim() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info))
+        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
         .await;
     server
         .database
@@ -2890,7 +2891,13 @@ async fn reconnect_from_roomed_temporary_connection_is_rejected_without_ghost_me
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, target_room_id, false, Some(reconnecting_info))
+        .register_disconnection(
+            reconnecting,
+            target_room_id,
+            false,
+            Some(reconnecting_info),
+            0,
+        )
         .await;
     server
         .database
@@ -2969,7 +2976,7 @@ async fn concurrent_reconnect_attempts_with_same_token_allow_exactly_one_winner(
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info))
+        .register_disconnection(reconnecting, room_id, false, Some(reconnecting_info), 0)
         .await;
     server
         .database

--- a/src/server/signaling_tests.rs
+++ b/src/server/signaling_tests.rs
@@ -2651,6 +2651,17 @@ async fn reconnect_restores_room_membership_plan_and_webrtc_pairing() {
         .await;
     assert!(reconnected, "valid reconnect should report success");
 
+    // The incarnation epoch resumes at `last_epoch + 1` (the pre-disconnect
+    // value 1 captured for `register_disconnection` above), so a recipient that
+    // stayed connected sees the reconnector's `(epoch, seq)` stream keep
+    // increasing across the reconnect instead of colliding at the first
+    // incarnation's `(1, …)`.
+    assert_eq!(
+        server.connection_manager.game_data_epoch(&reconnecting),
+        Some(2),
+        "reconnect must resume the incarnation epoch at last_epoch + 1"
+    );
+
     match recv(&mut current_rx).await.as_ref() {
         ServerMessage::Reconnected(payload) => {
             assert_eq!(payload.player_id, reconnecting);

--- a/src/server/spectator_service.rs
+++ b/src/server/spectator_service.rs
@@ -498,6 +498,52 @@ mod tests {
         );
     }
 
+    /// The `SpectatorJoined` snapshot is a third `Vec<PlayerInfo>` carrier
+    /// (beside `RoomJoined`/`Reconnected`) and is NOT run through the
+    /// per-recipient v3 stripping in `websocket::sending`. It stays v2-safe
+    /// only because it is cloned from `room.players`, whose room-state
+    /// `PlayerInfo.epoch` is always `None` (the incarnation epoch is stamped at
+    /// GameData-send time, never stored). Lock that invariant so a future change
+    /// that populates room-state epoch cannot silently leak it onto a v2
+    /// spectator's wire.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)]
+    async fn spectator_snapshot_never_carries_incarnation_epoch() {
+        let (service, room, _creator_id, coordinator, _database) = setup_service().await;
+        let spectator_id = PlayerId::new_v4();
+
+        service
+            .join(
+                &spectator_id,
+                room.game_name.clone(),
+                room.code.clone(),
+                "Snapshot Watcher".to_string(),
+            )
+            .await
+            .expect("spectator join succeeds");
+
+        let payload = coordinator
+            .messages_for(&spectator_id)
+            .await
+            .into_iter()
+            .find_map(|message| match message {
+                ServerMessage::SpectatorJoined(payload) => Some(payload),
+                _ => None,
+            })
+            .expect("spectator receives a SpectatorJoined snapshot");
+
+        assert!(
+            !payload.current_players.is_empty(),
+            "the snapshot lists the room's existing members"
+        );
+        for player in &payload.current_players {
+            assert!(
+                player.epoch.is_none(),
+                "a spectator snapshot must never carry the incarnation epoch: {player:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn leave_detaches_spectator_and_sends_disconnect_notifications() {

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -376,10 +376,10 @@ pub(super) async fn handle_socket(
 
     let effective_player_id = Arc::new(RwLock::new(player_id));
 
-    // Periodic per-connection RelayStats emission (protocol v4, opt-in via
+    // Periodic per-connection RelayStats emission (protocol v3, opt-in via
     // `websocket.delivery_stats_interval_secs`; default 0 = disabled, so no
-    // task is spawned at all). The v4 gate is enforced at EMISSION on every
-    // tick — a pre-v4 connection on a stats-enabled deployment never observes
+    // task is spawned at all). The v3 gate is enforced at EMISSION on every
+    // tick — a pre-v3 connection on a stats-enabled deployment never observes
     // the frame — and re-reads the effective player id so the ticker follows
     // a reconnection reassignment.
     let delivery_stats_interval_secs = server
@@ -406,7 +406,7 @@ pub(super) async fn handle_socket(
                     }
                     _ = ticker.tick() => {
                         let current_player_id = *effective_player_id_for_stats.read().await;
-                        if !server_for_stats.client_supports_v4(&current_player_id) {
+                        if !server_for_stats.client_supports_v3(&current_player_id) {
                             continue;
                         }
                         let Some(stats) = server_for_stats

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -45,12 +45,12 @@ pub(super) async fn send_single_message(
             seq,
             epoch,
         } => {
-            // Per-recipient v4 gate: the relay stamp (seq + incarnation epoch)
-            // reaches only recipients that negotiated protocol v4+ — pre-v4
-            // recipients' bytes stay byte-identical to the frozen v2/v3 wire.
-            let v4 = server.client_supports_v4(player_id);
-            let seq = seq.filter(|_| v4);
-            let epoch = epoch.filter(|_| v4);
+            // Per-recipient v3 gate: the relay stamp (seq + incarnation epoch)
+            // reaches only recipients that negotiated protocol v3+ — a pre-v3
+            // (v2) recipient's bytes stay byte-identical to the frozen v2 wire.
+            let v3 = server.client_supports_v3(player_id);
+            let seq = seq.filter(|_| v3);
+            let epoch = epoch.filter(|_| v3);
             if server.prefers_encoding(player_id, *encoding) {
                 match encode_binary_game_data(*from_player, *encoding, payload, seq, epoch) {
                     Ok(frame_bytes) => {
@@ -117,28 +117,29 @@ pub(super) async fn send_single_message(
                 .await?;
             }
         }
-        // A stamped text relay bound for a pre-v4 recipient: serialize the
+        // A stamped text relay bound for a pre-v3 (v2) recipient: serialize the
         // borrowed legacy shadow (seq + epoch stripped) instead of cloning the
-        // payload, keeping pre-v4 bytes identical at ~the same cost as the
-        // pre-v4 serialization itself. v4 recipients (and unstamped messages)
-        // fall through to the shared-Arc path below untouched. (seq and epoch
-        // are always stamped together, so gating on `seq: Some(_)` also catches
-        // the epoch.)
+        // payload, keeping pre-v3 bytes identical at ~the same cost as the
+        // pre-v3 serialization itself. v3 recipients (and unstamped messages)
+        // fall through to the shared-Arc path below untouched. The guard fires
+        // when EITHER stamp is present (they are stamped together today, but
+        // keying on both — not just `seq` — keeps the strip robust if the fields
+        // ever diverge; `seq`/`epoch` are referenced only by the guard).
         ServerMessage::GameData {
             from_player,
             data,
-            seq: Some(_),
-            ..
-        } if !server.client_supports_v4(player_id) => {
+            seq,
+            epoch,
+        } if (seq.is_some() || epoch.is_some()) && !server.client_supports_v3(player_id) => {
             let legacy = LegacyGameDataEnvelope::new(*from_player, data);
             send_serialized_text(sender, &legacy, player_id).await?;
         }
-        // Broadcast room-snapshot frames carry a v4 incarnation `epoch` that
-        // must never reach a pre-v4 recipient (their bytes stay byte-identical
-        // to the frozen v2/v3 wire). Only the rare snapshot broadcasts hit this;
-        // the common relay path above is untouched.
+        // Broadcast room-snapshot frames carry a v3 incarnation `epoch` that
+        // must never reach a pre-v3 (v2) recipient (their bytes stay
+        // byte-identical to the frozen v2 wire). Only the rare snapshot
+        // broadcasts hit this; the common relay path above is untouched.
         ServerMessage::PlayerJoined { player }
-            if player.epoch.is_some() && !server.client_supports_v4(player_id) =>
+            if player.epoch.is_some() && !server.client_supports_v3(player_id) =>
         {
             let mut player = player.clone();
             player.epoch = None;
@@ -147,7 +148,7 @@ pub(super) async fn send_single_message(
         ServerMessage::PlayerReconnected {
             player_id: reconnected,
             epoch: Some(_),
-        } if !server.client_supports_v4(player_id) => {
+        } if !server.client_supports_v3(player_id) => {
             let stripped = ServerMessage::PlayerReconnected {
                 player_id: *reconnected,
                 epoch: None,
@@ -174,7 +175,7 @@ async fn send_binary_fallback(
     let data =
         decode_binary_to_json(encoding, payload).map_err(BinaryFallbackError::Undeliverable)?;
     // `seq`/`epoch` were already gated per recipient by the caller, so the enum
-    // form serializes correctly for v4 (present) and pre-v4 (absent) alike.
+    // form serializes correctly for v3 (present) and pre-v3 (absent) alike.
     let fallback = ServerMessage::GameData {
         from_player,
         data,
@@ -250,7 +251,7 @@ pub(super) async fn send_text_message(
 }
 
 /// Serialize any wire-shaped value to a JSON text frame and send it. Shared by
-/// the `ServerMessage` path and the borrowed pre-v4 GameData shadow
+/// the `ServerMessage` path and the borrowed pre-v3 GameData shadow
 /// ([`LegacyGameDataEnvelope`]); `Err(())` means the connection closed.
 async fn send_serialized_text<T: Serialize>(
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
@@ -277,9 +278,9 @@ async fn send_serialized_text<T: Serialize>(
     Ok(())
 }
 
-/// Borrowed wire shadow of a `ServerMessage::GameData` frame WITHOUT the v4
+/// Borrowed wire shadow of a `ServerMessage::GameData` frame WITHOUT the v3
 /// `seq` stamp, used to serialize a stamped shared-`Arc` relay message for a
-/// pre-v4 recipient without cloning the payload.
+/// pre-v3 recipient without cloning the payload.
 ///
 /// IMPORTANT: this must serialize byte-identically to
 /// `ServerMessage::GameData { from_player, data, seq: None }` — the adjacently
@@ -324,17 +325,17 @@ struct BinaryGameDataFrame<'a> {
     encoding: GameDataEncoding,
     #[serde(with = "serde_bytes")]
     payload: &'a [u8],
-    /// Server-stamped relay sequence (protocol v4): same counter and
+    /// Server-stamped relay sequence (protocol v3): same counter and
     /// semantics as `ServerMessage::GameData::seq`. Present as a trailing
-    /// `seq` map key only when the recipient negotiated v4 (the caller gates
-    /// it), so pre-v4 recipients' frames stay byte-identical to the frozen
+    /// `seq` map key only when the recipient negotiated v3 (the caller gates
+    /// it), so pre-v3 recipients' frames stay byte-identical to the frozen
     /// vectors below.
     #[serde(skip_serializing_if = "Option::is_none")]
     seq: Option<u64>,
-    /// Server-tracked incarnation epoch (protocol v4): same counter and
+    /// Server-tracked incarnation epoch (protocol v3): same counter and
     /// semantics as `ServerMessage::GameData::epoch`, riding beside `seq` as a
     /// trailing `epoch` map key. Gated per recipient by the caller (present
-    /// only for v4), so pre-v4 frames stay byte-identical to the frozen vectors.
+    /// only for v3), so pre-v3 frames stay byte-identical to the frozen vectors.
     #[serde(skip_serializing_if = "Option::is_none")]
     epoch: Option<u32>,
 }
@@ -345,7 +346,7 @@ struct BinaryGameDataFrame<'a> {
 /// private to the websocket module so the wire frame layout can be tested
 /// without becoming public library API.
 ///
-/// `seq`/`epoch` must already be gated per recipient (v4+ only). Only the
+/// `seq`/`epoch` must already be gated per recipient (v3+ only). Only the
 /// MessagePack frame has an envelope to carry them; the `Json` / `Rkyv`
 /// passthrough paths forward the sender's raw bytes and therefore cannot attach
 /// a stamp — recipients of those encodings rely on the text-relay stamp instead.
@@ -428,8 +429,8 @@ mod tests {
     #[test]
     fn binary_game_data_encoder_emits_bare_message_pack_frame() {
         let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
-        // Pre-v4 form (`seq`/`epoch` both None): bytes are FROZEN — they must
-        // never drift, v4 or not (pre-v4 recipients keep receiving exactly this
+        // Pre-v3 form (`seq`/`epoch` both None): bytes are FROZEN — they must
+        // never drift, v3 or not (pre-v3 recipients keep receiving exactly this
         // frame).
         let wire = encode_binary_game_data(
             player_a(),
@@ -477,8 +478,8 @@ mod tests {
         );
     }
 
-    /// v4 form: the stamp rides as trailing `seq` + `epoch` map keys (production
-    /// always pairs them). Frozen so the v4 binary wire cannot drift either.
+    /// v3 form: the stamp rides as trailing `seq` + `epoch` map keys (production
+    /// always pairs them). Frozen so the v3 binary wire cannot drift either.
     #[test]
     fn binary_game_data_encoder_appends_stamp_for_v4_recipients() {
         let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
@@ -494,11 +495,11 @@ mod tests {
         assert_eq!(
             hex(&wire),
             "85ab66726f6d5f706c61796572c4100000000000000000000000000000000aa8656e636f64696e67ac6d6573736167655f7061636ba77061796c6f6164c40401020304a373657107a565706f636803",
-            "v4 binary wire frame drift (BREAKING v4 wire change?)"
+            "v3 binary wire frame drift (BREAKING v3 wire change?)"
         );
 
         let decoded: DecodedBinaryGameDataFrame =
-            rmp_serde::from_slice(&wire).expect("v4 bare binary frame decodes");
+            rmp_serde::from_slice(&wire).expect("v3 bare binary frame decodes");
         assert_eq!(
             decoded,
             DecodedBinaryGameDataFrame {
@@ -526,7 +527,7 @@ mod tests {
                 "seq": 7,
                 "epoch": 3
             }),
-            "v4 binary frame field-name/casing drift (BREAKING v4 wire change?)"
+            "v3 binary frame field-name/casing drift (BREAKING v3 wire change?)"
         );
     }
 
@@ -550,8 +551,8 @@ mod tests {
         }
     }
 
-    /// The borrowed pre-v4 shadow must serialize byte-identically to the enum
-    /// with `seq: None` — this is what keeps pre-v4 recipients' text frames
+    /// The borrowed pre-v3 shadow must serialize byte-identically to the enum
+    /// with `seq: None` — this is what keeps pre-v3 recipients' text frames
     /// unchanged when the shared broadcast `Arc` carries a stamp.
     #[test]
     fn legacy_game_data_envelope_matches_enum_bytes_without_seq() {
@@ -568,18 +569,18 @@ mod tests {
         let enum_json = serde_json::to_string(&enum_form).expect("enum json");
         assert_eq!(
             legacy_json, enum_json,
-            "pre-v4 shadow must be byte-identical to the unstamped enum form"
+            "pre-v3 shadow must be byte-identical to the unstamped enum form"
         );
         assert_eq!(
             legacy_json,
             format!(
                 r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up","n":3}}}}}}"#
             ),
-            "pre-v4 GameData text frame drift (BREAKING v2 wire change?)"
+            "pre-v3 GameData text frame drift (BREAKING v2 wire change?)"
         );
 
         // And the stamped enum form differs ONLY by the trailing seq + epoch
-        // keys (production always pairs them for a v4 recipient).
+        // keys (production always pairs them for a v3 recipient).
         let stamped = crate::protocol::ServerMessage::GameData {
             from_player: player_a(),
             data,
@@ -592,7 +593,7 @@ mod tests {
             format!(
                 r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up","n":3}},"seq":42,"epoch":3}}}}"#
             ),
-            "v4 GameData text frame drift (BREAKING v4 wire change?)"
+            "v3 GameData text frame drift (BREAKING v3 wire change?)"
         );
     }
 }

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -43,13 +43,16 @@ pub(super) async fn send_single_message(
             encoding,
             payload,
             seq,
+            epoch,
         } => {
-            // Per-recipient v4 gate: the relay stamp reaches only recipients
-            // that negotiated protocol v4+ — pre-v4 recipients' bytes stay
-            // byte-identical to the frozen v2/v3 wire.
-            let seq = seq.filter(|_| server.client_supports_v4(player_id));
+            // Per-recipient v4 gate: the relay stamp (seq + incarnation epoch)
+            // reaches only recipients that negotiated protocol v4+ — pre-v4
+            // recipients' bytes stay byte-identical to the frozen v2/v3 wire.
+            let v4 = server.client_supports_v4(player_id);
+            let seq = seq.filter(|_| v4);
+            let epoch = epoch.filter(|_| v4);
             if server.prefers_encoding(player_id, *encoding) {
-                match encode_binary_game_data(*from_player, *encoding, payload, seq) {
+                match encode_binary_game_data(*from_player, *encoding, payload, seq, epoch) {
                     Ok(frame_bytes) => {
                         if sender
                             .send(Message::Binary(frame_bytes.into()))
@@ -77,6 +80,7 @@ pub(super) async fn send_single_message(
                             *encoding,
                             payload,
                             seq,
+                            epoch,
                             player_id,
                         )
                         .await;
@@ -92,9 +96,16 @@ pub(super) async fn send_single_message(
                     }
                 }
             } else {
-                let fallback =
-                    send_binary_fallback(sender, *from_player, *encoding, payload, seq, player_id)
-                        .await;
+                let fallback = send_binary_fallback(
+                    sender,
+                    *from_player,
+                    *encoding,
+                    payload,
+                    seq,
+                    epoch,
+                    player_id,
+                )
+                .await;
                 notify_or_close_on_fallback_failure(
                     sender,
                     fallback,
@@ -107,17 +118,41 @@ pub(super) async fn send_single_message(
             }
         }
         // A stamped text relay bound for a pre-v4 recipient: serialize the
-        // borrowed legacy shadow (seq stripped) instead of cloning the
+        // borrowed legacy shadow (seq + epoch stripped) instead of cloning the
         // payload, keeping pre-v4 bytes identical at ~the same cost as the
         // pre-v4 serialization itself. v4 recipients (and unstamped messages)
-        // fall through to the shared-Arc path below untouched.
+        // fall through to the shared-Arc path below untouched. (seq and epoch
+        // are always stamped together, so gating on `seq: Some(_)` also catches
+        // the epoch.)
         ServerMessage::GameData {
             from_player,
             data,
             seq: Some(_),
+            ..
         } if !server.client_supports_v4(player_id) => {
             let legacy = LegacyGameDataEnvelope::new(*from_player, data);
             send_serialized_text(sender, &legacy, player_id).await?;
+        }
+        // Broadcast room-snapshot frames carry a v4 incarnation `epoch` that
+        // must never reach a pre-v4 recipient (their bytes stay byte-identical
+        // to the frozen v2/v3 wire). Only the rare snapshot broadcasts hit this;
+        // the common relay path above is untouched.
+        ServerMessage::PlayerJoined { player }
+            if player.epoch.is_some() && !server.client_supports_v4(player_id) =>
+        {
+            let mut player = player.clone();
+            player.epoch = None;
+            send_text_message(sender, &ServerMessage::PlayerJoined { player }, player_id).await?;
+        }
+        ServerMessage::PlayerReconnected {
+            player_id: reconnected,
+            epoch: Some(_),
+        } if !server.client_supports_v4(player_id) => {
+            let stripped = ServerMessage::PlayerReconnected {
+                player_id: *reconnected,
+                epoch: None,
+            };
+            send_text_message(sender, &stripped, player_id).await?;
         }
         other => {
             send_text_message(sender, other, player_id).await?;
@@ -133,16 +168,18 @@ async fn send_binary_fallback(
     encoding: GameDataEncoding,
     payload: &[u8],
     seq: Option<u64>,
+    epoch: Option<u32>,
     player_id: &PlayerId,
 ) -> Result<(), BinaryFallbackError> {
     let data =
         decode_binary_to_json(encoding, payload).map_err(BinaryFallbackError::Undeliverable)?;
-    // `seq` was already gated per recipient by the caller, so the enum form
-    // serializes correctly for v4 (present) and pre-v4 (absent) alike.
+    // `seq`/`epoch` were already gated per recipient by the caller, so the enum
+    // form serializes correctly for v4 (present) and pre-v4 (absent) alike.
     let fallback = ServerMessage::GameData {
         from_player,
         data,
         seq,
+        epoch,
     };
     send_text_message(sender, &fallback, player_id)
         .await
@@ -294,6 +331,12 @@ struct BinaryGameDataFrame<'a> {
     /// vectors below.
     #[serde(skip_serializing_if = "Option::is_none")]
     seq: Option<u64>,
+    /// Server-tracked incarnation epoch (protocol v4): same counter and
+    /// semantics as `ServerMessage::GameData::epoch`, riding beside `seq` as a
+    /// trailing `epoch` map key. Gated per recipient by the caller (present
+    /// only for v4), so pre-v4 frames stay byte-identical to the frozen vectors.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    epoch: Option<u32>,
 }
 
 /// Encodes a binary game-data frame exactly as production puts it on the wire.
@@ -302,15 +345,16 @@ struct BinaryGameDataFrame<'a> {
 /// private to the websocket module so the wire frame layout can be tested
 /// without becoming public library API.
 ///
-/// `seq` must already be gated per recipient (v4+ only). Only the MessagePack
-/// frame has an envelope to carry it; the `Json` / `Rkyv` passthrough paths
-/// forward the sender's raw bytes and therefore cannot attach a stamp —
-/// recipients of those encodings rely on the text-relay stamp instead.
+/// `seq`/`epoch` must already be gated per recipient (v4+ only). Only the
+/// MessagePack frame has an envelope to carry them; the `Json` / `Rkyv`
+/// passthrough paths forward the sender's raw bytes and therefore cannot attach
+/// a stamp — recipients of those encodings rely on the text-relay stamp instead.
 pub(super) fn encode_binary_game_data(
     from_player: PlayerId,
     encoding: GameDataEncoding,
     payload: &[u8],
     seq: Option<u64>,
+    epoch: Option<u32>,
 ) -> Result<Vec<u8>, String> {
     match encoding {
         GameDataEncoding::MessagePack => {
@@ -319,6 +363,7 @@ pub(super) fn encode_binary_game_data(
                 encoding,
                 payload,
                 seq,
+                epoch,
             };
             to_vec_named(&frame).map_err(|err| err.to_string())
         }
@@ -376,16 +421,24 @@ mod tests {
         payload: Vec<u8>,
         #[serde(default)]
         seq: Option<u64>,
+        #[serde(default)]
+        epoch: Option<u32>,
     }
 
     #[test]
     fn binary_game_data_encoder_emits_bare_message_pack_frame() {
         let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
-        // Pre-v4 form (`seq: None`): bytes are FROZEN — they must never drift,
-        // v4 or not (pre-v4 recipients keep receiving exactly this frame).
-        let wire =
-            encode_binary_game_data(player_a(), GameDataEncoding::MessagePack, payload, None)
-                .expect("production binary encode");
+        // Pre-v4 form (`seq`/`epoch` both None): bytes are FROZEN — they must
+        // never drift, v4 or not (pre-v4 recipients keep receiving exactly this
+        // frame).
+        let wire = encode_binary_game_data(
+            player_a(),
+            GameDataEncoding::MessagePack,
+            payload,
+            None,
+            None,
+        )
+        .expect("production binary encode");
 
         assert_eq!(
             hex(&wire),
@@ -402,6 +455,7 @@ mod tests {
                 encoding: GameDataEncoding::MessagePack,
                 payload: payload.to_vec(),
                 seq: None,
+                epoch: None,
             }
         );
 
@@ -410,6 +464,7 @@ mod tests {
             encoding: GameDataEncoding::MessagePack,
             payload,
             seq: None,
+            epoch: None,
         };
         assert_eq!(
             serde_json::to_value(frame).expect("json value"),
@@ -422,18 +477,23 @@ mod tests {
         );
     }
 
-    /// v4 form: the stamp rides as a trailing `seq` map key. Frozen so the v4
-    /// binary wire cannot drift either.
+    /// v4 form: the stamp rides as trailing `seq` + `epoch` map keys (production
+    /// always pairs them). Frozen so the v4 binary wire cannot drift either.
     #[test]
-    fn binary_game_data_encoder_appends_seq_for_v4_recipients() {
+    fn binary_game_data_encoder_appends_stamp_for_v4_recipients() {
         let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
-        let wire =
-            encode_binary_game_data(player_a(), GameDataEncoding::MessagePack, payload, Some(7))
-                .expect("production binary encode with seq");
+        let wire = encode_binary_game_data(
+            player_a(),
+            GameDataEncoding::MessagePack,
+            payload,
+            Some(7),
+            Some(3),
+        )
+        .expect("production binary encode with stamp");
 
         assert_eq!(
             hex(&wire),
-            "84ab66726f6d5f706c61796572c4100000000000000000000000000000000aa8656e636f64696e67ac6d6573736167655f7061636ba77061796c6f6164c40401020304a373657107",
+            "85ab66726f6d5f706c61796572c4100000000000000000000000000000000aa8656e636f64696e67ac6d6573736167655f7061636ba77061796c6f6164c40401020304a373657107a565706f636803",
             "v4 binary wire frame drift (BREAKING v4 wire change?)"
         );
 
@@ -446,6 +506,7 @@ mod tests {
                 encoding: GameDataEncoding::MessagePack,
                 payload: payload.to_vec(),
                 seq: Some(7),
+                epoch: Some(3),
             }
         );
 
@@ -454,6 +515,7 @@ mod tests {
             encoding: GameDataEncoding::MessagePack,
             payload,
             seq: Some(7),
+            epoch: Some(3),
         };
         assert_eq!(
             serde_json::to_value(frame).expect("json value"),
@@ -461,7 +523,8 @@ mod tests {
                 "from_player": PLAYER_A_STR,
                 "encoding": "message_pack",
                 "payload": [1, 2, 3, 4],
-                "seq": 7
+                "seq": 7,
+                "epoch": 3
             }),
             "v4 binary frame field-name/casing drift (BREAKING v4 wire change?)"
         );
@@ -473,14 +536,14 @@ mod tests {
 
         // The passthrough paths have no envelope, so a stamp (gated or not)
         // can never alter the bytes.
-        for seq in [None, Some(9)] {
+        for (seq, epoch) in [(None, None), (Some(9), Some(3))] {
             assert_eq!(
-                encode_binary_game_data(player_a(), GameDataEncoding::Json, payload, seq)
+                encode_binary_game_data(player_a(), GameDataEncoding::Json, payload, seq, epoch)
                     .expect("json passthrough"),
                 payload.to_vec()
             );
             assert_eq!(
-                encode_binary_game_data(player_a(), GameDataEncoding::Rkyv, payload, seq)
+                encode_binary_game_data(player_a(), GameDataEncoding::Rkyv, payload, seq, epoch)
                     .expect("rkyv passthrough"),
                 payload.to_vec()
             );
@@ -498,6 +561,7 @@ mod tests {
             from_player: player_a(),
             data: data.clone(),
             seq: None,
+            epoch: None,
         };
 
         let legacy_json = serde_json::to_string(&legacy).expect("legacy json");
@@ -514,17 +578,19 @@ mod tests {
             "pre-v4 GameData text frame drift (BREAKING v2 wire change?)"
         );
 
-        // And the stamped enum form differs ONLY by the trailing seq key.
+        // And the stamped enum form differs ONLY by the trailing seq + epoch
+        // keys (production always pairs them for a v4 recipient).
         let stamped = crate::protocol::ServerMessage::GameData {
             from_player: player_a(),
             data,
             seq: Some(42),
+            epoch: Some(3),
         };
         let stamped_json = serde_json::to_string(&stamped).expect("stamped json");
         assert_eq!(
             stamped_json,
             format!(
-                r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up","n":3}},"seq":42}}}}"#
+                r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up","n":3}},"seq":42,"epoch":3}}}}"#
             ),
             "v4 GameData text frame drift (BREAKING v4 wire change?)"
         );

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -481,7 +481,7 @@ mod tests {
     /// v3 form: the stamp rides as trailing `seq` + `epoch` map keys (production
     /// always pairs them). Frozen so the v3 binary wire cannot drift either.
     #[test]
-    fn binary_game_data_encoder_appends_stamp_for_v4_recipients() {
+    fn binary_game_data_encoder_appends_stamp_for_v3_recipients() {
         let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
         let wire = encode_binary_game_data(
             player_a(),

--- a/tests/config_and_endpoints_tests.rs
+++ b/tests/config_and_endpoints_tests.rs
@@ -173,7 +173,7 @@ const CONFIG_REFERENCE_ROWS: &[ConfigReferenceRow] = &[
     ConfigReferenceRow {
         env: "SIGNAL_FISH__PROTOCOL__MAX_PROTOCOL_VERSION",
         path: "protocol.max_protocol_version",
-        default: Some("4"),
+        default: Some("3"),
     },
     ConfigReferenceRow {
         env: "SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE",
@@ -531,7 +531,7 @@ const README_REQUIRED_CONFIG_ROWS: &[ConfigReferenceRow] = &[
     ConfigReferenceRow {
         env: "SIGNAL_FISH__PROTOCOL__MAX_PROTOCOL_VERSION",
         path: "protocol.max_protocol_version",
-        default: Some("4"),
+        default: Some("3"),
     },
     ConfigReferenceRow {
         env: "SIGNAL_FISH__LOGGING__LEVEL",

--- a/tests/model_based_state_machines.rs
+++ b/tests/model_based_state_machines.rs
@@ -234,10 +234,10 @@ proptest! {
             // rooms' events consume global sequence numbers (the interleaving
             // that makes gap-based truncation predicates lie).
             manager
-                .register_disconnection(Uuid::from_u128(1), room_a, false, None)
+                .register_disconnection(Uuid::from_u128(1), room_a, false, None, 0)
                 .await;
             manager
-                .register_disconnection(Uuid::from_u128(2), room_b, false, None)
+                .register_disconnection(Uuid::from_u128(2), room_b, false, None, 0)
                 .await;
 
             let mut next_global_seq = 0u64;

--- a/tests/performance_tests.rs
+++ b/tests/performance_tests.rs
@@ -488,6 +488,7 @@ fn test_real_broadcast_message_zero_cost_cloning() {
         from_player: Uuid::new_v4(),
         data: serde_json::json!({"action": "move", "x": 100, "y": 200}),
         seq: None,
+        epoch: None,
     };
 
     let broadcast = BroadcastMessage::new(message);
@@ -549,6 +550,7 @@ fn test_real_broadcast_message_performance() {
         from_player: Uuid::new_v4(),
         data: serde_json::json!({"state": "x".repeat(1000)}),
         seq: None,
+        epoch: None,
     };
 
     let broadcast = BroadcastMessage::new(message);
@@ -581,6 +583,7 @@ fn test_real_server_message_serialization_roundtrip() {
             from_player: player_id,
             data: serde_json::json!({"x": 1, "y": 2}),
             seq: None,
+            epoch: None,
         },
         ServerMessage::PlayerJoined {
             player: PlayerInfo {
@@ -591,6 +594,7 @@ fn test_real_server_message_serialization_roundtrip() {
                 connected_at: chrono::Utc::now(),
                 connection_info: None,
                 region_id: "test".to_string(),
+                epoch: None,
             },
         },
     ];
@@ -619,6 +623,7 @@ fn test_real_broadcast_room_simulation() {
         from_player: room_players[0],
         data: serde_json::json!({"move": "forward", "speed": 5}),
         seq: None,
+        epoch: None,
     };
 
     let broadcast = BroadcastMessage::new(message);

--- a/tests/protocol_fuzz_hardening.rs
+++ b/tests/protocol_fuzz_hardening.rs
@@ -465,7 +465,7 @@ fn invalid_utf8_returns_err() {
     }
 }
 
-/// Protocol v4 `GameData.seq` boundary values on BOTH wire encodings: absent,
+/// Protocol v3 `GameData.seq` boundary values on BOTH wire encodings: absent,
 /// 0 (never produced by the server, whose first stamp is 1, but must decode),
 /// 1, and u64::MAX all decode, round-trip exactly, and never panic. Also pins
 /// the rejection (not panic) of out-of-domain seq values on the text path.
@@ -473,7 +473,7 @@ fn invalid_utf8_returns_err() {
 fn game_data_seq_boundary_values_decode_on_both_paths() {
     let uuid = "00000000-0000-0000-0000-000000000001";
 
-    // Absent seq: decodes to None (the entire pre-v4 wire).
+    // Absent seq: decodes to None (the entire pre-v3 wire).
     let bare = format!(r#"{{"type":"GameData","data":{{"from_player":"{uuid}","data":{{}}}}}}"#);
     match serde_json::from_str::<ServerMessage>(&bare).expect("bare GameData decodes") {
         ServerMessage::GameData { seq, .. } => assert_eq!(seq, None),

--- a/tests/protocol_v3_negotiation.rs
+++ b/tests/protocol_v3_negotiation.rs
@@ -619,60 +619,60 @@ fn session_plan_default_ice_servers_when_field_absent() {
 }
 
 // ---------------------------------------------------------------------------
-// Protocol v4 negotiation: the [2, 4] clamp matrix at the config level. The
+// Protocol v3 negotiation: the [2, 4] clamp matrix at the config level. The
 // same matrix is exercised end-to-end (through Authenticate/ProtocolInfo) in
 // `tests/v3_negotiation_e2e.rs`.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn v4_negotiation_clamp_matrix() {
+fn v3_negotiation_clamp_matrix() {
     use signal_fish_server::config::{ProtocolConfig, SERVER_MAX_PROTOCOL_VERSION};
 
     assert_eq!(
-        SERVER_MAX_PROTOCOL_VERSION, 4,
-        "this build implements protocol v4 (server-stamped GameData seq + RelayStats)"
+        SERVER_MAX_PROTOCOL_VERSION, 3,
+        "this build implements protocol v3 (the single unshipped current version: \
+         WebRTC signaling + server-stamped GameData seq/epoch + RelayStats)"
     );
 
-    // Default deployment range is [2, 4].
+    // Default deployment range is [2, 3].
     let cfg = ProtocolConfig::default();
-    assert_eq!(cfg.max_protocol_version, 4, "default ceiling is v4");
-    assert!(cfg.validate().is_ok(), "default [2, 4] range validates");
+    assert_eq!(cfg.max_protocol_version, 3, "default ceiling is v3");
+    assert!(cfg.validate().is_ok(), "default [2, 3] range validates");
 
-    // client asks 4 => gets 4.
-    assert_eq!(cfg.negotiate_protocol_version(Some(4)), 4);
-    // client asks 5 (future) => clamped down to 4.
-    assert_eq!(cfg.negotiate_protocol_version(Some(5)), 4);
-    // client asks 3 => stays 3 (v4 is opt-in, never forced).
+    // client asks 3 => gets 3.
     assert_eq!(cfg.negotiate_protocol_version(Some(3)), 3);
-    // client asks 2 / omits => the v2 floor.
+    // client asks 4/5 (future, or a stale v3-era client) => clamped down to 3.
+    assert_eq!(cfg.negotiate_protocol_version(Some(4)), 3);
+    assert_eq!(cfg.negotiate_protocol_version(Some(5)), 3);
+    // client asks 2 / omits => the v2 floor (v3 is opt-in, never forced).
     assert_eq!(cfg.negotiate_protocol_version(Some(2)), 2);
     assert_eq!(cfg.negotiate_protocol_version(None), 2);
 
-    // Deployment clamped back to max 3 by config: a v4 client is negotiated
-    // down to 3 and the narrowed range still validates.
+    // Deployment clamped back to max 2 (pure v2) by config: a v3 client is
+    // negotiated down to 2 and the narrowed range still validates.
     let clamped = ProtocolConfig {
-        max_protocol_version: 3,
+        max_protocol_version: 2,
         ..ProtocolConfig::default()
     };
-    assert!(clamped.validate().is_ok(), "[2, 3] stays a valid range");
-    assert_eq!(clamped.negotiate_protocol_version(Some(4)), 3);
-    assert_eq!(clamped.negotiate_protocol_version(Some(3)), 3);
+    assert!(clamped.validate().is_ok(), "[2, 2] stays a valid range");
+    assert_eq!(clamped.negotiate_protocol_version(Some(3)), 2);
+    assert_eq!(clamped.negotiate_protocol_version(Some(2)), 2);
 
-    // The full [2, 4] range is accepted by config validation; above the
+    // The full [2, 3] range is accepted by config validation; above the
     // build ceiling is rejected.
     let full = ProtocolConfig {
         min_protocol_version: 2,
-        max_protocol_version: 4,
+        max_protocol_version: 3,
         ..ProtocolConfig::default()
     };
     assert!(full.validate().is_ok());
     let beyond = ProtocolConfig {
-        max_protocol_version: 5,
+        max_protocol_version: 4,
         ..ProtocolConfig::default()
     };
     assert!(
         beyond.validate().is_err(),
-        "max above the build ceiling (4) must be rejected"
+        "max above the build ceiling (3) must be rejected"
     );
 }
 

--- a/tests/protocol_v3_negotiation.rs
+++ b/tests/protocol_v3_negotiation.rs
@@ -619,7 +619,7 @@ fn session_plan_default_ice_servers_when_field_absent() {
 }
 
 // ---------------------------------------------------------------------------
-// Protocol v3 negotiation: the [2, 4] clamp matrix at the config level. The
+// Protocol v3 negotiation: the [2, 3] clamp matrix at the config level. The
 // same matrix is exercised end-to-end (through Authenticate/ProtocolInfo) in
 // `tests/v3_negotiation_e2e.rs`.
 // ---------------------------------------------------------------------------

--- a/tests/reconnect_window_races_e2e.rs
+++ b/tests/reconnect_window_races_e2e.rs
@@ -302,7 +302,7 @@ async fn register_reconnect_token(
     game_server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(player_id, room_id, false, Some(player_info))
+        .register_disconnection(player_id, room_id, false, Some(player_info), 0)
         .await
 }
 

--- a/tests/reconnection_replay_e2e.rs
+++ b/tests/reconnection_replay_e2e.rs
@@ -261,6 +261,11 @@ async fn register_reconnect_token(
     game_server
         .reconnection_manager()
         .expect("reconnection enabled")
+        // `last_epoch = 0`: `disconnect_client` above already removed the
+        // connection, so its incarnation epoch is no longer reachable via
+        // `game_data_epoch` — the documented fallback (resume at epoch 1). This
+        // e2e reconnects over a fresh socket and asserts replay/snapshot
+        // behavior, not cross-disconnect epoch monotonicity.
         .register_disconnection(player_id, room_id, false, Some(player_info), 0)
         .await
 }

--- a/tests/reconnection_replay_e2e.rs
+++ b/tests/reconnection_replay_e2e.rs
@@ -410,6 +410,20 @@ async fn missed_control_events_are_replayed_completely() {
         "first missed event must be the churner's PlayerJoined: {:?}",
         reconnected.missed_events
     );
+    // Regression (missed_events epoch leak): the replay ring stores the
+    // churner's PlayerJoined in its live-broadcast form, which carries the v4
+    // incarnation `epoch`. `missed_events` is embedded in the `Reconnected`
+    // payload and bypasses the per-recipient strip in `websocket::sending`, so a
+    // pre-v4 (v3) reconnector must have that `epoch` stripped server-side —
+    // otherwise its `Reconnected` wire is no longer byte-identical to v2/v3.
+    // Deserialized `None` proves wire-absence (`epoch` is skip-if-none).
+    let ServerMessage::PlayerJoined { player } = &reconnected.missed_events[0] else {
+        unreachable!("asserted PlayerJoined above");
+    };
+    assert_eq!(
+        player.epoch, None,
+        "a v3 reconnector's replayed PlayerJoined must omit the v4 epoch"
+    );
     assert!(
         matches!(
             &reconnected.missed_events[1],
@@ -422,6 +436,62 @@ async fn missed_control_events_are_replayed_completely() {
         reconnected.replay,
         Some(ReplayStatus::Complete),
         "nothing was evicted, so the v3 recipient is told the replay is complete"
+    );
+
+    assert_message_conservation(&game_server.metrics()).await;
+}
+
+/// Non-vacuity for the missed_events epoch strip: a v4 reconnector MUST still
+/// see the churner's incarnation `epoch` replayed. This proves the strip in the
+/// previous test is CONDITIONED on the reconnector being pre-v4, not an
+/// unconditional wipe that would also hide the field from v4 clients that want
+/// it.
+#[tokio::test]
+async fn missed_events_carry_epoch_for_v4_reconnector() {
+    let (addr, game_server) = start_server_default().await;
+
+    let mut peer_a = connect(addr).await;
+    authenticate(&mut peer_a, Some(4)).await;
+    let joined_a = join_room(&mut peer_a, "replay-game", None, "PeerA").await;
+
+    let mut peer_b = connect(addr).await;
+    authenticate(&mut peer_b, Some(4)).await;
+    let joined_b = join_room(
+        &mut peer_b,
+        "replay-game",
+        Some(joined_a.room_code.clone()),
+        "PeerB",
+    )
+    .await;
+
+    let token = register_reconnect_token(&game_server, joined_b.player_id, joined_b.room_id).await;
+    let _ = peer_b.close(None).await;
+
+    // While B is away, a churner joins+leaves; its PlayerJoined is buffered with
+    // the churner's incarnation epoch (first join ⇒ 1).
+    let churner_id = churn_join_leave(addr, &joined_a.room_code, "Churner", &mut peer_a).await;
+
+    let mut replacement = connect(addr).await;
+    authenticate(&mut replacement, Some(4)).await;
+    let reconnected = reconnect(
+        &mut replacement,
+        joined_b.player_id,
+        joined_b.room_id,
+        token,
+    )
+    .await;
+
+    let ServerMessage::PlayerJoined { player } = &reconnected.missed_events[0] else {
+        panic!(
+            "first missed event must be the churner's PlayerJoined: {:?}",
+            reconnected.missed_events
+        );
+    };
+    assert_eq!(player.id, churner_id, "first missed event is the churner");
+    assert_eq!(
+        player.epoch,
+        Some(1),
+        "a v4 reconnector's replayed PlayerJoined carries the churner's epoch"
     );
 
     assert_message_conservation(&game_server.metrics()).await;

--- a/tests/reconnection_replay_e2e.rs
+++ b/tests/reconnection_replay_e2e.rs
@@ -410,19 +410,18 @@ async fn missed_control_events_are_replayed_completely() {
         "first missed event must be the churner's PlayerJoined: {:?}",
         reconnected.missed_events
     );
-    // Regression (missed_events epoch leak): the replay ring stores the
-    // churner's PlayerJoined in its live-broadcast form, which carries the v4
-    // incarnation `epoch`. `missed_events` is embedded in the `Reconnected`
-    // payload and bypasses the per-recipient strip in `websocket::sending`, so a
-    // pre-v4 (v3) reconnector must have that `epoch` stripped server-side —
-    // otherwise its `Reconnected` wire is no longer byte-identical to v2/v3.
-    // Deserialized `None` proves wire-absence (`epoch` is skip-if-none).
+    // The replay ring stores the churner's PlayerJoined in its live-broadcast
+    // form, carrying the v3 incarnation `epoch`. This reconnector negotiated v3,
+    // so that epoch is PRESERVED in the replay (a v3 client wants it). The pre-v3
+    // (v2) strip — which keeps a v2 reconnector's `Reconnected` byte-identical to
+    // the frozen v2 wire — is exercised by the companion test below.
     let ServerMessage::PlayerJoined { player } = &reconnected.missed_events[0] else {
         unreachable!("asserted PlayerJoined above");
     };
     assert_eq!(
-        player.epoch, None,
-        "a v3 reconnector's replayed PlayerJoined must omit the v4 epoch"
+        player.epoch,
+        Some(1),
+        "a v3 reconnector's replayed PlayerJoined carries the churner's epoch (first join ⇒ 1)"
     );
     assert!(
         matches!(
@@ -441,21 +440,27 @@ async fn missed_control_events_are_replayed_completely() {
     assert_message_conservation(&game_server.metrics()).await;
 }
 
-/// Non-vacuity for the missed_events epoch strip: a v4 reconnector MUST still
-/// see the churner's incarnation `epoch` replayed. This proves the strip in the
-/// previous test is CONDITIONED on the reconnector being pre-v4, not an
-/// unconditional wipe that would also hide the field from v4 clients that want
-/// it.
+/// Regression (missed_events epoch leak) + non-vacuity for the previous test:
+/// the replay ring stores the churner's PlayerJoined in its live-broadcast form,
+/// carrying the v3 incarnation `epoch`. `missed_events` is embedded in the
+/// `Reconnected` payload and bypasses the per-recipient strip in
+/// `websocket::sending`, so a PRE-v3 (v2) reconnector must have that `epoch`
+/// stripped server-side — otherwise its `Reconnected` wire is no longer
+/// byte-identical to the frozen v2 wire. (A v2 socket reaches this path by
+/// reconnecting with a token minted for its earlier v3 incarnation.) Deserialized
+/// `None` proves wire-absence; that the v3 reconnector above KEEPS the same
+/// epoch proves the strip is CONDITIONED on the reconnector being pre-v3, not an
+/// unconditional wipe.
 #[tokio::test]
-async fn missed_events_carry_epoch_for_v4_reconnector() {
+async fn missed_events_strip_epoch_for_pre_v3_reconnector() {
     let (addr, game_server) = start_server_default().await;
 
     let mut peer_a = connect(addr).await;
-    authenticate(&mut peer_a, Some(4)).await;
+    authenticate(&mut peer_a, Some(3)).await;
     let joined_a = join_room(&mut peer_a, "replay-game", None, "PeerA").await;
 
     let mut peer_b = connect(addr).await;
-    authenticate(&mut peer_b, Some(4)).await;
+    authenticate(&mut peer_b, Some(3)).await;
     let joined_b = join_room(
         &mut peer_b,
         "replay-game",
@@ -471,8 +476,10 @@ async fn missed_events_carry_epoch_for_v4_reconnector() {
     // the churner's incarnation epoch (first join ⇒ 1).
     let churner_id = churn_join_leave(addr, &joined_a.room_code, "Churner", &mut peer_a).await;
 
+    // Reconnect on a PRE-v3 (v2) socket: the replayed epoch must be stripped so
+    // the v2 wire stays byte-identical.
     let mut replacement = connect(addr).await;
-    authenticate(&mut replacement, Some(4)).await;
+    authenticate(&mut replacement, Some(2)).await;
     let reconnected = reconnect(
         &mut replacement,
         joined_b.player_id,
@@ -489,9 +496,8 @@ async fn missed_events_carry_epoch_for_v4_reconnector() {
     };
     assert_eq!(player.id, churner_id, "first missed event is the churner");
     assert_eq!(
-        player.epoch,
-        Some(1),
-        "a v4 reconnector's replayed PlayerJoined carries the churner's epoch"
+        player.epoch, None,
+        "a pre-v3 (v2) reconnector's replayed PlayerJoined must omit the v3 epoch"
     );
 
     assert_message_conservation(&game_server.metrics()).await;

--- a/tests/reconnection_replay_e2e.rs
+++ b/tests/reconnection_replay_e2e.rs
@@ -261,7 +261,7 @@ async fn register_reconnect_token(
     game_server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(player_id, room_id, false, Some(player_info))
+        .register_disconnection(player_id, room_id, false, Some(player_info), 0)
         .await
 }
 

--- a/tests/scenario_realworld_e2e.rs
+++ b/tests/scenario_realworld_e2e.rs
@@ -865,7 +865,7 @@ async fn register_reconnect_token(
     game_server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(player_id, room_id, false, Some(player_info))
+        .register_disconnection(player_id, room_id, false, Some(player_info), 0)
         .await
 }
 

--- a/tests/slow_consumer_no_cascade_e2e.rs
+++ b/tests/slow_consumer_no_cascade_e2e.rs
@@ -10,7 +10,7 @@
 //! receiver keeps flowing (`relay_backpressure_e2e::
 //! slow_consumer_is_disconnected_loudly_and_room_keeps_flowing`,
 //! `wedged_socket_write_is_preempted_and_fd_released`;
-//! `v4_game_data_sequencing_e2e::evicted_recipient_observes_seq_gap_after_reconnect`).
+//! `v3_game_data_sequencing_e2e::evicted_recipient_observes_seq_gap_after_reconnect`).
 //! But "cascade" is inherently a MULTI-peer phenomenon, and every one of those
 //! tests uses a single healthy witness and asserts only
 //! `slow_consumer_disconnects >= 1` — none pins that the eviction did not

--- a/tests/thread_safety_tests.rs
+++ b/tests/thread_safety_tests.rs
@@ -27,6 +27,7 @@ fn make_player(player_id: Uuid) -> PlayerInfo {
         is_ready: false,
         connected_at: chrono::Utc::now(),
         connection_info: None,
+        epoch: None,
         region_id: "us-east-1".to_string(),
     }
 }

--- a/tests/v2_wire_golden.rs
+++ b/tests/v2_wire_golden.rs
@@ -65,7 +65,7 @@ fn player_info_a() -> PlayerInfo {
         is_ready: false,
         connected_at: fixed_time(),
         connection_info: None,
-        // v4-only incarnation epoch: `None` is skipped, so the v2 snapshot
+        // v3-only incarnation epoch: `None` is skipped, so the v2 snapshot
         // goldens below stay byte-identical.
         epoch: None,
         region_id: String::new(),
@@ -611,7 +611,7 @@ fn golden_server_game_data() {
     let msg = ServerMessage::GameData {
         from_player: player_a(),
         data: json!({ "move": "up" }),
-        // v4-only relay stamp: `None` is skipped entirely, so the golden v2
+        // v3-only relay stamp: `None` is skipped entirely, so the golden v2
         // bytes below stay byte-identical.
         seq: None,
         epoch: None,
@@ -639,7 +639,7 @@ fn golden_server_game_data_binary_json_fallback() {
     let fallback = ServerMessage::GameData {
         from_player: player_a(),
         data: json!({ "move": "up" }),
-        // v4-only relay stamp: `None` is skipped entirely, so the golden v2
+        // v3-only relay stamp: `None` is skipped entirely, so the golden v2
         // fallback frame stays byte-identical.
         seq: None,
         epoch: None,
@@ -668,7 +668,7 @@ fn golden_server_game_data_binary_in_memory_repr_not_wire() {
         from_player: player_a(),
         encoding: GameDataEncoding::MessagePack,
         payload: Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]),
-        // v4-only relay stamp: `None` is skipped entirely, so the in-memory
+        // v3-only relay stamp: `None` is skipped entirely, so the in-memory
         // repr snapshot stays byte-identical.
         seq: None,
         epoch: None,
@@ -866,7 +866,7 @@ fn golden_server_reconnection_failed() {
 fn golden_server_player_reconnected() {
     let msg = ServerMessage::PlayerReconnected {
         player_id: player_a(),
-        // v4-only epoch: `None` is skipped, so the v2 wire stays byte-identical.
+        // v3-only epoch: `None` is skipped, so the v2 wire stays byte-identical.
         epoch: None,
     };
     assert_json(

--- a/tests/v2_wire_golden.rs
+++ b/tests/v2_wire_golden.rs
@@ -65,6 +65,9 @@ fn player_info_a() -> PlayerInfo {
         is_ready: false,
         connected_at: fixed_time(),
         connection_info: None,
+        // v4-only incarnation epoch: `None` is skipped, so the v2 snapshot
+        // goldens below stay byte-identical.
+        epoch: None,
         region_id: String::new(),
     }
 }
@@ -80,6 +83,7 @@ fn player_info_b() -> PlayerInfo {
             host: "10.0.0.5".to_string(),
             port: 7777,
         }),
+        epoch: None,
         region_id: String::new(),
     }
 }
@@ -610,6 +614,7 @@ fn golden_server_game_data() {
         // v4-only relay stamp: `None` is skipped entirely, so the golden v2
         // bytes below stay byte-identical.
         seq: None,
+        epoch: None,
     };
     assert_json(
         &msg,
@@ -637,6 +642,7 @@ fn golden_server_game_data_binary_json_fallback() {
         // v4-only relay stamp: `None` is skipped entirely, so the golden v2
         // fallback frame stays byte-identical.
         seq: None,
+        epoch: None,
     };
     assert_json(
         &fallback,
@@ -665,6 +671,7 @@ fn golden_server_game_data_binary_in_memory_repr_not_wire() {
         // v4-only relay stamp: `None` is skipped entirely, so the in-memory
         // repr snapshot stays byte-identical.
         seq: None,
+        epoch: None,
     };
     assert_json(
         &msg,
@@ -859,6 +866,8 @@ fn golden_server_reconnection_failed() {
 fn golden_server_player_reconnected() {
     let msg = ServerMessage::PlayerReconnected {
         player_id: player_a(),
+        // v4-only epoch: `None` is skipped, so the v2 wire stays byte-identical.
+        epoch: None,
     };
     assert_json(
         &msg,

--- a/tests/v3_game_data_sequencing_e2e.rs
+++ b/tests/v3_game_data_sequencing_e2e.rs
@@ -1,14 +1,14 @@
-//! End-to-end protocol v4 GameData sequencing tests through the real
+//! End-to-end protocol v3 GameData sequencing tests through the real
 //! WebSocket stack.
 //!
-//! v4 adds a server-stamped, per-(sender, room) `seq` to relayed `GameData` so
+//! v3 adds a server-stamped, per-(sender, room) `seq` to relayed `GameData` so
 //! recipients can DETECT any server-side loss as a gap — the protocol-level
 //! capability the reporter of issue #131 lacked (they had to keep manual
 //! sent-vs-received deficit counters). The contract under test:
 //!
 //! - `seq` starts at 1 per (sender, room) and is strictly contiguous per
 //!   sender for a recipient that stays connected;
-//! - pre-v4 recipients never see the key (their bytes are byte-identical to
+//! - pre-v3 recipients never see the key (their bytes are byte-identical to
 //!   v3 and earlier — frozen separately by `tests/v2_wire_golden.rs`);
 //! - the counter RESTARTS at 1 when the sender leaves and rejoins a room
 //!   (recipients must treat `PlayerLeft`/`PlayerJoined` — and their own
@@ -45,7 +45,7 @@ const BURST_MESSAGE_COUNT: u64 = 2_000;
 
 /// Protocol config for these tests: default `[2, 4]` version range with SDK
 /// platform enforcement off so a bare `Authenticate` (no platform) succeeds.
-fn v4_protocol_config() -> ProtocolConfig {
+fn v3_protocol_config() -> ProtocolConfig {
     let mut protocol_config = ProtocolConfig::default();
     protocol_config.sdk_compatibility.enforce = false;
     protocol_config
@@ -54,7 +54,7 @@ fn v4_protocol_config() -> ProtocolConfig {
 async fn start_test_server(
     server_config: ServerConfig,
 ) -> (std::net::SocketAddr, Arc<EnhancedGameServer>) {
-    let server = create_test_server_with_config(server_config, v4_protocol_config()).await;
+    let server = create_test_server_with_config(server_config, v3_protocol_config()).await;
     let addr = start_server(server.clone()).await;
     (addr, server)
 }
@@ -104,7 +104,7 @@ async fn authenticate_with_version(
     send(
         ws,
         &ClientMessage::Authenticate {
-            app_id: "v4-seq-test".to_string(),
+            app_id: "v3-seq-test".to_string(),
             sdk_version: None,
             platform: None,
             game_data_format: None,
@@ -140,8 +140,8 @@ async fn authenticate_with_version(
     );
 }
 
-async fn authenticate_v4(ws: &mut WsStream) {
-    authenticate_with_version(ws, 4, Some(4)).await;
+async fn authenticate_v3(ws: &mut WsStream) {
+    authenticate_with_version(ws, 3, Some(3)).await;
 }
 
 async fn authenticate_v2(ws: &mut WsStream) {
@@ -150,7 +150,7 @@ async fn authenticate_v2(ws: &mut WsStream) {
 
 fn join_message(room_code: &str, player_name: &str) -> ClientMessage {
     ClientMessage::JoinRoom {
-        game_name: "v4_seq_game".to_string(),
+        game_name: "v3_seq_game".to_string(),
         room_code: Some(room_code.to_string()),
         player_name: player_name.to_string(),
         max_players: Some(8),
@@ -247,18 +247,18 @@ fn assert_contiguous_seqs(frames: &[ReceivedGameData], first: u64, last: u64, wh
     }
 }
 
-/// (a) A 2000-message burst from one v4 sender reaches a v4 recipient with a
+/// (a) A 2000-message burst from one v3 sender reaches a v3 recipient with a
 /// server-stamped `seq` on every frame — exactly 1..=2000, contiguous, in
 /// order — so any server-side loss would be observable as a gap.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn v4_burst_is_seq_stamped_contiguously_from_one() {
+async fn v3_burst_is_seq_stamped_contiguously_from_one() {
     let (addr, server) = start_test_server(test_server_config()).await;
     let metrics = server.metrics();
 
     let mut sender = connect(addr).await;
     let mut recipient = connect(addr).await;
-    authenticate_v4(&mut sender).await;
-    authenticate_v4(&mut recipient).await;
+    authenticate_v3(&mut sender).await;
+    authenticate_v3(&mut recipient).await;
     join_room(&mut sender, "SEQBS1", "SeqSender").await;
     join_room(&mut recipient, "SEQBS1", "SeqRecipient").await;
 
@@ -288,7 +288,7 @@ async fn v4_burst_is_seq_stamped_contiguously_from_one() {
     let _sender = writer_result.expect("burst writer task panicked");
     let (frames, _recipient) = reader_result.expect("burst reader task panicked");
 
-    assert_contiguous_seqs(&frames, 1, BURST_MESSAGE_COUNT, "v4 recipient");
+    assert_contiguous_seqs(&frames, 1, BURST_MESSAGE_COUNT, "v3 recipient");
     // Payload order must match stamp order (the stamp is assigned at relay
     // time on the sender's in-order message stream).
     for (index, frame) in frames.iter().enumerate() {
@@ -302,22 +302,22 @@ async fn v4_burst_is_seq_stamped_contiguously_from_one() {
     assert_message_conservation(&metrics).await;
 }
 
-/// (b) Mixed room: the v4 recipient's raw JSON frame carries a `seq` key; the
+/// (b) Mixed room: the v3 recipient's raw JSON frame carries a `seq` key; the
 /// v2 recipient's raw JSON frame has NO `seq` key at all (byte-level absence,
-/// not just a null — the pre-v4 wire is unchanged).
+/// not just a null — the pre-v3 wire is unchanged).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn mixed_room_v2_recipient_raw_json_has_no_seq_key() {
     let (addr, server) = start_test_server(test_server_config()).await;
     let metrics = server.metrics();
 
     let mut sender = connect(addr).await;
-    let mut v4_recipient = connect(addr).await;
+    let mut v3_recipient = connect(addr).await;
     let mut v2_recipient = connect(addr).await;
-    authenticate_v4(&mut sender).await;
-    authenticate_v4(&mut v4_recipient).await;
+    authenticate_v3(&mut sender).await;
+    authenticate_v3(&mut v3_recipient).await;
     authenticate_v2(&mut v2_recipient).await;
     join_room(&mut sender, "SEQMIX", "MixSender").await;
-    join_room(&mut v4_recipient, "SEQMIX", "MixV4").await;
+    join_room(&mut v3_recipient, "SEQMIX", "MixV4").await;
     join_room(&mut v2_recipient, "SEQMIX", "MixV2").await;
 
     send(
@@ -328,25 +328,25 @@ async fn mixed_room_v2_recipient_raw_json_has_no_seq_key() {
     )
     .await;
 
-    let v4_raw = next_raw_game_data(&mut v4_recipient, "v4 recipient raw frame").await;
+    let v3_raw = next_raw_game_data(&mut v3_recipient, "v3 recipient raw frame").await;
     let v2_raw = next_raw_game_data(&mut v2_recipient, "v2 recipient raw frame").await;
 
-    let v4_value: serde_json::Value = serde_json::from_str(&v4_raw).expect("v4 frame JSON");
-    let v4_data = v4_value
+    let v3_value: serde_json::Value = serde_json::from_str(&v3_raw).expect("v3 frame JSON");
+    let v3_data = v3_value
         .get("data")
         .and_then(serde_json::Value::as_object)
-        .expect("v4 frame /data object");
+        .expect("v3 frame /data object");
     assert_eq!(
-        v4_data.get("seq").and_then(serde_json::Value::as_u64),
+        v3_data.get("seq").and_then(serde_json::Value::as_u64),
         Some(1),
-        "v4 recipient must see the server-stamped seq: {v4_raw}"
+        "v3 recipient must see the server-stamped seq: {v3_raw}"
     );
-    // The v4 recipient also sees the incarnation epoch (first incarnation ⇒ 1),
+    // The v3 recipient also sees the incarnation epoch (first incarnation ⇒ 1),
     // stamped together with seq.
     assert_eq!(
-        v4_data.get("epoch").and_then(serde_json::Value::as_u64),
+        v3_data.get("epoch").and_then(serde_json::Value::as_u64),
         Some(1),
-        "v4 recipient must see the server-stamped epoch: {v4_raw}"
+        "v3 recipient must see the server-stamped epoch: {v3_raw}"
     );
 
     let v2_value: serde_json::Value = serde_json::from_str(&v2_raw).expect("v2 frame JSON");
@@ -363,8 +363,8 @@ async fn mixed_room_v2_recipient_raw_json_has_no_seq_key() {
         "v2 recipient's raw frame must not contain an epoch key: {v2_raw}"
     );
     // Everything else is identical between the two recipients' frames.
-    assert_eq!(v2_data.get("from_player"), v4_data.get("from_player"));
-    assert_eq!(v2_data.get("data"), v4_data.get("data"));
+    assert_eq!(v2_data.get("from_player"), v3_data.get("from_player"));
+    assert_eq!(v2_data.get("data"), v3_data.get("data"));
 
     assert_message_conservation(&metrics).await;
 }
@@ -406,9 +406,9 @@ async fn interleaved_senders_have_independent_contiguous_seqs() {
     let mut sender_a = connect(addr).await;
     let mut sender_b = connect(addr).await;
     let mut recipient = connect(addr).await;
-    authenticate_v4(&mut sender_a).await;
-    authenticate_v4(&mut sender_b).await;
-    authenticate_v4(&mut recipient).await;
+    authenticate_v3(&mut sender_a).await;
+    authenticate_v3(&mut sender_b).await;
+    authenticate_v3(&mut recipient).await;
     let (id_a, _) = join_room(&mut sender_a, "SEQ2SX", "SenderA").await;
     let (id_b, _) = join_room(&mut sender_b, "SEQ2SX", "SenderB").await;
     join_room(&mut recipient, "SEQ2SX", "TwoSenderRecipient").await;
@@ -477,8 +477,8 @@ async fn sender_leave_and_rejoin_restarts_seq_at_one() {
 
     let mut sender = connect(addr).await;
     let mut recipient = connect(addr).await;
-    authenticate_v4(&mut sender).await;
-    authenticate_v4(&mut recipient).await;
+    authenticate_v3(&mut sender).await;
+    authenticate_v3(&mut recipient).await;
     let (sender_id, _) = join_room(&mut sender, "SEQRJX", "RejoinSender").await;
     join_room(&mut recipient, "SEQRJX", "RejoinRecipient").await;
 
@@ -543,7 +543,7 @@ async fn sender_leave_and_rejoin_restarts_seq_at_one() {
 }
 
 /// The incarnation epoch is a single monotonic per-connection counter and is
-/// deliberately NOT reset when a sender leaves one room and joins another: a v4
+/// deliberately NOT reset when a sender leaves one room and joins another: a v3
 /// recipient in the NEW room sees the sender's epoch carry forward (2, not a
 /// fresh 1) with `seq` restarted. This is the design that keeps `(epoch, seq)`
 /// strictly increasing per (sender, room) even across a same-room leave+rejoin
@@ -555,11 +555,11 @@ async fn epoch_carries_across_a_room_switch_not_reset_to_one() {
     let metrics = server.metrics();
 
     let mut sender = connect(addr).await;
-    authenticate_v4(&mut sender).await;
+    authenticate_v3(&mut sender).await;
 
     // Room A: the sender's first incarnation ⇒ epoch 1.
     let mut recipient_a = connect(addr).await;
-    authenticate_v4(&mut recipient_a).await;
+    authenticate_v3(&mut recipient_a).await;
     let (sender_id, _) = join_room(&mut sender, "EPRMA0", "Switcher").await;
     join_room(&mut recipient_a, "EPRMA0", "WatcherA").await;
     send(
@@ -591,7 +591,7 @@ async fn epoch_carries_across_a_room_switch_not_reset_to_one() {
     .await;
 
     let mut recipient_b = connect(addr).await;
-    authenticate_v4(&mut recipient_b).await;
+    authenticate_v3(&mut recipient_b).await;
     join_room(&mut sender, "EPRMB0", "Switcher").await;
     join_room(&mut recipient_b, "EPRMB0", "WatcherB").await;
     send(
@@ -639,9 +639,9 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
     let mut sender = connect(addr).await;
     let mut healthy = connect(addr).await;
     let mut victim = connect(addr).await;
-    authenticate_v4(&mut sender).await;
-    authenticate_v4(&mut healthy).await;
-    authenticate_v4(&mut victim).await;
+    authenticate_v3(&mut sender).await;
+    authenticate_v3(&mut healthy).await;
+    authenticate_v3(&mut victim).await;
     join_room(&mut sender, "SEQGAP", "GapSender").await;
     join_room(&mut healthy, "SEQGAP", "GapHealthy").await;
     let (victim_id, room_id) = join_room(&mut victim, "SEQGAP", "GapVictim").await;
@@ -741,7 +741,7 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
                     if let Ok(ServerMessage::GameData { seq, .. }) =
                         serde_json::from_str::<ServerMessage>(&text)
                     {
-                        let seq = seq.expect("v4 victim frames carry seq");
+                        let seq = seq.expect("v3 victim frames carry seq");
                         assert_eq!(
                             seq,
                             last_seen + 1,
@@ -766,7 +766,7 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
     );
 
     // Mint a reconnection token (server-side helper pattern) and reconnect on
-    // a fresh v4 socket under the same player id.
+    // a fresh v3 socket under the same player id.
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled in test config")
@@ -776,7 +776,7 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
         .await;
 
     let mut reconnected = connect(addr).await;
-    authenticate_v4(&mut reconnected).await;
+    authenticate_v3(&mut reconnected).await;
     send(
         &mut reconnected,
         &ClientMessage::Reconnect {
@@ -834,8 +834,8 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
 }
 
 /// Read text frames until the next server message of `type_name`, returning its
-/// parsed JSON `Value` so field presence/absence can be asserted directly (a v4
-/// field omitted for a pre-v4 recipient is ABSENT from the object, so
+/// parsed JSON `Value` so field presence/absence can be asserted directly (a v3
+/// field omitted for a pre-v3 recipient is ABSENT from the object, so
 /// `value["data"][..].get("epoch")` is `None`, not a JSON null).
 async fn next_message_value_of_type(
     ws: &mut WsStream,
@@ -862,18 +862,18 @@ async fn next_message_value_of_type(
     }
 }
 
-/// (f) Room snapshots carry the incarnation epoch for v4 recipients and OMIT it
-/// (byte-absent, not null) for pre-v4 recipients — both directions:
+/// (f) Room snapshots carry the incarnation epoch for v3 recipients and OMIT it
+/// (byte-absent, not null) for pre-v3 recipients — both directions:
 /// `RoomJoined.current_players[].epoch` (seen by the joiner) and
 /// `PlayerJoined.player.epoch` (seen by existing members).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn v4_room_snapshots_carry_epoch_pre_v4_omit_it() {
+async fn v3_room_snapshots_carry_epoch_pre_v4_omit_it() {
     let (addr, server) = start_test_server(test_server_config()).await;
     let metrics = server.metrics();
 
-    // Anchor A (v4) establishes the room; its first incarnation ⇒ epoch 1.
+    // Anchor A (v3) establishes the room; its first incarnation ⇒ epoch 1.
     let mut anchor = connect(addr).await;
-    authenticate_v4(&mut anchor).await;
+    authenticate_v3(&mut anchor).await;
     join_room(&mut anchor, "SNAPEP", "SnapAnchor").await;
 
     // A v2 joiner: its RoomJoined snapshot must OMIT epoch on every member.
@@ -895,39 +895,39 @@ async fn v4_room_snapshots_carry_epoch_pre_v4_omit_it() {
         );
     }
 
-    // A (v4) sees the v2 joiner arrive; the joiner's epoch (1) IS present on A's
-    // v4 wire (the server stamps it regardless of the joiner's own version).
+    // A (v3) sees the v2 joiner arrive; the joiner's epoch (1) IS present on A's
+    // v3 wire (the server stamps it regardless of the joiner's own version).
     let a_sees_v2 =
         next_message_value_of_type(&mut anchor, "PlayerJoined", "A sees the v2 join").await;
     assert_eq!(
         a_sees_v2["data"]["player"]["epoch"].as_u64(),
         Some(1),
-        "a v4 member sees a joiner's epoch on PlayerJoined: {a_sees_v2}"
+        "a v3 member sees a joiner's epoch on PlayerJoined: {a_sees_v2}"
     );
 
-    // A v4 joiner: its RoomJoined snapshot CARRIES each member's epoch (all 1).
-    let mut v4_joiner = connect(addr).await;
-    authenticate_v4(&mut v4_joiner).await;
-    send(&mut v4_joiner, &join_message("SNAPEP", "SnapV4")).await;
-    let v4_room = next_message_value_of_type(&mut v4_joiner, "RoomJoined", "v4 RoomJoined").await;
-    let v4_players = v4_room["data"]["current_players"]
+    // A v3 joiner: its RoomJoined snapshot CARRIES each member's epoch (all 1).
+    let mut v3_joiner = connect(addr).await;
+    authenticate_v3(&mut v3_joiner).await;
+    send(&mut v3_joiner, &join_message("SNAPEP", "SnapV4")).await;
+    let v3_room = next_message_value_of_type(&mut v3_joiner, "RoomJoined", "v3 RoomJoined").await;
+    let v3_players = v3_room["data"]["current_players"]
         .as_array()
-        .expect("v4 RoomJoined current_players array");
+        .expect("v3 RoomJoined current_players array");
     assert!(
-        !v4_players.is_empty(),
+        !v3_players.is_empty(),
         "the snapshot lists existing members"
     );
-    for player in v4_players {
+    for player in v3_players {
         assert_eq!(
             player["epoch"].as_u64(),
             Some(1),
-            "a v4 joiner's RoomJoined carries each member's epoch: {v4_room}"
+            "a v3 joiner's RoomJoined carries each member's epoch: {v3_room}"
         );
     }
 
-    // The v2 member now sees the v4 joiner arrive; its PlayerJoined omits epoch.
+    // The v2 member now sees the v3 joiner arrive; its PlayerJoined omits epoch.
     let v2_sees_v4 =
-        next_message_value_of_type(&mut v2_joiner, "PlayerJoined", "v2 sees the v4 join").await;
+        next_message_value_of_type(&mut v2_joiner, "PlayerJoined", "v2 sees the v3 join").await;
     assert!(
         v2_sees_v4["data"]["player"].get("epoch").is_none(),
         "a v2 member's PlayerJoined must omit epoch: {v2_sees_v4}"
@@ -950,11 +950,11 @@ async fn reconnecting_sender_bumps_epoch_and_stamps_it_on_game_data() {
 
     let mut sender = connect(addr).await;
     let mut recipient = connect(addr).await;
-    authenticate_v4(&mut sender).await;
-    authenticate_v4(&mut recipient).await;
+    authenticate_v3(&mut sender).await;
+    authenticate_v3(&mut recipient).await;
 
     // Join the sender directly so we can capture its pre-issued reconnection
-    // token from RoomJoined (v4 clients get one at join).
+    // token from RoomJoined (v3 clients get one at join).
     send(&mut sender, &join_message("RCEPCH", "RcSender")).await;
     let (sender_id, room_id, token) = next_matching_server_message_within(
         &mut sender,
@@ -973,7 +973,7 @@ async fn reconnecting_sender_bumps_epoch_and_stamps_it_on_game_data() {
         },
     )
     .await;
-    let token = token.expect("a v4 join issues a reconnection token");
+    let token = token.expect("a v3 join issues a reconnection token");
     join_room(&mut recipient, "RCEPCH", "RcRecipient").await;
 
     // First incarnation: epoch 1, seq 1.
@@ -999,10 +999,10 @@ async fn reconnecting_sender_bumps_epoch_and_stamps_it_on_game_data() {
     server.disconnect_client(&sender_id).await;
     drop(sender);
 
-    // Reconnect on a fresh v4 socket under the original id, with the pre-issued
+    // Reconnect on a fresh v3 socket under the original id, with the pre-issued
     // token.
     let mut reconnected = connect(addr).await;
-    authenticate_v4(&mut reconnected).await;
+    authenticate_v3(&mut reconnected).await;
     send(
         &mut reconnected,
         &ClientMessage::Reconnect {

--- a/tests/v3_game_data_sequencing_e2e.rs
+++ b/tests/v3_game_data_sequencing_e2e.rs
@@ -317,7 +317,7 @@ async fn mixed_room_v2_recipient_raw_json_has_no_seq_key() {
     authenticate_v3(&mut v3_recipient).await;
     authenticate_v2(&mut v2_recipient).await;
     join_room(&mut sender, "SEQMIX", "MixSender").await;
-    join_room(&mut v3_recipient, "SEQMIX", "MixV4").await;
+    join_room(&mut v3_recipient, "SEQMIX", "MixV3").await;
     join_room(&mut v2_recipient, "SEQMIX", "MixV2").await;
 
     send(
@@ -867,7 +867,7 @@ async fn next_message_value_of_type(
 /// `RoomJoined.current_players[].epoch` (seen by the joiner) and
 /// `PlayerJoined.player.epoch` (seen by existing members).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn v3_room_snapshots_carry_epoch_pre_v4_omit_it() {
+async fn v3_room_snapshots_carry_epoch_pre_v3_omit_it() {
     let (addr, server) = start_test_server(test_server_config()).await;
     let metrics = server.metrics();
 
@@ -908,7 +908,7 @@ async fn v3_room_snapshots_carry_epoch_pre_v4_omit_it() {
     // A v3 joiner: its RoomJoined snapshot CARRIES each member's epoch (all 1).
     let mut v3_joiner = connect(addr).await;
     authenticate_v3(&mut v3_joiner).await;
-    send(&mut v3_joiner, &join_message("SNAPEP", "SnapV4")).await;
+    send(&mut v3_joiner, &join_message("SNAPEP", "SnapV3")).await;
     let v3_room = next_message_value_of_type(&mut v3_joiner, "RoomJoined", "v3 RoomJoined").await;
     let v3_players = v3_room["data"]["current_players"]
         .as_array()
@@ -926,11 +926,11 @@ async fn v3_room_snapshots_carry_epoch_pre_v4_omit_it() {
     }
 
     // The v2 member now sees the v3 joiner arrive; its PlayerJoined omits epoch.
-    let v2_sees_v4 =
+    let v2_sees_v3 =
         next_message_value_of_type(&mut v2_joiner, "PlayerJoined", "v2 sees the v3 join").await;
     assert!(
-        v2_sees_v4["data"]["player"].get("epoch").is_none(),
-        "a v2 member's PlayerJoined must omit epoch: {v2_sees_v4}"
+        v2_sees_v3["data"]["player"].get("epoch").is_none(),
+        "a v2 member's PlayerJoined must omit epoch: {v2_sees_v3}"
     );
 
     assert_message_conservation(&metrics).await;

--- a/tests/v3_ice_pregather_e2e.rs
+++ b/tests/v3_ice_pregather_e2e.rs
@@ -510,7 +510,7 @@ async fn register_reconnect_token(
     game_server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(player_id, room_id, false, Some(player_info))
+        .register_disconnection(player_id, room_id, false, Some(player_info), 0)
         .await
 }
 

--- a/tests/v3_interop_downgrade_e2e.rs
+++ b/tests/v3_interop_downgrade_e2e.rs
@@ -108,8 +108,8 @@ fn host_session_config() -> SessionConfig {
 
 /// Boot the production router (`/v2` nest + `/v3/ws` alias) around a server
 /// built with the given `SessionConfig`, returning the bound address and the
-/// server handle (the reconnect test needs the handle to mint a token, exactly
-/// like `tests/v3_multipeer_e2e.rs` — the token never crosses the wire).
+/// server handle (the reconnect test mints the token in-process via the handle
+/// rather than receiving it over the wire, like `tests/v3_multipeer_e2e.rs`).
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (std::net::SocketAddr, Arc<EnhancedGameServer>) {
@@ -759,8 +759,8 @@ async fn host_downgrade_reconnect_reelects_and_empties_downgraded_plan() {
     )
     .await;
 
-    // Mint a reconnection token for the ex-host (token never crosses the wire;
-    // the in-process pattern from `v3_multipeer_e2e.rs`).
+    // Mint a reconnection token for the ex-host — obtained in-process here
+    // rather than over the wire (the pattern from `v3_multipeer_e2e.rs`).
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")

--- a/tests/v3_interop_downgrade_e2e.rs
+++ b/tests/v3_interop_downgrade_e2e.rs
@@ -764,7 +764,7 @@ async fn host_downgrade_reconnect_reelects_and_empties_downgraded_plan() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(host_id, room_id, false, Some(host_info))
+        .register_disconnection(host_id, room_id, false, Some(host_info), 0)
         .await;
 
     // The ex-host reconnects over a FRESH socket advertising RELAY-ONLY
@@ -851,7 +851,7 @@ async fn host_downgrade_reconnect_reelects_and_empties_downgraded_plan() {
             SERVER_MESSAGE_TIMEOUT,
             "PlayerReconnected",
             |message| match message {
-                ServerMessage::PlayerReconnected { player_id } => {
+                ServerMessage::PlayerReconnected { player_id, .. } => {
                     assert_eq!(player_id, host_id, "{who} saw the wrong reconnector");
                     Some(())
                 }

--- a/tests/v3_multipeer_e2e.rs
+++ b/tests/v3_multipeer_e2e.rs
@@ -1115,13 +1115,16 @@ async fn mesh_n3_reconnect_full_flow() {
     expect_player_left(&mut peer_a, dropper_id, "peer_a").await;
     expect_player_left(&mut peer_b, dropper_id, "peer_b").await;
 
-    // Mint a reconnection token through the server handle. The wire flow never
-    // delivers the token to the client (it is generated at
-    // disconnect-registration time, `src/server/reconnection_service.rs`), so
-    // this is the sanctioned in-process pattern from `v3_signaling_e2e.rs`.
-    // Registering AFTER PlayerLeft was observed guarantees the disconnect
-    // path's own auto-registration already ran, so this record (and token)
-    // deterministically replaces it.
+    // Mint a reconnection token through the server handle. `expect_player_left`
+    // above means the socket-drop path already auto-registered the disconnect
+    // with the dropper's pre-issued (join-time) token; this same-room
+    // re-registration PRESERVES that token (see
+    // `ReconnectionManager::register_disconnection`) rather than replacing it,
+    // so `token` is exactly what the dropper received in `RoomJoined` and would
+    // reconnect with — faithful to a real client. (The client-held-token
+    // invariant itself is locked at the unit level:
+    // `same_room_reregistration_keeps_pre_issued_token_claimable`.) This is the
+    // sanctioned in-process pattern from `v3_signaling_e2e.rs`.
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")

--- a/tests/v3_multipeer_e2e.rs
+++ b/tests/v3_multipeer_e2e.rs
@@ -136,8 +136,8 @@ fn assert_static_then_default_stun_ice(ice_servers: &[IceServer]) {
 
 /// Boot the production router (`/v2` nest + `/v3/ws` alias) around a server
 /// built with the given `SessionConfig`, returning the bound address and the
-/// server handle (the reconnect test needs the handle to mint a token, exactly
-/// like `tests/v3_signaling_e2e.rs` — the token never crosses the wire).
+/// server handle (the reconnect test mints the token in-process via the handle
+/// rather than receiving it over the wire, like `tests/v3_signaling_e2e.rs`).
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (std::net::SocketAddr, Arc<EnhancedGameServer>) {

--- a/tests/v3_multipeer_e2e.rs
+++ b/tests/v3_multipeer_e2e.rs
@@ -1125,7 +1125,7 @@ async fn mesh_n3_reconnect_full_flow() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(dropper_id, room_id, false, Some(dropper_info))
+        .register_disconnection(dropper_id, room_id, false, Some(dropper_info), 0)
         .await;
 
     // Reconnect over a FRESH socket using the real wire flow.
@@ -1197,7 +1197,7 @@ async fn mesh_n3_reconnect_full_flow() {
             SERVER_MESSAGE_TIMEOUT,
             "PlayerReconnected",
             |message| match message {
-                ServerMessage::PlayerReconnected { player_id } => {
+                ServerMessage::PlayerReconnected { player_id, .. } => {
                     assert_eq!(player_id, dropper_id, "{who} saw the wrong reconnector");
                     Some(())
                 }

--- a/tests/v3_negotiation_e2e.rs
+++ b/tests/v3_negotiation_e2e.rs
@@ -165,8 +165,8 @@ async fn v3_client_negotiates_v3_and_protocol_info_reports_it() {
             assert_eq!(info.min_protocol_version, Some(2));
             assert_eq!(
                 info.max_protocol_version,
-                Some(4),
-                "default deployment ceiling is v4"
+                Some(3),
+                "default deployment ceiling is v3"
             );
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
@@ -174,8 +174,8 @@ async fn v3_client_negotiates_v3_and_protocol_info_reports_it() {
 }
 
 // ---------------------------------------------------------------------------
-// Protocol v4: the [2, 4] clamp matrix end-to-end (matches the config-level
-// matrix in tests/protocol_v3_negotiation.rs::v4_negotiation_clamp_matrix).
+// Protocol v3: the [2, 3] clamp matrix end-to-end (matches the config-level
+// matrix in tests/protocol_v3_negotiation.rs::v3_negotiation_clamp_matrix).
 // ---------------------------------------------------------------------------
 
 /// Build an Authenticate message advertising only `protocol_version`.
@@ -192,65 +192,74 @@ fn version_only_auth(protocol_version: Option<u16>) -> ClientMessage {
 }
 
 #[tokio::test]
-async fn v4_client_negotiates_v4_on_default_server() {
-    let addr = start_auth_server().await;
-    let mut ws = connect(addr, "/v2/ws").await;
-
-    match authenticate(&mut ws, version_only_auth(Some(4))).await {
-        ServerMessage::ProtocolInfo(info) => {
-            assert_eq!(info.protocol_version, Some(4), "client asks 4 => gets 4");
-            assert_eq!(info.min_protocol_version, Some(2));
-            assert_eq!(info.max_protocol_version, Some(4));
-        }
-        other => panic!("expected ProtocolInfo, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn future_v5_client_is_clamped_to_v4() {
-    let addr = start_auth_server().await;
-    let mut ws = connect(addr, "/v2/ws").await;
-
-    match authenticate(&mut ws, version_only_auth(Some(5))).await {
-        ServerMessage::ProtocolInfo(info) => {
-            assert_eq!(
-                info.protocol_version,
-                Some(4),
-                "client asks 5 => clamped down to the build ceiling (4)"
-            );
-        }
-        other => panic!("expected ProtocolInfo, got {other:?}"),
-    }
-}
-
-#[tokio::test]
-async fn v3_client_stays_v3_on_v4_server() {
+async fn v3_client_negotiates_v3_on_default_server() {
     let addr = start_auth_server().await;
     let mut ws = connect(addr, "/v2/ws").await;
 
     match authenticate(&mut ws, version_only_auth(Some(3))).await {
         ServerMessage::ProtocolInfo(info) => {
-            assert_eq!(
-                info.protocol_version,
-                Some(3),
-                "v4 is opt-in: a v3 client is never upgraded"
-            );
-            assert_eq!(info.max_protocol_version, Some(4));
+            assert_eq!(info.protocol_version, Some(3), "client asks 3 => gets 3");
+            assert_eq!(info.min_protocol_version, Some(2));
+            assert_eq!(info.max_protocol_version, Some(3));
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn v4_client_is_clamped_to_v3_when_deployment_caps_at_v3() {
-    // Deployment clamps `protocol.max_protocol_version` back to 3: a v4
-    // client is negotiated down to 3 and told so via ProtocolInfo.
+async fn future_v4_client_is_clamped_to_v3() {
+    // A stale v3-era (or future) client that still advertises 4/5 negotiates
+    // down to the build ceiling (3) — v3 no longer exists as a distinct version.
+    let addr = start_auth_server().await;
+    let mut ws = connect(addr, "/v2/ws").await;
+
+    for asked in [Some(4), Some(5)] {
+        match authenticate(&mut ws, version_only_auth(asked)).await {
+            ServerMessage::ProtocolInfo(info) => {
+                assert_eq!(
+                    info.protocol_version,
+                    Some(3),
+                    "client asks {asked:?} => clamped down to the build ceiling (3)"
+                );
+            }
+            other => panic!("expected ProtocolInfo, got {other:?}"),
+        }
+        ws = connect(addr, "/v2/ws").await;
+    }
+}
+
+#[tokio::test]
+async fn v2_client_stays_v2_on_default_server() {
+    let addr = start_auth_server().await;
+    let mut ws = connect(addr, "/v2/ws").await;
+
+    match authenticate(&mut ws, version_only_auth(Some(2))).await {
+        ServerMessage::ProtocolInfo(info) => {
+            // A v2-negotiated client gets the FROZEN v2 ProtocolInfo: the v3
+            // version-negotiation fields are additive (gated on negotiated >= 3)
+            // and so are all absent. `None` here is exactly "not upgraded" —
+            // a v3 client would instead see `protocol_version = Some(3)`.
+            assert_eq!(
+                info.protocol_version, None,
+                "v3 is opt-in: a v2 client is never upgraded (no version echo)"
+            );
+            assert_eq!(info.min_protocol_version, None);
+            assert_eq!(info.max_protocol_version, None);
+        }
+        other => panic!("expected ProtocolInfo, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn v3_client_is_clamped_to_v2_when_deployment_caps_at_v2() {
+    // Deployment clamps `protocol.max_protocol_version` back to 2 (pure v2): a
+    // v3 client is negotiated down to 2 and told so via ProtocolInfo.
     let mut server_config: ServerConfig = test_server_config();
     server_config.auth_enabled = true;
 
     let mut protocol_config = test_protocol_config();
     protocol_config.sdk_compatibility.enforce = false;
-    protocol_config.max_protocol_version = 3;
+    protocol_config.max_protocol_version = 2;
 
     let game_server = EnhancedGameServer::new(
         server_config,
@@ -270,14 +279,16 @@ async fn v4_client_is_clamped_to_v3_when_deployment_caps_at_v3() {
     let addr = start_server(game_server).await;
 
     let mut ws = connect(addr, "/v2/ws").await;
-    match authenticate(&mut ws, version_only_auth(Some(4))).await {
+    match authenticate(&mut ws, version_only_auth(Some(3))).await {
         ServerMessage::ProtocolInfo(info) => {
+            // Clamped down to 2 (< 3), so the client is served the frozen v2
+            // ProtocolInfo with no version fields — observably distinct from an
+            // un-clamped v3 client, which would see `protocol_version = Some(3)`.
             assert_eq!(
-                info.protocol_version,
-                Some(3),
-                "config-clamped server negotiates a v4 client down to 3"
+                info.protocol_version, None,
+                "config-clamped server negotiates a v3 client down to 2 (frozen v2 ProtocolInfo)"
             );
-            assert_eq!(info.max_protocol_version, Some(3));
+            assert_eq!(info.max_protocol_version, None);
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }

--- a/tests/v3_negotiation_e2e.rs
+++ b/tests/v3_negotiation_e2e.rs
@@ -209,7 +209,7 @@ async fn v3_client_negotiates_v3_on_default_server() {
 #[tokio::test]
 async fn future_v4_client_is_clamped_to_v3() {
     // A stale v3-era (or future) client that still advertises 4/5 negotiates
-    // down to the build ceiling (3) — v3 no longer exists as a distinct version.
+    // down to the build ceiling (3) — v4+ is not a negotiated version.
     let addr = start_auth_server().await;
     let mut ws = connect(addr, "/v2/ws").await;
 

--- a/tests/v3_relay_stats_e2e.rs
+++ b/tests/v3_relay_stats_e2e.rs
@@ -1,15 +1,15 @@
-//! End-to-end protocol v4 `RelayStats` emission tests through the real
+//! End-to-end protocol v3 `RelayStats` emission tests through the real
 //! WebSocket stack.
 //!
 //! The contract under test (config-gated, default OFF):
 //!
 //! - with `websocket.delivery_stats_interval_secs > 0`, a connection that
-//!   negotiated v4 receives periodic `RelayStats` frames with plausible
+//!   negotiated v3 receives periodic `RelayStats` frames with plausible
 //!   cumulative fields;
-//! - a v3 connection on the SAME deployment never receives one (the v4 gate
+//! - a v3 connection on the SAME deployment never receives one (the v3 gate
 //!   is enforced at emission);
 //! - with the default config (interval 0), nobody receives one — not even a
-//!   v4 connection.
+//!   v3 connection.
 
 mod test_helpers;
 mod websocket_test_helpers;
@@ -33,7 +33,7 @@ const SERVER_MESSAGE_TIMEOUT: tokio::time::Duration = tokio::time::Duration::fro
 /// interval, so an erroneous emission would land well inside it.
 const ABSENCE_WINDOW: tokio::time::Duration = tokio::time::Duration::from_millis(2_500);
 
-fn v4_protocol_config() -> ProtocolConfig {
+fn v3_protocol_config() -> ProtocolConfig {
     let mut protocol_config = ProtocolConfig::default();
     protocol_config.sdk_compatibility.enforce = false;
     protocol_config
@@ -44,7 +44,7 @@ async fn start_test_server(
 ) -> (std::net::SocketAddr, Arc<EnhancedGameServer>) {
     let mut server_config = test_server_config();
     server_config.websocket_config.delivery_stats_interval_secs = delivery_stats_interval_secs;
-    let server = create_test_server_with_config(server_config, v4_protocol_config()).await;
+    let server = create_test_server_with_config(server_config, v3_protocol_config()).await;
 
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -76,7 +76,7 @@ async fn connect(addr: std::net::SocketAddr) -> WsStream {
 /// ProtocolInfo handshake.
 async fn authenticate(ws: &mut WsStream, protocol_version: u16) {
     let auth = ClientMessage::Authenticate {
-        app_id: "v4-relay-stats-test".to_string(),
+        app_id: "v3-relay-stats-test".to_string(),
         sdk_version: None,
         platform: None,
         game_data_format: None,
@@ -106,10 +106,10 @@ async fn authenticate(ws: &mut WsStream, protocol_version: u16) {
 }
 
 #[tokio::test]
-async fn v4_client_receives_periodic_relay_stats_when_enabled() {
+async fn v3_client_receives_periodic_relay_stats_when_enabled() {
     let (addr, _server) = start_test_server(1).await;
     let mut ws = connect(addr).await;
-    authenticate(&mut ws, 4).await;
+    authenticate(&mut ws, 3).await;
 
     // Two consecutive frames prove periodic emission (not a one-shot), and
     // the cumulative counters must be plausible and monotonic.
@@ -161,15 +161,15 @@ async fn v4_client_receives_periodic_relay_stats_when_enabled() {
 }
 
 #[tokio::test]
-async fn v3_client_never_receives_relay_stats_even_when_enabled() {
+async fn v2_client_never_receives_relay_stats_even_when_enabled() {
     let (addr, _server) = start_test_server(1).await;
     let mut ws = connect(addr).await;
-    authenticate(&mut ws, 3).await;
+    authenticate(&mut ws, 2).await;
 
     let stray = maybe_next_matching_server_message_within(
         &mut ws,
         ABSENCE_WINDOW,
-        "RelayStats absence for a v3 connection",
+        "RelayStats absence for a v2 connection",
         |message| match message {
             ServerMessage::RelayStats { .. } => Some(()),
             _ => None,
@@ -178,7 +178,8 @@ async fn v3_client_never_receives_relay_stats_even_when_enabled() {
     .await;
     assert!(
         stray.is_none(),
-        "RelayStats is v4-only and must never be emitted to a v3 connection"
+        "RelayStats is part of the v3 reliability surface and must never be \
+         emitted to a pre-v3 (v2) connection"
     );
 }
 
@@ -187,7 +188,7 @@ async fn nobody_receives_relay_stats_with_default_config() {
     // Default config: delivery_stats_interval_secs = 0 (disabled).
     let (addr, _server) = start_test_server(0).await;
     let mut ws = connect(addr).await;
-    authenticate(&mut ws, 4).await;
+    authenticate(&mut ws, 3).await;
 
     let stray = maybe_next_matching_server_message_within(
         &mut ws,

--- a/tests/v3_relay_stats_e2e.rs
+++ b/tests/v3_relay_stats_e2e.rs
@@ -6,8 +6,8 @@
 //! - with `websocket.delivery_stats_interval_secs > 0`, a connection that
 //!   negotiated v3 receives periodic `RelayStats` frames with plausible
 //!   cumulative fields;
-//! - a v3 connection on the SAME deployment never receives one (the v3 gate
-//!   is enforced at emission);
+//! - a pre-v3 (v2) connection on the SAME deployment never receives one (the
+//!   v3 gate is enforced at emission);
 //! - with the default config (interval 0), nobody receives one — not even a
 //!   v3 connection.
 

--- a/tests/v3_reliability_wire_golden.rs
+++ b/tests/v3_reliability_wire_golden.rs
@@ -1,10 +1,12 @@
-//! GOLDEN v4 WIRE SNAPSHOTS — these lock the protocol v4 additions.
+//! GOLDEN v3 WIRE SNAPSHOTS — these lock the protocol v3 delivery-reliability
+//! additions.
 //!
-//! v4 is additive over v2/v3: the server-stamped `GameData.seq` /
-//! `GameDataBinary.seq` relay sequence and the opt-in `RelayStats` frame. The
-//! pre-v4 forms (`seq: None`, no RelayStats) are frozen byte-for-byte in
-//! `tests/v2_wire_golden.rs`, which MUST keep passing unchanged; this file
-//! freezes the v4-recipient forms with the same assertion strategy:
+//! v3 is additive over the frozen v2 floor: the server-stamped `GameData.seq` /
+//! `GameDataBinary.seq` relay sequence + incarnation `epoch`, and the opt-in
+//! `RelayStats` frame. The pre-v3 (v2) forms (`seq: None`, no RelayStats) are
+//! frozen byte-for-byte in `tests/v2_wire_golden.rs`, which MUST keep passing
+//! unchanged; this file freezes the v3-recipient forms with the same assertion
+//! strategy:
 //!
 //! - JSON: structural equality against a `json!` value AND a raw-string
 //!   assertion to catch field-name / casing / ordering drift.
@@ -49,12 +51,12 @@ fn assert_json<T: Serialize>(value: &T, expected: Value, raw: &str) {
     let actual_value = serde_json::to_value(value).expect("json value");
     assert_eq!(
         actual_value, expected,
-        "JSON structural mismatch (BREAKING v4 wire change?)"
+        "JSON structural mismatch (BREAKING v3 wire change?)"
     );
     let actual_raw = serde_json::to_string(value).expect("json string");
     assert_eq!(
         actual_raw, raw,
-        "JSON raw-string mismatch — field name/casing/ordering drift (BREAKING v4 wire change?)"
+        "JSON raw-string mismatch — field name/casing/ordering drift (BREAKING v3 wire change?)"
     );
 }
 
@@ -73,12 +75,12 @@ fn assert_msgpack<T: Serialize>(value: &T, expected_hex: &str) {
     let actual_hex = hex(&bytes);
     assert_eq!(
         actual_hex, expected_hex,
-        "MessagePack byte mismatch (BREAKING v4 wire change?)\n  actual: {actual_hex}\n  golden: {expected_hex}"
+        "MessagePack byte mismatch (BREAKING v3 wire change?)\n  actual: {actual_hex}\n  golden: {expected_hex}"
     );
 }
 
 // ===========================================================================
-// GameData with the server-stamped seq (v4 recipients).
+// GameData with the server-stamped seq (v3 recipients).
 // ===========================================================================
 
 #[test]
@@ -157,7 +159,7 @@ fn golden_server_game_data_binary_with_seq_in_memory_repr_not_wire() {
 }
 
 // ===========================================================================
-// RelayStats (v4-only, config-gated).
+// RelayStats (v3-only, config-gated).
 // ===========================================================================
 
 #[test]
@@ -185,12 +187,12 @@ fn golden_server_relay_stats() {
 }
 
 // ===========================================================================
-// Round-trips: v4 fields survive both wire encodings, and the unstamped form
+// Round-trips: v3 fields survive both wire encodings, and the unstamped form
 // still decodes with `seq: None` (backward decode compatibility).
 // ===========================================================================
 
 #[test]
-fn v4_game_data_seq_and_epoch_round_trip_json_and_msgpack() {
+fn v3_game_data_seq_and_epoch_round_trip_json_and_msgpack() {
     // seq and epoch are stamped together; also cover each independently absent
     // (backward-decode compatibility) and their max values.
     for (seq, epoch) in [
@@ -237,9 +239,9 @@ fn v4_game_data_seq_and_epoch_round_trip_json_and_msgpack() {
 // Epoch carriage on room snapshots (E1): PlayerReconnected + PlayerInfo.
 // ===========================================================================
 
-/// `PlayerReconnected` gains the reconnector's new incarnation epoch (v4). The
-/// pre-v4 form (`epoch: None`) is frozen byte-identically in
-/// `tests/v2_wire_golden.rs`; this freezes the v4-recipient form.
+/// `PlayerReconnected` gains the reconnector's new incarnation epoch (v3). The
+/// pre-v3 form (`epoch: None`) is frozen byte-identically in
+/// `tests/v2_wire_golden.rs`; this freezes the v3-recipient form.
 #[test]
 fn golden_player_reconnected_with_epoch() {
     let msg = ServerMessage::PlayerReconnected {
@@ -260,7 +262,7 @@ fn golden_player_reconnected_with_epoch() {
 }
 
 /// A `PlayerInfo` inside a `PlayerJoined` snapshot carries the joiner's epoch
-/// (v4). Freeze the exact placement (trailing `epoch` key, after
+/// (v3). Freeze the exact placement (trailing `epoch` key, after
 /// `connection_info` which is omitted here) so the snapshot wire cannot drift.
 #[test]
 fn golden_player_joined_player_info_with_epoch() {
@@ -296,7 +298,7 @@ fn golden_player_joined_player_info_with_epoch() {
 }
 
 #[test]
-fn v4_relay_stats_round_trips_json_and_msgpack() {
+fn v3_relay_stats_round_trips_json_and_msgpack() {
     let msg = ServerMessage::RelayStats {
         interval_ms: 60_000,
         sent_to_you: u64::MAX,

--- a/tests/v3_reliability_wire_golden.rs
+++ b/tests/v3_reliability_wire_golden.rs
@@ -295,6 +295,10 @@ fn golden_player_joined_player_info_with_epoch() {
             r#"{{"type":"PlayerJoined","data":{{"player":{{"id":"{PLAYER_A_STR}","name":"P","is_authority":false,"is_ready":false,"connected_at":"{FIXED_TIME_STR}","epoch":4}}}}}}"#
         ),
     );
+    // Freeze the MessagePack encoding too (matching the other goldens here and
+    // in `v2_wire_golden.rs`), so the production binary snapshot wire cannot
+    // drift the trailing `epoch` key silently.
+    assert_msgpack(&msg, "82a474797065ac506c617965724a6f696e6564a46461746181a6706c6179657286a26964c4100000000000000000000000000000000aa46e616d65a150ac69735f617574686f72697479c2a869735f7265616479c2ac636f6e6e65637465645f6174b4323032342d30312d30325430333a30343a30355aa565706f636804");
 }
 
 #[test]

--- a/tests/v3_signaling_e2e.rs
+++ b/tests/v3_signaling_e2e.rs
@@ -296,7 +296,7 @@ async fn reconnected_websocket_uses_restored_player_id_for_later_signals() {
     let token = game_server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(peer2_id, room_id, false, Some(peer2_info))
+        .register_disconnection(peer2_id, room_id, false, Some(peer2_info), 0)
         .await;
 
     let mut replacement = connect(addr).await;

--- a/tests/v3_signaling_e2e.rs
+++ b/tests/v3_signaling_e2e.rs
@@ -293,6 +293,12 @@ async fn reconnected_websocket_uses_restored_player_id_for_later_signals() {
     game_server.disconnect_client(&peer2_id).await;
     let _ = old_peer2.close(None).await;
 
+    // `disconnect_client` already auto-registered the disconnect with peer2's
+    // pre-issued (join-time) token. This re-registration of the same
+    // still-pending room only surfaces that token to the test: it is idempotent
+    // on the token (a same-room re-registration preserves the client-held one),
+    // so `token` is exactly what peer2 received in `RoomJoined` and would
+    // reconnect with — the reconnect below stays faithful to a real client.
     let token = game_server
         .reconnection_manager()
         .expect("reconnection enabled")

--- a/tests/v3_transport_status_e2e.rs
+++ b/tests/v3_transport_status_e2e.rs
@@ -682,7 +682,11 @@ async fn reconnect_clears_stored_transport_status() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reporter_id, room_id, false, Some(reporter_info), 0)
+        // The reporter negotiated v3 and joined once, so its true pre-disconnect
+        // incarnation epoch is 1 (not 0 — that would model a sender with no v3
+        // stream and make the reconnect resume at epoch 1, colliding with the
+        // first incarnation).
+        .register_disconnection(reporter_id, room_id, false, Some(reporter_info), 1)
         .await;
 
     // Reconnect over a FRESH socket using the real wire flow.

--- a/tests/v3_transport_status_e2e.rs
+++ b/tests/v3_transport_status_e2e.rs
@@ -682,7 +682,7 @@ async fn reconnect_clears_stored_transport_status() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")
-        .register_disconnection(reporter_id, room_id, false, Some(reporter_info))
+        .register_disconnection(reporter_id, room_id, false, Some(reporter_info), 0)
         .await;
 
     // Reconnect over a FRESH socket using the real wire flow.
@@ -721,7 +721,7 @@ async fn reconnect_clears_stored_transport_status() {
         SERVER_MESSAGE_TIMEOUT,
         "PlayerReconnected",
         |message| match message {
-            ServerMessage::PlayerReconnected { player_id } if player_id == reporter_id => Some(()),
+            ServerMessage::PlayerReconnected { player_id, .. } if player_id == reporter_id => Some(()),
             _ => None,
         },
     )

--- a/tests/v3_transport_status_e2e.rs
+++ b/tests/v3_transport_status_e2e.rs
@@ -721,7 +721,9 @@ async fn reconnect_clears_stored_transport_status() {
         SERVER_MESSAGE_TIMEOUT,
         "PlayerReconnected",
         |message| match message {
-            ServerMessage::PlayerReconnected { player_id, .. } if player_id == reporter_id => Some(()),
+            ServerMessage::PlayerReconnected { player_id, .. } if player_id == reporter_id => {
+                Some(())
+            }
             _ => None,
         },
     )

--- a/tests/v3_transport_status_e2e.rs
+++ b/tests/v3_transport_status_e2e.rs
@@ -85,8 +85,8 @@ fn mesh_session_config() -> SessionConfig {
 
 /// Boot the production router (`/v2` nest + `/v3/ws` alias) around a server
 /// built with the given `SessionConfig`, returning the bound address and the
-/// server handle (the reconnect test needs the handle to mint a token, exactly
-/// like `tests/v3_multipeer_e2e.rs` — the token never crosses the wire).
+/// server handle (the reconnect test mints the token in-process via the handle
+/// rather than receiving it over the wire, like `tests/v3_multipeer_e2e.rs`).
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (std::net::SocketAddr, Arc<EnhancedGameServer>) {
@@ -677,8 +677,9 @@ async fn reconnect_clears_stored_transport_status() {
     )
     .await;
 
-    // Mint a reconnection token through the server handle (never crosses the
-    // wire; same sanctioned in-process pattern as `v3_multipeer_e2e.rs`).
+    // Mint a reconnection token through the server handle — obtained in-process
+    // here rather than over the wire (same sanctioned pattern as
+    // `v3_multipeer_e2e.rs`).
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled")

--- a/tests/v4_game_data_sequencing_e2e.rs
+++ b/tests/v4_game_data_sequencing_e2e.rs
@@ -542,6 +542,81 @@ async fn sender_leave_and_rejoin_restarts_seq_at_one() {
     assert_message_conservation(&metrics).await;
 }
 
+/// The incarnation epoch is a single monotonic per-connection counter and is
+/// deliberately NOT reset when a sender leaves one room and joins another: a v4
+/// recipient in the NEW room sees the sender's epoch carry forward (2, not a
+/// fresh 1) with `seq` restarted. This is the design that keeps `(epoch, seq)`
+/// strictly increasing per (sender, room) even across a same-room leave+rejoin
+/// (a per-room reset would replay a lower epoch there); clients baseline
+/// relatively, so a first-observed epoch above 1 is expected and harmless.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn epoch_carries_across_a_room_switch_not_reset_to_one() {
+    let (addr, server) = start_test_server(test_server_config()).await;
+    let metrics = server.metrics();
+
+    let mut sender = connect(addr).await;
+    authenticate_v4(&mut sender).await;
+
+    // Room A: the sender's first incarnation ⇒ epoch 1.
+    let mut recipient_a = connect(addr).await;
+    authenticate_v4(&mut recipient_a).await;
+    let (sender_id, _) = join_room(&mut sender, "EPRMA0", "Switcher").await;
+    join_room(&mut recipient_a, "EPRMA0", "WatcherA").await;
+    send(
+        &mut sender,
+        &ClientMessage::GameData {
+            data: serde_json::json!({ "room": "a" }),
+        },
+    )
+    .await;
+    let in_a = collect_game_data(&mut recipient_a, 1).await;
+    assert_eq!(
+        in_a[0].epoch,
+        Some(1),
+        "the first room membership is epoch 1"
+    );
+    assert_eq!(in_a[0].seq, Some(1));
+
+    // Leave A (observed), then join a DIFFERENT room B.
+    send(&mut sender, &ClientMessage::LeaveRoom).await;
+    next_matching_server_message_within(
+        &mut recipient_a,
+        SERVER_MESSAGE_TIMEOUT,
+        "sender departure from A",
+        |message| match message {
+            ServerMessage::PlayerLeft { player_id } if player_id == sender_id => Some(()),
+            _ => None,
+        },
+    )
+    .await;
+
+    let mut recipient_b = connect(addr).await;
+    authenticate_v4(&mut recipient_b).await;
+    join_room(&mut sender, "EPRMB0", "Switcher").await;
+    join_room(&mut recipient_b, "EPRMB0", "WatcherB").await;
+    send(
+        &mut sender,
+        &ClientMessage::GameData {
+            data: serde_json::json!({ "room": "b" }),
+        },
+    )
+    .await;
+    let in_b = collect_game_data(&mut recipient_b, 1).await;
+    // Carried forward + incremented (NOT reset to 1); seq restarted within it.
+    assert_eq!(
+        in_b[0].epoch,
+        Some(2),
+        "epoch carries across the room switch (monotonic per connection), not reset to 1"
+    );
+    assert_eq!(
+        in_b[0].seq,
+        Some(1),
+        "seq restarts within the new room incarnation"
+    );
+
+    assert_message_conservation(&metrics).await;
+}
+
 /// (e) The end-to-end loss-detection story #131's reporter lacked: a slow
 /// consumer is evicted mid-burst, reconnects with its reconnection token, and
 /// can OBSERVE the loss as a seq gap between its last-seen stamp and the next

--- a/tests/v4_game_data_sequencing_e2e.rs
+++ b/tests/v4_game_data_sequencing_e2e.rs
@@ -177,10 +177,12 @@ async fn join_room(ws: &mut WsStream, room_code: &str, player_name: &str) -> (Pl
     .await
 }
 
-/// A received relayed frame: `(from_player, server-stamped seq, payload)`.
+/// A received relayed frame: `(from_player, server-stamped seq, incarnation
+/// epoch, payload)`.
 struct ReceivedGameData {
     from_player: PlayerId,
     seq: Option<u64>,
+    epoch: Option<u32>,
     data: serde_json::Value,
 }
 
@@ -206,9 +208,11 @@ async fn collect_game_data(ws: &mut WsStream, expected: usize) -> Vec<ReceivedGa
                 from_player,
                 data,
                 seq,
+                epoch,
             } => received.push(ReceivedGameData {
                 from_player,
                 seq,
+                epoch,
                 data,
             }),
             ServerMessage::Error {
@@ -337,6 +341,13 @@ async fn mixed_room_v2_recipient_raw_json_has_no_seq_key() {
         Some(1),
         "v4 recipient must see the server-stamped seq: {v4_raw}"
     );
+    // The v4 recipient also sees the incarnation epoch (first incarnation ⇒ 1),
+    // stamped together with seq.
+    assert_eq!(
+        v4_data.get("epoch").and_then(serde_json::Value::as_u64),
+        Some(1),
+        "v4 recipient must see the server-stamped epoch: {v4_raw}"
+    );
 
     let v2_value: serde_json::Value = serde_json::from_str(&v2_raw).expect("v2 frame JSON");
     let v2_data = v2_value
@@ -346,6 +357,10 @@ async fn mixed_room_v2_recipient_raw_json_has_no_seq_key() {
     assert!(
         !v2_data.contains_key("seq"),
         "v2 recipient's raw frame must not contain a seq key: {v2_raw}"
+    );
+    assert!(
+        !v2_data.contains_key("epoch"),
+        "v2 recipient's raw frame must not contain an epoch key: {v2_raw}"
     );
     // Everything else is identical between the two recipients' frames.
     assert_eq!(v2_data.get("from_player"), v4_data.get("from_player"));
@@ -478,6 +493,14 @@ async fn sender_leave_and_rejoin_restarts_seq_at_one() {
     }
     let before = collect_game_data(&mut recipient, BEFORE_LEAVE as usize).await;
     assert_contiguous_seqs(&before, 1, BEFORE_LEAVE, "recipient before leave");
+    // First incarnation ⇒ epoch 1 on every pre-leave frame.
+    for frame in &before {
+        assert_eq!(
+            frame.epoch,
+            Some(1),
+            "the first incarnation's frames all carry epoch 1"
+        );
+    }
 
     // Leave, observe the departure, rejoin the same room.
     send(&mut sender, &ClientMessage::LeaveRoom).await;
@@ -505,6 +528,15 @@ async fn sender_leave_and_rejoin_restarts_seq_at_one() {
         after[0].seq,
         Some(1),
         "the per-(sender, room) counter must restart at 1 after leave + rejoin"
+    );
+    // The epoch bumps to 2 on the new incarnation, so the seq restart is
+    // SELF-DESCRIBING: the recipient sees (epoch 1, seq 3) then (epoch 2, seq 1)
+    // and attributes the backwards seq jump to the epoch bump directly — it does
+    // not have to correlate the separately-ordered PlayerLeft/PlayerJoined.
+    assert_eq!(
+        after[0].epoch,
+        Some(2),
+        "a leave + rejoin is a new incarnation, so the epoch advances to 2"
     );
 
     assert_message_conservation(&metrics).await;
@@ -663,7 +695,9 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
     let token = server
         .reconnection_manager()
         .expect("reconnection enabled in test config")
-        .register_disconnection(victim_id, room_id, false, Some(victim_info))
+        // last_epoch = 1: the victim joined once (its own incarnation epoch),
+        // though this test asserts the SENDER's stream, not the victim's epoch.
+        .register_disconnection(victim_id, room_id, false, Some(victim_info), 1)
         .await;
 
     let mut reconnected = connect(addr).await;
@@ -719,6 +753,233 @@ async fn evicted_recipient_observes_seq_gap_after_reconnect() {
     assert!(
         metrics.websocket_messages_dropped.load(Ordering::Relaxed) >= 1,
         "the gap must correspond to loudly counted drops"
+    );
+
+    assert_message_conservation(&metrics).await;
+}
+
+/// Read text frames until the next server message of `type_name`, returning its
+/// parsed JSON `Value` so field presence/absence can be asserted directly (a v4
+/// field omitted for a pre-v4 recipient is ABSENT from the object, so
+/// `value["data"][..].get("epoch")` is `None`, not a JSON null).
+async fn next_message_value_of_type(
+    ws: &mut WsStream,
+    type_name: &str,
+    context: &str,
+) -> serde_json::Value {
+    let deadline = tokio::time::Instant::now() + SERVER_MESSAGE_TIMEOUT;
+    loop {
+        let frame = tokio::time::timeout_at(deadline, ws.next())
+            .await
+            .unwrap_or_else(|_| panic!("{context}: timed out waiting for a {type_name} frame"))
+            .unwrap_or_else(|| panic!("{context}: websocket stream closed"))
+            .unwrap_or_else(|err| panic!("{context}: websocket error: {err}"));
+        let Message::Text(text) = frame else {
+            continue;
+        };
+        let value: serde_json::Value = serde_json::from_str(&text)
+            .unwrap_or_else(|err| panic!("{context}: invalid JSON text frame: {err}; {text:?}"));
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some(found) if found == type_name => return value,
+            Some("Error") => panic!("{context}: unexpected server error frame: {text}"),
+            _ => continue,
+        }
+    }
+}
+
+/// (f) Room snapshots carry the incarnation epoch for v4 recipients and OMIT it
+/// (byte-absent, not null) for pre-v4 recipients — both directions:
+/// `RoomJoined.current_players[].epoch` (seen by the joiner) and
+/// `PlayerJoined.player.epoch` (seen by existing members).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn v4_room_snapshots_carry_epoch_pre_v4_omit_it() {
+    let (addr, server) = start_test_server(test_server_config()).await;
+    let metrics = server.metrics();
+
+    // Anchor A (v4) establishes the room; its first incarnation ⇒ epoch 1.
+    let mut anchor = connect(addr).await;
+    authenticate_v4(&mut anchor).await;
+    join_room(&mut anchor, "SNAPEP", "SnapAnchor").await;
+
+    // A v2 joiner: its RoomJoined snapshot must OMIT epoch on every member.
+    let mut v2_joiner = connect(addr).await;
+    authenticate_v2(&mut v2_joiner).await;
+    send(&mut v2_joiner, &join_message("SNAPEP", "SnapV2")).await;
+    let v2_room = next_message_value_of_type(&mut v2_joiner, "RoomJoined", "v2 RoomJoined").await;
+    let v2_players = v2_room["data"]["current_players"]
+        .as_array()
+        .expect("v2 RoomJoined current_players array");
+    assert!(
+        !v2_players.is_empty(),
+        "the snapshot lists existing members"
+    );
+    for player in v2_players {
+        assert!(
+            player.get("epoch").is_none(),
+            "a v2 joiner's RoomJoined must omit epoch on every member: {v2_room}"
+        );
+    }
+
+    // A (v4) sees the v2 joiner arrive; the joiner's epoch (1) IS present on A's
+    // v4 wire (the server stamps it regardless of the joiner's own version).
+    let a_sees_v2 =
+        next_message_value_of_type(&mut anchor, "PlayerJoined", "A sees the v2 join").await;
+    assert_eq!(
+        a_sees_v2["data"]["player"]["epoch"].as_u64(),
+        Some(1),
+        "a v4 member sees a joiner's epoch on PlayerJoined: {a_sees_v2}"
+    );
+
+    // A v4 joiner: its RoomJoined snapshot CARRIES each member's epoch (all 1).
+    let mut v4_joiner = connect(addr).await;
+    authenticate_v4(&mut v4_joiner).await;
+    send(&mut v4_joiner, &join_message("SNAPEP", "SnapV4")).await;
+    let v4_room = next_message_value_of_type(&mut v4_joiner, "RoomJoined", "v4 RoomJoined").await;
+    let v4_players = v4_room["data"]["current_players"]
+        .as_array()
+        .expect("v4 RoomJoined current_players array");
+    assert!(
+        !v4_players.is_empty(),
+        "the snapshot lists existing members"
+    );
+    for player in v4_players {
+        assert_eq!(
+            player["epoch"].as_u64(),
+            Some(1),
+            "a v4 joiner's RoomJoined carries each member's epoch: {v4_room}"
+        );
+    }
+
+    // The v2 member now sees the v4 joiner arrive; its PlayerJoined omits epoch.
+    let v2_sees_v4 =
+        next_message_value_of_type(&mut v2_joiner, "PlayerJoined", "v2 sees the v4 join").await;
+    assert!(
+        v2_sees_v4["data"]["player"].get("epoch").is_none(),
+        "a v2 member's PlayerJoined must omit epoch: {v2_sees_v4}"
+    );
+
+    assert_message_conservation(&metrics).await;
+}
+
+/// (g) A reconnecting SENDER's incarnation epoch BUMPS and survives across the
+/// reconnect (the pre-disconnect epoch is captured into the reconnection record
+/// and resumed at `+1`): the recipient learns the new epoch via
+/// `PlayerReconnected`, AND the reconnected sender's `GameData` carries the same
+/// bumped epoch with `seq` restarted at 1 — so the `(epoch, seq)` stream
+/// strictly increases for a recipient that never left, making the reset
+/// self-describing without correlating the control message.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn reconnecting_sender_bumps_epoch_and_stamps_it_on_game_data() {
+    let (addr, server) = start_test_server(test_server_config()).await;
+    let metrics = server.metrics();
+
+    let mut sender = connect(addr).await;
+    let mut recipient = connect(addr).await;
+    authenticate_v4(&mut sender).await;
+    authenticate_v4(&mut recipient).await;
+
+    // Join the sender directly so we can capture its pre-issued reconnection
+    // token from RoomJoined (v4 clients get one at join).
+    send(&mut sender, &join_message("RCEPCH", "RcSender")).await;
+    let (sender_id, room_id, token) = next_matching_server_message_within(
+        &mut sender,
+        SERVER_MESSAGE_TIMEOUT,
+        "sender RoomJoined",
+        |message| match message {
+            ServerMessage::RoomJoined(payload) => Some((
+                payload.player_id,
+                payload.room_id,
+                payload.reconnection_token.clone(),
+            )),
+            ServerMessage::RoomJoinFailed { reason, error_code } => {
+                panic!("sender room join failed: {reason} ({error_code:?})")
+            }
+            _ => None,
+        },
+    )
+    .await;
+    let token = token.expect("a v4 join issues a reconnection token");
+    join_room(&mut recipient, "RCEPCH", "RcRecipient").await;
+
+    // First incarnation: epoch 1, seq 1.
+    send(
+        &mut sender,
+        &ClientMessage::GameData {
+            data: serde_json::json!({ "phase": "before" }),
+        },
+    )
+    .await;
+    let before = collect_game_data(&mut recipient, 1).await;
+    assert_eq!(before[0].seq, Some(1));
+    assert_eq!(before[0].epoch, Some(1), "the first incarnation is epoch 1");
+
+    // Disconnect the sender through the real teardown path. Call the
+    // server-side unregister DIRECTLY (socket still open) so it runs exactly
+    // once and deterministically: it captures epoch 1 from the still-live
+    // connection into the reconnection record, reuses the pre-issued token, and
+    // removes the connection before we reconnect (no PlayerAlreadyConnected
+    // race). Dropping the socket first would instead let the close-driven
+    // unregister consume the pre-issued token and this call mint a fresh one,
+    // invalidating the token we captured above.
+    server.disconnect_client(&sender_id).await;
+    drop(sender);
+
+    // Reconnect on a fresh v4 socket under the original id, with the pre-issued
+    // token.
+    let mut reconnected = connect(addr).await;
+    authenticate_v4(&mut reconnected).await;
+    send(
+        &mut reconnected,
+        &ClientMessage::Reconnect {
+            player_id: sender_id,
+            room_id,
+            auth_token: token,
+        },
+    )
+    .await;
+    next_matching_server_message_within(
+        &mut reconnected,
+        SERVER_MESSAGE_TIMEOUT,
+        "reconnect response",
+        |message| match message {
+            ServerMessage::Reconnected(payload) => Some(payload),
+            ServerMessage::ReconnectionFailed { reason, error_code } => {
+                panic!("reconnect failed: {reason} ({error_code:?})")
+            }
+            _ => None,
+        },
+    )
+    .await;
+
+    // The recipient (never left) learns of the reconnection with the sender's
+    // NEW epoch (2) — the pre-disconnect epoch 1 survived and bumped.
+    let notice = next_message_value_of_type(
+        &mut recipient,
+        "PlayerReconnected",
+        "recipient sees the reconnection",
+    )
+    .await;
+    assert_eq!(
+        notice["data"]["epoch"].as_u64(),
+        Some(2),
+        "PlayerReconnected advertises the reconnector's bumped epoch: {notice}"
+    );
+
+    // The reconnected sender's GameData carries the same new epoch, seq restarted
+    // — (epoch 1, seq 1) then (epoch 2, seq 1): strictly increasing, no ambiguity.
+    send(
+        &mut reconnected,
+        &ClientMessage::GameData {
+            data: serde_json::json!({ "phase": "after" }),
+        },
+    )
+    .await;
+    let after = collect_game_data(&mut recipient, 1).await;
+    assert_eq!(after[0].seq, Some(1), "seq restarts within the new epoch");
+    assert_eq!(
+        after[0].epoch,
+        Some(2),
+        "the reconnected sender stamps its GameData with the bumped epoch"
     );
 
     assert_message_conservation(&metrics).await;

--- a/tests/v4_wire_golden.rs
+++ b/tests/v4_wire_golden.rs
@@ -16,7 +16,7 @@
 
 use serde::Serialize;
 use serde_json::{json, Value};
-use signal_fish_server::protocol::ServerMessage;
+use signal_fish_server::protocol::{PlayerInfo, ServerMessage};
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -28,6 +28,16 @@ fn player_a() -> Uuid {
 }
 
 const PLAYER_A_STR: &str = "00000000-0000-0000-0000-00000000000a";
+
+/// Deterministic timestamp for `PlayerInfo` snapshot goldens (matches the
+/// `tests/v2_wire_golden.rs` fixture so the two files agree on the wire form).
+fn fixed_time() -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339("2024-01-02T03:04:05Z")
+        .expect("valid RFC3339 fixture")
+        .with_timezone(&chrono::Utc)
+}
+
+const FIXED_TIME_STR: &str = "2024-01-02T03:04:05Z";
 
 // ---------------------------------------------------------------------------
 // Assertion helpers (mirroring tests/v2_wire_golden.rs).
@@ -77,40 +87,43 @@ fn golden_server_game_data_with_seq() {
         from_player: player_a(),
         data: json!({ "move": "up" }),
         seq: Some(42),
+        epoch: Some(3),
     };
     assert_json(
         &msg,
         json!({
             "type": "GameData",
-            "data": { "from_player": PLAYER_A_STR, "data": { "move": "up" }, "seq": 42 }
+            "data": { "from_player": PLAYER_A_STR, "data": { "move": "up" }, "seq": 42, "epoch": 3 }
         }),
         &format!(
-            r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up"}},"seq":42}}}}"#
+            r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up"}},"seq":42,"epoch":3}}}}"#
         ),
     );
-    assert_msgpack(&msg, "82a474797065a847616d6544617461a46461746183ab66726f6d5f706c61796572c4100000000000000000000000000000000aa46461746181a46d6f7665a27570a37365712a");
+    assert_msgpack(&msg, "82a474797065a847616d6544617461a46461746184ab66726f6d5f706c61796572c4100000000000000000000000000000000aa46461746181a46d6f7665a27570a37365712aa565706f636803");
 }
 
-/// The seq stamp starts at 1 — freeze the first-stamp form explicitly so the
-/// "starts at 1" contract has a wire-level witness.
+/// The seq stamp starts at 1 within an epoch, and the first incarnation is
+/// epoch 1 — freeze the first-stamp form explicitly so the "starts at 1"
+/// contract has a wire-level witness for BOTH counters.
 #[test]
-fn golden_server_game_data_with_first_seq() {
+fn golden_server_game_data_with_first_seq_and_epoch() {
     let msg = ServerMessage::GameData {
         from_player: player_a(),
         data: json!({ "move": "up" }),
         seq: Some(1),
+        epoch: Some(1),
     };
     assert_json(
         &msg,
         json!({
             "type": "GameData",
-            "data": { "from_player": PLAYER_A_STR, "data": { "move": "up" }, "seq": 1 }
+            "data": { "from_player": PLAYER_A_STR, "data": { "move": "up" }, "seq": 1, "epoch": 1 }
         }),
         &format!(
-            r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up"}},"seq":1}}}}"#
+            r#"{{"type":"GameData","data":{{"from_player":"{PLAYER_A_STR}","data":{{"move":"up"}},"seq":1,"epoch":1}}}}"#
         ),
     );
-    assert_msgpack(&msg, "82a474797065a847616d6544617461a46461746183ab66726f6d5f706c61796572c4100000000000000000000000000000000aa46461746181a46d6f7665a27570a373657101");
+    assert_msgpack(&msg, "82a474797065a847616d6544617461a46461746184ab66726f6d5f706c61796572c4100000000000000000000000000000000aa46461746181a46d6f7665a27570a373657101a565706f636801");
 }
 
 /// In-memory representation ONLY — NOT the wire form (mirrors the v2 golden's
@@ -123,6 +136,7 @@ fn golden_server_game_data_binary_with_seq_in_memory_repr_not_wire() {
         encoding: signal_fish_server::protocol::GameDataEncoding::MessagePack,
         payload: bytes::Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]),
         seq: Some(7),
+        epoch: Some(3),
     };
     assert_json(
         &msg,
@@ -132,11 +146,12 @@ fn golden_server_game_data_binary_with_seq_in_memory_repr_not_wire() {
                 "from_player": PLAYER_A_STR,
                 "encoding": "message_pack",
                 "payload": [1, 2, 3, 4],
-                "seq": 7
+                "seq": 7,
+                "epoch": 3
             }
         }),
         &format!(
-            r#"{{"type":"GameDataBinary","data":{{"from_player":"{PLAYER_A_STR}","encoding":"message_pack","payload":[1,2,3,4],"seq":7}}}}"#
+            r#"{{"type":"GameDataBinary","data":{{"from_player":"{PLAYER_A_STR}","encoding":"message_pack","payload":[1,2,3,4],"seq":7,"epoch":3}}}}"#
         ),
     );
 }
@@ -175,26 +190,109 @@ fn golden_server_relay_stats() {
 // ===========================================================================
 
 #[test]
-fn v4_game_data_seq_round_trips_json_and_msgpack() {
-    for seq in [None, Some(1), Some(u64::MAX)] {
+fn v4_game_data_seq_and_epoch_round_trip_json_and_msgpack() {
+    // seq and epoch are stamped together; also cover each independently absent
+    // (backward-decode compatibility) and their max values.
+    for (seq, epoch) in [
+        (None, None),
+        (Some(1), Some(1)),
+        (Some(u64::MAX), Some(u32::MAX)),
+    ] {
         let msg = ServerMessage::GameData {
             from_player: player_a(),
             data: json!({ "k": "v" }),
             seq,
+            epoch,
         };
 
         let json = serde_json::to_string(&msg).expect("json");
         match serde_json::from_str::<ServerMessage>(&json).expect("json round-trip") {
-            ServerMessage::GameData { seq: rt_seq, .. } => assert_eq!(rt_seq, seq),
+            ServerMessage::GameData {
+                seq: rt_seq,
+                epoch: rt_epoch,
+                ..
+            } => {
+                assert_eq!(rt_seq, seq);
+                assert_eq!(rt_epoch, epoch);
+            }
             other => panic!("expected GameData, got {other:?}"),
         }
 
         let mp = rmp_serde::to_vec_named(&msg).expect("msgpack");
         match rmp_serde::from_slice::<ServerMessage>(&mp).expect("msgpack round-trip") {
-            ServerMessage::GameData { seq: rt_seq, .. } => assert_eq!(rt_seq, seq),
+            ServerMessage::GameData {
+                seq: rt_seq,
+                epoch: rt_epoch,
+                ..
+            } => {
+                assert_eq!(rt_seq, seq);
+                assert_eq!(rt_epoch, epoch);
+            }
             other => panic!("expected GameData, got {other:?}"),
         }
     }
+}
+
+// ===========================================================================
+// Epoch carriage on room snapshots (E1): PlayerReconnected + PlayerInfo.
+// ===========================================================================
+
+/// `PlayerReconnected` gains the reconnector's new incarnation epoch (v4). The
+/// pre-v4 form (`epoch: None`) is frozen byte-identically in
+/// `tests/v2_wire_golden.rs`; this freezes the v4-recipient form.
+#[test]
+fn golden_player_reconnected_with_epoch() {
+    let msg = ServerMessage::PlayerReconnected {
+        player_id: player_a(),
+        epoch: Some(2),
+    };
+    assert_json(
+        &msg,
+        json!({
+            "type": "PlayerReconnected",
+            "data": { "player_id": PLAYER_A_STR, "epoch": 2 }
+        }),
+        &format!(
+            r#"{{"type":"PlayerReconnected","data":{{"player_id":"{PLAYER_A_STR}","epoch":2}}}}"#
+        ),
+    );
+    assert_msgpack(&msg, "82a474797065b1506c617965725265636f6e6e6563746564a46461746182a9706c617965725f6964c4100000000000000000000000000000000aa565706f636802");
+}
+
+/// A `PlayerInfo` inside a `PlayerJoined` snapshot carries the joiner's epoch
+/// (v4). Freeze the exact placement (trailing `epoch` key, after
+/// `connection_info` which is omitted here) so the snapshot wire cannot drift.
+#[test]
+fn golden_player_joined_player_info_with_epoch() {
+    let msg = ServerMessage::PlayerJoined {
+        player: PlayerInfo {
+            id: player_a(),
+            name: "P".to_string(),
+            is_authority: false,
+            is_ready: false,
+            connected_at: fixed_time(),
+            connection_info: None,
+            epoch: Some(4),
+            region_id: String::new(),
+        },
+    };
+    assert_json(
+        &msg,
+        json!({
+            "type": "PlayerJoined",
+            "data": { "player": {
+                "id": PLAYER_A_STR,
+                "name": "P",
+                "is_authority": false,
+                "is_ready": false,
+                "connected_at": FIXED_TIME_STR,
+                "epoch": 4
+            } }
+        }),
+        &format!(
+            r#"{{"type":"PlayerJoined","data":{{"player":{{"id":"{PLAYER_A_STR}","name":"P","is_authority":false,"is_ready":false,"connected_at":"{FIXED_TIME_STR}","epoch":4}}}}}}"#
+        ),
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

First item of the protocol-v4 revision (**P10.E1**), gated by the merged D4/D5 TLA+ specs. Adds a per-`(sender, room)` **incarnation `epoch: u32`** stamped beside the v4 relay `seq`, closing **GAP-8**.

Today `seq` resets to 1 on every room (re)assignment and is attributable only because control and data share one FIFO. Once the E2 control-priority split breaks that ordering, the reset must be self-describing. With `epoch`, the pair `(epoch, seq)` is **strictly lexicographically increasing** per sender as observed by any single recipient, so a recipient attributes a backwards `seq` jump to the epoch bump directly — not by correlating a separately-ordered `PlayerLeft`/`PlayerJoined`/`PlayerReconnected`.

## Wire changes (v4-only; v2/v3 byte-identical)

All fields are `Option<u32>`, `skip_serializing_if = "Option::is_none"`, and stripped for pre-v4 recipients:

- `ServerMessage::GameData` / `GameDataBinary` gain `epoch` beside `seq`
- `PlayerInfo` gains `epoch` — carried on `RoomJoined.current_players[]`, `PlayerJoined.player`, `Reconnected` snapshots
- `ServerMessage::PlayerReconnected` gains `epoch`
- the bare `BinaryGameDataFrame` gains a trailing `epoch` map key

## Server

- `ClientConnection.game_data_epoch` increments at the two incarnation-start boundaries (join/seat-fill `assign_client_to_room`, reconnect `reassign_connection` — the same sites that reset `seq`), read atomically with `seq` via `next_relay_stamp -> RelayStamp { seq, epoch }`.
- **Epoch survives reconnect**: a fresh reconnect socket would reset the epoch to 1 and collide with the first incarnation. The pre-disconnect epoch is captured into `DisconnectedPlayer.last_epoch` and resumed at `last_epoch + 1`, so the stream stays strictly increasing for a recipient that never left.
- Snapshot epoch is gated per recipient (construction-time for single-recipient `RoomJoined`/`Reconnected`; sending-layer strip for broadcast `PlayerJoined`/`PlayerReconnected`).

`last_epoch` is a **dedicated** record field (not stuffed into `PlayerInfo.epoch`), so room-state `PlayerInfo.epoch` is never populated — every room-state-derived message stays byte-identical for all recipients, with no way for a stored value to leak to the wire.

## Tests (red-green)

- `tests/v4_game_data_sequencing_e2e.rs` — first-frame epoch 1; leave+rejoin bumps to 2 (self-describing reset); mixed room ⇒ v4 sees `epoch`, v2 has **no** epoch key (byte-absence); snapshot carriage both directions; **real reconnect path** (`disconnect_client`) bumps `PlayerReconnected.epoch` → 2 and the reconnected sender's `GameData` → epoch 2 / seq 1.
- `tests/v4_wire_golden.rs` — GameData/GameDataBinary goldens gain epoch; new `PlayerReconnected` + `PlayerJoined`(PlayerInfo.epoch) goldens.
- `tests/v2_wire_golden.rs` — `epoch: None` added, serialization **byte-identical** (proves the v2 freeze holds).
- `src/websocket/sending.rs` units — pre-v4 binary frame frozen; v4 frame carries `seq`+`epoch`; legacy text shadow byte-identical.

## Docs

`docs/protocol.md` (new "Incarnation epoch" subsection), `spec/signal-fish-protocol.asyncapi.yaml`, `CHANGELOG.md`.

## Verification

- `cargo fmt` + `cargo clippy --all-targets --all-features` clean
- `cargo nextest run --profile ci --all-features`: **1476 passed, 0 failed, 17 skipped**
- `clients/native` compiles against the changed lib (browser client is TS; ignores unknown fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes negotiated wire semantics (v3-only stamps, version ceiling) and reconnection token/epoch/replay behavior—areas where subtle bugs affect live clients and gap detection.
> 
> **Overview**
> **Protocol versioning:** Former **v4** delivery reliability (`GameData.seq`, `RelayStats`, etc.) now negotiates under **v3** only — `SERVER_MAX_PROTOCOL_VERSION` and defaults are **3**, clients advertising 4+ are clamped to 3, and v2 wire stays unchanged when stamps are stripped.
> 
> **P10.E1 incarnation `epoch`:** v3 recipients get **`epoch: u32`** with **`seq`** on relayed `GameData` / `GameDataBinary`, on **`PlayerInfo`** snapshots (`RoomJoined`, `PlayerJoined`, `Reconnected`), and on **`PlayerReconnected`**, so `(epoch, seq)` is strictly increasing per `(sender, room)` and `seq` resets are self-describing. Stamping uses **`next_relay_stamp`** / per-connection **`game_data_epoch`** (bumps on join/reconnect, not on leave).
> 
> **Reconnection:** Disconnect records capture **`last_epoch`**; reconnect sets **`last_epoch + 1`** via **`set_game_data_epoch`**. **`register_disconnection`** now preserves token, replay snapshot, **`player_info`**, and **`last_epoch`** on same-room re-registration while still pending; embedded **`missed_events`** strip **`epoch`** for pre-v3 reconnectors.
> 
> **CI:** **`quick-check`** runs **`cargo check`** on the out-of-tree **`fuzz/`** workspace so signature drift (e.g. **`register_disconnection`**) fails on every PR.
> 
> Docs/specs/changelog and test renames (`v3_*` goldens/e2e) align with v3 gating instead of a separate v4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e2a3b3405cf77696fc3314e2c5b64ca05a8f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->