### PR TITLE
[codex] P10.E8 ProtocolInfo transports seam

### DIFF
--- a/.llm/code-samples/protocol/v3-server-messages.jsonl
+++ b/.llm/code-samples/protocol/v3-server-messages.jsonl
@@ -1,4 +1,4 @@
-{"type": "ProtocolInfo", "data": {"capabilities": ["reconnection", "spectators", "authority"], "game_data_formats": ["json", "message_pack"], "protocol_version": 3, "min_protocol_version": 2, "max_protocol_version": 3}}
+{"type": "ProtocolInfo", "data": {"capabilities": ["reconnection", "spectators", "authority"], "game_data_formats": ["json", "message_pack"], "protocol_version": 3, "min_protocol_version": 2, "max_protocol_version": 3, "transports": ["websocket"]}}
 {"type": "NewPeer", "data": {"peer_id": "00000000-0000-0000-0000-00000000000b", "you_initiate": true}}
 {"type": "Signal", "data": {"from": "00000000-0000-0000-0000-00000000000b", "signal": {"Answer": "v=0\r\no=- 0 0 IN IP4 0.0.0.0\r\n..."}}}
 {"type": "SessionPlan", "data": {"topology": "mesh", "transport": "webrtc", "peers": [{"player_id": "00000000-0000-0000-0000-00000000000b", "player_name": "Bob", "is_authority": false, "initiate": true}], "ice_servers": [{"urls": ["stun:stun.l.google.com:19302"]}, {"urls": ["turn:turn.example.com:3478"], "username": "1700003600:00000000-0000-0000-0000-00000000000a", "credential": "7/zfauXrL6LSdBbV8YTfnCWafHk="}], "fallback": "relay"}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the v3-only `ProtocolInfo.transports` capability array (P10.E8). A
+  negotiated-v3 handshake now advertises the current server message lane as
+  `["websocket"]`, reserving the protocol seam for a future relay transport
+  without another negotiation redesign. Negotiated-v2 `ProtocolInfo` frames still
+  omit the field, so the frozen v2 JSON and MessagePack wire snapshots stay
+  byte-identical. The contract is documented in `docs/protocol.md`,
+  `docs/concepts/protocol-versions.md`, the Rust client guide, the AsyncAPI
+  schema, and the v3 canonical samples.
 - Added the protocol-v3 incarnation `epoch` (P10.E1) beside the relay `seq`.
   Every relayed `GameData` / `GameDataBinary` to a v3 recipient now carries an
   `epoch: u32` — a monotonic per-sender counter (tracked per connection, not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/docs/concepts/protocol-versions.md
+++ b/docs/concepts/protocol-versions.md
@@ -99,7 +99,8 @@ Connect to `/v3/ws` and add three optional fields to your first `Authenticate` m
 
 Advertise only what you can actually run. Always include `relay` so you remain a valid floor member. The
 negotiated result comes back in the extended `ProtocolInfo` (`protocol_version`, `min_protocol_version`,
-`max_protocol_version`).
+`max_protocol_version`, `transports`). For negotiated v3, `transports` currently advertises `["websocket"]`; it is
+omitted with the other v3-only fields on negotiated v2 connections.
 
 ### 2. Handle the five new server messages
 

--- a/docs/guides/building-a-client.md
+++ b/docs/guides/building-a-client.md
@@ -129,7 +129,8 @@ If you want peer-to-peer (WebRTC mesh or host topology), opt in during
 
 Omitting `supported_transports` / `supported_topologies` keeps you relay-only
 even on the `/v3/ws` endpoint. The server echoes the negotiated
-`protocol_version` and accepted range in `ProtocolInfo`.
+`protocol_version`, accepted range, and current server message `transports`
+(`["websocket"]` today) in `ProtocolInfo`.
 
 When a v3 room negotiates a non-relay plan, in addition to `GameStarting` you
 receive a per-recipient **`SessionPlan`** describing the chosen `topology`

--- a/docs/guides/rust-client.md
+++ b/docs/guides/rust-client.md
@@ -217,7 +217,7 @@ pub struct PlayerNameRulesPayload {
 /// Capability/version info sent in the `ProtocolInfo` frame that immediately
 /// follows `Authenticated`. The `protocol_version` fields are `None` (and
 /// omitted on the wire) on a negotiated v2 connection so the v2 frame stays
-/// byte-identical; they carry values only on v3.
+/// byte-identical; v3-only fields carry values only on v3.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolInfoPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -242,6 +242,8 @@ pub struct ProtocolInfoPayload {
     pub min_protocol_version: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_protocol_version: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transports: Option<Vec<String>>,
 }
 
 /// Messages sent from the server to the client.
@@ -1361,6 +1363,8 @@ pub struct ProtocolInfoPayload {
     pub min_protocol_version: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_protocol_version: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transports: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1860,9 +1864,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 On a successful authentication the server sends `Authenticated` and then,
 immediately after, a `ProtocolInfo` frame on every authenticated connection
-(both v2 and v3; only the `protocol_version` fields differ -- they are omitted
-on v2). Read and handle (or intentionally skip) the `ProtocolInfo` frame rather
-than treating it as unexpected.
+(both v2 and v3; v3-only fields such as `protocol_version` and `transports` are
+omitted on v2). Read and handle (or intentionally skip) the `ProtocolInfo` frame
+rather than treating it as unexpected.
 
 The `app_id` is a public identifier, not a secret. It is safe to embed in
 game builds. The server matches it against the `authorized_apps` list in the

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -995,8 +995,9 @@ The negotiated result is echoed back in an extended `ProtocolInfo` (the v2 field
 ```
 
 These v3-only fields are omitted from the wire for a negotiated v2 connection, so the v2 `ProtocolInfo` shape stays
-byte-identical. `transports` names the server message lanes available to the connection; today it is always
-`["websocket"]` for negotiated v3 and reserves a future advertisement point for another server relay lane.
+byte-identical. `ProtocolInfo.transports` names the server message lanes available to the connection; today it is
+always `["websocket"]` for negotiated v3 and reserves a future advertisement point for another server relay lane. It
+does not participate in the `Authenticate.supported_transports` data-path negotiation above.
 
 **Endpoints.** `/v2/ws` and `/v3/ws` share the same handler. `/v3/ws` only changes the _default_ protocol version
 to 3 when the client omits `protocol_version`; an explicit `protocol_version` in `Authenticate` always wins (then

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -973,8 +973,9 @@ The server clamps the negotiated version into its configured range:
 `min(client_max, max_protocol_version)` raised to at least `min_protocol_version`. A client that advertises a higher
 version than the deployment speaks is clamped **down** to `max_protocol_version`; one that omits the field is
 negotiated from the endpoint default (`/v2/ws` defaults to v2; `/v3/ws` defaults to v3). If the negotiated
-version is below 3, the connection is **relay-only** regardless of the advertised transports/topologies. If the
-negotiated version is 3 but transports/topologies are absent, the connection is v3 relay-only. Defaults:
+version is below 3, the connection is **relay-only** regardless of the advertised `supported_transports` /
+`supported_topologies`. If the negotiated version is 3 but `supported_transports` / `supported_topologies` are
+absent, the connection is v3 relay-only. Defaults:
 `min_protocol_version = 2`, `max_protocol_version = 3`.
 
 The negotiated result is echoed back in an extended `ProtocolInfo` (the v2 fields plus v3-only additions):

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -977,7 +977,7 @@ version is below 3, the connection is **relay-only** regardless of the advertise
 negotiated version is 3 but transports/topologies are absent, the connection is v3 relay-only. Defaults:
 `min_protocol_version = 2`, `max_protocol_version = 3`.
 
-The negotiated result is echoed back in an extended `ProtocolInfo` (the v2 fields plus three new ones):
+The negotiated result is echoed back in an extended `ProtocolInfo` (the v2 fields plus v3-only additions):
 
 ```json
 {
@@ -987,13 +987,15 @@ The negotiated result is echoed back in an extended `ProtocolInfo` (the v2 field
     "game_data_formats": ["json", "message_pack"],
     "protocol_version": 3,
     "min_protocol_version": 2,
-    "max_protocol_version": 3
+    "max_protocol_version": 3,
+    "transports": ["websocket"]
   }
 }
 ```
 
-The three new fields are omitted from the wire for a negotiated v2 connection, so the v2 `ProtocolInfo` shape stays
-byte-identical.
+These v3-only fields are omitted from the wire for a negotiated v2 connection, so the v2 `ProtocolInfo` shape stays
+byte-identical. `transports` names the server message lanes available to the connection; today it is always
+`["websocket"]` for negotiated v3 and reserves a future advertisement point for another server relay lane.
 
 **Endpoints.** `/v2/ws` and `/v3/ws` share the same handler. `/v3/ws` only changes the _default_ protocol version
 to 3 when the client omits `protocol_version`; an explicit `protocol_version` in `Authenticate` always wins (then

--- a/docs/scenarios/v3-mesh-webrtc.md
+++ b/docs/scenarios/v3-mesh-webrtc.md
@@ -46,7 +46,8 @@ The server replies with `Authenticated` (identical shape to the v2 scenario) fol
     "game_data_formats": ["json", "message_pack"],
     "protocol_version": 3,
     "min_protocol_version": 2,
-    "max_protocol_version": 3
+    "max_protocol_version": 3,
+    "transports": ["websocket"]
   }
 }
 ```

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -750,8 +750,8 @@ components:
       type: object
       description: >-
         Payload is a flattened ProtocolInfoPayload (newtype variant). v3 fields
-        protocol_version / min_protocol_version / max_protocol_version are absent
-        on negotiated v2 connections.
+        protocol_version / min_protocol_version / max_protocol_version /
+        transports are absent on negotiated v2 connections.
       properties:
         type: { const: ProtocolInfo }
         data:
@@ -772,6 +772,12 @@ components:
             protocol_version: { type: integer }
             min_protocol_version: { type: integer }
             max_protocol_version: { type: integer }
+            transports:
+              type: array
+              description: Server message transports available to this connection.
+              items:
+                type: string
+                enum: [websocket]
       required: [type, data]
     AuthenticationError:
       type: object

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -20,6 +20,7 @@ pub use types::{
     SessionPeer, SessionPlanPayload, SpectatorInfo, SpectatorStateChangeReason, Topology,
     Transport, DEFAULT_MAX_GAME_NAME_LENGTH, DEFAULT_MAX_PLAYERS_LIMIT,
     DEFAULT_MAX_PLAYER_NAME_LENGTH, DEFAULT_REGION_ID, DEFAULT_ROOM_CODE_LENGTH,
+    PROTOCOL_INFO_TRANSPORT_WEBSOCKET,
 };
 
 // From messages

--- a/src/protocol/types.rs
+++ b/src/protocol/types.rs
@@ -354,6 +354,9 @@ pub struct RateLimitInfo {
     pub per_day: u32,
 }
 
+/// ProtocolInfo transport token for the current WebSocket message lane.
+pub const PROTOCOL_INFO_TRANSPORT_WEBSOCKET: &str = "websocket";
+
 /// Describes negotiated protocol capabilities for a specific SDK.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolInfoPayload {
@@ -385,6 +388,12 @@ pub struct ProtocolInfoPayload {
     /// Highest protocol version this deployment speaks (v3+ only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_protocol_version: Option<u16>,
+    /// Server message transports available to this connection (v3+ only).
+    ///
+    /// `None` for negotiated v2 connections so the v2 wire contract stays
+    /// byte-identical.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transports: Option<Vec<String>>,
 }
 
 /// Describes the characters your deployment allows inside `player_name`.

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -5,6 +5,7 @@ use crate::coordination::{
 use crate::protocol::{
     ClientMessage, ErrorCode, GameDataEncoding, PlayerId, PlayerNameRulesPayload,
     ProtocolInfoPayload, RateLimitInfo, ServerMessage, Topology, Transport,
+    PROTOCOL_INFO_TRANSPORT_WEBSOCKET,
 };
 use crate::server::{EnhancedGameServer, NegotiatedProtocol, RegisterClientError};
 use axum::extract::ws::{Message, WebSocket};
@@ -971,14 +972,18 @@ pub(super) async fn handle_socket(
                                         response_protocol_version,
                                         response_min_protocol_version,
                                         response_max_protocol_version,
+                                        response_transports,
                                     ) = if negotiated_version >= 3 {
                                         (
                                             Some(negotiated_version),
                                             Some(min_protocol_version),
                                             Some(max_protocol_version),
+                                            Some(vec![
+                                                PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()
+                                            ]),
                                         )
                                     } else {
-                                        (None, None, None)
+                                        (None, None, None, None)
                                     };
                                     let protocol_info =
                                         ServerMessage::ProtocolInfo(ProtocolInfoPayload {
@@ -995,6 +1000,7 @@ pub(super) async fn handle_socket(
                                             protocol_version: response_protocol_version,
                                             min_protocol_version: response_min_protocol_version,
                                             max_protocol_version: response_max_protocol_version,
+                                            transports: response_transports,
                                         });
 
                                     enqueue_connection_message(

--- a/tests/protocol_v3_negotiation.rs
+++ b/tests/protocol_v3_negotiation.rs
@@ -8,7 +8,7 @@
 use serde_json::json;
 use signal_fish_server::protocol::{
     ClientMessage, GameDataEncoding, IceServer, PlayerId, ProtocolInfoPayload, ServerMessage,
-    SessionPeer, SessionPlanPayload, Topology, Transport,
+    SessionPeer, SessionPlanPayload, Topology, Transport, PROTOCOL_INFO_TRANSPORT_WEBSOCKET,
 };
 
 // ---------------------------------------------------------------------------
@@ -191,16 +191,18 @@ fn protocol_info_version_fields_skipped_when_none() {
         protocol_version: None,
         min_protocol_version: None,
         max_protocol_version: None,
+        transports: None,
     };
     let value = serde_json::to_value(&payload).unwrap();
     let obj = value.as_object().unwrap();
     assert!(!obj.contains_key("protocol_version"));
     assert!(!obj.contains_key("min_protocol_version"));
     assert!(!obj.contains_key("max_protocol_version"));
+    assert!(!obj.contains_key("transports"));
 }
 
 #[test]
-fn protocol_info_version_fields_present_when_some() {
+fn protocol_info_v3_fields_present_when_some() {
     let payload = ProtocolInfoPayload {
         platform: None,
         sdk_version: None,
@@ -213,11 +215,13 @@ fn protocol_info_version_fields_present_when_some() {
         protocol_version: Some(3),
         min_protocol_version: Some(2),
         max_protocol_version: Some(3),
+        transports: Some(vec![PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()]),
     };
     let value = serde_json::to_value(&payload).unwrap();
     assert_eq!(value["protocol_version"], json!(3));
     assert_eq!(value["min_protocol_version"], json!(2));
     assert_eq!(value["max_protocol_version"], json!(3));
+    assert_eq!(value["transports"], json!(["websocket"]));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/v2_wire_golden.rs
+++ b/tests/v2_wire_golden.rs
@@ -445,6 +445,7 @@ fn golden_server_protocol_info() {
         protocol_version: None,
         min_protocol_version: None,
         max_protocol_version: None,
+        transports: None,
     });
     assert_json(
         &msg,

--- a/tests/v3_multipeer_e2e.rs
+++ b/tests/v3_multipeer_e2e.rs
@@ -1319,6 +1319,31 @@ async fn expect_peer_transport_status(
     .await;
 }
 
+/// Assert no `PeerTransportStatus` arrives while draining known join-phase
+/// backlog. The duplicate-status contract is about no fan-out, not global
+/// silence from previously queued `PlayerJoined` / `LobbyStateChanged` events.
+async fn expect_no_peer_transport_status(ws: &mut WsStream, context: &str) {
+    assert!(
+        maybe_next_matching_server_message_within(
+            ws,
+            SILENCE_WINDOW,
+            context,
+            |message| match message {
+                ServerMessage::PeerTransportStatus { .. } => Some(()),
+                ServerMessage::PlayerJoined { .. } | ServerMessage::LobbyStateChanged { .. } => {
+                    None
+                }
+                other => panic!(
+                    "{context}: unexpected ServerMessage while checking no PeerTransportStatus: {other:?}"
+                ),
+            },
+        )
+        .await
+        .is_none(),
+        "{context}: duplicate TransportStatus must not fan out PeerTransportStatus"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn mesh_n3_transport_status_fan_out_and_dedup() {
     // One v3 member of an N=3 room reports TransportStatus { webrtc, true }:
@@ -1349,26 +1374,15 @@ async fn mesh_n3_transport_status_fan_out_and_dedup() {
     expect_peer_transport_status(&mut peer_b, "peer_b", id_a, Transport::WebRtc, true).await;
     expect_peer_transport_status(&mut peer_c, "peer_c", id_a, Transport::WebRtc, true).await;
 
-    // The reporter is excluded from its own fan-out (its join-phase backlog is
-    // drained here too, so the strict silence below is sound for it as well).
-    assert!(
-        maybe_next_matching_server_message_within(
-            &mut peer_a,
-            SILENCE_WINDOW,
-            "reporter echo check",
-            |message| matches!(message, ServerMessage::PeerTransportStatus { .. }).then_some(()),
-        )
-        .await
-        .is_none(),
-        "the reporter must never receive its own PeerTransportStatus"
-    );
+    // The reporter is excluded from its own fan-out.
+    expect_no_peer_transport_status(&mut peer_a, "reporter echo check").await;
 
-    // A byte-identical duplicate is dropped at the dedup gate: strict silence
-    // for every member (backlogs were fully consumed above).
+    // A byte-identical duplicate is dropped at the dedup gate: no
+    // PeerTransportStatus fans out to any member.
     report_transport_status(&mut peer_a, Transport::WebRtc, true).await;
-    expect_no_server_message_within(&mut peer_b, SILENCE_WINDOW, "peer_b after duplicate").await;
-    expect_no_server_message_within(&mut peer_c, SILENCE_WINDOW, "peer_c after duplicate").await;
-    expect_no_server_message_within(&mut peer_a, SILENCE_WINDOW, "reporter after duplicate").await;
+    expect_no_peer_transport_status(&mut peer_b, "peer_b after duplicate").await;
+    expect_no_peer_transport_status(&mut peer_c, "peer_c after duplicate").await;
+    expect_no_peer_transport_status(&mut peer_a, "reporter after duplicate").await;
 
     // The next REAL transition fans out again (the dedup gate is per-state,
     // not once-per-connection).

--- a/tests/v3_negotiation_e2e.rs
+++ b/tests/v3_negotiation_e2e.rs
@@ -9,7 +9,9 @@ mod websocket_test_helpers;
 
 use futures_util::SinkExt;
 use signal_fish_server::config::AppAuthEntry;
-use signal_fish_server::protocol::{ClientMessage, ServerMessage, Topology, Transport};
+use signal_fish_server::protocol::{
+    ClientMessage, ServerMessage, Topology, Transport, PROTOCOL_INFO_TRANSPORT_WEBSOCKET,
+};
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
 use signal_fish_server::websocket::{create_router, websocket_handler_v3};
 use std::sync::Arc;
@@ -168,6 +170,10 @@ async fn v3_client_negotiates_v3_and_protocol_info_reports_it() {
                 Some(3),
                 "default deployment ceiling is v3"
             );
+            assert_eq!(
+                info.transports,
+                Some(vec![PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()])
+            );
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -201,6 +207,10 @@ async fn v3_client_negotiates_v3_on_default_server() {
             assert_eq!(info.protocol_version, Some(3), "client asks 3 => gets 3");
             assert_eq!(info.min_protocol_version, Some(2));
             assert_eq!(info.max_protocol_version, Some(3));
+            assert_eq!(
+                info.transports,
+                Some(vec![PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()])
+            );
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -220,6 +230,10 @@ async fn future_v4_client_is_clamped_to_v3() {
                     info.protocol_version,
                     Some(3),
                     "client asks {asked:?} => clamped down to the build ceiling (3)"
+                );
+                assert_eq!(
+                    info.transports,
+                    Some(vec![PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()])
                 );
             }
             other => panic!("expected ProtocolInfo, got {other:?}"),
@@ -245,6 +259,7 @@ async fn v2_client_stays_v2_on_default_server() {
             );
             assert_eq!(info.min_protocol_version, None);
             assert_eq!(info.max_protocol_version, None);
+            assert_eq!(info.transports, None);
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -289,6 +304,7 @@ async fn v3_client_is_clamped_to_v2_when_deployment_caps_at_v2() {
                 "config-clamped server negotiates a v3 client down to 2 (frozen v2 ProtocolInfo)"
             );
             assert_eq!(info.max_protocol_version, None);
+            assert_eq!(info.transports, None);
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -314,11 +330,13 @@ async fn v2_client_omitting_fields_is_recorded_as_v2() {
             assert_eq!(info.protocol_version, None);
             assert_eq!(info.min_protocol_version, None);
             assert_eq!(info.max_protocol_version, None);
+            assert_eq!(info.transports, None);
             let value = serde_json::to_value(&info).expect("serializes");
             assert!(
                 value.get("protocol_version").is_none()
                     && value.get("min_protocol_version").is_none()
-                    && value.get("max_protocol_version").is_none(),
+                    && value.get("max_protocol_version").is_none()
+                    && value.get("transports").is_none(),
                 "negotiated v2 ProtocolInfo must not serialize v3-only keys: {value}"
             );
         }
@@ -348,6 +366,10 @@ async fn v3_ws_alias_defaults_to_v3_when_client_omits_version() {
                 info.protocol_version,
                 Some(3),
                 "/v3/ws path should default the omitted version to 3"
+            );
+            assert_eq!(
+                info.transports,
+                Some(vec![PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()])
             );
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
@@ -379,6 +401,7 @@ async fn v3_ws_alias_respects_explicit_client_version_over_path_default() {
             );
             assert_eq!(info.min_protocol_version, None);
             assert_eq!(info.max_protocol_version, None);
+            assert_eq!(info.transports, None);
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -402,6 +425,7 @@ async fn v2_ws_alias_defaults_to_v2_when_client_omits_version() {
     match authenticate(&mut ws, auth).await {
         ServerMessage::ProtocolInfo(info) => {
             assert_eq!(info.protocol_version, None);
+            assert_eq!(info.transports, None);
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -429,6 +453,10 @@ async fn auth_disabled_v3_ws_authenticate_still_negotiates_v3_webrtc() {
                 Some(3),
                 "auth-disabled /v3/ws Authenticate must still apply the path default"
             );
+            assert_eq!(
+                info.transports,
+                Some(vec![PROTOCOL_INFO_TRANSPORT_WEBSOCKET.to_string()])
+            );
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }
@@ -454,6 +482,7 @@ async fn auth_disabled_v3_ws_respects_explicit_v2_without_version_fields() {
             assert_eq!(info.protocol_version, None);
             assert_eq!(info.min_protocol_version, None);
             assert_eq!(info.max_protocol_version, None);
+            assert_eq!(info.transports, None);
         }
         other => panic!("expected ProtocolInfo, got {other:?}"),
     }


### PR DESCRIPTION
## Summary

- Add the v3-only `ProtocolInfo.transports` server-message transport advertisement.
- Populate negotiated-v3 handshakes with `["websocket"]` while preserving the frozen negotiated-v2 wire shape.
- Update protocol docs, AsyncAPI schema, canonical samples, changelog, and focused negotiation/golden tests.
- Keep the PR green by updating `crossbeam-epoch` for the current cargo-audit advisory and hardening the v3 transport-status dedup test against join-phase backlog.

## Why

P10.E8 reserves an explicit protocol seam for future server relay/message lanes without redesigning negotiation later. The change is intentionally narrow: it advertises the current WebSocket lane only for v3+ connections and omits the field for v2.

## Impact

v3 clients can read `ProtocolInfo.transports` to discover current server message lanes. v2 clients and v2 JSON/MessagePack goldens remain byte-identical because the field is omitted when negotiating v2. `ProtocolInfo.transports` is documented as separate from `Authenticate.supported_transports`, which remains the data-path negotiation input.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`
- `cargo deny check advisories`
- `cargo deny check`
- `./scripts/check-doc-consistency.sh`
- `cargo test --all-features --test docs_site_consistency`
- `cargo nextest run --all-features --test v3_multipeer_e2e`
- `git diff --check`
- GitHub PR checks on `31ebfd612ffd81f4bb145bee1b92745ff3078a80`: all passing, including Cursor Bugbot.
- Copilot reviewed `31ebfd612ffd81f4bb145bee1b92745ff3078a80` with no new comments; prior Copilot threads are resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive v3-only handshake field with v2 wire preserved; behavior change is limited to new metadata on v3 `ProtocolInfo` and stricter e2e assertions for transport-status dedup.
> 
> **Overview**
> **P10.E8** introduces a v3-only **`ProtocolInfo.transports`** array so clients learn which **server message lanes** are available on the connection. Negotiated **v3** handshakes now include **`["websocket"]`**; negotiated **v2** still **omit** the field (with the other v3-only keys) so v2 JSON/MessagePack goldens stay byte-identical.
> 
> The wire type gains `transports: Option<Vec<String>>` and a **`PROTOCOL_INFO_TRANSPORT_WEBSOCKET`** constant; the WebSocket auth path sets `transports` whenever `negotiated_version >= 3`. This is separate from **`Authenticate.supported_transports`** (P2P data-path negotiation).
> 
> Docs, AsyncAPI, canonical v3 samples, and changelog are updated. E2E coverage asserts `transports` across the negotiation matrix; **`mesh_n3_transport_status_fan_out_and_dedup`** now ignores join-phase **`PlayerJoined` / `LobbyStateChanged`** when asserting no duplicate **`PeerTransportStatus`** fan-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ebfd612ffd81f4bb145bee1b92745ff3078a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->