### PR TITLE
Document and prove the single-instance deployment contract

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -44,7 +44,7 @@ success-output = "never"
 # (plus, in its nightly-only tests, real client processes) and floods it, so
 # it shares the group for exactly the same isolation reasons.
 [[profile.default.overrides]]
-filter = 'binary(v3_multiprocess_e2e) or binary(multiprocess_delivery_e2e)'
+filter = 'binary(v3_multiprocess_e2e) or binary(multiprocess_delivery_e2e) or binary(split_brain_two_instances_e2e)'
 test-group = 'process-spawning'
 threads-required = 4
 

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -29,6 +29,9 @@
 #   - scenario-profiles: tests/scenario_realworld_e2e.rs with
 #     --run-ignored all — the PR-lane traffic profiles plus the nightly-only
 #     backgrounded-tab profile (multi-second absorbed pauses + eviction).
+#   - split-brain-catalog: tests/split_brain_two_instances_e2e.rs — two real
+#     server processes pin the unsupported multi-instance failure catalog used
+#     by the deployment doctrine.
 #
 # All targeted tests are `#[ignore]`d in-tree (a scheduling decision, not a
 # flakiness mask) and activated here with `--run-ignored all`. Job timeouts
@@ -54,6 +57,7 @@ on:
       - "tests/load_tests.rs"
       - "tests/multiprocess_delivery_e2e.rs"
       - "tests/scenario_realworld_e2e.rs"
+      - "tests/split_brain_two_instances_e2e.rs"
       - "tests/websocket_test_helpers/**"
       - "clients/native/**"
       - ".github/workflows/verification-nightly.yml"
@@ -399,3 +403,38 @@ jobs:
             tail -n 60 scenario-output.txt 2>/dev/null || echo "no scenario output captured"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+  split-brain-catalog:
+    name: Single-Instance Doctrine Catalog
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+      - name: Read Rust toolchain
+        id: toolchain
+        shell: bash
+        run: |
+          CHANNEL=$(bash scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
+          if [ -z "$CHANNEL" ]; then
+            echo "ERROR: Could not extract channel from rust-toolchain.toml"
+            exit 1
+          fi
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.channel }}
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2.82.9
+        with:
+          tool: cargo-nextest
+      - name: Run split-brain failure catalog
+        shell: bash
+        run: |
+          cargo nextest run --profile ci --locked --all-features \
+            --test split_brain_two_instances_e2e --run-ignored all

--- a/.gitignore
+++ b/.gitignore
@@ -68,5 +68,5 @@ site/
 
 progress/
 PLAN.md
-
+GOAL.md
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Document the single-instance deployment contract and prove its unsupported
+  multi-process failure modes with a nightly two-binary H5 experiment. Startup
+  logs now state that room/reconnect state is in-memory, room affinity is
+  required, and session handoff is unavailable. The scaling/deployment docs no
+  longer imply that generic sticky sessions provide horizontal safety. Added
+  ADR-0006 for the completed protocol-v3 delivery-reliability revision
+  (delivery classes, epoch, reconnect watermarks, drain, and WebSocket pings),
+  including the rejected/deferred feature cut list.
+
 - Add server-initiated RFC 6455 liveness probes (P10.E4). By default each
   connection receives a transport-level Ping every 10 seconds and must return
   the matching Pong within 5 seconds or close with `4003 activity_timeout`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multi-process failure modes with a nightly two-binary H5 experiment. Startup
   logs now state that room/reconnect state is in-memory, room affinity is
   required, and session handoff is unavailable. The scaling/deployment docs no
-  longer imply that generic sticky sessions provide horizontal safety. Added
-  ADR-0006 for the completed protocol-v3 delivery-reliability revision
+  longer imply that generic sticky sessions provide horizontal safety. Run-mode,
+  pre-deployment, configuration, API, and metrics descriptions now consistently
+  identify shipped coordination as process-local and remote coordination as a
+  future extension seam. Added ADR-0006 for the completed protocol-v3 delivery-reliability revision
   (delivery classes, epoch, reconnect watermarks, drain, and WebSocket pings),
   including the rejected/deferred feature cut list.
 

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ signal-fish-server/
 │   ├── lib.rs                   # Library crate root
 │   ├── server.rs                # EnhancedGameServer core
 │   ├── broadcast.rs             # Zero-copy broadcast primitives
-│   ├── distributed.rs           # In-memory distributed locking
+│   ├── distributed.rs           # In-memory coordination extension seams
 │   ├── logging.rs               # tracing-subscriber initialization
 │   ├── metrics.rs               # Atomic counters + HDR histograms
 │   ├── rate_limit.rs            # In-memory rate limiter

--- a/docs/adr/0006-protocol-v3-delivery-reliability.md
+++ b/docs/adr/0006-protocol-v3-delivery-reliability.md
@@ -1,0 +1,165 @@
+# Protocol v3 Delivery Reliability and Lifecycle Boundaries
+
+## Status
+
+ADR-0006 - Accepted
+
+## Context
+
+Protocol v3 was still pre-release when fault experiments exposed four holes in
+the original relay contract:
+
+- a sender's `seq` reset after a new room incarnation was not self-describing;
+- lossy/coalescing delivery could not be authorized by aggregate counters;
+- reconnect after replay truncation lacked a complete per-sender baseline; and
+- deploys and half-open sockets had no prompt, semantic lifecycle boundary.
+
+The revision had to preserve the frozen v2 wire exactly, keep relay as the
+universal floor, bound all server memory, and let a client classify every
+continuing-stream gap from causally prior wire evidence.
+
+## Decision
+
+Revise the single, unshipped protocol v3 in place. Do not introduce a separate
+protocol version for these changes.
+
+### Incarnations and reconnect baselines
+
+Every v3 relayed data frame carries `(epoch, seq)`. `epoch` identifies the
+sender's connection/room incarnation and increases when the sender rejoins or
+reconnects; `seq` starts again within that epoch. Room lifecycle snapshots
+announce epochs before data, and `Reconnected.sender_watermarks` atomically
+replaces the reconnecting recipient's baseline for every current sender.
+
+This makes reset and outage boundaries explicit without replaying high-rate
+game data. The composed
+[`EndToEndGapAccountability.tla`](../../formal/tla/EndToEndGapAccountability.tla)
+model proves the watermark is necessary to classify reconnect gaps from socket
+observations alone.
+
+### Delivery classes and exact accountability
+
+V3 JSON `GameData` supports three recipient-side delivery classes:
+
+- `reliable` retains bounded backpressure and fails closed;
+- keyed `latest` may supersede an older queued value for the same key; and
+- `volatile` may be omitted under pressure.
+
+Raw binary data and every v2 delivery remain reliable. Any permitted v3
+omission is authorized by a causally prior, bounded `DeliveryReport` carrying
+exact `(sender, epoch, inclusive sequence range, reason)` evidence. Aggregate
+counters are diagnostic only. A continuing same-epoch gap is valid only when
+the union of prior non-overlapping ranges covers every missing sequence.
+
+Priority lifecycle/accountability control may overtake an old data tail.
+Clients therefore retain its accounting cursor while suppressing stale
+application payload, require a lifecycle announcement for each future epoch,
+and treat room/spectator transitions and reconnect watermarks as generation
+barriers. The bounded 256-range report rollover and fail-closed queue behavior
+follow the formally checked
+[`DeliveryClasses.tla`](../../formal/tla/DeliveryClasses.tla) and
+[`ControlPriorityDelivery.tla`](../../formal/tla/ControlPriorityDelivery.tla)
+contracts.
+
+### Server lifecycle boundaries
+
+Planned shutdown uses a bounded drain: v3 clients may receive `GoingAway`, all
+remaining sockets close with `4000 server_shutdown`, new room creation stops,
+and no reconnect token is armed for the exiting in-memory instance.
+
+The socket layer sends RFC 6455 Ping probes independently of application
+queues. A missing matching Pong by the configured deadline closes with `4003
+activity_timeout`; successful replies refresh liveness and produce RTT metrics.
+This needs no protocol negotiation or browser/client release because compliant
+WebSocket stacks answer protocol Ping automatically.
+
+### Compatibility and future seam
+
+All new fields and messages are negotiated-v3 only. Projection strips them for
+pre-v3 recipients, and v2 JSON/MessagePack goldens remain byte-identical.
+`ProtocolInfo.transports = ["websocket"]` reserves discovery for a future
+server message lane without promising one today.
+
+## Explicit cut list
+
+- **Resume-from-sequence game-data replay:** rejected. Covering a 300-second
+  reconnect window for 16 senders at 60 messages/s and 1 KiB/message is about
+  281 MiB per room before overhead; a 1 MiB ring covers about 1.1 seconds.
+  Clients must handle truncation and application resync anyway. A future
+  latest-value-per-key snapshot may be considered only for a demonstrated use
+  case. See the [reconnection contract](../concepts/reconnection.md).
+- **WebTransport/QUIC relay now:** deferred. The capability seam is present,
+  but adding a production lane needs a mature implementation, deployment
+  evidence, and a fault/conformance matrix. The current contract advertises
+  only `websocket`; see [protocol negotiation](../protocol.md#protocolinfo).
+- **Multi-instance room sharding:** rejected for this revision. The shipped
+  state and coordination implementations are in-memory; split-brain seeds break
+  relay and replay invariants. Use the
+  [single-instance deployment contract](../architecture/single-instance-deployment.md).
+- **A separate `SeqReset` message:** rejected as redundant. The epoch appears
+  on data and lifecycle baselines, while reconnect watermarks replace every
+  sender cursor atomically; a second reset mechanism would create competing
+  truth sources.
+
+## Consequences
+
+### Positive
+
+- Every continuing v3 gap is either exactly authorized before observation or a
+  protocol violation.
+- Incarnation and reconnect resets are explicit per sender.
+- Lossy classes stay bounded and observable; reliable and v2 behavior remain
+  fail-closed.
+- Deploys and half-open sockets have semantic, measured close boundaries.
+- The frozen v2 wire remains unchanged.
+
+### Negative
+
+- V3 clients maintain per-sender/epoch cursors, exact-range unions, stale-tail
+  suppression, and generation barriers.
+- Exact reports consume priority-control capacity and can close a connection
+  when bounded accountability cannot be preserved.
+- Drain deliberately abandons in-memory rooms instead of handing them to a new
+  process.
+
+### Mitigations
+
+- The native and browser reference clients and `ConformanceAuditor` implement
+  the normative state machine.
+- JSON/MessagePack goldens, canonical samples, AsyncAPI, fuzzing, real-socket
+  tests, and formal seeded-bug models guard the wire and lifecycle rules.
+- V2 projection tests prevent new v3 state from leaking across negotiation.
+
+## Alternatives Considered
+
+### Aggregate loss counters only
+
+Rejected because a counter identifies neither sender, epoch, nor missing range
+and cannot authorize a specific gap.
+
+### One superseded-range scalar on the successor frame
+
+Rejected by the `ScalarInPlaceBug` formal trace: interleaved latest keys can
+make a successor-local scalar overstate a live value or require reordering.
+Exact reports remain causally prior without mutating successor payloads.
+
+### Replay all missed game data
+
+Rejected because bounded memory cannot cover the advertised reconnect window at
+game traffic rates, and applications still require state resynchronization for
+truncation and process loss.
+
+### Introduce protocol v4
+
+Rejected because v3 was not live. Revising the pre-release version avoids
+shipping two overlapping contracts and keeps v2 as the only compatibility
+floor.
+
+## References
+
+- [Protocol reference](../protocol.md) — normative wire and client rules
+- [Reconnection](../concepts/reconnection.md) — tokens, watermarks, and resync
+- [Transport fallback](../architecture/transport-fallback.md) — relay floor
+- [Formal verification](../architecture/formal-verification.md) — model scope
+- [Single-instance deployment](../architecture/single-instance-deployment.md)
+- [ADR-0001](0001-protocol-v3-two-axis.md) — original v3 topology/transport decision

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ ADRs are immutable once accepted. If a decision needs to be changed, a new ADR s
 | [ADR-0003](0003-formal-verification-and-fuzzing.md) | Formal Verification and Fuzzing for the Protocol v3 Session Core | Accepted |
 | [ADR-0004](0004-native-reference-client.md) | Native Reference Client with a Real WebRTC Stack | Accepted |
 | [ADR-0005](0005-browser-reference-client.md) | Browser Reference Client on Real Headless Chromium | Accepted |
+| [ADR-0006](0006-protocol-v3-delivery-reliability.md) | Protocol v3 Delivery Reliability and Lifecycle Boundaries | Accepted |
 
 > Numbering note: the legacy `ADR-001` (3-digit) predates the current `ADR-0001` 4-digit scheme.
 > New ADRs use the 4-digit `ADR-NNNN` form; the legacy ID is preserved as-is to keep existing links stable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,9 @@ App-based authentication and per-app rate limiting.
 
 **Location:** `src/coordination/`
 
-Distributed coordination primitives for multi-instance deployments.
+In-memory coordination primitives and extension seams. The shipped
+implementations do not coordinate multiple server processes; see the
+[single-instance deployment contract](architecture/single-instance-deployment.md).
 
 - `room_coordinator.rs` - Room operation coordination
 - `dedup.rs` - Deduplication cache (LRU)
@@ -239,17 +241,18 @@ Recommended per instance:
 
 ### Multi-Instance Deployment
 
-For horizontal scaling:
-
-1. **Session affinity** - Route by game_name or room_code at load balancer
-2. **Room sharding** - Distribute rooms across instances
-3. **Coordination** - Use `RoomOperationCoordinator` for distributed locking
+Transparent multi-instance deployment is not supported. `RoomOperationCoordinator`
+and `DistributedLock` use in-memory implementations and cannot preserve a room
+across processes. Run one active process per routing domain, or use an external
+directory that assigns isolated room homes before WebSocket connection. See
+[Single-Instance Deployment](architecture/single-instance-deployment.md).
 
 ### Storage Options
 
 - **In-Memory** (default) - Fast, ephemeral, no external dependencies
-- **Redis** - Implement `GameDatabase` trait with Redis backend
-- **PostgreSQL** - Implement `GameDatabase` trait with PostgreSQL backend
+- Custom persistent backends would require a separately designed distributed
+  authority and routing protocol; implementing `GameDatabase` alone is not
+  sufficient for multi-instance safety.
 
 ## Security Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,7 +105,8 @@ See:
 - [Transport Fallback (v3)](architecture/transport-fallback.md)
 - [Handoff & Topologies (v3)](architecture/handoff-and-topologies.md)
 - [Formal Verification (v3)](architecture/formal-verification.md)
-- [Scaling (Multi-Node)](architecture/scaling.md)
+- [Single-Instance Deployment](architecture/single-instance-deployment.md)
+- [Scaling](architecture/scaling.md)
 
 ### Configuration
 

--- a/docs/architecture/formal-verification.md
+++ b/docs/architecture/formal-verification.md
@@ -121,6 +121,32 @@ in
 each with the suite that covers
 it instead.
 
+## Single-instance theorems
+
+The formal suite makes the single-instance correctness boundary executable via
+two seeded counterexamples (full table in
+[`formal/README.md`](https://github.com/Ambiguous-Interactive/signal-fish-server/blob/main/formal/README.md)):
+
+- **`SplitBrainStampBug`** in
+  [`SequencedRelay.tla`](https://github.com/Ambiguous-Interactive/signal-fish-server/blob/main/formal/tla/SequencedRelay.tla)
+  — a second instance stamps the same sender's stream from an independent
+  counter (`counter2`); a no-affinity load balancer collapses both onto one
+  recipient queue, producing interleaved duplicate/regressing `seq` values that
+  violate `GapAccountable` in four actions.
+- **`SplitBrainCounterBug`** in
+  [`ReconnectReplay.tla`](https://github.com/Ambiguous-Interactive/signal-fish-server/blob/main/formal/tla/ReconnectReplay.tla)
+  — the reconnect is served by a second instance that created the room fresh
+  (empty ring, zero watermark, its own `next_sequence`); the empty replay drops
+  retained needed events, violating `ReplayFaithful` in three actions.
+  `StatusHonest` is also violated at five actions (masked by `ReplayFaithful`
+  failing first unless it is removed from `INVARIANTS`).
+
+The composed
+[`EndToEndGapAccountability.tla`](https://github.com/Ambiguous-Interactive/signal-fish-server/blob/main/formal/tla/EndToEndGapAccountability.tla)
+model proves these single-instance behaviors compose correctly. These
+counterexamples are the formal complement to the nightly two-process test in
+`tests/split_brain_two_instances_e2e.rs`.
+
 ## Correspondence-maintenance rule
 
 The TLA+ spec mirrors `src/server/session_policy.rs`, `src/server/signaling.rs`,

--- a/docs/architecture/scaling.md
+++ b/docs/architecture/scaling.md
@@ -1,123 +1,96 @@
-# Scaling Architecture (Multi-Node Signaling)
+# Scaling Architecture
 
-How to scale Signal Fish Server horizontally. The short version: the server holds
-only per-room, in-memory peer-routing state, so the natural scaling unit is the
-**room** — keep all of a room's peers on one node (room affinity) and every
-forwarding path stays in-process. No cross-node infrastructure is required until
-a single room must span nodes, which is explicitly out of scope today.
+Signal Fish Server scales **up** within one process. The shipped server does not
+provide transparent horizontal scaling: all room and reconnect state is
+in-memory, and a WebSocket is assigned to a process before its `JoinRoom`
+message supplies a room code. Read the
+[single-instance deployment contract](single-instance-deployment.md) before
+placing the server behind a load balancer.
 
-## What state a node actually holds
+## What state a process holds
 
-A signaling node is deliberately light. Per process it keeps, all in memory:
+A process keeps all authoritative state in memory:
 
-- **Room state** — rooms, room codes, players, lobby/ready state, held in the
-  in-memory database (`InMemoryDatabase`, hash maps under async locks).
-- **Peer routing** — one registered message channel per connected client, used to
-  deliver `ServerMessage`s to that client's WebSocket.
+- rooms, room codes, players, spectators, lobby and ready state;
+- one registered delivery route per connected client;
+- reconnection records, replay events, and token claims;
+- relay `(epoch, seq)` counters and delivery-accountability state; and
+- v3 session plans and transport status.
 
-Everything the server forwards is routed from that state:
+Every forwarding decision reads that local state. Relay-floor `GameData` fans
+out over local channels; WebRTC `Signal` validates both peers against the local
+room; session plans are computed from local membership. No shipped component
+replicates those facts to another process.
 
-- **Relay-floor `GameData`** fans out to the sender's room via
-  `broadcast_to_room_except` — an in-process loop over the room's registered
-  channels.
-- **WebRTC `Signal` relay** (v3) delivers each opaque offer/answer/candidate to
-  one target peer after validating, against local room state, that sender and
-  target share a room.
-- **`SessionPlan` emission** (finalization, host failover, late join) is computed
-  from the room's members and delivered to them.
+## The room is the conceptual scaling unit
 
-There is no per-message persistence and no cross-room state. When the last room
-on a node empties, the node holds nothing worth migrating.
+Rooms are independent within one process: two rooms never exchange messages,
+and v3 enforces same-room signaling on every hop. That makes a room the natural
+unit for a **future external routing layer**, but Signal Fish does not implement
+that layer.
 
-## The room is the scaling unit
+An application-owned directory may assign rooms to separate, isolated Signal
+Fish deployments and give clients a deployment-specific WebSocket URL before
+they connect. `server.room_code_prefix` can make generated codes carry a
+deployment hint (for example `EU7K2X`), but the prefix is only a hint: the server
+does not resolve it, redirect a WebSocket, or prevent another process from
+creating the same code. Adding or removing homes while rooms are live requires
+application-level drain and rebuild, not consistent-hash remapping.
 
-Because every forwarding decision is "look up the room, write to its members'
-channels", the only constraint a deployment must preserve is:
+Two consequences follow:
 
-> **All peers of a room are connected to the same node.**
+- Relay and signaling share the same boundary. A room's `GameData`, WebRTC
+  signals, reconnects, and re-plans must all use its one home process.
+- WebRTC can reduce server bandwidth after P2P establishment, but it does not
+  make room control state portable. The WebSocket relay remains the fallback.
 
-Within that constraint, rooms are independent — two rooms never exchange
-messages, and the v3 protocol enforces same-room signaling on every hop. So
-horizontal scale is achieved by **room affinity**: partition rooms across nodes
-and route each client to the node that owns its room.
+## Cross-process fan-out is not implemented
 
-Practically, route on a stable room key at the load-balancer / session-affinity
-layer — for example a consistent hash of the room identity (`game_name` +
-`room_code`) supplied at connection time, so adding or removing nodes remaps a
-minimal share of rooms. The server also helps the room code itself carry the
-routing hint: `server.room_code_prefix` prepends a configured, deployment-specific
-prefix to every generated room code (`generate_region_room_code`), so a code like
-`EU7K2X` (prefix `EU` plus a random tail) tells the edge which deployment hosts
-the room before any lookup.
+A message bus and shared database would be necessary but not sufficient for a
+room to span processes. The code contains extension seams:
 
-Two consequences fall out of room affinity:
+- `MessageCoordinator` abstracts send-to-player and broadcast-to-room;
+- `SequencedMessage` is an envelope with origin and targeting metadata; and
+- `DistributedLock` abstracts room-operation locking.
 
-- **Relay and signaling share the same constraint.** The relay floor
-  (`GameData` fan-out) and WebRTC signal forwarding both route within one room,
-  so a deployment that satisfies affinity for one satisfies it for both — no new
-  topology is introduced by enabling v3 upgrades.
-- **WebRTC offloads the heavy traffic anyway.** Once a room upgrades to a P2P
-  transport, game data flows peer-to-peer (or via TURN) and the signaling node
-  carries only the occasional re-plan or fallback traffic.
+Their shipped implementations are in-memory. They do not provide a shared room
+directory, consensus, sequence ownership, global deduplication, reconnect token
+handoff, or cross-process delivery. Treat them as local coordination tools and
+future seams, not as distributed behavior.
 
-## Cross-node fan-out is out of scope (but the seams exist)
+## Multi-region hints
 
-Redis pub/sub (or any message bus) between signaling nodes is only needed if a
-single room may span nodes. Today it may not: the shipped implementations are
-in-memory and single-process by design — the zero-dependency posture.
+`server.region_id` and `server.room_code_prefix` anticipate an external routing
+layer:
 
-The code does keep the seams a multi-node implementation would plug into, so the
-path is anticipated rather than precluded:
+- every room/player record carries the local region internally; and
+- generated room codes may carry a deployment-specific prefix.
 
-- `MessageCoordinator` (`src/coordination/mod.rs`) abstracts
-  send-to-player / broadcast-to-room behind a trait; the in-memory implementation
-  (`InMemoryMessageCoordinator` in `src/server.rs`) also implements
-  `handle_bus_message`, the entry point a cross-instance bus would call with a
-  `SequencedMessage`.
-- `SequencedMessage` (`src/distributed.rs`) wraps a `ServerMessage` with a
-  sequence id, originating instance id, and room/player targeting — the envelope
-  for cross-node delivery and deduplication.
-- `DistributedLock` (`src/distributed.rs`) abstracts cross-instance locking; the
-  in-memory `InMemoryDistributedLock` is what runs today.
+Neither changes protocol behavior. A prefix or region ID does not make a
+reconnect token routable and does not establish room affinity by itself.
 
-Until a concrete multi-node room requirement exists, prefer adding nodes with
-room affinity over wiring a bus: it preserves in-process forwarding latency and
-keeps the server dependency-free.
+## Capacity drivers
 
-## Multi-region anticipation: `region_id`
+- **Connections and rooms:** see the
+  [resource requirements](../deployment.md#resource-requirements) for current
+  per-process guidance.
+- **Relay-floor bandwidth:** rooms that do not upgrade to P2P keep all
+  `GameData` on the process, so message rate, payload size, and recipient fanout
+  dominate network and queue pressure.
+- **P2P signaling:** after WebRTC establishment, the process normally carries
+  only control, signaling, and fallback traffic.
+- **TURN:** TURN relay bandwidth is operated separately from the signaling
+  process; see the [TURN deployment guide](../deployment-turn.md).
 
-Multi-region routing is anticipated by existing `region_id` plumbing, which is
-internal-only today:
-
-- `server.region_id` (config, default `"default"`) identifies the deployment
-  region a node belongs to; the running server exposes it via
-  `GameServer::region_id()`.
-- Every `Room` records the `region_id` of the deployment hosting it, and each
-  stored `PlayerInfo` records the region currently hosting that player. The
-  player-side field is marked internal-only and is never serialized to the wire.
-- `server.room_code_prefix` complements this by letting generated room codes
-  carry a region/deployment discriminator, so a future cross-region directory
-  can route a join by code alone.
-
-None of this changes protocol behavior yet — it is the bookkeeping a
-region-aware routing layer would build on.
-
-## Capacity notes
-
-- **Signaling is light.** A node brokers small JSON/binary messages; see the
-  [resource requirements](../deployment.md#resource-requirements) for per-node
-  sizing (hundreds of rooms / thousands of players per instance).
-- **TURN bandwidth dominates cost.** Plan for 15–20% of P2P connections to be
-  relayed through TURN; that relay bandwidth, not signaling CPU, is the dominant
-  infrastructure cost of a WebRTC deployment. See the
-  [TURN deployment guide](../deployment-turn.md) for cost figures and setup.
-- **The relay floor is the elastic dimension.** Rooms that never upgrade to P2P
-  keep all `GameData` on the signaling node, so the share of relay-floor rooms —
-  not raw room count — drives per-node bandwidth.
+These are operational starting points, not measured saturation guarantees. The
+P10.F2 sizing table remains pending the planned 16-player knee and partition
+experiments.
 
 ## Related documents
 
-- [Deployment guide](../deployment.md) — scaling considerations, resources
+- [Single-instance deployment contract](single-instance-deployment.md) — the
+  supported topology and proven split-brain failure catalog
+- [Deployment guide](../deployment.md) — process/container operation
 - [TURN deployment guide](../deployment-turn.md) — relay capacity and cost
-- [Transport Fallback Contract](transport-fallback.md) — the relay floor
+- [Transport fallback](transport-fallback.md) — the relay floor
 - [Handoff and topologies](handoff-and-topologies.md) — session plan emission

--- a/docs/architecture/single-instance-deployment.md
+++ b/docs/architecture/single-instance-deployment.md
@@ -58,7 +58,7 @@ The formal suite makes the same boundary executable. `SplitBrainStampBug` in
 `SequencedRelay.tla` breaks gap accountability when two instances stamp one
 logical sender independently. `SplitBrainCounterBug` in `ReconnectReplay.tla`
 breaks replay faithfulness and status honesty when a reconnect lands on a fresh
-instance. See [Single-instance theorems](formal-verification.md) for the model
+instance. See [Single-instance theorems](formal-verification.md#single-instance-theorems) for the model
 scope and seeded counterexamples.
 
 ## Load balancer and drain behavior

--- a/docs/architecture/single-instance-deployment.md
+++ b/docs/architecture/single-instance-deployment.md
@@ -1,0 +1,104 @@
+# Single-Instance Deployment Contract
+
+Signal Fish Server is a **single-instance, in-memory room server**. One running
+process is the only authority for every room it hosts. Its room membership,
+WebSocket routes, reconnection records, relay sequence/epoch counters, replay
+ring, and active session plan are not shared with another process.
+
+This is a correctness boundary, not merely a deployment recommendation:
+
+> A room has exactly one home process. Every connection and reconnect for that
+> room must reach that process for the room's lifetime. Losing the home process
+> loses the room.
+
+The server logs this contract at startup as structured fields:
+`deployment_mode=single_instance`, `room_state=in_memory`,
+`room_affinity_required=true`, and `session_handoff=false`.
+
+## What one home means
+
+Keep all of these operations on the same process:
+
+- creating or joining a room;
+- reconnecting with a room token;
+- relay-floor `GameData` fan-out;
+- v3 WebRTC `Signal` relay and session re-planning; and
+- spectator joins and room lifecycle updates.
+
+Connection-level cookie or source-IP stickiness is insufficient unless it also
+guarantees the same room home. A client opens its WebSocket before it sends
+`JoinRoom`, so a conventional load balancer cannot route the initial upgrade by
+`room_code` unless an application-owned edge supplies that routing key outside
+the WebSocket protocol. Reconnect tokens also carry no routable instance hint.
+
+The safe supported deployment is one active Signal Fish process per routing
+domain. You may run several isolated deployments when an application-owned
+directory assigns each newly created room to one deployment and routes **every**
+participant to that deployment before the WebSocket upgrade. Signal Fish does
+not provide that directory, migrate a live room, or coordinate a room across
+processes.
+
+## Proven failure catalog
+
+The nightly two-process H5 experiment
+(`tests/split_brain_two_instances_e2e.rs`) runs the real binary twice and pins
+the unsupported behavior:
+
+| Misrouted operation | Observed result | Why |
+| --- | --- | --- |
+| Join the same `(game_name, room_code)` on process B after creation on process A | B silently creates a second room with the same public code and a different `room_id`; each room contains only its local player | Join-by-code creates an unknown room locally; there is no shared room directory |
+| Present A's real reconnect identity and token to B | `ReconnectionFailed` / `RECONNECTION_FAILED`, “No disconnection record found” | Reconnection records and token claims are process-local |
+| Signal from A's player to B's player ID | `SignalTargetNotFound`, “Signal target is not in any room” | B's player is absent from A's local registry, so A cannot even classify it as a different local room |
+
+These are clean local responses, but together they are a silent split brain at
+the application level. Health checks can remain green on both processes while
+the logical room is partitioned.
+
+The formal suite makes the same boundary executable. `SplitBrainStampBug` in
+`SequencedRelay.tla` breaks gap accountability when two instances stamp one
+logical sender independently. `SplitBrainCounterBug` in `ReconnectReplay.tla`
+breaks replay faithfulness and status honesty when a reconnect lands on a fresh
+instance. See [Single-instance theorems](formal-verification.md) for the model
+scope and seeded counterexamples.
+
+## Load balancer and drain behavior
+
+For the supported single-active deployment:
+
+1. Route readiness/health checks to `/v2/health`.
+2. Before planned maintenance, remove the process from new connection routing.
+3. Send `SIGTERM` (or Ctrl-C) and allow at least `server.drain_grace_secs`.
+4. The server rejects new upgrades, sends v3 `GoingAway`, and closes remaining
+   sockets with `4000 server_shutdown`.
+5. Clients create or join a fresh room after drain; they must not reconnect to
+   the exiting process, and the drain deliberately does not arm reconnect state.
+
+If an external room directory fronts multiple isolated deployments, it must
+stop assigning **new rooms** to a draining home before `SIGTERM`. Existing rooms
+are not handed off: clients receive the drain boundary and rebuild elsewhere.
+An unexpected process or host loss has the same room-loss outcome without the
+advisory.
+
+## What does not provide multi-instance safety
+
+The `DistributedLock`, `MessageCoordinator`, `SequencedMessage`, `region_id`,
+and room-code-prefix types are extension seams or local coordination tools.
+Their shipped implementations are in-memory. They do not provide shared
+storage, consensus, a cross-instance message bus, global deduplication, or
+reconnection/session handoff.
+
+Do not infer multi-instance support from those names. Supporting a room across
+processes would require a separately designed and verified distributed room
+authority, routing directory, message bus, shared reconnect state, and sequence
+ownership protocol. That system is out of scope for the current zero-external-
+runtime-dependency server.
+
+## Related documents
+
+- [Scaling architecture](scaling.md) — scale-up guidance and future extension
+  seams within this contract
+- [Deployment guide](../deployment.md) — process and container operation
+- [Reconnection](../concepts/reconnection.md) — token lifetime and drain rules
+- [Protocol](../protocol.md#goingaway) — `GoingAway` and close code `4000`
+- [Formal verification](formal-verification.md) — executable single-instance
+  theorem boundary

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,10 +171,10 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__AUTH__RATE_LIMIT_CACHE_CLEANUP_INTERVAL_SECS` | `auth.rate_limit_cache_cleanup_interval_secs` | `300` | Auth rate-limit cache cleanup interval |
 | `SIGNAL_FISH__AUTH__RATE_LIMIT_CACHE_RETENTION_SECS` | `auth.rate_limit_cache_retention_secs` | `172800` | Auth rate-limit cache retention window |
 | `SIGNAL_FISH__AUTH__RATE_LIMIT_CACHE_ALERT_ROWS` | `auth.rate_limit_cache_alert_rows` | `100000` | Auth rate-limit cache warning threshold |
-| `SIGNAL_FISH__COORDINATION__DEDUP_CACHE__CAPACITY` | `coordination.dedup_cache.capacity` | `100000` | Cross-instance dedup cache capacity |
-| `SIGNAL_FISH__COORDINATION__DEDUP_CACHE__TTL_SECS` | `coordination.dedup_cache.ttl_secs` | `60` | Cross-instance dedup cache TTL |
-| `SIGNAL_FISH__COORDINATION__DEDUP_CACHE__CLEANUP_INTERVAL_SECS` | `coordination.dedup_cache.cleanup_interval_secs` | `30` | Cross-instance dedup cache cleanup interval |
-| `SIGNAL_FISH__COORDINATION__MEMBERSHIP_SNAPSHOT_INTERVAL_SECS` | `coordination.membership_snapshot_interval_secs` | `30` | Membership snapshot interval |
+| `SIGNAL_FISH__COORDINATION__DEDUP_CACHE__CAPACITY` | `coordination.dedup_cache.capacity` | `100000` | In-memory coordinator dedup cache capacity (future-backend seam; not cross-process coordination) |
+| `SIGNAL_FISH__COORDINATION__DEDUP_CACHE__TTL_SECS` | `coordination.dedup_cache.ttl_secs` | `60` | In-memory coordinator dedup cache TTL |
+| `SIGNAL_FISH__COORDINATION__DEDUP_CACHE__CLEANUP_INTERVAL_SECS` | `coordination.dedup_cache.cleanup_interval_secs` | `30` | In-memory coordinator dedup cache cleanup interval |
+| `SIGNAL_FISH__COORDINATION__MEMBERSHIP_SNAPSHOT_INTERVAL_SECS` | `coordination.membership_snapshot_interval_secs` | `30` | Reserved membership-snapshot seam; the shipped coordinator is process-local |
 | `SIGNAL_FISH__METRICS__DASHBOARD_CACHE_REFRESH_INTERVAL_SECS` | `metrics.dashboard_cache_refresh_interval_secs` | `5` | Dashboard metrics refresh interval |
 | `SIGNAL_FISH__METRICS__DASHBOARD_CACHE_TTL_SECS` | `metrics.dashboard_cache_ttl_secs` | `30` | Dashboard metrics cache TTL |
 | `SIGNAL_FISH__METRICS__DASHBOARD_CACHE_HISTORY_WINDOW_SECS` | `metrics.dashboard_cache_history_window_secs` | `300` | Dashboard history window |

--- a/docs/deployment-turn.md
+++ b/docs/deployment-turn.md
@@ -173,8 +173,8 @@ hardening items in the [security checklist](deployment.md#security-checklist).
   pricing) this dwarfs the cost of running the signaling server itself.
 - **Signaling is light.** The signaling server only brokers small JSON messages
   (session plans, SDP/ICE signals, relay-floor `GameData`); see the
-  [scaling architecture notes](architecture/scaling.md) for how to scale it
-  horizontally.
+  [scaling architecture notes](architecture/scaling.md) for vertical capacity
+  drivers and externally routed isolated deployments.
 - **STUN is effectively free.** Public or self-hosted STUN handles the ~80–85% of
   connections that can hole-punch; only the remainder consumes TURN relay
   bandwidth.
@@ -184,6 +184,7 @@ hardening items in the [security checklist](deployment.md#security-checklist).
 - [Deployment guide](deployment.md) — Docker, reverse proxies, cloud providers
 - [TURN and STUN configuration reference](configuration.md#turn-and-stun-ice-credentials-protocol-v3)
 - [Transport Fallback Contract](architecture/transport-fallback.md) — the relay floor
-- [Scaling architecture notes](architecture/scaling.md) — multi-node signaling
+- [Scaling architecture notes](architecture/scaling.md) — single-process capacity
+  and future extension seams
 - [Protocol v3 ICE and TURN credentials](protocol.md#ice-and-turn-credentials)
 - [Platform Integration Guide](guides/platform-integration.md) — which client stacks consume these credentials

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -466,4 +466,5 @@ Enable file logging:
 - [Configuration](configuration.md) - Full configuration reference
 - [Authentication](authentication.md) - Securing your server
 - [TURN Deployment](deployment-turn.md) - TURN relay for WebRTC sessions
-- [Scaling Architecture](architecture/scaling.md) - Multi-node signaling
+- [Scaling Architecture](architecture/scaling.md) - Single-process capacity and
+  externally routed isolated deployments

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -387,19 +387,23 @@ scrape_configs:
 
 ## Scaling Considerations
 
-Signal Fish Server uses in-memory storage, so each instance maintains its own room state. For multi-instance
-deployments:
+Signal Fish Server's supported topology is one active, in-memory process per
+routing domain. A room, its WebSocket routes, reconnect records, and relay
+counters all live on that process; losing it loses the room. Generic load-
+balancer stickiness is not enough because the room code arrives after the
+WebSocket upgrade.
 
-1. **Session affinity** - Use sticky sessions at the load balancer
-2. **Room sharding** - Route by game_name or room_code so all of a room's peers land on the same instance
-3. **Health checks** - Monitor each instance independently
-4. **Graceful shutdown** - Allow in-flight connections to complete
+Scale the process vertically, or place an application-owned room directory in
+front of separate deployments so it selects the room home **before** clients
+connect. Do not put interchangeable active processes behind a round-robin or
+cookie-sticky load balancer: a misrouted join can silently create a second room
+with the same public code.
 
-The room is the scaling unit: all forwarding (relay-floor `GameData` and v3 WebRTC
-signaling) happens within a single room, so room affinity is the only constraint a
-multi-instance deployment must preserve. See the
-[scaling architecture notes](architecture/scaling.md) for the full reasoning,
-the cross-node seams in the code, and the `region_id` / room-code-prefix plumbing.
+See the
+[single-instance deployment contract](architecture/single-instance-deployment.md)
+for the proven two-process failure catalog and drain procedure, and the
+[scaling architecture notes](architecture/scaling.md) for capacity drivers and
+future extension seams.
 
 ## Resource Requirements
 

--- a/docs/pre-deployment-checklist.md
+++ b/docs/pre-deployment-checklist.md
@@ -106,13 +106,20 @@ cargo run -- --print-config
   `server.reconnection_window` and `server.event_buffer_size` match how long and
   how much you want to buffer for replay.
 
-## Multi-node (if applicable)
+## Deployment topology
 
-- [ ] Each node has a distinct `server.room_code_prefix` so the load balancer can
-  pin a room's peers to one node (room affinity is the only hard constraint).
-- [ ] `server.region_id` set for observability.
-- [ ] `coordination.*` intervals reviewed if running cross-instance coordination.
-- [ ] See the [scaling architecture notes](architecture/scaling.md).
+- [ ] One active Signal Fish process serves each routing domain; no generic
+  round-robin or cookie-sticky load balancer fronts interchangeable processes.
+- [ ] If operating several isolated deployments, an application-owned directory
+  assigns the room home before the WebSocket upgrade and routes every initial
+  connection and reconnect for that room to the same process.
+- [ ] `server.room_code_prefix` and `server.region_id`, if set, are treated as
+  routing/observability metadata rather than shared-state coordination.
+- [ ] The load balancer stops sending new connections before `SIGTERM`, and its
+  timeout allows at least `server.drain_grace_secs` for the close boundary.
+- [ ] Review the
+  [single-instance deployment contract](architecture/single-instance-deployment.md)
+  and [scaling architecture notes](architecture/scaling.md).
 
 ## Final smoke test
 

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -32,7 +32,7 @@ v2 relay floor, so enabling v3 never breaks a v2-only client.
 | TLS (built-in) | Terminates HTTPS/`wss://` in the server itself | `security.transport.tls.enabled=true`, `security.transport.tls.certificate_path`, `security.transport.tls.private_key_path` (env: `SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED=true`) | `cargo run` (with the three TLS keys set) |
 | TLS (reverse proxy) | Terminates TLS at nginx/Caddy; server stays plain `ws://` on loopback | none on the server; configure the proxy (see [reverse proxy setup](deployment.md#reverse-proxy-setup)) | `cargo run` (server) + proxy in front |
 | Metrics + Prometheus | Exposes JSON + Prometheus metrics, optionally behind a bearer token | `security.require_metrics_auth=true`, `security.metrics_auth_token=<token>` (env: `SIGNAL_FISH__SECURITY__METRICS_AUTH_TOKEN`) | `SIGNAL_FISH__SECURITY__METRICS_AUTH_TOKEN="$(openssl rand -hex 32)" SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=true cargo run` |
-| Multi-node behind a load balancer | Several instances share a fleet; room-code prefixes give the LB an affinity key so a room's peers land on one node | `server.room_code_prefix="us-east-"`, `server.region_id="us-east"` (env: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east-`) | `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east- SIGNAL_FISH__SERVER__REGION_ID=us-east cargo run` |
+| Externally routed isolated deployments | An application-owned directory chooses one independent, single-process room home before any peer opens its WebSocket; Signal Fish does not share or hand off room state | Optional observability metadata: `server.room_code_prefix="us-east-"`, `server.region_id="us-east"` (env: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east-`) | After deploying the external directory: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east- SIGNAL_FISH__SERVER__REGION_ID=us-east cargo run` |
 
 Per-feature JSON snippets (with env equivalents and "when to use") live in the
 [configuration recipes](configuration-recipes.md).
@@ -148,13 +148,19 @@ Prometheus at `/metrics/prom` (see
 [metrics-auth recipe](configuration-recipes.md#metrics-auth) covers the scrape
 config with a bearer token.
 
-### Multi-node behind a load balancer
+### Externally routed isolated deployments
 
-The server uses in-memory state, so each instance owns its own rooms. The **room
-is the scaling unit**: all forwarding for a room happens on one node, so the only
-constraint a fleet must preserve is room affinity. Give each node a distinct
-`server.room_code_prefix` so generated room codes carry a routable prefix the
-load balancer can hash on, and set `server.region_id` for observability:
+Signal Fish does not support a fleet of interchangeable active processes behind
+a generic load balancer. Room state, reconnect tokens, routes, and sequence
+counters are process-local, and the room code arrives only after the WebSocket
+upgrade. Neither cookie stickiness nor `server.room_code_prefix` can establish
+the required room home by itself.
+
+You may operate several isolated deployments only when an application-owned
+directory chooses the home **before** clients connect and sends every initial
+connection and reconnect for that room to the same process. A prefix can be part
+of that external routing scheme, and `server.region_id` can label metrics, but
+both are metadata rather than coordination:
 
 ```bash
 SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east- \
@@ -162,8 +168,11 @@ SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east- \
   cargo run
 ```
 
-See the [scaling architecture notes](architecture/scaling.md) for the full
-reasoning and the cross-node seams.
+See the
+[single-instance deployment contract](architecture/single-instance-deployment.md)
+for the exact boundary and failure catalog, and the
+[scaling architecture notes](architecture/scaling.md) for capacity drivers and
+future extension seams.
 
 ## CLI flags
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
       - Transport Fallback (v3): architecture/transport-fallback.md
       - Handoff & Topologies (v3): architecture/handoff-and-topologies.md
       - Formal Verification (v3): architecture/formal-verification.md
-      - Scaling (Multi-Node): architecture/scaling.md
+      - Single-Instance Deployment: architecture/single-instance-deployment.md
+      - Scaling: architecture/scaling.md
       - Library Usage: library-usage.md
       - Development: development.md

--- a/scripts/hooks/pre-commit.ps1
+++ b/scripts/hooks/pre-commit.ps1
@@ -24,6 +24,7 @@ $script:UseWorktreeTextForStagedFiles = $false
 $script:RustPanicPolicyLoaded = $false
 $script:StagedChangedFileSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 $script:WorktreeChangedFileSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$script:WorktreeUntrackedFileSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 $script:HookBudgetMs = 1000
 $script:CheckTimings = [System.Collections.Generic.List[object]]::new()
 $script:HookPolicyFiles = @(
@@ -146,26 +147,45 @@ function Get-WorktreeChangedFiles {
     $seenPaths = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
     $script:StagedChangedFileSet.Clear()
     $script:WorktreeChangedFileSet.Clear()
+    $script:WorktreeUntrackedFileSet.Clear()
 
-    $stagedArgs = @("diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMR", "--") + $Pathspecs
-    Add-UniqueGitPaths -NulDelimitedPaths (Invoke-Git -Arguments $stagedArgs).Stdout -OrderedPaths $orderedPaths -SeenPaths $seenPaths -ChangedSet $script:StagedChangedFileSet
+    # One porcelain query replaces separate staged, unstaged, and untracked
+    # discovery processes. `-z` makes paths literal and NUL-delimited; rename
+    # records carry a second NUL-delimited source path, which is skipped because
+    # policy evaluates the current destination.
+    $arguments = @("status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=no", "--") + $Pathspecs
+    $records = (Invoke-Git -Arguments $arguments).Stdout.Split([char]0, [System.StringSplitOptions]::RemoveEmptyEntries)
+    $skipRenameSource = $false
+    foreach ($record in $records) {
+        if ($skipRenameSource) {
+            $skipRenameSource = $false
+            continue
+        }
+        if ($record.Length -lt 4 -or $record[2] -ne " ") {
+            throw "Unable to parse git status porcelain record: $record"
+        }
 
-    if ($script:StagedChangedFileSet.Count -gt 0) {
-        $stagedPaths = [string[]]@($script:StagedChangedFileSet)
-        $stagedWorktreeArgs = @("diff", "--name-only", "-z", "--diff-filter=ACDMR", "--") + $stagedPaths
-        Add-UniqueGitPaths -NulDelimitedPaths (Invoke-Git -Arguments $stagedWorktreeArgs).Stdout -OrderedPaths $orderedPaths -SeenPaths $seenPaths -ChangedSet $script:WorktreeChangedFileSet
-        foreach ($path in $script:StagedChangedFileSet) {
-            if ($script:WorktreeChangedFileSet.Contains($path)) {
-                foreach ($changedPath in $orderedPaths) {
-                    $changedPath
-                }
-                return
+        $indexStatus = [string]$record[0]
+        $worktreeStatus = [string]$record[1]
+        $path = $record.Substring(3)
+        if ($seenPaths.Add($path)) {
+            [void]$orderedPaths.Add($path)
+        }
+
+        if ($indexStatus -eq "?" -and $worktreeStatus -eq "?") {
+            [void]$script:WorktreeChangedFileSet.Add($path)
+            [void]$script:WorktreeUntrackedFileSet.Add($path)
+        } else {
+            if ($indexStatus -ne " ") {
+                [void]$script:StagedChangedFileSet.Add($path)
+            }
+            if ($worktreeStatus -ne " ") {
+                [void]$script:WorktreeChangedFileSet.Add($path)
             }
         }
-    }
 
-    $worktreeArgs = @("ls-files", "-z", "-m", "-d", "-o", "--exclude-standard", "--") + $Pathspecs
-    Add-UniqueGitPaths -NulDelimitedPaths (Invoke-Git -Arguments $worktreeArgs).Stdout -OrderedPaths $orderedPaths -SeenPaths $seenPaths -ChangedSet $script:WorktreeChangedFileSet
+        $skipRenameSource = $indexStatus -in @("R", "C") -or $worktreeStatus -in @("R", "C")
+    }
 
     foreach ($path in $orderedPaths) {
         $path
@@ -633,6 +653,42 @@ function Test-ProductionRustSourcePath {
     }
 
     -not ($Path.Contains("/test/") -or $Path.Contains("/tests/"))
+}
+
+function Test-RustPanicPolicyRelevantDiff {
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Pathspecs)
+
+    if ($Pathspecs.Count -eq 0) {
+        return $false
+    }
+
+    # `git diff HEAD` cannot see untracked files, so keep their full scanner
+    # fail-closed. Tracked worktree edits and staged changes can share the fast
+    # pickaxe query below.
+    if ($script:InspectWorktree -and @($Pathspecs | Where-Object {
+                $script:WorktreeUntrackedFileSet.Contains($_)
+            }).Count -gt 0) {
+        return $true
+    }
+
+    $panicPattern = "(^|[^[:alnum:]_])(panic|todo|unimplemented|unreachable)[[:space:]]*(/\*[^*]*\*+([^/*][^*]*\*+)*/[[:space:]]*)*!"
+    $testContextPattern = "#\[[[:space:]]*(cfg[[:space:]]*\(|test|tokio::test|async_std::test|rstest)"
+    $grepPattern = "($panicPattern)|($testContextPattern)"
+    $diffBase = if ($script:InspectWorktree) { "HEAD" } else { "--cached" }
+    $result = Invoke-Native -FileName "git" -Arguments (@(
+            "diff", $diffBase, "--quiet", "-G", $grepPattern, "--"
+        ) + $Pathspecs)
+    if ($result.ExitCode -eq 0) {
+        return $false
+    }
+    if ($result.ExitCode -eq 1) {
+        return $true
+    }
+    if ($script:InspectWorktree -and $result.Output -match "unknown revision|bad revision|ambiguous argument 'HEAD'|Not a valid object name HEAD") {
+        return $true
+    }
+
+    throw "git diff Rust panic policy precheck failed:`n$($result.Output)"
 }
 
 function Test-WorktreeIndexPolicyConsistency {
@@ -1466,6 +1522,8 @@ if (-not (Invoke-Check "Hook speed policy" { Test-FastHookSource })) { Complete-
 $changedProductionRustFiles = [string[]]@($allChangedFiles | Where-Object { Test-ProductionRustSourcePath -Path $_ })
 if ($changedProductionRustFiles.Count -eq 0) {
     if (-not (Invoke-Check "Rust panic patterns" { Skip "Rust panic patterns" "no production Rust files staged" })) { Complete-PreCommit }
+} elseif (-not (Test-RustPanicPolicyRelevantDiff -Pathspecs $changedProductionRustFiles)) {
+    if (-not (Invoke-Check "Rust panic patterns" { Pass "Rust panic patterns" })) { Complete-PreCommit }
 } else {
     if (-not (Invoke-Check "Rust panic patterns" {
                 if (-not $script:RustPanicPolicyLoaded) {

--- a/scripts/hooks/pre-push.ps1
+++ b/scripts/hooks/pre-push.ps1
@@ -15,6 +15,9 @@ $script:Failed = 0
 $script:Skipped = 0
 $script:WorktreePseudoCommit = "__WORKTREE__"
 $script:HookBudgetMs = 1000
+$script:MaxBatchedBlobBytes = 8 * 1024 * 1024
+$script:CommitBlobTextCache = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::Ordinal)
+$script:MissingCommitBlobCache = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 
 . (Join-Path $PSScriptRoot "native-process.ps1")
 
@@ -214,6 +217,112 @@ function Get-ChangedFilesForWorktreePreflight {
     $files
 }
 
+function Get-CommitBlobCacheKey {
+    param(
+        [Parameter(Mandatory = $true)][string]$Commit,
+        [Parameter(Mandatory = $true)][string]$File
+    )
+
+    "${Commit}`n${File}"
+}
+
+function Read-AsciiLineFromBytes {
+    param(
+        [Parameter(Mandatory = $true)][byte[]]$Bytes,
+        [Parameter(Mandatory = $true)][ref]$Offset
+    )
+
+    if ($Offset.Value -ge $Bytes.Length) {
+        return $null
+    }
+
+    $start = $Offset.Value
+    while ($Offset.Value -lt $Bytes.Length -and $Bytes[$Offset.Value] -ne 10) {
+        $Offset.Value++
+    }
+
+    $length = $Offset.Value - $start
+    $line = [System.Text.Encoding]::ASCII.GetString($Bytes, $start, $length).TrimEnd("`r")
+    if ($Offset.Value -lt $Bytes.Length -and $Bytes[$Offset.Value] -eq 10) {
+        $Offset.Value++
+    }
+
+    $line
+}
+
+function Initialize-CommitBlobTextCache {
+    param([System.Collections.Generic.Dictionary[string, System.Collections.Generic.HashSet[string]]]$ChangedFiles)
+
+    $requests = [System.Collections.Generic.List[object]]::new()
+    foreach ($file in $ChangedFiles.Keys) {
+        $isHookPolicyFile = $file -in @(
+            ".githooks/pre-commit",
+            ".githooks/pre-push",
+            "scripts/hooks/native-process.ps1",
+            "scripts/hooks/pre-commit.ps1",
+            "scripts/hooks/pre-commit-rust.ps1",
+            "scripts/hooks/pre-push.ps1"
+        )
+        if (-not $isHookPolicyFile -and $file -notmatch "^\.github/workflows/.*\.ya?ml$") {
+            continue
+        }
+
+        foreach ($commit in $ChangedFiles[$file]) {
+            if ($commit -eq $script:WorktreePseudoCommit) {
+                continue
+            }
+            [void]$requests.Add([pscustomobject]@{
+                    Expression = "${commit}:${file}"
+                    Key = Get-CommitBlobCacheKey -Commit $commit -File $file
+                })
+        }
+    }
+
+    if ($requests.Count -eq 0) {
+        return
+    }
+
+    $batchInput = (($requests | ForEach-Object { $_.Expression }) -join "`n") + "`n"
+    $result = Invoke-NativeBytesWithInput -FileName "git" -Arguments @("cat-file", "--batch") -InputText $batchInput
+    if ($result.ExitCode -ne 0) {
+        throw "git cat-file --batch failed:`n$($result.Output)"
+    }
+
+    $offset = 0
+    $totalByteCount = [int64]0
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    foreach ($request in $requests) {
+        $header = Read-AsciiLineFromBytes -Bytes $result.StdoutBytes -Offset ([ref]$offset)
+        if ($null -eq $header) {
+            throw "git cat-file --batch ended before $($request.Expression)"
+        }
+        if ($header.EndsWith(" missing", [System.StringComparison]::Ordinal)) {
+            [void]$script:MissingCommitBlobCache.Add($request.Key)
+            continue
+        }
+
+        $headerFields = @($header.Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries))
+        if ($headerFields.Count -ne 3 -or $headerFields[1] -ne "blob") {
+            throw "Unexpected git cat-file header for $($request.Expression): $header"
+        }
+
+        $byteCount = [int64]::Parse($headerFields[2], [System.Globalization.CultureInfo]::InvariantCulture)
+        $totalByteCount += $byteCount
+        if ($totalByteCount -gt $script:MaxBatchedBlobBytes) {
+            throw "Pushed hook/workflow blob batch is $totalByteCount bytes, above the $script:MaxBatchedBlobBytes byte pre-push limit."
+        }
+        if ($byteCount -gt [int]::MaxValue -or $offset + $byteCount -gt $result.StdoutBytes.Length) {
+            throw "git cat-file --batch returned truncated or oversized content for $($request.Expression)"
+        }
+
+        $script:CommitBlobTextCache[$request.Key] = $utf8NoBom.GetString($result.StdoutBytes, $offset, [int]$byteCount)
+        $offset += [int]$byteCount
+        if ($offset -lt $result.StdoutBytes.Length -and $result.StdoutBytes[$offset] -eq 10) {
+            $offset++
+        }
+    }
+}
+
 function Get-CommitBlobText {
     param(
         [Parameter(Mandatory = $true)][string]$Commit,
@@ -226,6 +335,14 @@ function Get-CommitBlobText {
             return $null
         }
         return [System.IO.File]::ReadAllText($path)
+    }
+
+    $cacheKey = Get-CommitBlobCacheKey -Commit $Commit -File $File
+    if ($script:CommitBlobTextCache.ContainsKey($cacheKey)) {
+        return $script:CommitBlobTextCache[$cacheKey]
+    }
+    if ($script:MissingCommitBlobCache.Contains($cacheKey)) {
+        return $null
     }
 
     $result = Invoke-Native -FileName "git" -Arguments @("show", "${Commit}:$File")
@@ -563,6 +680,7 @@ if ($changedFiles.Count -eq 0) {
     Pass "Changed file discovery"
 }
 
+Initialize-CommitBlobTextCache -ChangedFiles $changedFiles
 Test-FastHookSource -ChangedFiles $changedFiles
 Test-WorkflowDirectScriptInvocations -ChangedFiles $changedFiles
 

--- a/src/config/coordination.rs
+++ b/src/config/coordination.rs
@@ -1,4 +1,4 @@
-//! Coordination and cross-instance configuration types.
+//! Process-local coordination configuration and future-backend seams.
 
 use super::defaults::{
     default_dedup_cache_capacity, default_dedup_cache_cleanup_interval_secs,
@@ -6,12 +6,13 @@ use super::defaults::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Coordination configuration for cross-instance messaging.
+/// Configuration for the in-memory coordinator.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct CoordinationConfig {
     #[serde(default)]
     pub dedup_cache: DedupCacheConfig,
-    /// Interval between cross-instance membership snapshots (seconds).
+    /// Reserved interval for a future membership-snapshot backend (seconds).
+    /// The shipped coordinator does not exchange snapshots between processes.
     #[serde(default = "default_membership_snapshot_interval_secs")]
     pub membership_snapshot_interval_secs: u64,
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@
 //! - [`crate::config::session`]: Session topology / transport selection (protocol v3)
 //! - [`crate::config::turn`]: TURN / STUN ICE-server configuration (protocol v3)
 //! - [`crate::config::logging`]: Logging configuration
-//! - [`crate::config::coordination`]: Cross-instance coordination settings
+//! - [`crate::config::coordination`]: Process-local coordination settings and future-backend seams
 //! - [`crate::config::metrics`]: Metrics configuration
 //! - [`crate::config::websocket`]: WebSocket connection settings
 //! - [`crate::config::loader`]: Configuration loading functions

--- a/src/coordination/dedup.rs
+++ b/src/coordination/dedup.rs
@@ -1,7 +1,8 @@
-//! Message deduplication cache for cross-instance coordination
+//! Message deduplication cache for the coordination extension seam.
 //!
-//! This module provides an LRU-based cache for deduplicating cross-instance messages,
-//! ensuring that messages are only processed once even when delivered via multiple paths.
+//! The shipped coordinator is process-local. This LRU cache preserves the
+//! deduplication contract for local envelopes and a possible future remote
+//! backend; it does not provide cross-process delivery by itself.
 
 #![allow(dead_code)]
 

--- a/src/coordination/mod.rs
+++ b/src/coordination/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides facilities for coordinating messages and room operations:
 //! - Message deduplication (LRU-based cache)
-//! - Room operation coordination with distributed locking
+//! - Room operation coordination with process-local locking
 //!
 //! For signal-fish-server, this is an in-memory-only implementation.
 
@@ -1416,7 +1416,7 @@ pub trait MessageCoordinator: Send + Sync {
     }
 }
 
-/// Membership update for cross-instance coordination.
+/// Membership-update extension seam for a future remote coordinator.
 #[derive(Debug, Clone, serde::Deserialize)]
 #[allow(dead_code)]
 pub struct MembershipUpdate {

--- a/src/coordination/room_coordinator.rs
+++ b/src/coordination/room_coordinator.rs
@@ -1,7 +1,8 @@
-//! Room operation coordination for distributed state management
+//! Room operation coordination for process-local state management.
 //!
 //! This module provides coordinators for managing room operations (lobby transitions,
-//! authority transfers, player ready states) with distributed locking to ensure consistency.
+//! authority transfers, player ready states) with in-memory locking to ensure
+//! consistency inside one server process.
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -171,7 +171,7 @@ pub trait GameDatabase: Send + Sync {
     /// Health check
     async fn health_check(&self) -> bool;
 
-    /// Update player's last_seen (heartbeat) for cross-instance liveness
+    /// Update a player's `last_seen` timestamp for local liveness and cleanup.
     async fn update_player_last_seen(&self, player_id: &PlayerId) -> Result<()>;
 
     /// Get room counts by game name for metrics
@@ -221,11 +221,12 @@ pub trait GameDatabase: Send + Sync {
     async fn get_room_spectators(&self, room_id: &RoomId) -> Result<Vec<SpectatorInfo>>;
 
     /// Try to claim a room cleanup operation for idempotency.
-    /// Returns true if this instance should process the cleanup (we claimed it),
-    /// false if another instance already processed it.
+    /// Returns true if this cleanup path claimed the operation, or false if an
+    /// earlier cleanup path in the process already claimed it.
     ///
-    /// This is used in multi-instance deployments to ensure post-cleanup operations
-    /// (publishing room_closed events, clearing relay sessions, etc.) only happen once.
+    /// The shipped database is process-local, so this prevents duplicate
+    /// post-cleanup operations within one process. A future shared backend would
+    /// also need a separately verified room-authority and routing protocol.
     async fn try_claim_room_cleanup(
         &self,
         room_id: &RoomId,

--- a/src/distributed.rs
+++ b/src/distributed.rs
@@ -7,7 +7,10 @@ use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
-/// Distributed lock interface for cross-instance coordination
+/// Lock interface used for process-local room coordination.
+///
+/// The shipped implementation is in-memory and cannot coordinate server
+/// processes. The trait is only an extension seam for a future backend.
 #[async_trait]
 pub trait DistributedLock: Send + Sync {
     /// Acquire a lock with specified TTL
@@ -29,7 +32,7 @@ pub trait DistributedLock: Send + Sync {
     async fn cleanup_expired_locks(&self) -> Result<usize>;
 }
 
-/// Handle for a distributed lock
+/// Handle for a coordination lock.
 #[derive(Debug, Clone)]
 pub struct LockHandle {
     pub key: String,
@@ -57,7 +60,7 @@ impl LockHandle {
     }
 }
 
-/// In-memory distributed lock
+/// In-memory, process-local coordination lock.
 pub struct InMemoryDistributedLock {
     locks: Arc<RwLock<HashMap<String, LockEntry>>>,
 }
@@ -235,7 +238,7 @@ struct CircuitBreakerInner {
     last_failure_time: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-/// Circuit breaker for cross-instance operations
+/// Circuit breaker extension seam for fallible coordination operations.
 pub struct CircuitBreaker {
     inner: Arc<Mutex<CircuitBreakerInner>>,
     failure_threshold: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod coordination;
 /// Database abstraction layer (in-memory implementation)
 pub mod database;
 
-/// Distributed locking (in-memory implementation)
+/// Process-local locking behind a future coordination extension seam
 pub mod distributed;
 
 /// Structured logging configuration

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,13 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
 
     tracing::info!(%addr, "Starting Signal Fish server");
+    tracing::info!(
+        deployment_mode = "single_instance",
+        room_state = "in_memory",
+        room_affinity_required = true,
+        session_handoff = false,
+        "Deployment contract: one process owns each room; losing the process loses its rooms"
+    );
 
     // Create server configuration from loaded config
     let server_config = ServerConfig {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -139,7 +139,7 @@ pub struct ServerMetrics {
     pub retry_attempts: AtomicU64,
     pub retry_successes: AtomicU64,
 
-    // Cross-instance communication metrics
+    // Reserved remote-coordination seam metrics (the shipped backend is local)
     pub cross_instance_messages: AtomicU64,
     pub dedup_cache_hits: AtomicU64,
     pub dedup_cache_misses: AtomicU64,
@@ -900,7 +900,7 @@ impl ServerMetrics {
         self.retry_successes.fetch_add(1, Ordering::Relaxed);
     }
 
-    // Cross-instance communication metrics
+    // Reserved remote-coordination seam metrics (the shipped backend is local)
     #[allow(dead_code)]
     pub fn increment_cross_instance_messages(&self) {
         self.cross_instance_messages.fetch_add(1, Ordering::Relaxed);

--- a/src/protocol/room_state.rs
+++ b/src/protocol/room_state.rs
@@ -141,8 +141,8 @@ use super::types::{
 // - **Authority Player Leaves**: If the authority player disconnects, authority
 //   is cleared (`authority_player = None`) with no automatic reassignment.
 //
-// - **Stale Finalization**: Ready state version tracking prevents multiple
-//   server instances from finalizing the same room (distributed lock protection).
+// - **Stale Finalization**: Ready-state version tracking and the process-local
+//   room lock prevent concurrent handlers from finalizing the same room twice.
 //
 // ## Timestamps and Activity Tracking
 //

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -79,7 +79,7 @@ pub enum RetryableError {
     RoomCodeCollision,
     /// Authority conflict
     AuthorityConflict,
-    /// Cross-instance communication failure
+    /// Remote-coordination extension failure (no shipped remote backend)
     CrossInstanceFailure(String),
     /// Temporary resource unavailable
     ResourceUnavailable(String),

--- a/src/server.rs
+++ b/src/server.rs
@@ -71,7 +71,7 @@ use spectator_service::SpectatorService;
 
 // Removed unused imports
 
-/// Enhanced GameServer with distributed coordination
+/// Enhanced game server with process-local coordination.
 pub struct EnhancedGameServer {
     /// In-memory game state storage
     database: Arc<dyn GameDatabase>,
@@ -91,11 +91,11 @@ pub struct EnhancedGameServer {
     rate_limiter: Arc<RoomRateLimiter>,
     /// Server metrics
     pub(crate) metrics: Arc<crate::metrics::ServerMetrics>,
-    /// Message coordinator for cross-instance communication
+    /// Process-local message coordinator behind a future remote-backend seam
     message_coordinator: Arc<dyn MessageCoordinator>,
-    /// Room operation coordinator for distributed state management
+    /// Process-local room operation coordinator
     room_coordinator: Arc<dyn RoomOperationCoordinatorTrait>,
-    /// Distributed locking system
+    /// Process-local coordination lock
     distributed_lock: Arc<dyn DistributedLock>,
     /// Instance identifier
     instance_id: Uuid,
@@ -251,7 +251,7 @@ impl EnhancedGameServer {
         ));
         dashboard_metrics_cache.spawn(database.clone());
 
-        // Setup distributed coordination - in-memory only
+        // Set up process-local coordination behind the extension interfaces.
         let distributed_lock = Arc::new(InMemoryDistributedLock::new());
         let message_coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(
             Duration::from_millis(config.websocket_config.slow_consumer_timeout_ms),

--- a/src/server/authority.rs
+++ b/src/server/authority.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use super::EnhancedGameServer;
 
 impl EnhancedGameServer {
-    /// Handle authority request with distributed coordination.
+    /// Handle an authority request under process-local room coordination.
     pub async fn handle_authority_request(&self, player_id: &PlayerId, become_authority: bool) {
         let Some(lifecycle) = self.connection_manager.client_lifecycle(player_id) else {
             return;

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -642,8 +642,8 @@ impl ConnectionManager {
     /// Returns true if the threshold has elapsed since the last update, and marks
     /// the update as performed. Returns false if update should be skipped.
     ///
-    /// This throttling mechanism reduces update overhead while maintaining
-    /// the 5-minute cross-instance staleness window accuracy (30s << 5min).
+    /// This throttling mechanism reduces database writes while keeping local
+    /// liveness and cleanup timestamps current.
     pub fn should_update_last_seen(
         &self,
         player_id: &PlayerId,

--- a/src/server/heartbeat.rs
+++ b/src/server/heartbeat.rs
@@ -28,7 +28,7 @@ impl EnhancedGameServer {
     }
 
     /// Conditionally updates `last_seen` if the throttle threshold has elapsed.
-    /// This reduces update overhead while maintaining cross-instance staleness accuracy.
+    /// This reduces database writes while keeping local liveness timestamps current.
     pub(super) async fn maybe_update_last_seen(&self, player_id: &PlayerId) {
         let threshold = self.config.heartbeat_throttle;
 

--- a/src/server/maintenance.rs
+++ b/src/server/maintenance.rs
@@ -141,12 +141,11 @@ impl EnhancedGameServer {
         count
     }
 
-    /// Enhanced cleanup task with distributed coordination and idempotency
+    /// Enhanced cleanup task with process-local coordination and idempotency.
     ///
-    /// In multi-instance deployments, this task uses idempotency keys to ensure
-    /// that post-cleanup operations (event publishing, relay session cleanup,
-    /// application mapping cleanup) only happen once per room, even if multiple
-    /// instances attempt cleanup simultaneously.
+    /// Idempotency keys ensure post-cleanup operations (event publishing, relay
+    /// session cleanup, application mapping cleanup) happen once per room in
+    /// this process. They do not coordinate cleanup between server processes.
     pub async fn cleanup_task(self: &Arc<Self>) {
         self.cleanup_task_until(std::future::pending::<()>()).await;
     }
@@ -308,7 +307,7 @@ impl EnhancedGameServer {
                         for room_id in &deleted_room_ids {
                             // The stored v3 session decision is per-node in-memory
                             // state, so it is dropped unconditionally for every
-                            // deleted room — independent of the cross-instance
+                            // deleted room — independent of the cleanup
                             // idempotency claim below.
                             self.clear_active_session_plan(room_id);
 

--- a/src/server/ready_state.rs
+++ b/src/server/ready_state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use super::EnhancedGameServer;
 
 impl EnhancedGameServer {
-    /// Handle a player ready-state toggle with distributed coordination.
+    /// Handle a player ready-state toggle under process-local room coordination.
     ///
     /// Readiness can be toggled at any time while the room is open; it no longer
     /// starts the game. The server broadcasts the updated lobby snapshot (with

--- a/src/server/room_service.rs
+++ b/src/server/room_service.rs
@@ -88,7 +88,7 @@ impl EnhancedGameServer {
         self.metrics.increment_players_left();
     }
 
-    /// Enhanced room joining with distributed coordination
+    /// Join a room under process-local coordination.
     #[allow(clippy::too_many_arguments)]
     pub async fn handle_join_room(
         self: &Arc<Self>,
@@ -288,7 +288,7 @@ impl EnhancedGameServer {
         };
         room_join_span.record("room_code", tracing::field::display(&room_code));
 
-        // Use distributed coordination for room operations
+        // Serialize room operations with the process-local coordinator.
         let room_join_result = self
             .join_room_with_coordination(
                 player_id,
@@ -595,7 +595,7 @@ impl EnhancedGameServer {
                     %game_name,
                     room_code = %room.code,
                     instance_id = %self.instance_id,
-                    "Player joined room with distributed coordination"
+                    "Player joined room with process-local coordination"
                 );
             }
             Err(error) => {
@@ -678,9 +678,9 @@ impl EnhancedGameServer {
             }
             Ok(None) => {
                 // Persistence is authoritative. A stale local assignment can
-                // survive a prior cross-instance removal, so converge routing
-                // and publish the terminal event below even though this call
-                // did not perform the durable removal itself.
+                // survive a prior removal path, so converge routing and publish
+                // the terminal event below even though this call did not
+                // perform the durable removal itself.
                 tracing::warn!(%player_id, %room_id, "Player persistence entry was already absent during leave");
                 self.pending_durable_player_detaches
                     .remove(&(room_id, *player_id));
@@ -877,7 +877,7 @@ impl EnhancedGameServer {
             %room_id,
             room_code = latest_room_code.as_deref().unwrap_or("unknown"),
             instance_id = %self.instance_id,
-            "Player left room with distributed coordination"
+            "Player left room with process-local coordination"
         );
     }
 
@@ -925,7 +925,7 @@ impl EnhancedGameServer {
         );
     }
 
-    /// Join room with distributed coordination
+    /// Join a room with process-local admission coordination.
     pub(super) async fn join_room_with_coordination(
         &self,
         player_id: &PlayerId,

--- a/src/websocket/prometheus.rs
+++ b/src/websocket/prometheus.rs
@@ -444,7 +444,7 @@ pub(crate) fn render_prometheus_metrics(snapshot: &MetricsSnapshot) -> String {
     counter(
         &mut buf,
         "signal_fish_cross_instance_messages_total",
-        "Total cross-instance messages processed",
+        "Reserved remote-coordination envelopes processed (zero for the shipped in-memory backend)",
         snapshot.cross_instance.cross_instance_messages,
     );
     counter(
@@ -480,31 +480,31 @@ pub(crate) fn render_prometheus_metrics(snapshot: &MetricsSnapshot) -> String {
     counter(
         &mut buf,
         "signal_fish_cross_instance_membership_updates_published_total",
-        "Total membership deltas/snapshots published to the cross-instance bus",
+        "Reserved membership updates published to a remote-coordination backend",
         snapshot.cross_instance.remote_membership_updates_published,
     );
     counter(
         &mut buf,
         "signal_fish_cross_instance_membership_updates_received_total",
-        "Total membership deltas/snapshots consumed from the cross-instance bus",
+        "Reserved membership updates consumed from a remote-coordination backend",
         snapshot.cross_instance.remote_membership_updates_received,
     );
     counter(
         &mut buf,
         "signal_fish_cross_instance_membership_known_broadcasts_total",
-        "Room broadcasts sent because remote members are known to be listening",
+        "Reserved room broadcasts sent to known remote members",
         snapshot.cross_instance.remote_membership_known_broadcasts,
     );
     counter(
         &mut buf,
         "signal_fish_cross_instance_membership_forced_broadcasts_total",
-        "Room broadcasts sent without cached remote membership info (safety fallback)",
+        "Reserved remote broadcasts sent without cached membership information",
         snapshot.cross_instance.remote_membership_forced_broadcasts,
     );
     counter(
         &mut buf,
         "signal_fish_cross_instance_membership_skipped_broadcasts_total",
-        "Room broadcasts skipped because no remote listeners are known",
+        "Reserved remote broadcasts skipped because no listeners are known",
         snapshot.cross_instance.remote_membership_skipped_broadcasts,
     );
 

--- a/src/websocket/routes.rs
+++ b/src/websocket/routes.rs
@@ -114,6 +114,13 @@ pub async fn run_server(
     // Start server
     let listener = tokio::net::TcpListener::bind(addr).await?;
     tracing::info!(%addr, "Starting enhanced Signal Fish server");
+    tracing::info!(
+        deployment_mode = "single_instance",
+        room_state = "in_memory",
+        room_affinity_required = true,
+        session_handoff = false,
+        "Deployment contract: one process owns each room; losing the process loses its rooms"
+    );
 
     axum::serve(
         listener,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -17442,6 +17442,11 @@ fn test_pre_push_hook_checks_workflow_direct_script_invocations() {
         content.contains("Test-WorkflowDirectScriptInvocations")
             && content.contains("^\\.github/workflows/.*\\.ya?ml$")
             && content.contains("scripts/hooks/pre-commit-rust.ps1")
+            && content.contains("Initialize-CommitBlobTextCache")
+            && content.contains("Invoke-NativeBytesWithInput")
+            && content.contains("\"cat-file\", \"--batch\"")
+            && content.contains("CommitBlobTextCache")
+            && content.contains("MaxBatchedBlobBytes")
             && content.contains("Get-CommitBlobText")
             && content.contains("Test-WorkflowContentForDirectScripts")
             && content.contains("Test-CommandTextForDirectScript")
@@ -17452,8 +17457,9 @@ fn test_pre_push_hook_checks_workflow_direct_script_invocations() {
             && content.contains("HookBudgetMs")
             && content.contains("runBlockIndent"),
         "pre-push runner must keep a workflow direct-script invocation guard that \
-         reads pushed commit content, scans only run commands, and permits local \
-         scripts only when invoked through an interpreter."
+         batch-reads bounded pushed commit content without per-blob process fanout, \
+         scans only run commands, and permits local scripts only when invoked through \
+         an interpreter."
     );
 }
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -17175,6 +17175,7 @@ fn test_pre_commit_rust_panic_scan_is_scoped_to_production_sources() {
         runner.contains("pre-commit-rust.ps1")
             && runner.contains("$changedProductionRustFiles")
             && runner.contains("Test-RustAddedPanicPatterns")
+            && runner.contains("Test-RustPanicPolicyRelevantDiff")
             && runner.contains("RustPanicPolicyLoaded")
             && !runner.contains("function Get-RustTestLineSet"),
         "pre-commit must lazy-load the Rust panic policy only when production Rust \
@@ -17223,6 +17224,104 @@ fn test_pre_commit_rust_panic_scan_is_scoped_to_production_sources() {
 }
 
 #[test]
+fn test_pre_commit_rust_panic_fast_gate_fails_closed_when_pwsh_available() {
+    let root = repo_root();
+    let output = Command::new("pwsh")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            r#"
+                . ./scripts/hooks/pre-commit.ps1 -SourceOnly
+                function Assert($condition, $message) {
+                    if (-not $condition) { throw $message }
+                }
+                $script:InspectWorktree = $false
+                $script:NextExitCode = 0
+                $script:Calls = 0
+                $script:CapturedArguments = @()
+                function Invoke-Native {
+                    param([string]$FileName, [string[]]$Arguments)
+                    $script:Calls++
+                    $script:CapturedArguments = [string[]]$Arguments
+                    [pscustomobject]@{
+                        ExitCode = $script:NextExitCode
+                        Stdout = ""
+                        Stderr = "fixture failure"
+                        Output = "fixture failure"
+                    }
+                }
+
+                $changed = Test-RustPanicPolicyRelevantDiff -Pathspecs @("src/lib.rs")
+                Assert (-not $changed) "exit 0 should skip the full Rust scanner"
+                Assert ($script:Calls -eq 1) "staged fast gate should run one git query"
+                Assert ($script:CapturedArguments -contains "--cached") "fast gate must inspect the staged index"
+                Assert ($script:CapturedArguments -contains "--quiet") "fast gate should avoid materializing a diff"
+                $patternIndex = [array]::IndexOf($script:CapturedArguments, "-G") + 1
+                Assert ($patternIndex -gt 0) "fast gate must use a pickaxe regex"
+                $pattern = $script:CapturedArguments[$patternIndex]
+                Assert ($pattern.Contains("panic|todo|unimplemented|unreachable")) "fast gate must detect panic macro edits"
+                Assert ($pattern.Contains("tokio::test")) "fast gate must detect test-context edits"
+
+                $script:NextExitCode = 1
+                Assert (Test-RustPanicPolicyRelevantDiff -Pathspecs @("src/lib.rs")) "exit 1 should load the full scanner"
+
+                $script:NextExitCode = 2
+                $threw = $false
+                try {
+                    Test-RustPanicPolicyRelevantDiff -Pathspecs @("src/lib.rs")
+                } catch {
+                    $threw = $true
+                }
+                Assert $threw "unexpected git failures must fail closed"
+
+                $script:InspectWorktree = $true
+                $script:WorktreeUntrackedFileSet.Add("src/lib.rs") | Out-Null
+                $script:Calls = 0
+                Assert (Test-RustPanicPolicyRelevantDiff -Pathspecs @("src/lib.rs")) "worktree mode must retain the full scanner"
+                Assert ($script:Calls -eq 0) "worktree mode must not trust a diff that omits untracked files"
+
+                $script:WorktreeUntrackedFileSet.Clear()
+                $script:NextExitCode = 0
+                Assert (-not (Test-RustPanicPolicyRelevantDiff -Pathspecs @("src/lib.rs"))) "tracked worktree edits should use the fast gate"
+                Assert ($script:CapturedArguments -contains "HEAD") "worktree fast gate must include staged and unstaged edits"
+
+                $nul = [char]0
+                $script:StatusFixture = " M src/lib.rs${nul}M  src/main.rs${nul}MM src/server.rs${nul}?? src/new.rs${nul}R  src/new_name.rs${nul}src/old_name.rs${nul}"
+                function Invoke-Git {
+                    param([string[]]$Arguments)
+                    [pscustomobject]@{ ExitCode = 0; Stdout = $script:StatusFixture; Stderr = ""; Output = $script:StatusFixture }
+                }
+                $paths = [string[]]@(Get-WorktreeChangedFiles)
+                Assert ($paths.Count -eq 5) "porcelain parser should return each current path once"
+                Assert ($script:StagedChangedFileSet.Contains("src/main.rs")) "index-only edit should be staged"
+                Assert ($script:StagedChangedFileSet.Contains("src/server.rs")) "mixed edit should be staged"
+                Assert ($script:StagedChangedFileSet.Contains("src/new_name.rs")) "rename destination should be staged"
+                Assert ($script:WorktreeChangedFileSet.Contains("src/lib.rs")) "worktree-only edit should be tracked"
+                Assert ($script:WorktreeChangedFileSet.Contains("src/server.rs")) "mixed edit should be in the worktree set"
+                Assert ($script:WorktreeUntrackedFileSet.Contains("src/new.rs")) "untracked edit should fail closed"
+                Assert (-not ($paths -contains "src/old_name.rs")) "rename source metadata is not a current policy path"
+            "#,
+        ])
+        .current_dir(&root)
+        .output();
+
+    let Ok(output) = output else {
+        eprintln!("Skipping PowerShell Rust panic fast-gate test because pwsh is unavailable.");
+        return;
+    };
+
+    assert!(
+        output.status.success(),
+        "PowerShell Rust panic fast gate should skip only irrelevant staged diffs and fail closed otherwise.\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn test_pre_commit_runner_has_worktree_preflight_mode_for_agents() {
     let root = repo_root();
     let runner = read_live_file(&root.join("scripts/hooks/pre-commit.ps1"));
@@ -17232,13 +17331,11 @@ fn test_pre_commit_runner_has_worktree_preflight_mode_for_agents() {
     assert!(
         content.contains("[switch]$Worktree")
             && content.contains("Get-WorktreeChangedFiles")
-            && content.contains(
-                "\"diff\", \"--cached\", \"--name-only\", \"-z\", \"--diff-filter=ACDMR\""
-            )
             && content
-                .contains("\"ls-files\", \"-z\", \"-m\", \"-d\", \"-o\", \"--exclude-standard\"")
+                .contains("\"status\", \"--porcelain=v1\", \"-z\", \"--untracked-files=all\"")
             && content.contains("StagedChangedFileSet")
             && content.contains("WorktreeChangedFileSet")
+            && content.contains("WorktreeUntrackedFileSet")
             && content.contains("Test-WorktreeIndexPolicyConsistency")
             && content.contains("Worktree/index policy consistency")
             && content.contains("Changed file discovery")

--- a/tests/split_brain_two_instances_e2e.rs
+++ b/tests/split_brain_two_instances_e2e.rs
@@ -1,0 +1,210 @@
+//! P10.H5 documentation experiment: prove the failure modes produced when two
+//! independent Signal Fish processes receive members of the same logical room.
+//!
+//! This is not a supported topology or a test expected to "pass" multi-node
+//! operation. Its product is the executable failure catalog consumed by the
+//! single-instance deployment contract:
+//!
+//! - the same `(game_name, room_code)` silently creates one room per instance;
+//! - reconnect state is stranded on the instance that issued the token; and
+//! - a cross-instance WebRTC target is explicitly rejected, never relayed.
+
+mod v3_conformance_helpers;
+mod websocket_test_helpers;
+
+use serde_json::json;
+use signal_fish_server::protocol::{
+    ClientMessage, ErrorCode, PlayerId, RoomJoinedPayload, ServerMessage, Topology, Transport,
+};
+use tokio_tungstenite::connect_async;
+use v3_conformance_helpers::{send, SERVER_MESSAGE_TIMEOUT};
+use websocket_test_helpers::server_process::{spawn_server, CONNECT_TIMEOUT};
+use websocket_test_helpers::{next_matching_server_message_within, WsStream};
+
+const APP_ID: &str = "split-brain-catalog-app";
+const GAME_NAME: &str = "split-brain-catalog-game";
+
+fn config_overlay() -> serde_json::Value {
+    json!({
+        "session": {
+            "default_topology": "mesh",
+            "enable_webrtc": true
+        }
+    })
+}
+
+async fn connect_v3(port: u16) -> WsStream {
+    let url = format!("ws://127.0.0.1:{port}/v3/ws");
+    let (mut ws, _) = tokio::time::timeout(CONNECT_TIMEOUT, connect_async(&url))
+        .await
+        .expect("websocket connect timeout")
+        .expect("websocket connect");
+
+    send(
+        &mut ws,
+        &ClientMessage::Authenticate {
+            app_id: APP_ID.to_string(),
+            sdk_version: None,
+            platform: None,
+            game_data_format: None,
+            protocol_version: Some(3),
+            supported_transports: Some(vec![Transport::Relay, Transport::WebRtc]),
+            supported_topologies: Some(vec![Topology::Relay, Topology::Mesh]),
+        },
+    )
+    .await;
+
+    next_matching_server_message_within(
+        &mut ws,
+        SERVER_MESSAGE_TIMEOUT,
+        "split-brain authentication",
+        |message| matches!(message, ServerMessage::Authenticated { .. }).then_some(()),
+    )
+    .await;
+    next_matching_server_message_within(
+        &mut ws,
+        SERVER_MESSAGE_TIMEOUT,
+        "split-brain protocol negotiation",
+        |message| match message {
+            ServerMessage::ProtocolInfo(info) => {
+                assert_eq!(info.protocol_version, Some(3));
+                Some(())
+            }
+            _ => None,
+        },
+    )
+    .await;
+
+    ws
+}
+
+async fn join_room(
+    ws: &mut WsStream,
+    room_code: Option<String>,
+    player_name: &str,
+) -> Box<RoomJoinedPayload> {
+    send(
+        ws,
+        &ClientMessage::JoinRoom {
+            game_name: GAME_NAME.to_string(),
+            room_code,
+            player_name: player_name.to_string(),
+            max_players: Some(2),
+            supports_authority: Some(false),
+            relay_transport: None,
+        },
+    )
+    .await;
+
+    next_matching_server_message_within(
+        ws,
+        SERVER_MESSAGE_TIMEOUT,
+        "split-brain room join",
+        |message| match message {
+            ServerMessage::RoomJoined(payload) => Some(payload),
+            ServerMessage::RoomJoinFailed { reason, error_code } => {
+                panic!("split-brain room join failed: {reason} ({error_code:?})")
+            }
+            _ => None,
+        },
+    )
+    .await
+}
+
+async fn expect_signal_rejection(ws: &mut WsStream, target: PlayerId) {
+    send(
+        ws,
+        &ClientMessage::Signal {
+            to: target,
+            signal: json!({"Offer": "cross-instance-offer"}),
+        },
+    )
+    .await;
+
+    next_matching_server_message_within(
+        ws,
+        SERVER_MESSAGE_TIMEOUT,
+        "cross-instance signal rejection",
+        |message| match message {
+            ServerMessage::Error {
+                message,
+                error_code,
+            } => {
+                assert_eq!(error_code, Some(ErrorCode::SignalTargetNotFound));
+                assert_eq!(message, "Signal target is not in any room");
+                Some(())
+            }
+            ServerMessage::Signal { .. } => {
+                panic!("a cross-instance Signal must never be relayed")
+            }
+            _ => None,
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "nightly-only documentation experiment (verification-nightly.yml): spawns two real server processes"]
+async fn two_instances_produce_the_documented_split_brain_catalog() {
+    let instance_a = spawn_server(config_overlay()).await;
+    let instance_b = spawn_server(config_overlay()).await;
+
+    let mut peer_a = connect_v3(instance_a.port).await;
+    let joined_a = join_room(&mut peer_a, None, "InstanceAPlayer").await;
+    let reconnect_token = joined_a
+        .reconnection_token
+        .clone()
+        .expect("v3 RoomJoined must issue a reconnect token");
+
+    // Joining the same logical key on another process does not discover the
+    // first room. Join-by-code creates a second local room without warning.
+    let mut peer_b = connect_v3(instance_b.port).await;
+    let joined_b = join_room(
+        &mut peer_b,
+        Some(joined_a.room_code.clone()),
+        "InstanceBPlayer",
+    )
+    .await;
+    assert_eq!(joined_b.room_code, joined_a.room_code);
+    assert_eq!(joined_b.game_name, joined_a.game_name);
+    assert_ne!(
+        joined_b.room_id, joined_a.room_id,
+        "the two processes must expose the silent split as distinct room identities"
+    );
+    assert_eq!(joined_a.current_players.len(), 1);
+    assert_eq!(joined_b.current_players.len(), 1);
+
+    // The second process has neither the player identity nor the pending
+    // disconnection registry entry, even when presented with the real token.
+    let mut cross_instance_reconnector = connect_v3(instance_b.port).await;
+    send(
+        &mut cross_instance_reconnector,
+        &ClientMessage::Reconnect {
+            player_id: joined_a.player_id,
+            room_id: joined_a.room_id,
+            auth_token: reconnect_token,
+        },
+    )
+    .await;
+    let (reason, error_code) = next_matching_server_message_within(
+        &mut cross_instance_reconnector,
+        SERVER_MESSAGE_TIMEOUT,
+        "cross-instance reconnect rejection",
+        |message| match message {
+            ServerMessage::ReconnectionFailed { reason, error_code } => Some((reason, error_code)),
+            ServerMessage::Reconnected(payload) => panic!(
+                "a different process must not reconnect instance A player {}",
+                payload.player_id
+            ),
+            _ => None,
+        },
+    )
+    .await;
+    assert_eq!(error_code, ErrorCode::ReconnectionFailed);
+    assert_eq!(reason, "No disconnection record found");
+
+    // Instance A cannot see instance B's player registry. The rejection is
+    // explicit and deterministic, but it cannot identify this as CrossRoom:
+    // the target is entirely absent from A's local world.
+    expect_signal_rejection(&mut peer_a, joined_b.player_id).await;
+}

--- a/tests/split_brain_two_instances_e2e.rs
+++ b/tests/split_brain_two_instances_e2e.rs
@@ -14,12 +14,13 @@ mod websocket_test_helpers;
 
 use serde_json::json;
 use signal_fish_server::protocol::{
-    ClientMessage, ErrorCode, PlayerId, RoomJoinedPayload, ServerMessage, Topology, Transport,
+    ClientMessage, ErrorCode, LobbyState, PlayerId, RoomJoinedPayload, ServerMessage, Topology,
+    Transport,
 };
 use tokio_tungstenite::connect_async;
 use v3_conformance_helpers::{send, SERVER_MESSAGE_TIMEOUT};
 use websocket_test_helpers::server_process::{spawn_server, CONNECT_TIMEOUT};
-use websocket_test_helpers::{next_matching_server_message_within, WsStream};
+use websocket_test_helpers::{next_server_message_within, WsStream};
 
 const APP_ID: &str = "split-brain-catalog-app";
 const GAME_NAME: &str = "split-brain-catalog-game";
@@ -54,26 +55,27 @@ async fn connect_v3(port: u16) -> WsStream {
     )
     .await;
 
-    next_matching_server_message_within(
+    let authenticated = next_server_message_within(
         &mut ws,
         SERVER_MESSAGE_TIMEOUT,
         "split-brain authentication",
-        |message| matches!(message, ServerMessage::Authenticated { .. }).then_some(()),
     )
     .await;
-    next_matching_server_message_within(
+    assert!(
+        matches!(authenticated, ServerMessage::Authenticated { .. }),
+        "expected Authenticated, got {authenticated:?}"
+    );
+
+    let protocol_info = next_server_message_within(
         &mut ws,
         SERVER_MESSAGE_TIMEOUT,
         "split-brain protocol negotiation",
-        |message| match message {
-            ServerMessage::ProtocolInfo(info) => {
-                assert_eq!(info.protocol_version, Some(3));
-                Some(())
-            }
-            _ => None,
-        },
     )
     .await;
+    let ServerMessage::ProtocolInfo(info) = protocol_info else {
+        panic!("expected ProtocolInfo, got {protocol_info:?}");
+    };
+    assert_eq!(info.protocol_version, Some(3));
 
     ws
 }
@@ -96,19 +98,36 @@ async fn join_room(
     )
     .await;
 
-    next_matching_server_message_within(
+    let message =
+        next_server_message_within(ws, SERVER_MESSAGE_TIMEOUT, "split-brain room join").await;
+    let payload = match message {
+        ServerMessage::RoomJoined(payload) => payload,
+        ServerMessage::RoomJoinFailed { reason, error_code } => {
+            panic!("split-brain room join failed: {reason} ({error_code:?})")
+        }
+        other => panic!("expected RoomJoined, got {other:?}"),
+    };
+
+    let lobby_transition = next_server_message_within(
         ws,
         SERVER_MESSAGE_TIMEOUT,
-        "split-brain room join",
-        |message| match message {
-            ServerMessage::RoomJoined(payload) => Some(payload),
-            ServerMessage::RoomJoinFailed { reason, error_code } => {
-                panic!("split-brain room join failed: {reason} ({error_code:?})")
-            }
-            _ => None,
-        },
+        "split-brain first-player lobby transition",
     )
-    .await
+    .await;
+    match lobby_transition {
+        ServerMessage::LobbyStateChanged {
+            lobby_state,
+            ready_players,
+            all_ready,
+        } => {
+            assert_eq!(lobby_state, LobbyState::Lobby);
+            assert!(ready_players.is_empty());
+            assert!(!all_ready);
+        }
+        other => panic!("expected LobbyStateChanged, got {other:?}"),
+    }
+
+    payload
 }
 
 async fn expect_signal_rejection(ws: &mut WsStream, target: PlayerId) {
@@ -121,26 +140,23 @@ async fn expect_signal_rejection(ws: &mut WsStream, target: PlayerId) {
     )
     .await;
 
-    next_matching_server_message_within(
+    let rejection = next_server_message_within(
         ws,
         SERVER_MESSAGE_TIMEOUT,
         "cross-instance signal rejection",
-        |message| match message {
-            ServerMessage::Error {
-                message,
-                error_code,
-            } => {
-                assert_eq!(error_code, Some(ErrorCode::SignalTargetNotFound));
-                assert_eq!(message, "Signal target is not in any room");
-                Some(())
-            }
-            ServerMessage::Signal { .. } => {
-                panic!("a cross-instance Signal must never be relayed")
-            }
-            _ => None,
-        },
     )
     .await;
+    match rejection {
+        ServerMessage::Error {
+            message,
+            error_code,
+        } => {
+            assert_eq!(error_code, Some(ErrorCode::SignalTargetNotFound));
+            assert_eq!(message, "Signal target is not in any room");
+        }
+        ServerMessage::Signal { .. } => panic!("a cross-instance Signal must never be relayed"),
+        other => panic!("expected SignalTargetNotFound, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -186,20 +202,20 @@ async fn two_instances_produce_the_documented_split_brain_catalog() {
         },
     )
     .await;
-    let (reason, error_code) = next_matching_server_message_within(
+    let reconnect_rejection = next_server_message_within(
         &mut cross_instance_reconnector,
         SERVER_MESSAGE_TIMEOUT,
         "cross-instance reconnect rejection",
-        |message| match message {
-            ServerMessage::ReconnectionFailed { reason, error_code } => Some((reason, error_code)),
-            ServerMessage::Reconnected(payload) => panic!(
-                "a different process must not reconnect instance A player {}",
-                payload.player_id
-            ),
-            _ => None,
-        },
     )
     .await;
+    let (reason, error_code) = match reconnect_rejection {
+        ServerMessage::ReconnectionFailed { reason, error_code } => (reason, error_code),
+        ServerMessage::Reconnected(payload) => panic!(
+            "a different process must not reconnect instance A player {}",
+            payload.player_id
+        ),
+        other => panic!("expected ReconnectionFailed, got {other:?}"),
+    };
     assert_eq!(error_code, ErrorCode::ReconnectionFailed);
     assert_eq!(reason, "No disconnection record found");
 


### PR DESCRIPTION
## Summary

- prove the unsupported two-instance failure catalog with a real-binary nightly experiment
- publish the single-instance deployment contract and correct every public multi-node implication
- record the completed protocol-v3 delivery-reliability revision in ADR-0006
- add structured startup fields for the in-memory/no-handoff boundary
- keep the pre-commit Rust panic guard on its sub-second fast path

## Why

The shipped database, room coordinator, reconnect state, routing tables, sequence counters, and locks are process-local. Existing documentation still suggested that generic sticky sessions, room-code prefixes, or coordination settings made interchangeable multi-process deployment safe. That could silently split one logical room across healthy processes.

The test demonstrates the actual behavior: duplicate public room codes with different room IDs, stranded reconnect state, and explicit cross-instance signal rejection.

## User impact

Operators now get one consistent deployment rule: one process owns a room for its lifetime. Multiple isolated deployments require an application-owned directory that chooses the room home before the WebSocket upgrade. Startup logs expose this boundary as structured fields.

## Validation

- targeted clippy for the split-brain and CI-policy suites with warnings denied
- real two-process split-brain catalog test
- 271 CI configuration policy tests
- 14 documentation consistency policy/script tests
- documentation consistency, CI config, workflow hygiene, tooling parity, cargo-deny, hook readiness, and pre-push checks
- actual pre-commit hook measured at 607 ms and 446 ms for the two follow-up commits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Operator-facing deployment guidance changes materially (no interchangeable LB fleet), but runtime behavior for correctly routed single-process deploys is unchanged; risk is mainly misconfiguration if teams ignore the new contract.
> 
> **Overview**
> This PR **documents and enforces the single-instance deployment boundary**: one process owns each room’s in-memory state, reconnect tokens, and relay sequencing, with no session handoff across processes.
> 
> It adds **`docs/architecture/single-instance-deployment.md`**, rewrites **`scaling.md`** and related deployment/run-mode/checklist pages to drop implied multi-node safety from sticky sessions, prefixes, and coordination config, and aligns comments/metrics in coordination, `distributed`, and server code to **process-local** semantics. **Startup logs** in `main.rs` and `websocket/routes.rs` now emit structured fields (`deployment_mode`, `room_affinity_required`, etc.).
> 
> **`tests/split_brain_two_instances_e2e.rs`** runs two real server binaries nightly to pin duplicate room codes, stranded reconnects, and cross-instance signal rejection; it is wired into **`verification-nightly.yml`** and the **`process-spawning`** nextest group. **ADR-0006** records the completed protocol v3 delivery-reliability revision; formal-verification docs link TLA split-brain counterexamples to that test.
> 
> Hook/CI tweaks keep **pre-commit** on a **`git diff -G` fast path** for Rust panic policy and batch **pre-push** workflow blob reads; **CHANGELOG** and **mkdocs** index the new doctrine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 494bd3fe3e2c060e37b61d9cdfa13386b54d5566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->