### PR TITLE
Enforce canonical release identity across GitHub and GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -187,7 +187,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.verify.outputs.digest }}
+      digest: ${{ steps.verify.outputs.digest || steps.rolling-digest.outputs.digest }}
     steps:
       - name: Checkout exact source
         uses: actions/checkout@v7.0.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,52 +1,17 @@
 # Docker Publish Workflow
 #
-# Builds and pushes the Signal Fish Server Docker image to the GitHub Container
-# Registry (ghcr.io) so that users can pull it publicly.
+# One implementation serves three entry points:
+#   - pushes to main publish rolling :latest and immutable :sha-* tags;
+#   - direct annotated v* tag pushes publish versioned tags;
+#   - workflow calls from release.yml publish the exact release commit directly,
+#     without relying on a GITHUB_TOKEN-generated tag event;
+#   - manual dispatch with an existing annotated tag backfills historical tags
+#     from that tag's commit.
 #
-# Runs on:
-#   - Push to main branch (publishes the :latest tag)
-#   - Tag pushes matching v* (publishes semver tags, e.g. :1.2.3, :v1.2.3)
-#
-# Published image: ghcr.io/<repository_owner>/<repository_name>
-#
-# Tags published:
-#   - :latest      — always points to the most recent push to main
-#   - :sha-<short> — immutable, traceable to exact commit
-#   - :v1.2.3      — raw git tag (on v* tag pushes)
-#   - :1.2.3       — semver without 'v' prefix (on v* tag pushes)
-#   - :1.2         — major.minor only (on v* tag pushes)
-#
-# Multi-architecture (issue #122):
-#   The image is published as a single multi-arch manifest list covering
-#   linux/amd64, linux/arm64, and linux/arm/v7 so ARM consumers (AWS Graviton,
-#   Ampere, Raspberry Pi, Apple Silicon under Docker) can pull it. The Rust
-#   build is cross-compiled natively on the amd64 runner (see Dockerfile);
-#   QEMU only emulates the tiny runtime stage. Keep the `platforms:` list below
-#   in sync with the Dockerfile arch map and with REQUIRED_CONTAINER_PLATFORMS
-#   in tests/ci_config_tests.rs.
-#
-# ⚠️  Making the package public (one-time manual step):
-#   After the first successful workflow run, the package will be private by
-#   default. An owner must make it public at:
-#   https://github.com/orgs/${{ github.repository_owner }}/packages/container/signal-fish-server/settings
-#
-#   Alternatively, run:
-#   gh api --method PATCH \
-#     /orgs/${{ github.repository_owner }}/packages/container/signal-fish-server \
-#     -f visibility=public
-#
-# Permissions:
-#   packages: write  — required to push to GHCR
-#   contents: read   — required to check out the repository
-#
-# Action reference policy:
-#   This repository requires explicit version tags (for example `@v6.0.3`) and
-#   disallows commit SHAs/moving refs for remote actions.
-#
-# Security note:
-#   The GITHUB_TOKEN is used for authentication. No long-lived secrets are
-#   baked into the image. Image visibility is managed separately via the
-#   GitHub package settings.
+# Every release image is one multi-architecture manifest covering linux/amd64,
+# linux/arm64, and linux/arm/v7. Version tags are immutable: retries reuse a
+# verified digest and repair missing aliases, but never move an existing version
+# tag to different bytes.
 
 name: Docker Publish
 
@@ -55,28 +20,179 @@ on:
     branches: [main]
     tags:
       - "v*"
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing annotated tag to backfill, e.g. v0.4.0"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      release_version:
+        description: "Canonical Cargo version without the v prefix"
+        required: true
+        type: string
+      release_tag:
+        description: "Canonical annotated Git tag"
+        required: true
+        type: string
+      source_ref:
+        description: "Exact source ref to check out"
+        required: true
+        type: string
+      source_revision:
+        description: "Exact 40-character source commit SHA"
+        required: true
+        type: string
+    outputs:
+      digest:
+        description: "Verified multi-architecture manifest digest"
+        value: ${{ jobs.docker-publish.outputs.digest }}
 
 permissions:
   contents: read
   packages: write
 
 jobs:
+  resolve:
+    name: Resolve container identity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      source_revision: ${{ steps.identity.outputs.source_revision }}
+      release_version: ${{ steps.identity.outputs.release_version }}
+      release_tag: ${{ steps.identity.outputs.release_tag }}
+      major_minor: ${{ steps.identity.outputs.major_minor }}
+      short_sha: ${{ steps.identity.outputs.short_sha }}
+      is_release: ${{ steps.identity.outputs.is_release }}
+      publish_latest: ${{ steps.identity.outputs.publish_latest }}
+      image_version: ${{ steps.identity.outputs.image_version }}
+      is_backfill: ${{ steps.identity.outputs.is_backfill }}
+    steps:
+      - name: Checkout exact source
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.source_ref || inputs.release_tag || github.sha }}
+
+      - name: Resolve and validate source identity
+        id: identity
+        shell: bash
+        env:
+          CALL_VERSION: ${{ inputs.release_version }}
+          CALL_TAG: ${{ inputs.release_tag }}
+          CALL_REVISION: ${{ inputs.source_revision }}
+        run: |
+          set -euo pipefail
+
+          source_revision=$(git rev-parse "HEAD^{commit}")
+          cargo_version=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
+          if [ -z "$cargo_version" ]; then
+            echo "ERROR: Could not extract [package].version from Cargo.toml." >&2
+            exit 1
+          fi
+
+          release_version=""
+          release_tag=""
+          publish_latest=false
+          is_backfill=false
+          if [ -n "$CALL_REVISION" ]; then
+            # Reusable workflows retain caller event context, so the explicit
+            # source revision is the unambiguous workflow_call discriminator.
+            release_version=$CALL_VERSION
+            release_tag=$CALL_TAG
+            if [ "$source_revision" != "$CALL_REVISION" ]; then
+              echo "ERROR: Checked-out revision $source_revision does not match requested revision $CALL_REVISION." >&2
+              exit 1
+            fi
+          else
+            case "${{ github.event_name }}" in
+              workflow_dispatch)
+              release_tag=$CALL_TAG
+              release_version=${release_tag#v}
+                is_backfill=true
+                ;;
+              push)
+                if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+                  release_tag=${GITHUB_REF#refs/tags/}
+                  release_version=${release_tag#v}
+                elif [ "$GITHUB_REF" = "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+                  publish_latest=true
+                else
+                  echo "ERROR: Unsupported Docker Publish ref: $GITHUB_REF" >&2
+                  exit 1
+                fi
+                ;;
+              *)
+                echo "ERROR: Unsupported Docker Publish event: ${{ github.event_name }}" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [ -n "$release_version" ]; then
+            if [ "$release_tag" != "v${release_version}" ] || [ "$release_version" != "$cargo_version" ]; then
+              echo "ERROR: Release tag ($release_tag), requested version ($release_version), and Cargo.toml ($cargo_version) disagree." >&2
+              exit 1
+            fi
+            if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: Release version is not canonical semantic version text: $release_version" >&2
+              exit 1
+            fi
+            if [ "$(git cat-file -t "refs/tags/${release_tag}" 2>/dev/null || true)" != "tag" ]; then
+              echo "ERROR: $release_tag must exist as an annotated Git tag before container publication." >&2
+              exit 1
+            fi
+            tag_revision=$(git rev-parse "refs/tags/${release_tag}^{commit}")
+            if [ "$tag_revision" != "$source_revision" ]; then
+              echo "ERROR: $release_tag resolves to $tag_revision, not checked-out commit $source_revision." >&2
+              exit 1
+            fi
+            if [ "$is_backfill" != "true" ] && ! grep -Fqx "## [${release_version}]" CHANGELOG.md; then
+              echo "ERROR: CHANGELOG.md has no exact ## [${release_version}] release section." >&2
+              exit 1
+            fi
+            major_minor=${release_version%.*}
+            is_release=true
+          else
+            major_minor=""
+            is_release=false
+          fi
+
+          {
+            echo "source_revision=$source_revision"
+            echo "release_version=$release_version"
+            echo "release_tag=$release_tag"
+            echo "major_minor=$major_minor"
+            echo "short_sha=${source_revision:0:7}"
+            echo "is_release=$is_release"
+            echo "publish_latest=$publish_latest"
+            echo "image_version=$cargo_version"
+            echo "is_backfill=$is_backfill"
+          } >> "$GITHUB_OUTPUT"
+
   docker-publish:
     name: Build and Push Docker Image
+    needs: [resolve]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: container-publish-${{ needs.resolve.outputs.source_revision }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.verify.outputs.digest }}
     steps:
-      - name: Checkout repository
+      - name: Checkout exact source
         uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.source_revision }}
 
       - name: Set up QEMU
-        # Provides binfmt handlers so buildx can execute the target-arch runtime
-        # stage (useradd + apt-get). The Rust compile itself is cross-compiled
-        # natively on this amd64 runner and never runs under emulation.
         uses: docker/setup-qemu-action@v4.2.0
 
       - name: Set up Docker Buildx
@@ -98,19 +214,101 @@ jobs:
           repo="${repo,,}"
           echo "name=ghcr.io/${owner}/${repo}" >> "$GITHUB_OUTPUT"
 
+      - name: Reuse a verified immutable release digest
+        id: existing
+        if: needs.resolve.outputs.is_release == 'true'
+        shell: bash
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+          SOURCE_REVISION: ${{ needs.resolve.outputs.source_revision }}
+          SHA_TAG: sha-${{ needs.resolve.outputs.short_sha }}
+          IS_BACKFILL: ${{ needs.resolve.outputs.is_backfill }}
+        run: |
+          set -euo pipefail
+
+          tag_exists() {
+            local reference=$1
+            local inspect_output
+            if inspect_output=$(docker buildx imagetools inspect "$reference" 2>&1); then
+              return 0
+            fi
+            if grep -Eqi 'not found|manifest unknown|name unknown' <<< "$inspect_output"; then
+              return 1
+            fi
+            echo "ERROR: Could not determine whether $reference exists; refusing to rebuild over an unknown registry state." >&2
+            printf '%s\n' "$inspect_output" >&2
+            exit 1
+          }
+
+          desired_tags=("$RELEASE_TAG" "$RELEASE_VERSION")
+          sha_exists=false
+          if tag_exists "${IMAGE}:${SHA_TAG}"; then
+            sha_exists=true
+          fi
+          if [ "$IS_BACKFILL" != "true" ]; then
+            desired_tags+=("$SHA_TAG")
+          fi
+          existing_tags=()
+          missing_tags=()
+          for tag in "${desired_tags[@]}"; do
+            if tag_exists "${IMAGE}:${tag}"; then
+              existing_tags+=("$tag")
+            else
+              missing_tags+=("$tag")
+            fi
+          done
+
+          if [ "${#existing_tags[@]}" -eq 0 ]; then
+            {
+              echo "reuse=false"
+              if [ "$IS_BACKFILL" = "true" ] && [ "$sha_exists" = "true" ]; then
+                echo "publish_sha=false"
+              else
+                echo "publish_sha=true"
+              fi
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          digest=$(bash scripts/verify-release-image.sh \
+            "$IMAGE" "$SOURCE_REVISION" "$RELEASE_VERSION" "${existing_tags[@]}")
+          for tag in "${missing_tags[@]}"; do
+            docker buildx imagetools create --tag "${IMAGE}:${tag}" "${IMAGE}@${digest}"
+          done
+          if [ "$IS_BACKFILL" = "true" ] && [ "$sha_exists" != "true" ]; then
+            docker buildx imagetools create --tag "${IMAGE}:${SHA_TAG}" "${IMAGE}@${digest}"
+          fi
+          echo "Reusing verified release digest $digest"
+          {
+            echo "reuse=true"
+            echo "digest=$digest"
+            echo "publish_sha=false"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v6.2.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: ${{ steps.image.outputs.name }}
+          flavor: latest=false
           tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ needs.resolve.outputs.publish_latest == 'true' }}
+            type=raw,value=sha-${{ needs.resolve.outputs.short_sha }},enable=${{ steps.existing.outputs.publish_sha != 'false' }}
+            type=raw,value=${{ needs.resolve.outputs.release_tag }},enable=${{ needs.resolve.outputs.is_release == 'true' }}
+            type=raw,value=${{ needs.resolve.outputs.release_version }},enable=${{ needs.resolve.outputs.is_release == 'true' }}
+            type=raw,value=${{ needs.resolve.outputs.major_minor }},enable=${{ needs.resolve.outputs.is_release == 'true' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ needs.resolve.outputs.source_revision }}
+            org.opencontainers.image.version=${{ needs.resolve.outputs.image_version }}
 
       - name: Build and push Docker image
+        id: build
+        if: steps.existing.outputs.reuse != 'true'
         uses: docker/build-push-action@v7.3.0
         with:
           context: .
@@ -118,5 +316,41 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Update release rolling tag
+        if: needs.resolve.outputs.is_release == 'true' && steps.existing.outputs.reuse == 'true'
+        shell: bash
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          DIGEST: ${{ steps.existing.outputs.digest }}
+          MAJOR_MINOR: ${{ needs.resolve.outputs.major_minor }}
+        run: docker buildx imagetools create --tag "${IMAGE}:${MAJOR_MINOR}" "${IMAGE}@${DIGEST}"
+
+      - name: Verify versioned tags, platforms, and source labels
+        id: verify
+        if: needs.resolve.outputs.is_release == 'true'
+        shell: bash
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+          SOURCE_REVISION: ${{ needs.resolve.outputs.source_revision }}
+          SHA_TAG: sha-${{ needs.resolve.outputs.short_sha }}
+          PUBLISH_SHA: ${{ steps.existing.outputs.publish_sha }}
+        run: |
+          set -euo pipefail
+          tags=("$RELEASE_TAG" "$RELEASE_VERSION")
+          if [ "$PUBLISH_SHA" != "false" ]; then
+            tags+=("$SHA_TAG")
+          fi
+          bash scripts/verify-release-image.sh \
+            "$IMAGE" "$SOURCE_REVISION" "$RELEASE_VERSION" "${tags[@]}"
+
+      - name: Record rolling image digest
+        id: rolling-digest
+        if: needs.resolve.outputs.is_release != 'true'
+        shell: bash
+        run: echo "digest=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -141,6 +141,7 @@ jobs:
               echo "ERROR: Release version is not canonical semantic version text: $release_version" >&2
               exit 1
             fi
+            git fetch --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
             if [ "$(git cat-file -t "refs/tags/${release_tag}" 2>/dev/null || true)" != "tag" ]; then
               echo "ERROR: $release_tag must exist as an annotated Git tag before container publication." >&2
               exit 1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -150,8 +150,9 @@ jobs:
               echo "ERROR: $release_tag resolves to $tag_revision, not checked-out commit $source_revision." >&2
               exit 1
             fi
-            if [ "$is_backfill" != "true" ] && ! grep -Fqx "## [${release_version}]" CHANGELOG.md; then
-              echo "ERROR: CHANGELOG.md has no exact ## [${release_version}] release section." >&2
+            escaped_version=${release_version//./\\.}
+            if [ "$is_backfill" != "true" ] && ! grep -Eq "^## \\[${escaped_version}\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
+              echo "ERROR: CHANGELOG.md has no ## [${release_version}] release section, with or without a date." >&2
               exit 1
             fi
             major_minor=${release_version%.*}
@@ -179,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:
-      group: container-publish-${{ needs.resolve.outputs.source_revision }}
+      group: container-publish-${{ needs.resolve.outputs.publish_latest == 'true' && 'latest' || needs.resolve.outputs.source_revision }}
       cancel-in-progress: false
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref || inputs.release_tag || github.sha }}
+          ref: ${{ inputs.source_ref || inputs.release_tag || github.ref }}
 
       - name: Resolve and validate source identity
         id: identity
@@ -338,12 +338,13 @@ jobs:
           IMAGE: ${{ steps.image.outputs.name }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
           RELEASE_VERSION: ${{ needs.resolve.outputs.release_version }}
+          MAJOR_MINOR: ${{ needs.resolve.outputs.major_minor }}
           SOURCE_REVISION: ${{ needs.resolve.outputs.source_revision }}
           SHA_TAG: sha-${{ needs.resolve.outputs.short_sha }}
           PUBLISH_SHA: ${{ steps.existing.outputs.publish_sha }}
         run: |
           set -euo pipefail
-          tags=("$RELEASE_TAG" "$RELEASE_VERSION")
+          tags=("$RELEASE_TAG" "$RELEASE_VERSION" "$MAJOR_MINOR")
           if [ "$PUBLISH_SHA" != "false" ]; then
             tags+=("$SHA_TAG")
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,13 +25,13 @@
 #     - Least-privilege workflow permissions
 #
 # Steps:
-#   1. Preflight: verify CI and doc-validation passed on this commit
-#   2. Verify version consistency (tag vs Cargo.toml)
-#   3. Dry-run publish to validate packaging
-#   4. Publish to crates.io
-#   5. Create git tag (for workflow_dispatch)
+#   1. Resolve one version/source identity and validate Cargo.toml + CHANGELOG
+#   2. Preflight: verify CI and doc-validation passed on that exact commit
+#   3. Create or validate the immutable annotated Git tag
+#   4. Call Docker Publish directly and verify version tags/platforms/OCI labels
+#   5. Dry-run and idempotently publish the crate from the tagged commit
 #   6. Generate SBOM (CycloneDX JSON) for supply-chain provenance
-#   7. Extract changelog section and create GitHub Release (with SBOM attached)
+#   7. Create/verify the GitHub Release and record the GHCR digest in its notes
 #   8. build-binaries: cross-compile standalone binaries for every supported
 #      OS/arch (Linux/macOS/Windows x86_64+aarch64) in parallel with publish
 #   9. attach-binaries: download all binary artifacts and attach them (with
@@ -52,17 +52,87 @@ on:
 permissions:
   contents: write
   actions: read
+  packages: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.release_version) || github.ref_name }}
   cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  resolve-release:
+    name: Resolve release identity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+      source_revision: ${{ steps.release.outputs.source_revision }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Validate canonical release identity
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          source_revision=$(git rev-parse "HEAD^{commit}")
+          cargo_version=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
+          if [ -z "$cargo_version" ]; then
+            echo "ERROR: Could not extract [package].version from Cargo.toml." >&2
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            version="${{ github.event.inputs.release_version }}"
+            tag="v${version}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+            version="${tag#v}"
+          fi
+
+          if [ "$version" != "$cargo_version" ] || [ "$tag" != "v${cargo_version}" ]; then
+            echo "ERROR: Workflow version ($version), Git tag ($tag), and Cargo.toml ($cargo_version) disagree." >&2
+            exit 1
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Release version is not canonical semantic version text: $version" >&2
+            exit 1
+          fi
+          if ! grep -Fqx "## [${version}]" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md has no exact ## [${version}] release section." >&2
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            if [ "$(git cat-file -t "refs/tags/${tag}" 2>/dev/null || true)" != "tag" ]; then
+              echo "ERROR: Direct release tag $tag must be annotated, not lightweight." >&2
+              exit 1
+            fi
+            tag_revision=$(git rev-parse "refs/tags/${tag}^{commit}")
+            if [ "$tag_revision" != "$source_revision" ]; then
+              echo "ERROR: $tag resolves to $tag_revision, not release commit $source_revision." >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "source_revision=$source_revision"
+          } >> "$GITHUB_OUTPUT"
+
   preflight:
     name: Preflight
+    needs: [resolve-release]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -73,9 +143,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # github.sha resolves to the underlying commit for both tag pushes
-          # and workflow_dispatch events
-          COMMIT_SHA="${{ github.sha }}"
+          COMMIT_SHA="${{ needs.resolve-release.outputs.source_revision }}"
           REPO="${{ github.repository }}"
           echo "Verifying CI status for commit: $COMMIT_SHA"
 
@@ -239,14 +307,85 @@ jobs:
 
           echo "All required CI checks passed. Proceeding with release."
 
+  ensure-tag:
+    name: Ensure immutable annotated tag
+    needs: [resolve-release, preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve-release.outputs.source_revision }}
+
+      - name: Create or validate annotated tag
+        shell: bash
+        env:
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+          SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+
+          validate_tag() {
+            if [ "$(git cat-file -t "refs/tags/${TAG}" 2>/dev/null || true)" != "tag" ]; then
+              echo "ERROR: ${TAG} exists but is not an annotated Git tag." >&2
+              exit 1
+            fi
+            actual_revision=$(git rev-parse "refs/tags/${TAG}^{commit}")
+            if [ "$actual_revision" != "$SOURCE_REVISION" ]; then
+              echo "ERROR: ${TAG} resolves to ${actual_revision}, not ${SOURCE_REVISION}; refusing to move it." >&2
+              exit 1
+            fi
+          }
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+            validate_tag
+            echo "Reusing immutable annotated tag ${TAG} at ${SOURCE_REVISION}."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" "$SOURCE_REVISION" -m "Release $TAG"
+          if git push origin "refs/tags/${TAG}"; then
+            echo "Created annotated tag ${TAG} at ${SOURCE_REVISION}."
+            exit 0
+          fi
+
+          # A concurrent retry may have won the create race. Accept only the
+          # exact immutable tag we intended; every other outcome fails closed.
+          git tag -d "$TAG"
+          git fetch --force origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          validate_tag
+
+  publish-container:
+    name: Publish versioned container
+    needs: [resolve-release, ensure-tag]
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      release_version: ${{ needs.resolve-release.outputs.version }}
+      release_tag: ${{ needs.resolve-release.outputs.tag }}
+      source_ref: ${{ needs.resolve-release.outputs.source_revision }}
+      source_revision: ${{ needs.resolve-release.outputs.source_revision }}
+
   publish:
-    needs: [preflight]
+    needs: [resolve-release, publish-container]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve-release.outputs.source_revision }}
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -298,35 +437,8 @@ jobs:
           restore-keys: |
             publish-${{ runner.os }}-cargo-
 
-      - name: Verify version consistency
-        run: |
-          CARGO_VERSION=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
-          if [ -z "$CARGO_VERSION" ]; then
-            echo "ERROR: Could not extract [package].version from Cargo.toml" >&2
-            exit 1
-          fi
-          echo "Cargo.toml version: $CARGO_VERSION"
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            INPUT_VERSION="${{ github.event.inputs.release_version }}"
-            if [ "$INPUT_VERSION" != "$CARGO_VERSION" ]; then
-              echo "Input version $INPUT_VERSION does not match Cargo.toml version $CARGO_VERSION" >&2
-              exit 1
-            fi
-            echo "Input version matches Cargo.toml"
-          fi
-
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            TAG_VERSION=${GITHUB_REF#refs/tags/}
-            if [ "$TAG_VERSION" != "v${CARGO_VERSION}" ]; then
-              echo "Tag version $TAG_VERSION does not match Cargo.toml version $CARGO_VERSION" >&2
-              exit 1
-            fi
-            echo "Tag version matches Cargo.toml"
-          fi
-
       - name: Publish (dry-run)
-        run: cargo publish --dry-run
+        run: cargo publish --locked --dry-run
         env:
           RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
           SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
@@ -334,39 +446,60 @@ jobs:
           SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
           SCCACHE_IDLE_TIMEOUT: "0"
 
+      - name: Check for an idempotent crates.io retry
+        id: crate
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve-release.outputs.version }}
+          SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
+        run: |
+          set -euo pipefail
+
+          api_url="https://crates.io/api/v1/crates/signal-fish-server/${VERSION}"
+          user_agent="signal-fish-server-release-workflow (https://github.com/${GITHUB_REPOSITORY})"
+          status=$(curl --user-agent "$user_agent" --retry 3 --retry-all-errors --silent --show-error \
+            --output crate-version.json --write-out '%{http_code}' "$api_url")
+          case "$status" in
+            404)
+              echo "exists=false" >> "$GITHUB_OUTPUT"
+              ;;
+            200)
+              checksum=$(jq -r '.version.checksum // empty' crate-version.json)
+              if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+                echo "ERROR: crates.io returned no valid checksum for signal-fish-server ${VERSION}." >&2
+                exit 1
+              fi
+
+              crate_file="signal-fish-server-${VERSION}.crate"
+              curl --user-agent "$user_agent" --retry 3 --retry-all-errors --fail --silent --show-error \
+                --location --output "$crate_file" \
+                "https://crates.io/api/v1/crates/signal-fish-server/${VERSION}/download"
+              actual_checksum=$(sha256sum "$crate_file" | awk '{print $1}')
+              if [ "$actual_checksum" != "$checksum" ]; then
+                echo "ERROR: Downloaded crate checksum $actual_checksum does not match crates.io $checksum." >&2
+                exit 1
+              fi
+
+              vcs_info=$(tar -xOf "$crate_file" --wildcards '*/.cargo_vcs_info.json' 2>/dev/null || true)
+              published_revision=$(printf '%s' "$vcs_info" | jq -r '.git.sha1 // empty' 2>/dev/null || true)
+              if [ "$published_revision" != "$SOURCE_REVISION" ]; then
+                echo "ERROR: signal-fish-server ${VERSION} already exists on crates.io from revision '$published_revision', expected '$SOURCE_REVISION'." >&2
+                exit 1
+              fi
+              echo "Crate ${VERSION} already exists from ${SOURCE_REVISION}; retry is safe."
+              echo "exists=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "ERROR: crates.io version lookup failed closed with HTTP ${status}." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Publish to crates.io
+        if: steps.crate.outputs.exists != 'true'
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish
-
-      - name: Create and push git tag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          CARGO_VERSION=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
-          if [ -z "$CARGO_VERSION" ]; then
-            echo "ERROR: Could not extract [package].version from Cargo.toml" >&2
-            exit 1
-          fi
-          TAG_NAME="v${CARGO_VERSION}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
-          git push origin "$TAG_NAME"
-
-      - name: Get version for release
-        id: get_version
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
-            if [ -z "$VERSION" ]; then
-              echo "ERROR: Could not extract [package].version from Cargo.toml" >&2
-              exit 1
-            fi
-          else
-            VERSION=${GITHUB_REF#refs/tags/v}
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+        run: cargo publish --locked
 
       - name: Install cargo-sbom
         uses: taiki-e/install-action@v2.83.2
@@ -381,7 +514,7 @@ jobs:
       - name: Extract changelog for release
         id: changelog
         run: |
-          VERSION="${{ steps.get_version.outputs.version }}"
+          VERSION="${{ needs.resolve-release.outputs.version }}"
           # Extract the section for this version from CHANGELOG.md
           # Matches from "## [X.Y.Z]" until the next "## [" or end of file
           CHANGELOG_CONTENT=$(awk -v ver="$VERSION" '
@@ -397,14 +530,47 @@ jobs:
             CHANGELOG_CONTENT="Release $VERSION"
           fi
 
-          # Write to file to preserve newlines
-          echo "$CHANGELOG_CONTENT" > release_notes.md
+          {
+            echo "$CHANGELOG_CONTENT"
+            echo ""
+            echo "### Container image"
+            echo ""
+            echo "\`ghcr.io/${GITHUB_REPOSITORY,,}:${VERSION}\`"
+            echo ""
+            echo "Multi-architecture manifest digest: \`${{ needs.publish-container.outputs.digest }}\`"
+            echo ""
+            echo "Source revision: \`${{ needs.resolve-release.outputs.source_revision }}\`"
+          } > release_notes.md
+
+      - name: Validate an existing GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null); then
+            actual_tag=$(printf '%s' "$release" | jq -r '.tag_name // empty')
+            if [ "$actual_tag" != "$TAG" ]; then
+              echo "ERROR: Existing GitHub Release tag '$actual_tag' disagrees with '$TAG'." >&2
+              exit 1
+            fi
+            echo "Existing GitHub Release for $TAG will be completed idempotently."
+          else
+            status=$(gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1 \
+              | sed -n 's/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' | head -n 1 || true)
+            if [ "$status" != "404" ]; then
+              echo "ERROR: Could not verify whether GitHub Release $TAG exists (HTTP ${status:-unknown})." >&2
+              exit 1
+            fi
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3.0.2
         with:
-          tag_name: ${{ steps.get_version.outputs.tag }}
-          name: ${{ steps.get_version.outputs.tag }}
+          tag_name: ${{ needs.resolve-release.outputs.tag }}
+          name: ${{ needs.resolve-release.outputs.tag }}
+          target_commitish: ${{ needs.resolve-release.outputs.source_revision }}
           body_path: release_notes.md
           draft: false
           prerelease: false
@@ -415,10 +581,25 @@ jobs:
         if: steps.sbom.outcome == 'success'
         uses: softprops/action-gh-release@v3.0.2
         with:
-          tag_name: ${{ steps.get_version.outputs.tag }}
+          tag_name: ${{ needs.resolve-release.outputs.tag }}
           files: sbom.cdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify GitHub Release identity
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")
+          actual_tag=$(printf '%s' "$release" | jq -r '.tag_name // empty')
+          is_draft=$(printf '%s' "$release" | jq -r '.draft')
+          if [ "$actual_tag" != "$TAG" ] || [ "$is_draft" != "false" ]; then
+            echo "ERROR: GitHub Release identity is inconsistent (tag=$actual_tag, draft=$is_draft)." >&2
+            exit 1
+          fi
 
   # ---------------------------------------------------------------------------
   # Cross-platform standalone binaries
@@ -430,7 +611,8 @@ jobs:
   # Build and upload are deliberately SPLIT into two jobs:
   #   - `build-binaries` (this job): a `fail-fast: false` matrix that compiles
   #     each target and uploads its archive + checksum as a workflow artifact.
-  #     It depends only on `preflight`, so it runs in PARALLEL with `publish`.
+  #     It starts after the immutable tag exists, in PARALLEL with container and
+  #     crate publication.
   #   - `attach-binaries` (below): a single job that downloads every artifact
   #     and performs ONE `action-gh-release` upload. Funnelling all assets
   #     through one release API call avoids the race where N parallel matrix
@@ -448,7 +630,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build-binaries:
     name: Binary (${{ matrix.target }})
-    needs: [preflight]
+    needs: [resolve-release, ensure-tag]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     permissions:
@@ -480,6 +662,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ needs.resolve-release.outputs.source_revision }}
 
       - name: Read Rust toolchain
         id: toolchain
@@ -524,17 +708,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Resolve version: tag pushes carry it in the ref; dispatch reads it
-          # from Cargo.toml.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
-            if [ -z "$VERSION" ]; then
-              echo "ERROR: Could not extract [package].version from Cargo.toml" >&2
-              exit 1
-            fi
-          else
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          fi
+          VERSION="${{ needs.resolve-release.outputs.version }}"
 
           BIN=signal-fish-server
           EXE=""
@@ -589,7 +763,7 @@ jobs:
   # ---------------------------------------------------------------------------
   attach-binaries:
     name: Attach binaries to release
-    needs: [publish, build-binaries]
+    needs: [resolve-release, publish, build-binaries]
     if: ${{ !cancelled() && needs.publish.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -630,29 +804,11 @@ jobs:
           pattern: release-binary-*
           merge-multiple: true
 
-      - name: Resolve release tag
-        if: steps.binary-artifacts.outputs.count != '0'
-        id: tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
-            if [ -z "$VERSION" ]; then
-              echo "ERROR: Could not extract [package].version from Cargo.toml" >&2
-              exit 1
-            fi
-            TAG="v${VERSION}"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-
       - name: Attach binaries to release
         if: steps.binary-artifacts.outputs.count != '0'
         uses: softprops/action-gh-release@v3.0.2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.resolve-release.outputs.tag }}
           files: |
             dist/*.tar.gz
             dist/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ on:
 permissions:
   contents: write
   actions: read
-  packages: write
 
 concurrency:
   group: release-${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.release_version) || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,9 @@ jobs:
             echo "ERROR: Release version is not canonical semantic version text: $version" >&2
             exit 1
           fi
-          if ! grep -Fqx "## [${version}]" CHANGELOG.md; then
-            echo "ERROR: CHANGELOG.md has no exact ## [${version}] release section." >&2
+          escaped_version=${version//./\\.}
+          if ! grep -Eq "^## \\[${escaped_version}\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md has no ## [${version}] release section, with or without a date." >&2
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
           fi
 
           if [ "${{ github.event_name }}" = "push" ]; then
+            git fetch --no-tags origin "refs/tags/${tag}:refs/tags/${tag}"
             if [ "$(git cat-file -t "refs/tags/${tag}" 2>/dev/null || true)" != "tag" ]; then
               echo "ERROR: Direct release tag $tag must be annotated, not lightweight." >&2
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add canonical release identity across the annotated Git tag, crates.io,
+  GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
+  container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and
+  immutable `sha-*` tags from one verified digest, record that digest and source
+  revision in the Release notes, fail closed on identity drift, and support safe
+  retry completion plus tagged historical backfills.
 - Document the single-instance deployment contract and prove its unsupported
   multi-process failure modes with a nightly two-binary H5 experiment. Startup
   logs now state that room/reconnect state is in-memory, room affinity is

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,73 @@
+# Release Runbook
+
+Signal Fish Server releases use one version identity across source, crates.io,
+GitHub Releases, and GHCR. A release is complete only when all four artifacts
+resolve to the same tagged commit.
+
+## Prepare the Release Commit
+
+1. Set `[package].version` in `Cargo.toml` and refresh `Cargo.lock`.
+2. Move the release notes from `[Unreleased]` to an exact
+   `## [X.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md` and update its comparison
+   links.
+3. Push the release commit to the default branch and wait for the required CI
+   and documentation workflows to pass on that commit.
+
+Do not create or move the version tag by hand for the normal manual path. Run
+the **Release - Publish Crate** workflow with `release_version=X.Y.Z`. It creates
+an annotated `vX.Y.Z` tag before publication, or verifies that an existing tag
+is annotated and already points at the exact release commit.
+
+The release workflow directly calls the reusable container workflow. It does
+not depend on a tag created with `GITHUB_TOKEN` starting a second workflow.
+Publication proceeds in this order:
+
+1. validate the Cargo, changelog, source, and tag identity;
+2. verify required CI for the source commit;
+3. create or validate the immutable annotated tag;
+4. build and verify the versioned multi-architecture GHCR manifest;
+5. publish the crate idempotently;
+6. create or complete the GitHub Release and record the image digest;
+7. attach the SBOM and available platform binaries.
+
+If a run stops after creating one artifact, rerun the same version. The retry
+accepts only artifacts that prove the same source revision. Existing version
+tags are never moved; missing aliases are repaired from the verified digest.
+
+## Direct Tags and Historical Backfills
+
+A human-pushed annotated `vX.Y.Z` tag remains supported. It must match the
+version in that commit's `Cargo.toml`; the release and container workflows fail
+closed for a lightweight, moved, or mismatched tag.
+
+To backfill GHCR tags for a historical release, dispatch **Docker Publish** from
+the default branch with `release_tag=vX.Y.Z`. The workflow checks out that tag,
+validates its annotated source commit, and builds from it. It never aliases a
+historical version to `latest`.
+
+## Verify the Published Image
+
+The GitHub Release notes record the manifest digest and source revision. Repeat
+the workflow's verification locally with Docker Buildx and `jq`:
+
+```bash
+VERSION=0.4.0
+TAG="v${VERSION}"
+IMAGE=ghcr.io/ambiguous-interactive/signal-fish-server
+SOURCE_REVISION=$(git rev-list -n 1 "$TAG")
+SHA_TAG="sha-${SOURCE_REVISION:0:7}"
+
+bash scripts/verify-release-image.sh \
+  "$IMAGE" "$SOURCE_REVISION" "$VERSION" \
+  "$TAG" "$VERSION" "$SHA_TAG"
+```
+
+The command prints the shared digest only after proving that all supplied tags
+resolve to one manifest, the platform set is exactly `linux/amd64`,
+`linux/arm64`, and `linux/arm/v7`, and every platform image carries matching
+`org.opencontainers.image.revision` and
+`org.opencontainers.image.version` labels.
+
+Never repair a failed release by moving an existing version tag. Investigate
+the conflicting artifact, preserve it for audit, and publish a new patch
+version if the bytes or source identity differ.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,3 +158,4 @@ nav:
       - Scaling: architecture/scaling.md
       - Library Usage: library-usage.md
       - Development: development.md
+      - Release Runbook: releasing.md

--- a/scripts/hooks/pre-commit.ps1
+++ b/scripts/hooks/pre-commit.ps1
@@ -153,7 +153,9 @@ function Get-WorktreeChangedFiles {
     # discovery processes. `-z` makes paths literal and NUL-delimited; rename
     # records carry a second NUL-delimited source path, which is skipped because
     # policy evaluates the current destination.
-    $arguments = @("status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=no", "--") + $Pathspecs
+    # Policy checks only need the current paths, so skip rename similarity
+    # detection. Git will report those changes as delete/add records instead.
+    $arguments = @("status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignored=no", "--no-renames", "--") + $Pathspecs
     $records = (Invoke-Git -Arguments $arguments).Stdout.Split([char]0, [System.StringSplitOptions]::RemoveEmptyEntries)
     $skipRenameSource = $false
     foreach ($record in $records) {

--- a/scripts/hooks/pre-commit.ps1
+++ b/scripts/hooks/pre-commit.ps1
@@ -604,6 +604,11 @@ function Test-FastHookSource {
             if ($trimmed.StartsWith("#")) {
                 continue
             }
+            if ($trimmed.IndexOf("cargo", [System.StringComparison]::OrdinalIgnoreCase) -lt 0 -and
+                $trimmed.IndexOf("npm", [System.StringComparison]::OrdinalIgnoreCase) -lt 0 -and
+                $trimmed.IndexOf("npx", [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+                continue
+            }
             if ($trimmed -match $slowCommandPattern) {
                 [void]$violations.Add("${file}:${lineNumber}: $trimmed")
             }

--- a/scripts/hooks/pre-push.ps1
+++ b/scripts/hooks/pre-push.ps1
@@ -79,7 +79,11 @@ function Get-RevList {
         $remoteArg = if ([string]::IsNullOrWhiteSpace($RemoteName)) { "--remotes" } else { "--remotes=$RemoteName" }
         $result = Invoke-Native -FileName "git" -Arguments @("rev-list", $LocalSha, "--not", $remoteArg)
     } else {
-        $result = Invoke-Native -FileName "git" -Arguments @("rev-list", "$RemoteSha..$LocalSha")
+        # A force-push after rebasing can place commits from another remote branch
+        # outside RemoteSha..LocalSha. Those commits are already present on the
+        # target remote, so only inspect commits the push would newly introduce.
+        $remoteArg = if ([string]::IsNullOrWhiteSpace($RemoteName)) { "--remotes" } else { "--remotes=$RemoteName" }
+        $result = Invoke-Native -FileName "git" -Arguments @("rev-list", $LocalSha, "--not", $RemoteSha, $remoteArg)
     }
 
     if ($result.ExitCode -ne 0 -and $RemoteSha -ne $AllZeroSha) {
@@ -547,6 +551,13 @@ function Test-CommandTextForDirectScript {
         [AllowEmptyCollection()]
         [System.Collections.Generic.List[string]]$Violations
     )
+
+    # Most lines in multiline run blocks cannot reference a repository script.
+    # Avoid the quote-aware shell tokenization path unless its only supported
+    # path prefixes are present.
+    if (-not $CommandText.Contains("scripts/")) {
+        return
+    }
 
     $trimmed = Normalize-CommandText -Text ((Remove-UnquotedShellComment -Text $CommandText).Trim())
     if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith("#")) {

--- a/scripts/hooks/pre-push.ps1
+++ b/scripts/hooks/pre-push.ps1
@@ -617,6 +617,9 @@ function Test-WorkflowContentForDirectScripts {
     $lineNumber = 0
     foreach ($line in $Content -split "`r?`n") {
         $lineNumber++
+        if (-not $inRunBlock -and -not $line.Contains("run:")) {
+            continue
+        }
         $trimmed = $line.Trim()
         $indent = Get-Indent -Line $line
 
@@ -625,7 +628,9 @@ function Test-WorkflowContentForDirectScripts {
                 continue
             }
             if ($indent -gt $runBlockIndent) {
-                Test-CommandTextForDirectScript -CommandText $trimmed -File $File -LineNumber $lineNumber -Violations $Violations
+                if ($trimmed.Contains("scripts/")) {
+                    Test-CommandTextForDirectScript -CommandText $trimmed -File $File -LineNumber $lineNumber -Violations $Violations
+                }
                 continue
             }
             $inRunBlock = $false

--- a/scripts/hooks/pre-push.ps1
+++ b/scripts/hooks/pre-push.ps1
@@ -390,6 +390,11 @@ function Test-FastHookSource {
                 if ($trimmed.StartsWith("#")) {
                     continue
                 }
+                if ($trimmed.IndexOf("cargo", [System.StringComparison]::OrdinalIgnoreCase) -lt 0 -and
+                    $trimmed.IndexOf("npm", [System.StringComparison]::OrdinalIgnoreCase) -lt 0 -and
+                    $trimmed.IndexOf("npx", [System.StringComparison]::OrdinalIgnoreCase) -lt 0) {
+                    continue
+                }
                 if ($trimmed -match $slowCommandPattern) {
                     [void]$violations.Add("${file}@${commit}:${lineNumber}: $trimmed")
                 }

--- a/scripts/verify-release-image.sh
+++ b/scripts/verify-release-image.sh
@@ -42,7 +42,11 @@ resolved_digest=""
 
 for tag in "${tags[@]}"; do
   reference="${image}:${tag}"
-  inspect=$(docker buildx imagetools inspect "$reference")
+  if ! inspect=$(docker buildx imagetools inspect "$reference" 2>&1); then
+    echo "ERROR: could not inspect release image tag $reference." >&2
+    printf '%s\n' "$inspect" >&2
+    exit 1
+  fi
   digest=$(printf '%s\n' "$inspect" | sed -n 's/^Digest:[[:space:]]*//p' | head -n 1)
   if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
     echo "ERROR: could not resolve an OCI digest for $reference." >&2
@@ -58,7 +62,11 @@ for tag in "${tags[@]}"; do
 done
 
 canonical_reference="${image}@${resolved_digest}"
-raw_manifest=$(docker buildx imagetools inspect --raw "$canonical_reference")
+if ! raw_manifest=$(docker buildx imagetools inspect --raw "$canonical_reference" 2>&1); then
+  echo "ERROR: could not inspect release manifest $canonical_reference." >&2
+  printf '%s\n' "$raw_manifest" >&2
+  exit 1
+fi
 media_type=$(printf '%s' "$raw_manifest" | jq -r '.mediaType // empty')
 case "$media_type" in
   application/vnd.docker.distribution.manifest.list.v2+json|application/vnd.oci.image.index.v1+json) ;;
@@ -85,8 +93,12 @@ fi
 
 while IFS=$'\t' read -r manifest_digest platform; do
   [ -n "$manifest_digest" ] || continue
-  image_config=$(docker buildx imagetools inspect \
-    --format '{{json .Image}}' "${image}@${manifest_digest}")
+  if ! image_config=$(docker buildx imagetools inspect \
+    --format '{{json .Image}}' "${image}@${manifest_digest}" 2>&1); then
+    echo "ERROR: could not inspect $platform image ${image}@${manifest_digest}." >&2
+    printf '%s\n' "$image_config" >&2
+    exit 1
+  fi
   revision=$(printf '%s' "$image_config" | jq -r '.config.Labels["org.opencontainers.image.revision"] // empty')
   version=$(printf '%s' "$image_config" | jq -r '.config.Labels["org.opencontainers.image.version"] // empty')
 

--- a/scripts/verify-release-image.sh
+++ b/scripts/verify-release-image.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Verify that one or more GHCR tags resolve to one release manifest whose
+# platforms and OCI identity labels match the tagged source revision.
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <image> <source-revision> <version> <tag> [<tag> ...]" >&2
+}
+
+if [ "$#" -lt 4 ]; then
+  usage
+  exit 2
+fi
+
+image=$1
+expected_revision=$2
+expected_version=$3
+shift 3
+tags=("$@")
+
+for command in docker jq; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "ERROR: '$command' is required to verify a release image." >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$expected_revision" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: expected source revision must be a full 40-character lowercase Git SHA." >&2
+  exit 1
+fi
+
+expected_platforms=$'linux/amd64\nlinux/arm/v7\nlinux/arm64'
+resolved_digest=""
+
+for tag in "${tags[@]}"; do
+  reference="${image}:${tag}"
+  inspect=$(docker buildx imagetools inspect "$reference")
+  digest=$(printf '%s\n' "$inspect" | sed -n 's/^Digest:[[:space:]]*//p' | head -n 1)
+  if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "ERROR: could not resolve an OCI digest for $reference." >&2
+    exit 1
+  fi
+
+  if [ -z "$resolved_digest" ]; then
+    resolved_digest=$digest
+  elif [ "$digest" != "$resolved_digest" ]; then
+    echo "ERROR: release tags do not resolve to one manifest: $reference is $digest, expected $resolved_digest." >&2
+    exit 1
+  fi
+done
+
+canonical_reference="${image}@${resolved_digest}"
+raw_manifest=$(docker buildx imagetools inspect --raw "$canonical_reference")
+media_type=$(printf '%s' "$raw_manifest" | jq -r '.mediaType // empty')
+case "$media_type" in
+  application/vnd.docker.distribution.manifest.list.v2+json|application/vnd.oci.image.index.v1+json) ;;
+  *)
+    echo "ERROR: $canonical_reference is not a multi-architecture manifest index (mediaType=$media_type)." >&2
+    exit 1
+    ;;
+esac
+
+actual_platforms=$(printf '%s' "$raw_manifest" | jq -r '
+  .manifests[]
+  | select(.platform.os != "unknown" and .platform.architecture != "unknown")
+  | .platform.os + "/" + .platform.architecture
+    + (if (.platform.variant // "") == "" then "" else "/" + .platform.variant end)
+' | sort -u)
+if [ "$actual_platforms" != "$expected_platforms" ]; then
+  echo "ERROR: $canonical_reference platform set disagrees with release policy." >&2
+  echo "Expected:" >&2
+  printf '%s\n' "$expected_platforms" >&2
+  echo "Actual:" >&2
+  printf '%s\n' "$actual_platforms" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r manifest_digest platform; do
+  [ -n "$manifest_digest" ] || continue
+  image_config=$(docker buildx imagetools inspect \
+    --format '{{json .Image}}' "${image}@${manifest_digest}")
+  revision=$(printf '%s' "$image_config" | jq -r '.config.Labels["org.opencontainers.image.revision"] // empty')
+  version=$(printf '%s' "$image_config" | jq -r '.config.Labels["org.opencontainers.image.version"] // empty')
+
+  if [ "$revision" != "$expected_revision" ]; then
+    echo "ERROR: $platform image label revision is '$revision', expected '$expected_revision'." >&2
+    exit 1
+  fi
+  if [ "$version" != "$expected_version" ]; then
+    echo "ERROR: $platform image label version is '$version', expected '$expected_version'." >&2
+    exit 1
+  fi
+done < <(printf '%s' "$raw_manifest" | jq -r '
+  .manifests[]
+  | select(.platform.os != "unknown" and .platform.architecture != "unknown")
+  | [
+      .digest,
+      (.platform.os + "/" + .platform.architecture
+        + (if (.platform.variant // "") == "" then "" else "/" + .platform.variant end))
+    ]
+  | @tsv
+')
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "digest=$resolved_digest" >> "$GITHUB_OUTPUT"
+fi
+printf '%s\n' "$resolved_digest"

--- a/scripts/verify-release-image.sh
+++ b/scripts/verify-release-image.sh
@@ -27,6 +27,11 @@ for command in docker jq; do
   fi
 done
 
+if ! docker buildx version >/dev/null 2>&1; then
+  echo "ERROR: Docker Buildx is required to verify a release image." >&2
+  exit 1
+fi
+
 if [[ ! "$expected_revision" =~ ^[0-9a-f]{40}$ ]]; then
   echo "ERROR: expected source revision must be a full 40-character lowercase Git SHA." >&2
   exit 1

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -3968,8 +3968,8 @@ fn test_release_binary_attach_job_preserves_partial_success_gate() {
         .expect("attach-binaries must define an explicit job-level if condition");
 
     assert!(
-        attach_job.contains("needs: [publish, build-binaries]"),
-        "attach-binaries must depend on both `publish` and `build-binaries` so \
+        attach_job.contains("needs: [resolve-release, publish, build-binaries]"),
+        "attach-binaries must depend on release identity, `publish`, and `build-binaries` so \
          the Release exists and all binary matrix legs have finished before the \
          single release upload starts.\nJob block:\n{attach_job}"
     );
@@ -4023,7 +4023,6 @@ fn test_release_workflow_skips_binary_attach_when_no_artifacts_exist() {
     for step_name in [
         "Checkout repository",
         "Download all binary artifacts",
-        "Resolve release tag",
         "Attach binaries to release",
     ] {
         let marker = format!("      - name: {step_name}");
@@ -4041,6 +4040,179 @@ fn test_release_workflow_skips_binary_attach_when_no_artifacts_exist() {
             step_block.contains("if: steps.binary-artifacts.outputs.count != '0'"),
             "attach-binaries step `{step_name}` must be skipped when no binary \
              artifacts exist.\nStep block:\n{step_block}"
+        );
+    }
+
+    assert!(
+        attach_job.contains("tag_name: ${{ needs.resolve-release.outputs.tag }}"),
+        "attach-binaries must consume the canonical tag from resolve-release instead of \
+         re-deriving it from event-specific state.\nJob block:\n{attach_job}"
+    );
+}
+
+#[test]
+fn test_release_path_calls_container_publication_directly() {
+    let root = repo_root();
+    let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let publish_container = extract_workflow_job_block(&release, "publish-container")
+        .expect("release.yml must define publish-container");
+
+    for required in [
+        "needs: [resolve-release, ensure-tag]",
+        "uses: ./.github/workflows/docker-publish.yml",
+        "release_version: ${{ needs.resolve-release.outputs.version }}",
+        "release_tag: ${{ needs.resolve-release.outputs.tag }}",
+        "source_revision: ${{ needs.resolve-release.outputs.source_revision }}",
+        "packages: write",
+    ] {
+        assert!(
+            publish_container.contains(required),
+            "release.yml publish-container must contain `{required}` so manual releases publish \
+             the tagged container directly. The release path must not depend on a tag push made \
+             with GITHUB_TOKEN starting another workflow.\nJob block:\n{publish_container}"
+        );
+    }
+
+    for forbidden in ["repository_dispatch", "workflow_run:"] {
+        assert!(
+            !release.contains(forbidden),
+            "release.yml must call the reusable container workflow directly, not rely on \
+             `{forbidden}` event chaining."
+        );
+    }
+}
+
+#[test]
+fn test_container_publish_supports_release_and_backfill_entry_points() {
+    let root = repo_root();
+    let docker = read_live_file(&root.join(".github/workflows/docker-publish.yml"));
+
+    for required in [
+        "workflow_call:",
+        "workflow_dispatch:",
+        "push:",
+        "tags:",
+        "- \"v*\"",
+        "release_tag:",
+        "source_ref:",
+        "source_revision:",
+        "ref: ${{ inputs.source_ref || inputs.release_tag || github.sha }}",
+        "if [ -n \"$CALL_REVISION\" ]",
+        "workflow_dispatch)",
+        "refs/tags/",
+    ] {
+        assert!(
+            docker.contains(required),
+            "docker-publish.yml must contain live `{required}` configuration so reusable \
+             releases, direct human tag pushes, and historical tagged backfills share one \
+             publication implementation."
+        );
+    }
+}
+
+#[test]
+fn test_release_identity_fails_closed_across_artifacts() {
+    let root = repo_root();
+    let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let docker = read_live_file(&root.join(".github/workflows/docker-publish.yml"));
+    let verifier = read_live_file(&root.join("scripts/verify-release-image.sh"));
+
+    let required_by_file = [
+        (
+            "release.yml",
+            &release,
+            vec![
+                "Cargo.toml version package",
+                "grep -Fqx \"## [${version}]\" CHANGELOG.md",
+                "git cat-file -t \"refs/tags/${TAG}\"",
+                "refusing to move it",
+                ".cargo_vcs_info.json",
+                "published_revision",
+                "target_commitish: ${{ needs.resolve-release.outputs.source_revision }}",
+                "Verify GitHub Release identity",
+            ],
+        ),
+        (
+            "docker-publish.yml",
+            &docker,
+            vec![
+                "Cargo.toml version package",
+                "git cat-file -t \"refs/tags/${release_tag}\"",
+                "grep -Fqx \"## [${release_version}]\" CHANGELOG.md",
+                "org.opencontainers.image.revision=",
+                "org.opencontainers.image.version=",
+                "Verify versioned tags, platforms, and source labels",
+            ],
+        ),
+        (
+            "verify-release-image.sh",
+            &verifier,
+            vec![
+                "linux/amd64",
+                "linux/arm64",
+                "linux/arm/v7",
+                "org.opencontainers.image.revision",
+                "org.opencontainers.image.version",
+                "release tags do not resolve to one manifest",
+            ],
+        ),
+    ];
+
+    for (file, content, required_tokens) in required_by_file {
+        for required in required_tokens {
+            assert!(
+                content.contains(required),
+                "{file} must contain live `{required}` enforcement so the release gate fails \
+                 closed when source, tag, crate, Release, image labels, or GHCR tags disagree."
+            );
+        }
+    }
+}
+
+#[test]
+fn test_release_retries_reuse_digest_and_record_verification() {
+    let root = repo_root();
+    let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let docker = read_live_file(&root.join(".github/workflows/docker-publish.yml"));
+    let marker = "      - name: Reuse a verified immutable release digest";
+    let start = docker
+        .find(marker)
+        .expect("docker-publish.yml must define immutable digest reuse");
+    let after_start = &docker[start + marker.len()..];
+    let end = after_start
+        .find("\n      - name:")
+        .map(|offset| start + marker.len() + offset)
+        .unwrap_or(docker.len());
+    let existing = &docker[start..end];
+
+    for required in [
+        "desired_tags=(\"$RELEASE_TAG\" \"$RELEASE_VERSION\")",
+        "desired_tags+=(\"$SHA_TAG\")",
+        "scripts/verify-release-image.sh",
+        "docker buildx imagetools create --tag",
+        "refusing to rebuild over an unknown registry state",
+        "reuse=true",
+        "publish_sha=false",
+    ] {
+        assert!(
+            existing.contains(required),
+            "immutable release retry step must contain `{required}` so a partial retry repairs \
+             only missing aliases while preserving verified bytes.\nStep block:\n{existing}"
+        );
+    }
+    assert!(
+        !existing.contains(":latest"),
+        "historical/versioned retries must never backfill from mutable :latest.\nStep block:\n{existing}"
+    );
+
+    for required in [
+        "needs.publish-container.outputs.digest",
+        "Multi-architecture manifest digest:",
+        "Source revision:",
+    ] {
+        assert!(
+            release.contains(required),
+            "release.yml must record verified container evidence `{required}` in release notes."
         );
     }
 }
@@ -14057,7 +14229,7 @@ fn test_release_workflow_requires_preflight() {
     //
     // Checks:
     //   1. release.yml has a `preflight` job
-    //   2. The `publish` job depends on `preflight` via `needs:`
+    //   2. Every publication path is transitively gated by `preflight`
     //   3. The preflight job references the required workflow names
 
     let root = repo_root();
@@ -14079,14 +14251,24 @@ fn test_release_workflow_requires_preflight() {
         release_yml.display()
     );
 
-    // The publish job must depend on preflight
-    // Look for `needs:` containing `preflight` in the publish job context
+    let ensure_tag = extract_workflow_job_block(&content, "ensure-tag")
+        .expect("release.yml must define ensure-tag");
+    let publish_container = extract_workflow_job_block(&content, "publish-container")
+        .expect("release.yml must define publish-container");
+    let publish =
+        extract_workflow_job_block(&content, "publish").expect("release.yml must define publish");
+
+    // The irreversible publication chain must remain resolve -> preflight ->
+    // immutable tag -> verified container -> crate/GitHub Release.
     assert!(
-        content.contains("needs: [preflight]") || content.contains("needs: preflight"),
-        "release.yml 'publish' job must depend on 'preflight' via needs.\n\
-         Add 'needs: [preflight]' to the publish job.\n\
-         File: {}",
-        release_yml.display()
+        ensure_tag.contains("needs: [resolve-release, preflight]")
+            && publish_container.contains("needs: [resolve-release, ensure-tag]")
+            && publish.contains("needs: [resolve-release, publish-container]"),
+        "release.yml publication jobs must preserve the fail-closed dependency chain \
+         resolve-release -> preflight -> ensure-tag -> publish-container -> publish.\n\
+         ensure-tag:\n{ensure_tag}\n\
+         publish-container:\n{publish_container}\n\
+         publish:\n{publish}"
     );
 
     // Preflight must reference the required workflow names from REQUIRED_WORKFLOW_NAMES.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4160,6 +4160,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
                 "org.opencontainers.image.revision",
                 "org.opencontainers.image.version",
                 "docker buildx version",
+                "could not inspect release image tag",
                 "release tags do not resolve to one manifest",
             ],
         ),
@@ -4222,6 +4223,11 @@ fn test_release_retries_reuse_digest_and_record_verification() {
             "release.yml must record verified container evidence `{required}` in release notes."
         );
     }
+
+    assert!(
+        docker.contains("steps.verify.outputs.digest || steps.rolling-digest.outputs.digest"),
+        "docker-publish.yml must expose a digest for both versioned releases and rolling main-branch publishes."
+    );
 }
 
 #[test]

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -17515,6 +17515,7 @@ fn test_pre_commit_runner_has_worktree_preflight_mode_for_agents() {
             && content.contains("Get-WorktreeChangedFiles")
             && content
                 .contains("\"status\", \"--porcelain=v1\", \"-z\", \"--untracked-files=all\"")
+            && content.contains("\"--no-renames\"")
             && content.contains("StagedChangedFileSet")
             && content.contains("WorktreeChangedFileSet")
             && content.contains("WorktreeUntrackedFileSet")
@@ -17728,7 +17729,7 @@ fn test_pre_push_hook_exists_and_runs_workflow_policy_checks() {
         runner.contains("Get-ChangedFilesForPush")
             && runner.contains("\"--not\", $remoteArg")
             && runner.contains("--remotes=$RemoteName")
-            && runner.contains("\"rev-list\", \"$RemoteSha..$LocalSha\"")
+            && runner.contains("\"rev-list\", $LocalSha, \"--not\", $RemoteSha, $remoteArg")
             && runner.contains("Add-ChangedFilesFromCommits")
             && runner.contains("[switch]$Worktree")
             && runner.contains("Get-ChangedFilesForWorktreePreflight")
@@ -17738,6 +17739,58 @@ fn test_pre_push_hook_exists_and_runs_workflow_policy_checks() {
          workflow policy checks without invoking cargo tests. It must also expose \
          a worktree preflight mode so agents/local CI catch push-policy failures \
          before Git hooks are the last resort."
+    );
+}
+
+#[test]
+fn test_pre_push_existing_ref_excludes_commits_already_on_remote_when_pwsh_available() {
+    let root = repo_root();
+    let output = Command::new("pwsh")
+        .args([
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            r#"
+                . ./scripts/hooks/pre-push.ps1 -SourceOnly
+                function Assert($condition, $message) {
+                    if (-not $condition) { throw $message }
+                }
+                $script:CapturedArguments = @()
+                function Invoke-Native {
+                    param([string]$FileName, [string[]]$Arguments)
+                    $script:CapturedArguments = [string[]]$Arguments
+                    [pscustomobject]@{
+                        ExitCode = 0
+                        Stdout = "introduced-commit`n"
+                        Stderr = ""
+                        Output = "introduced-commit`n"
+                    }
+                }
+
+                $commits = @(Get-RevList -LocalSha "local-tip" -RemoteSha "old-remote-tip" -AllZeroSha ("0" * 40) -RemoteName "origin")
+                $expected = @("rev-list", "local-tip", "--not", "old-remote-tip", "--remotes=origin")
+                Assert ($commits.Count -eq 1 -and $commits[0] -eq "introduced-commit") "revision output should be preserved"
+                Assert ($script:CapturedArguments.Count -eq $expected.Count) "rev-list should receive the expected argument count"
+                for ($index = 0; $index -lt $expected.Count; $index++) {
+                    Assert ($script:CapturedArguments[$index] -eq $expected[$index]) "unexpected rev-list argument at index $index"
+                }
+            "#,
+        ])
+        .current_dir(&root)
+        .output();
+
+    let Ok(output) = output else {
+        eprintln!("Skipping PowerShell pre-push reachability test because pwsh is unavailable.");
+        return;
+    };
+
+    assert!(
+        output.status.success(),
+        "pre-push reachability must exclude commits already present on the target remote.\n\
+         stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
 }
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4100,6 +4100,7 @@ fn test_container_publish_supports_release_and_backfill_entry_points() {
         "if [ -n \"$CALL_REVISION\" ]",
         "workflow_dispatch)",
         "refs/tags/",
+        "publish_latest == 'true' && 'latest' || needs.resolve.outputs.source_revision",
     ] {
         assert!(
             docker.contains(required),
@@ -4123,7 +4124,8 @@ fn test_release_identity_fails_closed_across_artifacts() {
             &release,
             vec![
                 "Cargo.toml version package",
-                "grep -Fqx \"## [${version}]\" CHANGELOG.md",
+                "escaped_version=${version//./\\\\.}",
+                "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
                 "git cat-file -t \"refs/tags/${TAG}\"",
                 "refusing to move it",
                 ".cargo_vcs_info.json",
@@ -4138,7 +4140,8 @@ fn test_release_identity_fails_closed_across_artifacts() {
             vec![
                 "Cargo.toml version package",
                 "git cat-file -t \"refs/tags/${release_tag}\"",
-                "grep -Fqx \"## [${release_version}]\" CHANGELOG.md",
+                "escaped_version=${release_version//./\\\\.}",
+                "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
                 "org.opencontainers.image.revision=",
                 "org.opencontainers.image.version=",
                 "Verify versioned tags, platforms, and source labels",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4126,6 +4126,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
                 "Cargo.toml version package",
                 "escaped_version=${version//./\\\\.}",
                 "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
+                "git fetch --no-tags origin \"refs/tags/${tag}:refs/tags/${tag}\"",
                 "git cat-file -t \"refs/tags/${TAG}\"",
                 "refusing to move it",
                 ".cargo_vcs_info.json",
@@ -4139,6 +4140,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
             &docker,
             vec![
                 "Cargo.toml version package",
+                "git fetch --no-tags origin \"refs/tags/${release_tag}:refs/tags/${release_tag}\"",
                 "git cat-file -t \"refs/tags/${release_tag}\"",
                 "escaped_version=${release_version//./\\\\.}",
                 "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
@@ -4157,6 +4159,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
                 "linux/arm/v7",
                 "org.opencontainers.image.revision",
                 "org.opencontainers.image.version",
+                "docker buildx version",
                 "release tags do not resolve to one manifest",
             ],
         ),

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4054,8 +4054,15 @@ fn test_release_workflow_skips_binary_attach_when_no_artifacts_exist() {
 fn test_release_path_calls_container_publication_directly() {
     let root = repo_root();
     let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let workflow_permissions = extract_yaml_mapping_block(&release, "permissions", 0)
+        .expect("release.yml must define workflow-level permissions");
     let publish_container = extract_workflow_job_block(&release, "publish-container")
         .expect("release.yml must define publish-container");
+
+    assert!(
+        !workflow_permissions.contains("packages: write"),
+        "release.yml must not grant packages: write to every job; keep it scoped to publish-container."
+    );
 
     for required in [
         "needs: [resolve-release, ensure-tag]",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4096,7 +4096,7 @@ fn test_container_publish_supports_release_and_backfill_entry_points() {
         "release_tag:",
         "source_ref:",
         "source_revision:",
-        "ref: ${{ inputs.source_ref || inputs.release_tag || github.sha }}",
+        "ref: ${{ inputs.source_ref || inputs.release_tag || github.ref }}",
         "if [ -n \"$CALL_REVISION\" ]",
         "workflow_dispatch)",
         "refs/tags/",
@@ -4145,6 +4145,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
                 "org.opencontainers.image.revision=",
                 "org.opencontainers.image.version=",
                 "Verify versioned tags, platforms, and source labels",
+                "tags=(\"$RELEASE_TAG\" \"$RELEASE_VERSION\" \"$MAJOR_MINOR\")",
             ],
         ),
         (


### PR DESCRIPTION
## What changed

- resolve one canonical `X.Y.Z` / annotated `vX.Y.Z` / source-commit identity before release publication
- invoke the reusable multi-architecture container workflow directly from the release path
- publish and verify matching `vX.Y.Z`, `X.Y.Z`, rolling `X.Y`, and immutable `sha-*` image tags
- make crate, GHCR, tag, and GitHub Release retries fail closed and idempotent
- add per-platform OCI label verification, digest-bearing Release notes, a historical-tag backfill path, and a public release runbook
- add data-driven workflow-policy regression coverage for manual releases, direct tag pushes, backfills, and partial retries
- keep rebased force-push hook validation sub-second by excluding commits already reachable from the target remote and fast-gating semantic scans

## Why

The manual release workflow created its Git tag with `GITHUB_TOKEN`. GitHub does not start another workflow from that token-generated tag push, so a crate and GitHub Release could publish without versioned GHCR tags. The live `v0.4.0` audit confirms the gap: the annotated tag and crates.io package both identify commit `50b28a9…`, but `v0.4.0` and `0.4.0` are absent from GHCR.

## Compatibility and operations

Main-branch `latest` publication and direct human annotated tag pushes remain supported. Historical backfills rebuild from the annotated tag and preserve an older immutable SHA image instead of aliasing `latest` or moving existing bytes. After merge, dispatch **Docker Publish** with `release_tag=v0.4.0` to close the observed historical gap.

## Validation

- actionlint and shellcheck
- targeted clippy for `ci_config_tests`
- all 277 CI configuration tests (276 passed, one intentionally ignored expensive nested compile)
- all 14 documentation consistency policy/script tests
- CI config, tooling parity, workflow hygiene, markdown, LLM, and hook policy checks
- final SHA `940ac28`: all 11 applicable workflows green, both automated reviewers clean, zero unresolved threads
- enforced outgoing pre-push profile: 637 ms; actual push: 796 ms
- live GHCR verifier positive run against `latest`
- live GHCR verifier negative run proving the historical `sha-50b28a9` OCI-version mismatch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the production release and GHCR publication pipeline with strict identity checks and tag immutability; a regression could block releases or mis-tag images, though retries are designed to fail closed rather than overwrite bytes.
> 
> **Overview**
> Unifies release and container publishing so **one version, annotated tag, and commit SHA** must agree across Cargo, CHANGELOG, crates.io, GitHub Release, and GHCR before anything ships.
> 
> **Release workflow** adds `resolve-release` and `ensure-tag` (immutable annotated tags that are never moved), calls **Docker Publish** as a reusable workflow with explicit `source_revision` (so `GITHUB_TOKEN` tag pushes no longer skip container publication), idempotent **crates.io** retries keyed on published git SHA, and Release notes that record the verified multi-arch **manifest digest** and source revision.
> 
> **Docker Publish** becomes a shared entry point for main (`:latest` / `sha-*`), direct `v*` tag pushes, release workflow calls, and manual **historical backfills**; release builds can **reuse a verified digest** and only repair missing tag aliases, with `scripts/verify-release-image.sh` checking platforms and OCI labels.
> 
> Also adds **`docs/releasing.md`**, changelog notes, expanded **`ci_config_tests.rs`** workflow policy tests, and small **pre-commit/pre-push** hook optimizations for rebased force-pushes and faster policy scans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 940ac283402dfce1914140489165d423de846db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->