### PR TITLE
test: prove 16-player WebRTC mesh budget

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -44,9 +44,16 @@ success-output = "never"
 # (plus, in its nightly-only tests, real client processes) and floods it, so
 # it shares the group for exactly the same isolation reasons.
 [[profile.default.overrides]]
-filter = 'binary(v3_multiprocess_e2e) or binary(multiprocess_delivery_e2e) or binary(split_brain_two_instances_e2e)'
+filter = 'binary(v3_multiprocess_e2e) or binary(multiprocess_delivery_e2e) or binary(split_brain_two_instances_e2e) or binary(webrtc_mesh_budget_e2e)'
 test-group = 'process-spawning'
 threads-required = 4
+
+# The real 16-client mesh has a 300s watchdog per child plus startup and
+# server-metric settlement. Keep nextest's outer deadline strictly above those
+# composed bounds so the clients, rather than nextest, emit useful diagnostics.
+[[profile.default.overrides]]
+filter = 'binary(webrtc_mesh_budget_e2e)'
+slow-timeout = { period = "300s", terminate-after = 2 }
 
 # Per-test override: serialize the two heavy CPU/IO tests that otherwise starve
 # each other under a loaded runner — the trybuild / compile-fail UI test

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,7 +48,7 @@ filter = 'binary(v3_multiprocess_e2e) or binary(multiprocess_delivery_e2e) or bi
 test-group = 'process-spawning'
 threads-required = 4
 
-# The real 16-client mesh has a 300s watchdog per child plus startup and
+# The real 16-client mesh has a 540s watchdog per child plus startup and
 # server-metric settlement. Keep nextest's outer deadline strictly above those
 # composed bounds so the clients, rather than nextest, emit useful diagnostics.
 [[profile.default.overrides]]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -81,6 +81,7 @@ test-group = 'powershell-subprocess'
 # Activate with: cargo nextest run --profile ci
 # Inherits all [profile.default] settings and adds CI-tuned overrides.
 [profile.ci]
+inherits = "default"
 fail-fast = true
 failure-output = "immediate-final"
 success-output = "never"

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -23,6 +23,7 @@
 #     + REAL client processes with OS faults (SIGSTOP/SIGKILL); the two
 #     ignored child-process tests need the pre-built native reference client
 #     (SIGNAL_FISH_CLIENT_BIN), which is why they are nightly-only.
+#     The same job runs the H8 empirical 16-client WebRTC mesh budget proof.
 #   - starved-runtime: clients/native/tests/starved_runtime_e2e.rs — the
 #     --runtime current / --tick-stall-ms conformance matrix pinning the
 #     documented "continuously drive your runtime" requirement.
@@ -58,6 +59,7 @@ on:
       - "tests/delivery_concurrency_stress.rs"
       - "tests/load_tests.rs"
       - "tests/multiprocess_delivery_e2e.rs"
+      - "tests/webrtc_mesh_budget_e2e.rs"
       - "tests/scenario_realworld_e2e.rs"
       - "tests/sixteen_player_matrix_e2e.rs"
       - "tests/split_brain_two_instances_e2e.rs"
@@ -287,6 +289,15 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test multiprocess_delivery_e2e --run-ignored all \
             --success-output final 2>&1 | tee multiprocess-output.txt
+      - name: Run 16-player WebRTC mesh budget experiment
+        shell: bash
+        env:
+          SIGNAL_FISH_CLIENT_BIN: ${{ github.workspace }}/clients/native/target/debug/signal-fish-reference-native
+        run: |
+          set -o pipefail
+          cargo nextest run --profile ci --locked --all-features \
+            --test webrtc_mesh_budget_e2e --run-ignored all \
+            --success-output final 2>&1 | tee webrtc-mesh-budget-output.txt
       - name: Report multi-process results to job summary
         if: always()
         shell: bash
@@ -296,6 +307,12 @@ jobs:
             echo
             echo '```text'
             tail -n 60 multiprocess-output.txt 2>/dev/null || echo "no multiprocess output captured"
+            echo '```'
+            echo
+            echo "### H8 16-player WebRTC mesh budget"
+            echo
+            echo '```text'
+            tail -n 80 webrtc-mesh-budget-output.txt 2>/dev/null || echo "no WebRTC mesh budget output captured"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   peer connection's terminal ICE-gathering marker before freezing the signal
   ledger. Normal client exit behavior is unchanged when the new flag is
   omitted, the soft run deadline does not break an active barrier hold, and
-  hard-watchdog diagnostics name the exact release path. Release-path metadata
+  a release observed after that deadline still honors the post-success linger.
+  Hard-watchdog diagnostics name the exact release path. Release-path metadata
   errors fail immediately with the underlying I/O diagnostic instead of
   masquerading as an absent file.
 - Add canonical release identity across the annotated Git tag, crates.io,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   peer connection's terminal ICE-gathering marker before freezing the signal
   ledger. Normal client exit behavior is unchanged when the new flag is
   omitted, the soft run deadline does not break an active barrier hold, and
-  hard-watchdog diagnostics name the exact release path.
+  hard-watchdog diagnostics name the exact release path. Release-path metadata
+  errors fail immediately with the underlying I/O diagnostic instead of
+  masquerading as an absent file.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowing the experiment to prove the simultaneous 120-edge graph, exact
   reliable/unreliable channel ledgers, relay-floor delivery, and production
   600-signal budget without teardown races. Normal client exit behavior is
-  unchanged when the new flag is omitted.
+  unchanged when the new flag is omitted, and barrier-timeout diagnostics name
+  the exact path still awaited.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Held clients sleep until that linger expires instead of spinning on an
   elapsed soft deadline, and the nightly harness keeps explicit watchdog
   headroom for its barrier assertions before coordinated release.
+  Once success is reported, the release hold remains authoritative even if
+  criteria temporarily regress; criteria are revalidated after release.
   Hard-watchdog diagnostics name the exact release path. Release-path metadata
   errors fail immediately with the underlying I/O diagnostic instead of
   masquerading as an absent file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   headroom for its barrier assertions before coordinated release.
   Once success is reported, the release hold remains authoritative even if
   criteria temporarily regress; criteria are revalidated after release.
+  Release-file metadata polling runs off the async networking executor.
   Hard-watchdog diagnostics name the exact release path. Release-path metadata
   errors fail immediately with the underlying I/O diagnostic instead of
   masquerading as an absent file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ledger. Normal client exit behavior is unchanged when the new flag is
   omitted, the soft run deadline does not break an active barrier hold, and
   a release observed after that deadline still honors the post-success linger.
+  Held clients sleep until that linger expires instead of spinning on an
+  elapsed soft deadline, and the nightly harness keeps explicit watchdog
+  headroom for its barrier assertions before coordinated release.
   Hard-watchdog diagnostics name the exact release path. Release-path metadata
   errors fail immediately with the underlying I/O diagnostic instead of
   masquerading as an absent file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `success_criteria_met` and remain connected until a release file appears,
   allowing the experiment to prove the simultaneous 120-edge graph, exact
   reliable/unreliable channel ledgers, relay-floor delivery, and production
-  600-signal budget without teardown races. Normal client exit behavior is
-  unchanged when the new flag is omitted, the soft run deadline does not break
-  an active barrier hold, and hard-watchdog diagnostics name the exact release
-  path.
+  600-signal budget without teardown races. The barrier waits for every current
+  peer connection's terminal ICE-gathering marker before freezing the signal
+  ledger. Normal client exit behavior is unchanged when the new flag is
+  omitted, the soft run deadline does not break an active barrier hold, and
+  hard-watchdog diagnostics name the exact release path.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowing the experiment to prove the simultaneous 120-edge graph, exact
   reliable/unreliable channel ledgers, relay-floor delivery, and production
   600-signal budget without teardown races. Normal client exit behavior is
-  unchanged when the new flag is omitted, and barrier-timeout diagnostics name
-  the exact path still awaited.
+  unchanged when the new flag is omitted, the soft run deadline does not break
+  an active barrier hold, and hard-watchdog diagnostics name the exact release
+  path.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a harness-only native reference-client success barrier and a nightly
+  16-player WebRTC mesh experiment. The client can emit
+  `success_criteria_met` and remain connected until a release file appears,
+  allowing the experiment to prove the simultaneous 120-edge graph, exact
+  reliable/unreliable channel ledgers, relay-floor delivery, and production
+  600-signal budget without teardown races. Normal client exit behavior is
+  unchanged when the new flag is omitted.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -61,6 +61,7 @@ Exactly one of `--create-room` / `--join-code` is required; everything else has 
 | `--p2p-timeout-secs <S>` | `15` | Window for WebRTC pair establishment before the overall transport status resolves |
 | `--run-for-secs <S>` | `30` | Soft cap: exit 1 if the flag-driven success criteria are still unmet |
 | `--max-runtime-secs <S>` | `60` | Hard watchdog: abort with exit 4 no matter what (the no-hang guarantee) |
+| `--success-release-file <PATH>` | — | Test harness only: after success criteria hold, emit `success_criteria_met` and stay connected until PATH exists; the normal bounded exit behavior is unchanged when omitted |
 | `--protocol-version <V>` | `3` | `2` omits every v3 `Authenticate` field — a pure v2 client for mixed-room tests |
 | `--supported-topologies <LIST>` | `relay,host,mesh` | Comma-separated topologies advertised in v3 `Authenticate` |
 | `--supported-transports <LIST>` | `relay,webrtc` | Comma-separated transports advertised in v3 `Authenticate` |
@@ -127,6 +128,7 @@ process continues to its normal bounded exit.
 | `game_data_sent` | — | The `--relay-payload` GameData was sent |
 | `game_data_received` | `from`, `payload` | A validated, application-current relayed GameData payload arrived; lifecycle-overtaken stale tails are accounted but suppressed |
 | `fallback_engaged` | — | The P2P window resolved with ZERO connected pairs; the relay floor carries the session |
+| `success_criteria_met` | — | Harness-only barrier emitted when criteria hold and `--success-release-file` was supplied; the client remains connected until the path exists |
 | `error` | `message` | Non-fatal or fatal error (fatal ones are followed by `exiting`) |
 | `exiting` | `code` | Final event before process exit |
 

--- a/clients/native/src/cli.rs
+++ b/clients/native/src/cli.rs
@@ -7,6 +7,7 @@
 
 use clap::{ArgGroup, Parser, ValueEnum};
 use signal_fish_server::protocol::{Topology, Transport};
+use std::path::PathBuf;
 
 /// Native Rust reference client for the Signal Fish protocol v3.
 ///
@@ -104,6 +105,13 @@ pub struct Cli {
     /// what (the guarantee that this process can never hang a harness).
     #[arg(long, default_value_t = 60)]
     pub max_runtime_secs: u64,
+
+    /// Test-harness coordination: after all success criteria are met, emit
+    /// `success_criteria_met` and keep the connection/pairs alive until this
+    /// path exists. Normal runs omit this flag and retain immediate bounded
+    /// success exit behavior.
+    #[arg(long)]
+    pub success_release_file: Option<PathBuf>,
 
     /// Protocol version to advertise in Authenticate. 2 omits every v3 field
     /// entirely (a pure v2 client for mixed-room tests).
@@ -260,6 +268,7 @@ mod tests {
         assert_eq!(cli.runtime, RuntimeFlavor::Multi);
         assert_eq!(cli.runtime.as_str(), "multi");
         assert_eq!(cli.tick_stall_ms, 0, "fault injection is off by default");
+        assert_eq!(cli.success_release_file, None);
         assert_eq!(
             cli.topologies(),
             vec![Topology::Relay, Topology::Host, Topology::Mesh]
@@ -331,6 +340,22 @@ mod tests {
         assert_eq!(cli.runtime, RuntimeFlavor::Current);
         assert_eq!(cli.runtime.as_str(), "current");
         assert_eq!(cli.tick_stall_ms, 750);
+    }
+
+    #[test]
+    fn success_release_file_parses() {
+        let cli = Cli::parse_from([
+            "signal-fish-reference-native",
+            "--server-url",
+            "ws://127.0.0.1:9000/v3/ws",
+            "--create-room",
+            "--success-release-file",
+            "/tmp/signal-fish-release",
+        ]);
+        assert_eq!(
+            cli.success_release_file.as_deref(),
+            Some(std::path::Path::new("/tmp/signal-fish-release"))
+        );
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -728,7 +728,11 @@ impl Orchestrator<'_> {
     /// Earliest pending timer (the run deadline at the latest), so the select
     /// loop always wakes for due work even on a silent wire.
     fn next_wake(&self) -> Instant {
-        let mut wake = self.run_deadline;
+        // Once a harness-held client has reported success, the soft run
+        // deadline no longer applies: the release path or the binary-wide
+        // hard watchdog is authoritative. Starting from the poll deadline
+        // avoids a busy loop after `run_deadline` passes.
+        let mut wake = self.success_release_poll_at.unwrap_or(self.run_deadline);
         if !self.relay_sent {
             if let Some(at) = self.relay_send_at {
                 wake = wake.min(at);
@@ -812,25 +816,17 @@ impl Orchestrator<'_> {
         }
 
         if now >= self.run_deadline {
-            if self.criteria_met() && !self.success_release_pending() {
+            if self.criteria_met() {
+                if self.success_release_pending() {
+                    return Ok(None);
+                }
                 return Ok(Some(EXIT_SUCCESS));
             }
             emit(&Event::Error {
-                message: if self.criteria_met() {
-                    match &self.cli.success_release_file {
-                        Some(path) => format!(
-                            "--run-for-secs elapsed while waiting for --success-release-file {}",
-                            path.display()
-                        ),
-                        None => "--run-for-secs elapsed while waiting for the success release file"
-                            .to_string(),
-                    }
-                } else {
-                    format!(
-                        "--run-for-secs elapsed with unmet success criteria: {}",
-                        self.unmet_criteria().join(", ")
-                    )
-                },
+                message: format!(
+                    "--run-for-secs elapsed with unmet success criteria: {}",
+                    self.unmet_criteria().join(", ")
+                ),
             });
             return Ok(Some(EXIT_CRITERIA_UNMET));
         }

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -808,7 +808,7 @@ impl Orchestrator<'_> {
             self.p2p_deadline = None;
         }
 
-        self.arm_success_linger(now)?;
+        self.arm_success_linger(now).await?;
         if self.linger_until.is_some_and(|at| now >= at) {
             // Criteria can regress during the linger: an authoritative plan or
             // a freshly connected pair adds new obligations (exchange,
@@ -826,7 +826,7 @@ impl Orchestrator<'_> {
         }
 
         if now >= self.run_deadline {
-            let release_pending = self.success_release_pending()?;
+            let release_pending = self.success_release_pending().await?;
             if should_defer_success_at_run_deadline(
                 release_pending,
                 self.success_criteria_reported,
@@ -848,10 +848,10 @@ impl Orchestrator<'_> {
         Ok(None)
     }
 
-    fn arm_success_linger(&mut self, now: Instant) -> Result<(), FatalError> {
+    async fn arm_success_linger(&mut self, now: Instant) -> Result<(), FatalError> {
         if !self.criteria_met() {
             let release_pending =
-                self.success_criteria_reported && self.success_release_pending()?;
+                self.success_criteria_reported && self.success_release_pending().await?;
             self.success_release_poll_at = release_pending.then_some(now + SUCCESS_RELEASE_POLL);
             return Ok(());
         }
@@ -859,7 +859,7 @@ impl Orchestrator<'_> {
             emit(&Event::SuccessCriteriaMet);
             self.success_criteria_reported = true;
         }
-        if self.success_release_pending()? {
+        if self.success_release_pending().await? {
             self.linger_until = None;
             self.success_release_poll_at = Some(now + SUCCESS_RELEASE_POLL);
         } else {
@@ -871,16 +871,23 @@ impl Orchestrator<'_> {
         Ok(())
     }
 
-    fn success_release_pending(&self) -> Result<bool, FatalError> {
+    async fn success_release_pending(&self) -> Result<bool, FatalError> {
         let Some(path) = &self.cli.success_release_file else {
             return Ok(false);
         };
-        path.try_exists().map(|exists| !exists).map_err(|error| {
-            FatalError::connection(format!(
-                "inspect --success-release-file {}: {error}",
-                path.display()
-            ))
-        })
+        let path = path.clone();
+        let display = path.display().to_string();
+        tokio::task::spawn_blocking(move || path.try_exists())
+            .await
+            .map_err(|error| {
+                FatalError::connection(format!(
+                    "inspect --success-release-file {display}: metadata task failed: {error}"
+                ))
+            })?
+            .map(|exists| !exists)
+            .map_err(|error| {
+                FatalError::connection(format!("inspect --success-release-file {display}: {error}"))
+            })
     }
 
     async fn handle_server_message(&mut self, message: ServerMessage) -> Result<(), FatalError> {

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -826,15 +826,15 @@ impl Orchestrator<'_> {
         }
 
         if now >= self.run_deadline {
+            let release_pending = self.success_release_pending()?;
+            if should_defer_success_at_run_deadline(
+                release_pending,
+                self.success_criteria_reported,
+                self.linger_until.is_some(),
+            ) {
+                return Ok(None);
+            }
             if self.criteria_met() {
-                let release_pending = self.success_release_pending()?;
-                if should_defer_success_at_run_deadline(
-                    release_pending,
-                    self.success_criteria_reported,
-                    self.linger_until.is_some(),
-                ) {
-                    return Ok(None);
-                }
                 return Ok(Some(EXIT_SUCCESS));
             }
             emit(&Event::Error {
@@ -850,7 +850,9 @@ impl Orchestrator<'_> {
 
     fn arm_success_linger(&mut self, now: Instant) -> Result<(), FatalError> {
         if !self.criteria_met() {
-            self.success_release_poll_at = None;
+            let release_pending =
+                self.success_criteria_reported && self.success_release_pending()?;
+            self.success_release_poll_at = release_pending.then_some(now + SUCCESS_RELEASE_POLL);
             return Ok(());
         }
         if self.cli.success_release_file.is_some() && !self.success_criteria_reported {
@@ -1676,7 +1678,7 @@ fn should_defer_success_at_run_deadline(
     success_criteria_reported: bool,
     success_linger_pending: bool,
 ) -> bool {
-    release_pending || (success_criteria_reported && success_linger_pending)
+    success_criteria_reported && (release_pending || success_linger_pending)
 }
 
 fn harness_aware_base_wake(
@@ -1737,7 +1739,17 @@ mod tests {
         assert!(should_defer_success_at_run_deadline(true, true, false));
         assert!(should_defer_success_at_run_deadline(false, true, true));
         assert!(!should_defer_success_at_run_deadline(false, true, false));
+        assert!(!should_defer_success_at_run_deadline(true, false, false));
         assert!(!should_defer_success_at_run_deadline(false, false, true));
+    }
+
+    #[test]
+    fn reported_success_keeps_soft_deadline_deferred_during_regression() {
+        assert!(should_defer_success_at_run_deadline(true, true, false));
+        assert!(
+            !should_defer_success_at_run_deadline(false, true, false),
+            "release ends the hold so regressed criteria can fail normally"
+        );
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -735,9 +735,14 @@ impl Orchestrator<'_> {
     fn next_wake(&self) -> Instant {
         // Once a harness-held client has reported success, the soft run
         // deadline no longer applies: the release path or the binary-wide
-        // hard watchdog is authoritative. Starting from the poll deadline
-        // avoids a busy loop after `run_deadline` passes.
-        let mut wake = self.success_release_poll_at.unwrap_or(self.run_deadline);
+        // hard watchdog is authoritative. Starting from the release poll or
+        // post-release linger avoids a busy loop after `run_deadline` passes.
+        let mut wake = harness_aware_base_wake(
+            self.run_deadline,
+            self.success_release_poll_at,
+            self.linger_until,
+            self.success_criteria_reported,
+        );
         if !self.relay_sent {
             if let Some(at) = self.relay_send_at {
                 wake = wake.min(at);
@@ -1674,6 +1679,21 @@ fn should_defer_success_at_run_deadline(
     release_pending || (success_criteria_reported && success_linger_pending)
 }
 
+fn harness_aware_base_wake(
+    run_deadline: Instant,
+    success_release_poll_at: Option<Instant>,
+    linger_until: Option<Instant>,
+    success_criteria_reported: bool,
+) -> Instant {
+    if success_criteria_reported {
+        success_release_poll_at
+            .or(linger_until)
+            .unwrap_or(run_deadline)
+    } else {
+        run_deadline
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -1689,7 +1709,7 @@ mod tests {
 
     use super::{
         authoritative_peer_delta, changed_transport_status, clear_departed_membership_plan,
-        connection_targets_for_plan, consume_join_accountability_preface,
+        connection_targets_for_plan, consume_join_accountability_preface, harness_aware_base_wake,
         is_terminal_peer_connection_state, negotiated_version_from, next_handshake_message,
         require_finalized_membership_plan, requires_authoritative_finalization_plan,
         restore_reconnected_member, should_buffer_signal_for_unpaired_peer,
@@ -1718,6 +1738,22 @@ mod tests {
         assert!(should_defer_success_at_run_deadline(false, true, true));
         assert!(!should_defer_success_at_run_deadline(false, true, false));
         assert!(!should_defer_success_at_run_deadline(false, false, true));
+    }
+
+    #[test]
+    fn harness_linger_replaces_elapsed_soft_deadline_as_next_wake() {
+        let now = tokio::time::Instant::now();
+        let elapsed_run_deadline = now - std::time::Duration::from_secs(1);
+        let linger_until = now + super::EXIT_LINGER;
+        assert_eq!(
+            harness_aware_base_wake(elapsed_run_deadline, None, Some(linger_until), true),
+            linger_until
+        );
+        assert_eq!(
+            harness_aware_base_wake(elapsed_run_deadline, None, Some(linger_until), false),
+            elapsed_run_deadline,
+            "ordinary clients retain the soft-deadline behavior"
+        );
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -76,6 +76,8 @@ const RELAY_SEND_SETTLE: Duration = Duration::from_millis(250);
 /// Grace period between meeting all success criteria and exiting, so the last
 /// unreliable-channel sends are not torn down mid-flight for slower siblings.
 const EXIT_LINGER: Duration = Duration::from_millis(250);
+/// Poll cadence for an optional harness-controlled success release file.
+const SUCCESS_RELEASE_POLL: Duration = Duration::from_millis(100);
 
 /// Keepalive cadence. `docs/guides/building-a-client.md` makes a periodic
 /// `Ping` mandatory for every client (the server evicts idle connections);
@@ -202,6 +204,8 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         pending_signals: BTreeMap::new(),
         run_deadline,
         linger_until: None,
+        success_criteria_reported: false,
+        success_release_poll_at: None,
         next_ping_at: Instant::now() + PING_INTERVAL,
         pong_deadline: None,
         pong_grace_applied: false,
@@ -613,6 +617,10 @@ struct Orchestrator<'a> {
     run_deadline: Instant,
     /// Set once all criteria are met; exit 0 when it elapses.
     linger_until: Option<Instant>,
+    /// Whether the stable machine event announcing complete criteria was sent.
+    success_criteria_reported: bool,
+    /// Next poll for an optional harness-controlled release-file barrier.
+    success_release_poll_at: Option<Instant>,
     /// Next keepalive `Ping` send (the mandatory client keepalive contract).
     next_ping_at: Instant,
     /// Deadline for the `Pong` answering the most recent `Ping`; `None` while
@@ -732,6 +740,9 @@ impl Orchestrator<'_> {
         if let Some(at) = self.linger_until {
             wake = wake.min(at);
         }
+        if let Some(at) = self.success_release_poll_at {
+            wake = wake.min(at);
+        }
         wake = wake.min(self.next_ping_at);
         if let Some(at) = self.pong_deadline {
             wake = wake.min(at);
@@ -801,14 +812,19 @@ impl Orchestrator<'_> {
         }
 
         if now >= self.run_deadline {
-            if self.criteria_met() {
+            if self.criteria_met() && !self.success_release_pending() {
                 return Ok(Some(EXIT_SUCCESS));
             }
             emit(&Event::Error {
-                message: format!(
-                    "--run-for-secs elapsed with unmet success criteria: {}",
-                    self.unmet_criteria().join(", ")
-                ),
+                message: if self.criteria_met() {
+                    "--run-for-secs elapsed while waiting for --success-release-file"
+                        .to_string()
+                } else {
+                    format!(
+                        "--run-for-secs elapsed with unmet success criteria: {}",
+                        self.unmet_criteria().join(", ")
+                    )
+                },
             });
             return Ok(Some(EXIT_CRITERIA_UNMET));
         }
@@ -816,9 +832,30 @@ impl Orchestrator<'_> {
     }
 
     fn arm_success_linger(&mut self, now: Instant) {
-        if self.linger_until.is_none() && self.criteria_met() {
-            self.linger_until = Some(now + EXIT_LINGER);
+        if !self.criteria_met() {
+            self.success_release_poll_at = None;
+            return;
         }
+        if self.cli.success_release_file.is_some() && !self.success_criteria_reported {
+            emit(&Event::SuccessCriteriaMet);
+            self.success_criteria_reported = true;
+        }
+        if self.success_release_pending() {
+            self.linger_until = None;
+            self.success_release_poll_at = Some(now + SUCCESS_RELEASE_POLL);
+        } else {
+            self.success_release_poll_at = None;
+            if self.linger_until.is_none() {
+                self.linger_until = Some(now + EXIT_LINGER);
+            }
+        }
+    }
+
+    fn success_release_pending(&self) -> bool {
+        self.cli
+            .success_release_file
+            .as_ref()
+            .is_some_and(|path| !path.exists())
     }
 
     async fn handle_server_message(&mut self, message: ServerMessage) -> Result<(), FatalError> {

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -822,7 +822,12 @@ impl Orchestrator<'_> {
 
         if now >= self.run_deadline {
             if self.criteria_met() {
-                if self.success_release_pending()? {
+                let release_pending = self.success_release_pending()?;
+                if should_defer_success_at_run_deadline(
+                    release_pending,
+                    self.success_criteria_reported,
+                    self.linger_until.is_some(),
+                ) {
                     return Ok(None);
                 }
                 return Ok(Some(EXIT_SUCCESS));
@@ -1658,6 +1663,17 @@ impl Orchestrator<'_> {
     }
 }
 
+/// A harness-held client treats the soft run deadline as advisory after it has
+/// reported success. It must wait both for the harness release and for the
+/// post-release linger that was armed on the release-observation tick.
+fn should_defer_success_at_run_deadline(
+    release_pending: bool,
+    success_criteria_reported: bool,
+    success_linger_pending: bool,
+) -> bool {
+    release_pending || (success_criteria_reported && success_linger_pending)
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
@@ -1677,8 +1693,8 @@ mod tests {
         is_terminal_peer_connection_state, negotiated_version_from, next_handshake_message,
         require_finalized_membership_plan, requires_authoritative_finalization_plan,
         restore_reconnected_member, should_buffer_signal_for_unpaired_peer,
-        should_resolve_connected_pair, validate_json_negotiated_server_message,
-        EXIT_PROTOCOL_ERROR,
+        should_defer_success_at_run_deadline, should_resolve_connected_pair,
+        validate_json_negotiated_server_message, EXIT_PROTOCOL_ERROR,
     };
     use tokio_tungstenite::tungstenite::{Bytes, Message};
     use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
@@ -1694,6 +1710,14 @@ mod tests {
         assert!(!wire::is_transparent_transport_control(&Message::Binary(
             Bytes::new()
         )));
+    }
+
+    #[test]
+    fn harness_release_after_soft_deadline_still_honors_exit_linger() {
+        assert!(should_defer_success_at_run_deadline(true, true, false));
+        assert!(should_defer_success_at_run_deadline(false, true, true));
+        assert!(!should_defer_success_at_run_deadline(false, true, false));
+        assert!(!should_defer_success_at_run_deadline(false, false, true));
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -189,6 +189,7 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         webrtc_plan_seen: false,
         expected_peers: BTreeSet::new(),
         connected_pairs: BTreeSet::new(),
+        ice_gathering_complete: BTreeSet::new(),
         last_ice_servers: Vec::new(),
         transport_status: None,
         p2p_deadline: None,
@@ -593,6 +594,10 @@ struct Orchestrator<'a> {
     /// Peers whose pair fully connected (both channels open) at some point.
     /// Drives the `--exchange` obligations and the Appendix G resolution.
     connected_pairs: BTreeSet<PlayerId>,
+    /// Peers whose current connection generation emitted the terminal local
+    /// ICE gathering callback. Harness-held success uses this as the exact
+    /// outbound signal-ledger boundary.
+    ice_gathering_complete: BTreeSet<PlayerId>,
     /// ICE servers from the most recent plan (also used for compatible `NewPeer`).
     last_ice_servers: Vec<IceServer>,
     /// Last reported overall WebRTC state, retained to suppress duplicates.
@@ -1198,6 +1203,9 @@ impl Orchestrator<'_> {
                 )
                 .await?;
             }
+            EngineEvent::IceGatheringComplete { peer, .. } => {
+                self.ice_gathering_complete.insert(peer);
+            }
             EngineEvent::PcState { peer, state, .. } => {
                 emit(&Event::PcState {
                     peer,
@@ -1205,6 +1213,7 @@ impl Orchestrator<'_> {
                 });
                 if is_terminal_peer_connection_state(&state) {
                     self.connected_pairs.remove(&peer);
+                    self.ice_gathering_complete.remove(&peer);
                     self.sent_labels.remove(&peer);
                     self.received_labels.remove(&peer);
                     self.pending_signals.remove(&peer);
@@ -1259,6 +1268,9 @@ impl Orchestrator<'_> {
         }
         let newly_expected = self.expected_peers.insert(peer);
         let needs_connection = !self.engine.is_paired(peer);
+        if needs_connection {
+            self.ice_gathering_complete.remove(&peer);
+        }
         if (newly_expected || needs_connection) && !self.connected_pairs.contains(&peer) {
             self.p2p_deadline =
                 Some(Instant::now() + Duration::from_secs(self.cli.p2p_timeout_secs));
@@ -1289,6 +1301,7 @@ impl Orchestrator<'_> {
     async fn remove_pair_obligation(&mut self, peer: PlayerId) {
         self.expected_peers.remove(&peer);
         self.connected_pairs.remove(&peer);
+        self.ice_gathering_complete.remove(&peer);
         self.peer_status_from.remove(&peer);
         self.sent_labels.remove(&peer);
         self.received_labels.remove(&peer);
@@ -1574,6 +1587,13 @@ impl Orchestrator<'_> {
                 for peer in &self.expected_peers {
                     if !self.peer_status_from.contains(peer) {
                         unmet.push(format!("no PeerTransportStatus from {peer}"));
+                    }
+                }
+            }
+            if self.cli.success_release_file.is_some() {
+                for peer in &self.expected_peers {
+                    if !self.ice_gathering_complete.contains(peer) {
+                        unmet.push(format!("ICE gathering incomplete for {peer}"));
                     }
                 }
             }

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -817,7 +817,14 @@ impl Orchestrator<'_> {
             }
             emit(&Event::Error {
                 message: if self.criteria_met() {
-                    "--run-for-secs elapsed while waiting for --success-release-file".to_string()
+                    match &self.cli.success_release_file {
+                        Some(path) => format!(
+                            "--run-for-secs elapsed while waiting for --success-release-file {}",
+                            path.display()
+                        ),
+                        None => "--run-for-secs elapsed while waiting for the success release file"
+                            .to_string(),
+                    }
                 } else {
                     format!(
                         "--run-for-secs elapsed with unmet success criteria: {}",

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -817,8 +817,7 @@ impl Orchestrator<'_> {
             }
             emit(&Event::Error {
                 message: if self.criteria_met() {
-                    "--run-for-secs elapsed while waiting for --success-release-file"
-                        .to_string()
+                    "--run-for-secs elapsed while waiting for --success-release-file".to_string()
                 } else {
                     format!(
                         "--run-for-secs elapsed with unmet success criteria: {}",

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -803,7 +803,7 @@ impl Orchestrator<'_> {
             self.p2p_deadline = None;
         }
 
-        self.arm_success_linger(now);
+        self.arm_success_linger(now)?;
         if self.linger_until.is_some_and(|at| now >= at) {
             // Criteria can regress during the linger: an authoritative plan or
             // a freshly connected pair adds new obligations (exchange,
@@ -822,7 +822,7 @@ impl Orchestrator<'_> {
 
         if now >= self.run_deadline {
             if self.criteria_met() {
-                if self.success_release_pending() {
+                if self.success_release_pending()? {
                     return Ok(None);
                 }
                 return Ok(Some(EXIT_SUCCESS));
@@ -838,16 +838,16 @@ impl Orchestrator<'_> {
         Ok(None)
     }
 
-    fn arm_success_linger(&mut self, now: Instant) {
+    fn arm_success_linger(&mut self, now: Instant) -> Result<(), FatalError> {
         if !self.criteria_met() {
             self.success_release_poll_at = None;
-            return;
+            return Ok(());
         }
         if self.cli.success_release_file.is_some() && !self.success_criteria_reported {
             emit(&Event::SuccessCriteriaMet);
             self.success_criteria_reported = true;
         }
-        if self.success_release_pending() {
+        if self.success_release_pending()? {
             self.linger_until = None;
             self.success_release_poll_at = Some(now + SUCCESS_RELEASE_POLL);
         } else {
@@ -856,13 +856,19 @@ impl Orchestrator<'_> {
                 self.linger_until = Some(now + EXIT_LINGER);
             }
         }
+        Ok(())
     }
 
-    fn success_release_pending(&self) -> bool {
-        self.cli
-            .success_release_file
-            .as_ref()
-            .is_some_and(|path| !path.exists())
+    fn success_release_pending(&self) -> Result<bool, FatalError> {
+        let Some(path) = &self.cli.success_release_file else {
+            return Ok(false);
+        };
+        path.try_exists().map(|exists| !exists).map_err(|error| {
+            FatalError::connection(format!(
+                "inspect --success-release-file {}: {error}",
+                path.display()
+            ))
+        })
     }
 
     async fn handle_server_message(&mut self, message: ServerMessage) -> Result<(), FatalError> {

--- a/clients/native/src/engine.rs
+++ b/clients/native/src/engine.rs
@@ -61,6 +61,9 @@ pub enum EngineEvent {
         generation: u64,
         candidate_json: String,
     },
+    /// This peer connection emitted the end-of-gathering marker after all
+    /// local candidates for its generation.
+    IceGatheringComplete { peer: PlayerId, generation: u64 },
     /// Peer-connection state transition (informational `pc_state` events).
     PcState {
         peer: PlayerId,
@@ -94,6 +97,7 @@ impl EngineEvent {
             Self::LocalCandidate {
                 peer, generation, ..
             }
+            | Self::IceGatheringComplete { peer, generation }
             | Self::PcState {
                 peer, generation, ..
             }
@@ -425,13 +429,16 @@ impl Engine {
         let events = self.events.clone();
         let crippled = self.crippled;
         pc.on_ice_candidate(Box::new(move |candidate| {
-            // `None` marks end-of-gathering; crippled mode drops everything.
+            // `None` marks end-of-gathering. Preserve that boundary even in
+            // crippled mode so a harness can prove its signal ledger is
+            // complete; crippled mode drops only the actual candidates.
+            let Some(candidate) = candidate else {
+                let _ = events.send(EngineEvent::IceGatheringComplete { peer, generation });
+                return Box::pin(async {});
+            };
             if crippled {
                 return Box::pin(async {});
             }
-            let Some(candidate) = candidate else {
-                return Box::pin(async {});
-            };
             match candidate
                 .to_json()
                 .map_err(anyhow::Error::from)
@@ -599,6 +606,10 @@ mod tests {
                 peer,
                 generation: stale_generation,
                 candidate_json: "{}".to_string(),
+            },
+            EngineEvent::IceGatheringComplete {
+                peer,
+                generation: stale_generation,
             },
             EngineEvent::PcState {
                 peer,

--- a/clients/native/src/events.rs
+++ b/clients/native/src/events.rs
@@ -99,6 +99,10 @@ pub enum Event {
     },
     /// The P2P window resolved with zero connected pairs; relay carries the session.
     FallbackEngaged,
+    /// Every flag-driven success criterion currently holds. When a harness
+    /// supplied `--success-release-file`, the client remains live until that
+    /// file appears.
+    SuccessCriteriaMet,
     /// A non-fatal or fatal error (fatal errors are followed by `exiting`).
     Error { message: String },
     /// Final event before process exit with the given code.
@@ -223,6 +227,7 @@ mod tests {
             ),
             (Event::GameDataSent, "game_data_sent"),
             (Event::FallbackEngaged, "fallback_engaged"),
+            (Event::SuccessCriteriaMet, "success_criteria_met"),
             (Event::Exiting { code: 0 }, "exiting"),
         ];
         for (event, expected_tag) in cases {

--- a/clients/native/src/main.rs
+++ b/clients/native/src/main.rs
@@ -56,10 +56,17 @@ fn main() {
             Ok(code) => code,
             Err(_elapsed) => {
                 emit(&Event::Error {
-                    message: format!(
-                        "--max-runtime-secs ({}) watchdog fired; hard abort",
-                        cli.max_runtime_secs
-                    ),
+                    message: match &cli.success_release_file {
+                        Some(path) => format!(
+                            "--max-runtime-secs ({}) watchdog fired; hard abort; success release path: {}",
+                            cli.max_runtime_secs,
+                            path.display()
+                        ),
+                        None => format!(
+                            "--max-runtime-secs ({}) watchdog fired; hard abort",
+                            cli.max_runtime_secs
+                        ),
+                    },
                 });
                 EXIT_HARD_TIMEOUT
             }

--- a/tests/multiprocess_delivery_e2e.rs
+++ b/tests/multiprocess_delivery_e2e.rs
@@ -59,17 +59,16 @@
 //! keeps plain `cargo test` from co-scheduling the floods in one process.
 #![cfg(unix)]
 
+#[path = "websocket_test_helpers/native_client_process.rs"]
+mod native_client_process;
 mod websocket_test_helpers;
 
-use std::path::PathBuf;
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use native_client_process::{spawn_native_client, NativeClientProcess};
 use serde_json::{json, Value};
 use signal_fish_server::protocol::{ClientMessage, PlayerId, ServerMessage};
-use tokio::io::{AsyncBufReadExt, BufReader, Lines};
-use tokio::process::ChildStdout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use websocket_test_helpers::delivery_ledger::{extract, LedgerPayload};
 use websocket_test_helpers::prometheus_scrape::{
@@ -124,98 +123,6 @@ fn config_overlay(knobs: DeliveryKnobs) -> Value {
     })
 }
 
-// ---------------------------------------------------------------------------
-// Native reference client process harness (JSONL stdout consumer; adapted
-// from clients/native/tests/harness/mod.rs, which this crate cannot import).
-// ---------------------------------------------------------------------------
-
-/// Locate the `signal-fish-reference-native` binary: `SIGNAL_FISH_CLIENT_BIN`
-/// when set (CI pre-builds it), else a once-per-process
-/// `cargo build --manifest-path clients/native/Cargo.toml` fallback for local
-/// runs. Panics with actionable instructions on failure.
-fn native_client_binary() -> PathBuf {
-    if let Some(raw) = std::env::var_os("SIGNAL_FISH_CLIENT_BIN") {
-        let path = PathBuf::from(raw);
-        assert!(
-            path.is_file(),
-            "SIGNAL_FISH_CLIENT_BIN points at {path:?}, which is not a file. Run \
-             `cargo build --manifest-path clients/native/Cargo.toml --bin \
-             signal-fish-reference-native` and point the variable at the built binary."
-        );
-        return path;
-    }
-
-    static BUILT: OnceLock<PathBuf> = OnceLock::new();
-    BUILT
-        .get_or_init(|| {
-            let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-            let manifest = root.join("clients").join("native").join("Cargo.toml");
-            let mut command = std::process::Command::new(env!("CARGO"));
-            command
-                .arg("build")
-                .arg("--manifest-path")
-                .arg(&manifest)
-                .args(["--bin", "signal-fish-reference-native"]);
-            // Instrumented parent cargo processes (coverage/sanitizer lanes)
-            // must not leak flags into the nested build (same scrub set as
-            // tests/common/mod.rs `scrub_nested_cargo_env`).
-            for var in [
-                "RUSTFLAGS",
-                "CARGO_ENCODED_RUSTFLAGS",
-                "RUSTDOCFLAGS",
-                "CARGO_TARGET_DIR",
-                "ASAN_OPTIONS",
-                "LSAN_OPTIONS",
-                "UBSAN_OPTIONS",
-                "TSAN_OPTIONS",
-                "MIRIFLAGS",
-            ] {
-                command.env_remove(var);
-            }
-            let status = command
-                .status()
-                .expect("run `cargo build` for the native reference client");
-            assert!(
-                status.success(),
-                "building the native reference client failed ({status}); build it manually with \
-                 `cargo build --manifest-path clients/native/Cargo.toml --bin \
-                 signal-fish-reference-native` or set SIGNAL_FISH_CLIENT_BIN"
-            );
-            let path = root
-                .join("clients")
-                .join("native")
-                .join("target")
-                .join("debug")
-                .join("signal-fish-reference-native");
-            assert!(
-                path.is_file(),
-                "the nested client build succeeded but {path:?} does not exist"
-            );
-            path
-        })
-        .clone()
-}
-
-/// Guard around one spawned reference-client process; collects its JSONL
-/// stdout events. Dropping it kills the child.
-struct ClientProcess {
-    name: String,
-    child: Option<tokio::process::Child>,
-    lines: Lines<BufReader<ChildStdout>>,
-    events: Vec<Value>,
-    stderr_path: PathBuf,
-}
-
-impl Drop for ClientProcess {
-    fn drop(&mut self) {
-        if let Some(child) = self.child.as_mut() {
-            if let Err(error) = child.start_kill() {
-                eprintln!("failed to kill client {} on drop: {error}", self.name);
-            }
-        }
-    }
-}
-
 /// Spawn one native reference client that joins `room_code` and lingers,
 /// reading relay traffic, for the given soft window. `peers` is set to a
 /// count the room never reaches a full lobby with, so the client stays a
@@ -227,185 +134,24 @@ fn spawn_lingering_client(
     peers: usize,
     run_for_secs: u64,
     workdir: &std::path::Path,
-) -> ClientProcess {
-    let stderr_path = workdir.join(format!("client-{name}-stderr.log"));
-    let stderr_file = std::fs::File::create(&stderr_path).expect("create client stderr capture");
-
-    let mut command = tokio::process::Command::new(native_client_binary());
-    command
-        .arg("--server-url")
-        .arg(format!("ws://127.0.0.1:{server_port}/v3/ws"))
-        .arg("--join-code")
-        .arg(room_code)
-        .arg("--game-name")
-        .arg(GAME_NAME)
-        .arg("--player-name")
-        .arg(name)
-        .arg("--peers")
-        .arg(peers.to_string())
-        .arg("--run-for-secs")
-        .arg(run_for_secs.to_string())
-        .arg("--max-runtime-secs")
-        .arg((run_for_secs + 60).to_string())
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::from(stderr_file))
-        .env("RUST_LOG", "info")
-        .kill_on_drop(true);
-
-    let mut child = command.spawn().expect("spawn the native reference client");
-    let stdout = child.stdout.take().expect("client stdout is piped");
-    ClientProcess {
-        name: name.to_string(),
-        child: Some(child),
-        lines: BufReader::new(stdout).lines(),
-        events: Vec::new(),
-        stderr_path,
-    }
-}
-
-impl ClientProcess {
-    /// OS pid of the still-running client (panics once reaped).
-    fn pid(&self) -> u32 {
-        self.child
-            .as_ref()
-            .and_then(tokio::process::Child::id)
-            .expect("client process already exited or was reaped")
-    }
-
-    /// Read events until one named `event_name` arrives; panics with
-    /// diagnostics on timeout, EOF, or a non-JSONL stdout line.
-    async fn await_event(&mut self, event_name: &str, timeout: Duration) -> Value {
-        let deadline = tokio::time::Instant::now() + timeout;
-        loop {
-            match self
-                .next_event_before(deadline, &format!("awaiting `{event_name}`"))
-                .await
-            {
-                Some(event) => {
-                    if event.get("event").and_then(Value::as_str) == Some(event_name) {
-                        return event;
-                    }
-                }
-                None => panic!(
-                    "client {}: stdout ended before `{event_name}`;\n{}",
-                    self.name,
-                    self.diagnostics()
-                ),
-            }
-        }
-    }
-
-    /// Read events until `count` events named `event_name` have been recorded
-    /// in total (already-recorded ones included).
-    async fn await_event_count(&mut self, event_name: &str, count: usize, timeout: Duration) {
-        let deadline = tokio::time::Instant::now() + timeout;
-        while self.recorded_event_count(event_name) < count {
-            let context = format!(
-                "awaiting {count} `{event_name}` events (have {})",
-                self.recorded_event_count(event_name)
-            );
-            let event = self.next_event_before(deadline, &context).await;
-            assert!(
-                event.is_some(),
-                "client {}: stdout ended with {} of {count} `{event_name}` events;\n{}",
-                self.name,
-                self.recorded_event_count(event_name),
-                self.diagnostics()
-            );
-        }
-    }
-
-    fn recorded_event_count(&self, event_name: &str) -> usize {
-        self.events
-            .iter()
-            .filter(|event| event.get("event").and_then(Value::as_str) == Some(event_name))
-            .count()
-    }
-
-    /// Read and record the next event line before `deadline`; `None` on EOF.
-    async fn next_event_before(
-        &mut self,
-        deadline: tokio::time::Instant,
-        context: &str,
-    ) -> Option<Value> {
-        let read = tokio::time::timeout_at(deadline, self.lines.next_line()).await;
-        let line = read
-            .unwrap_or_else(|_elapsed| {
-                panic!(
-                    "client {}: timed out {context};\n{}",
-                    self.name,
-                    self.diagnostics()
-                )
-            })
-            .unwrap_or_else(|error| {
-                panic!(
-                    "client {}: stdout read error: {error};\n{}",
-                    self.name,
-                    self.diagnostics()
-                )
-            })?;
-        let event: Value = serde_json::from_str(&line).unwrap_or_else(|error| {
-            panic!(
-                "client {}: stdout line is not a JSON event ({error}): {line}",
-                self.name
-            )
-        });
-        self.events.push(event.clone());
-        Some(event)
-    }
-
-    /// Drain every remaining event to EOF, reap the child, and return its
-    /// exit status (callers assert code vs. signal explicitly).
-    async fn drain_to_termination(&mut self, timeout: Duration) -> std::process::ExitStatus {
-        let deadline = tokio::time::Instant::now() + timeout;
-        while let Some(_event) = self
-            .next_event_before(deadline, "draining events to process exit")
-            .await
-        {
-            // Recorded by next_event_before; nothing else to do.
-        }
-        let mut child = self.child.take().expect("client child already reaped");
-        tokio::time::timeout_at(deadline, child.wait())
-            .await
-            .unwrap_or_else(|_elapsed| {
-                panic!(
-                    "client {}: stdout closed but the process did not exit;\n{}",
-                    self.name,
-                    self.diagnostics()
-                )
-            })
-            .unwrap_or_else(|error| panic!("client {}: failed to reap process: {error}", self.name))
-    }
-
-    /// All `error`-event messages recorded so far.
-    fn error_messages(&self) -> Vec<String> {
-        self.events
-            .iter()
-            .filter(|event| event.get("event").and_then(Value::as_str) == Some("error"))
-            .filter_map(|event| event.get("message").and_then(Value::as_str))
-            .map(str::to_string)
-            .collect()
-    }
-
-    /// Recent events plus captured stderr, for failure messages.
-    fn diagnostics(&self) -> String {
-        const EVENT_TAIL: usize = 12;
-        let tail_start = self.events.len().saturating_sub(EVENT_TAIL);
-        let recent: Vec<String> = self.events[tail_start..]
-            .iter()
-            .map(|event| event.to_string())
-            .collect();
-        let stderr = std::fs::read_to_string(&self.stderr_path)
-            .unwrap_or_else(|error| format!("<failed to read stderr: {error}>"));
-        format!(
-            "last {} events:\n{}\n--- client {} stderr ---\n{}",
-            recent.len(),
-            recent.join("\n"),
-            self.name,
-            stderr
-        )
-    }
+) -> NativeClientProcess {
+    let args = vec![
+        "--server-url".to_string(),
+        format!("ws://127.0.0.1:{server_port}/v3/ws"),
+        "--join-code".to_string(),
+        room_code.to_string(),
+        "--game-name".to_string(),
+        GAME_NAME.to_string(),
+        "--player-name".to_string(),
+        name.to_string(),
+        "--peers".to_string(),
+        peers.to_string(),
+        "--run-for-secs".to_string(),
+        run_for_secs.to_string(),
+        "--max-runtime-secs".to_string(),
+        (run_for_secs + 60).to_string(),
+    ];
+    spawn_native_client(name, &args, workdir)
 }
 
 /// Deliver `signal` (e.g. "-STOP") to `pid` via the portable `kill` binary —
@@ -817,11 +563,7 @@ async fn sigkill_client_mid_burst_conserves() {
 
     // SIGKILL: no goodbye, no close frame — the kernel does the teardown.
     signal_process(victim.pid(), "-KILL", "kill the native client mid-burst");
-    let mut victim_child = victim.child.take().expect("victim child already reaped");
-    let status = tokio::time::timeout(EVENT_DEADLINE, victim_child.wait())
-        .await
-        .expect("timed out reaping the SIGKILLed client")
-        .expect("failed to reap the SIGKILLed client");
+    let status = victim.drain_to_termination(EVENT_DEADLINE).await;
     assert!(
         status.code().is_none(),
         "a SIGKILLed process terminates by signal, got exit status {status}"

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -170,6 +170,26 @@ async fn wait_for_metrics_quiescence(port: u16) {
     }
 }
 
+async fn wait_for_exact_signal_ledger(port: u16, expected: u64) {
+    let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
+    loop {
+        let metrics = fetch_prometheus_text(port).await;
+        let relayed = sample_value(&metrics, "signal_fish_transport_signals_relayed_total");
+        if relayed == expected {
+            return;
+        }
+        assert!(
+            relayed < expected,
+            "server relayed {relayed} signals after every client reported ICE gathering complete, exceeding the exact client ledger {expected}"
+        );
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "server signal ledger did not reach {expected} within {EVENT_DEADLINE:?}; last value {relayed}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
 fn assert_exact_peer_events(
     events: &[Value],
     event: &str,
@@ -499,12 +519,12 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
         "clean mesh messages dropped before coordinated teardown"
     );
     assert_scraped_message_conservation(&held_counters);
-    let held_metrics = fetch_prometheus_text(server.port).await;
-    assert_eq!(
-        sample_value(&held_metrics, "signal_fish_transport_signals_relayed_total"),
+    wait_for_exact_signal_ledger(
+        server.port,
         u64::try_from(total_signals).expect("signal total fits u64"),
-        "server accepted signal count must equal client emission ledger"
-    );
+    )
+    .await;
+    let held_metrics = fetch_prometheus_text(server.port).await;
     assert_eq!(
         sample_value(&held_metrics, "signal_fish_websocket_ping_timeouts_total"),
         0,

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -1,0 +1,515 @@
+//! P10.H8 empirical 16-player native WebRTC mesh signal-budget experiment.
+//!
+//! The model test proves the arithmetic. This nightly real-process experiment
+//! proves the implementation: 16 native clients form all 120 peer connections
+//! under the production 600-signal per-connection budget, open both channels
+//! on every edge, exchange an exact clean ledger, and keep the WebSocket relay
+//! floor live. It is ignored because building/running 16 real webrtc-rs stacks
+//! is intentionally outside the PR machine's cheap local test budget.
+
+#![cfg(unix)]
+
+#[path = "websocket_test_helpers/native_client_process.rs"]
+mod native_client_process;
+mod websocket_test_helpers;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::time::Duration;
+
+use futures_util::future::join_all;
+use native_client_process::{spawn_native_client, NativeClientProcess};
+use serde_json::{json, Value};
+use signal_fish_server::config::Config;
+use uuid::Uuid;
+use websocket_test_helpers::prometheus_scrape::{
+    assert_scraped_message_conservation, fetch_prometheus_text, sample_value,
+    scrape_delivery_counters,
+};
+use websocket_test_helpers::server_process::{spawn_server, ServerProcess};
+
+const PLAYERS: usize = 16;
+const GAME_NAME: &str = "webrtc-mesh-budget";
+const EVENT_DEADLINE: Duration = Duration::from_secs(60);
+const CLIENT_EXIT_DEADLINE: Duration = Duration::from_secs(360);
+const METRIC_QUIESCENCE_DEADLINE: Duration = Duration::from_secs(30);
+const CHANNEL_LABELS: [&str; 2] = ["reliable", "unreliable"];
+
+fn event_name(event: &Value) -> Option<&str> {
+    event.get("event").and_then(Value::as_str)
+}
+
+fn events_named<'a>(events: &'a [Value], name: &str) -> Vec<&'a Value> {
+    events
+        .iter()
+        .filter(|event| event_name(event) == Some(name))
+        .collect()
+}
+
+fn string_field<'a>(event: &'a Value, field: &str, who: &str) -> &'a str {
+    event
+        .get(field)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{who}: event lacks string field {field:?}: {event}"))
+}
+
+fn single_event<'a>(events: &'a [Value], name: &str, who: &str) -> &'a Value {
+    let found = events_named(events, name);
+    assert_eq!(
+        found.len(),
+        1,
+        "{who}: expected exactly one {name:?} event, got {}: {found:?}",
+        found.len()
+    );
+    found[0]
+}
+
+fn success_window<'a>(events: &'a [Value], who: &str) -> &'a [Value] {
+    let end = events
+        .iter()
+        .position(|event| event_name(event) == Some("success_criteria_met"))
+        .unwrap_or_else(|| panic!("{who}: missing success_criteria_met barrier event"));
+    assert_eq!(
+        events_named(events, "success_criteria_met").len(),
+        1,
+        "{who}: success barrier must be emitted exactly once"
+    );
+    &events[..=end]
+}
+
+fn client_args(
+    server: &ServerProcess,
+    name: &str,
+    room_code: Option<&str>,
+    success_release_file: &Path,
+) -> Vec<String> {
+    let mut args = vec![
+        "--server-url".to_string(),
+        format!("ws://127.0.0.1:{}/v3/ws", server.port),
+        "--game-name".to_string(),
+        GAME_NAME.to_string(),
+        "--player-name".to_string(),
+        name.to_string(),
+        "--peers".to_string(),
+        PLAYERS.to_string(),
+        "--exchange".to_string(),
+        "--relay-payload".to_string(),
+        format!("relay-from-{name}"),
+        "--supported-topologies".to_string(),
+        "mesh".to_string(),
+        "--p2p-timeout-secs".to_string(),
+        "180".to_string(),
+        "--run-for-secs".to_string(),
+        "240".to_string(),
+        "--max-runtime-secs".to_string(),
+        "300".to_string(),
+        "--success-release-file".to_string(),
+        success_release_file.to_string_lossy().into_owned(),
+    ];
+    match room_code {
+        Some(code) => args.extend(["--join-code".to_string(), code.to_string()]),
+        None => args.push("--create-room".to_string()),
+    }
+    args
+}
+
+fn mesh_server_config() -> Value {
+    json!({
+        "session": {
+            "default_topology": "mesh",
+            "enable_webrtc": true
+        },
+        "turn": {
+            "enabled": false,
+            "stun_urls": []
+        }
+    })
+}
+
+fn rss_kib(pid: u32) -> Option<u64> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).ok()?;
+    let line = status.lines().find(|line| line.starts_with("VmRSS:"))?;
+    line.split_whitespace().nth(1)?.parse().ok()
+}
+
+async fn sample_peak_rss(pids: Vec<u32>, mut stop: tokio::sync::watch::Receiver<bool>) -> Vec<u64> {
+    let mut peaks = vec![0; pids.len()];
+    loop {
+        for (peak, pid) in peaks.iter_mut().zip(&pids) {
+            if let Some(sample) = rss_kib(*pid) {
+                *peak = (*peak).max(sample);
+            }
+        }
+        tokio::select! {
+            result = stop.changed() => {
+                if result.is_err() || *stop.borrow() {
+                    return peaks;
+                }
+            }
+            () = tokio::time::sleep(Duration::from_millis(250)) => {}
+        }
+    }
+}
+
+async fn wait_for_metrics_quiescence(port: u16) {
+    let deadline = tokio::time::Instant::now() + METRIC_QUIESCENCE_DEADLINE;
+    loop {
+        let counters = scrape_delivery_counters(port).await;
+        let resolved = counters.enqueued + counters.channel_closed + counters.canceled;
+        if counters.active_connections == 0
+            && resolved <= counters.attempts
+            && counters.attempts <= resolved + counters.dropped
+        {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "server metrics did not quiesce within {METRIC_QUIESCENCE_DEADLINE:?}: {counters:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn assert_exact_peer_events(
+    events: &[Value],
+    event: &str,
+    field: &str,
+    expected_peers: &BTreeSet<&str>,
+    who: &str,
+) {
+    let mut counts = BTreeMap::<&str, usize>::new();
+    for item in events_named(events, event) {
+        *counts.entry(string_field(item, field, who)).or_default() += 1;
+    }
+    let actual: BTreeSet<&str> = counts.keys().copied().collect();
+    assert_eq!(actual, *expected_peers, "{who}: {event} peer set");
+    for (peer, count) in counts {
+        assert_eq!(count, 1, "{who}: duplicate {event} for {peer}");
+    }
+}
+
+fn assert_exact_channel_ledger(
+    events: &[Value],
+    event: &str,
+    expected_peers: &BTreeSet<&str>,
+    player_id: &str,
+    who: &str,
+) {
+    let mut counts = BTreeMap::<(&str, &str), usize>::new();
+    for item in events_named(events, event) {
+        let peer = string_field(item, "peer", who);
+        let label = string_field(item, "label", who);
+        assert!(
+            expected_peers.contains(peer),
+            "{who}: {event} names unexpected peer {peer}"
+        );
+        assert!(
+            CHANNEL_LABELS.contains(&label),
+            "{who}: {event} names unexpected channel {label}"
+        );
+        if event != "channel_open" {
+            let text = string_field(item, "text", who);
+            let payload: Value = serde_json::from_str(text).unwrap_or_else(|error| {
+                panic!("{who}: invalid {event} JSON payload {text:?}: {error}")
+            });
+            let expected_from = if event == "channel_message_sent" {
+                player_id
+            } else {
+                peer
+            };
+            assert_eq!(
+                payload.get("from").and_then(Value::as_str),
+                Some(expected_from),
+                "{who}: {event} payload sender for peer {peer}"
+            );
+            assert_eq!(
+                payload.get("channel").and_then(Value::as_str),
+                Some(label),
+                "{who}: {event} payload channel for peer {peer}"
+            );
+            assert_eq!(
+                payload.get("seq").and_then(Value::as_u64),
+                Some(0),
+                "{who}: {event} payload sequence for peer {peer}"
+            );
+            assert_eq!(
+                payload.as_object().map(serde_json::Map::len),
+                Some(3),
+                "{who}: {event} payload must contain only from/channel/seq"
+            );
+        }
+        *counts.entry((peer, label)).or_default() += 1;
+    }
+    for peer in expected_peers {
+        for label in CHANNEL_LABELS {
+            assert_eq!(
+                counts.get(&(*peer, label)),
+                Some(&1),
+                "{who}: expected exactly one {event} for ({peer}, {label}); ledger={counts:?}"
+            );
+        }
+    }
+    assert_eq!(
+        counts.len(),
+        expected_peers.len() * CHANNEL_LABELS.len(),
+        "{who}: {event} contains stray ledger entries: {counts:?}"
+    );
+}
+
+fn assert_client_log(
+    client: &NativeClientProcess,
+    player_id: &str,
+    all_ids: &BTreeSet<&str>,
+    names_by_id: &BTreeMap<&str, &str>,
+    signal_budget: usize,
+) -> usize {
+    let who = &client.name;
+    let window = success_window(&client.events, who);
+    let expected_peers: BTreeSet<&str> = all_ids
+        .iter()
+        .copied()
+        .filter(|candidate| *candidate != player_id)
+        .collect();
+
+    assert!(
+        events_named(&client.events, "error").is_empty(),
+        "{who}: errors in successful mesh run: {:?}",
+        client.error_messages()
+    );
+    assert!(
+        events_named(&client.events, "fallback_engaged").is_empty(),
+        "{who}: clean full mesh must never engage fallback"
+    );
+    let exit = single_event(&client.events, "exiting", who);
+    assert_eq!(exit.get("code").and_then(Value::as_i64), Some(0));
+
+    let plan = single_event(window, "session_plan", who);
+    assert_eq!(string_field(plan, "topology", who), "mesh");
+    assert_eq!(string_field(plan, "transport", who), "webrtc");
+    assert_eq!(string_field(plan, "fallback", who), "relay");
+    assert!(plan.get("host").is_some_and(Value::is_null));
+    assert_eq!(
+        plan.get("ice_servers_count").and_then(Value::as_u64),
+        Some(0),
+        "{who}: loopback experiment must not contact external ICE servers"
+    );
+    let peers = plan
+        .get("peers")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("{who}: session plan lacks peers: {plan}"));
+    assert_eq!(peers.len(), PLAYERS - 1, "{who}: session-plan peer count");
+    let mut planned = BTreeSet::new();
+    let self_uuid = Uuid::parse_str(player_id).expect("player id is a UUID");
+    for peer in peers {
+        let peer_id = string_field(peer, "player_id", who);
+        assert!(
+            planned.insert(peer_id),
+            "{who}: duplicate planned peer {peer_id}"
+        );
+        let peer_uuid = Uuid::parse_str(peer_id).expect("planned peer id is a UUID");
+        assert_eq!(
+            peer.get("initiate").and_then(Value::as_bool),
+            Some(self_uuid < peer_uuid),
+            "{who}: glare role for {peer_id} must follow UUID ordering"
+        );
+    }
+    assert_eq!(planned, expected_peers, "{who}: exact mesh plan peer set");
+
+    assert_exact_peer_events(window, "p2p_pair_connected", "peer", &expected_peers, who);
+    assert_exact_channel_ledger(window, "channel_open", &expected_peers, player_id, who);
+    assert_exact_channel_ledger(
+        window,
+        "channel_message_sent",
+        &expected_peers,
+        player_id,
+        who,
+    );
+    assert_exact_channel_ledger(window, "channel_message", &expected_peers, player_id, who);
+
+    let status = single_event(window, "transport_status_sent", who);
+    assert_eq!(string_field(status, "transport", who), "webrtc");
+    assert_eq!(status.get("connected").and_then(Value::as_bool), Some(true));
+    assert_exact_peer_events(
+        window,
+        "peer_transport_status",
+        "peer",
+        &expected_peers,
+        who,
+    );
+    for peer_status in events_named(window, "peer_transport_status") {
+        assert_eq!(
+            string_field(peer_status, "transport", who),
+            "webrtc",
+            "{who}: peer status transport"
+        );
+        assert_eq!(
+            peer_status.get("connected").and_then(Value::as_bool),
+            Some(true),
+            "{who}: peer transport status must report connected: {peer_status}"
+        );
+    }
+
+    single_event(window, "game_data_sent", who);
+    let relay_events = events_named(window, "game_data_received");
+    let mut relay_ledger = BTreeMap::new();
+    for event in relay_events {
+        let from = string_field(event, "from", who);
+        let payload = event
+            .get("payload")
+            .and_then(|value| value.get("relay_msg"))
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("{who}: relay event lacks relay_msg: {event}"));
+        let sender_name = names_by_id
+            .get(from)
+            .copied()
+            .unwrap_or_else(|| panic!("{who}: relay sender {from} is outside the mesh"));
+        assert_eq!(payload, format!("relay-from-{sender_name}"));
+        assert!(
+            relay_ledger.insert(from, payload).is_none(),
+            "{who}: duplicate relay payload from {from}"
+        );
+    }
+    assert_eq!(
+        relay_ledger.keys().copied().collect::<BTreeSet<_>>(),
+        expected_peers,
+        "{who}: relay-floor sender ledger"
+    );
+
+    let signal_count = events_named(&client.events, "signal_sent").len();
+    assert!(
+        signal_count <= signal_budget,
+        "{who}: emitted {signal_count} signals, exceeding production budget {signal_budget}"
+    );
+    signal_count
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 16 real webrtc-rs clients"]
+async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
+    let total_started = tokio::time::Instant::now();
+    let signal_budget = usize::try_from(Config::default().rate_limit.max_signals)
+        .expect("production signal budget fits usize");
+    assert_eq!(
+        signal_budget, 600,
+        "H8 is registered against the real default"
+    );
+
+    let server = spawn_server(mesh_server_config()).await;
+    let workdir = tempfile::tempdir().expect("create native-client workdir");
+    let success_release_file = workdir.path().join("release-success");
+    assert!(!success_release_file.exists());
+    let mut creator = spawn_native_client(
+        "c00",
+        &client_args(&server, "c00", None, &success_release_file),
+        workdir.path(),
+    );
+    let created = creator.await_event("room_created", EVENT_DEADLINE).await;
+    let room_code = string_field(&created, "room_code", "c00").to_string();
+
+    let mut clients = Vec::with_capacity(PLAYERS);
+    clients.push(creator);
+    for ordinal in 1..PLAYERS {
+        let name = format!("c{ordinal:02}");
+        clients.push(spawn_native_client(
+            &name,
+            &client_args(&server, &name, Some(&room_code), &success_release_file),
+            workdir.path(),
+        ));
+    }
+
+    let pids: Vec<u32> = std::iter::once(server.pid())
+        .chain(clients.iter().map(NativeClientProcess::pid))
+        .collect();
+    let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+    let rss_task = tokio::spawn(sample_peak_rss(pids, stop_rx));
+    let barrier_started = tokio::time::Instant::now();
+    join_all(
+        clients.iter_mut().map(|client| {
+            client.await_event_count("success_criteria_met", 1, CLIENT_EXIT_DEADLINE)
+        }),
+    )
+    .await;
+    let barrier_elapsed = barrier_started.elapsed();
+    std::fs::write(&success_release_file, b"release")
+        .expect("release successful clients from the mesh barrier");
+    let statuses = join_all(
+        clients
+            .iter_mut()
+            .map(|client| client.drain_to_termination(CLIENT_EXIT_DEADLINE)),
+    )
+    .await;
+    let total_elapsed = total_started.elapsed();
+    stop_tx.send(true).expect("stop RSS sampler");
+    let peak_rss = rss_task.await.expect("RSS sampler task succeeds");
+    for (client, status) in clients.iter().zip(&statuses) {
+        assert!(
+            status.success(),
+            "{} exited {status};\n{}",
+            client.name,
+            client.diagnostics()
+        );
+    }
+
+    let ids: Vec<String> = clients
+        .iter()
+        .map(|client| {
+            string_field(
+                single_event(&client.events, "room_joined", &client.name),
+                "player_id",
+                &client.name,
+            )
+            .to_string()
+        })
+        .collect();
+    let all_ids: BTreeSet<&str> = ids.iter().map(String::as_str).collect();
+    assert_eq!(all_ids.len(), PLAYERS, "all player ids must be distinct");
+    let names_by_id: BTreeMap<&str, &str> = ids
+        .iter()
+        .zip(&clients)
+        .map(|(id, client)| (id.as_str(), client.name.as_str()))
+        .collect();
+
+    let mut per_client_signals = Vec::with_capacity(PLAYERS);
+    for (client, id) in clients.iter().zip(&ids) {
+        per_client_signals.push(assert_client_log(
+            client,
+            id,
+            &all_ids,
+            &names_by_id,
+            signal_budget,
+        ));
+    }
+    let total_signals: usize = per_client_signals.iter().sum();
+    let mut sorted_signals = per_client_signals.clone();
+    sorted_signals.sort_unstable();
+    let signal_p50 = sorted_signals[(sorted_signals.len() - 1) / 2];
+    let signal_p99 = *sorted_signals.last().expect("the matrix has clients");
+
+    wait_for_metrics_quiescence(server.port).await;
+    let counters = scrape_delivery_counters(server.port).await;
+    assert_eq!(counters.backpressure_events, 0, "clean mesh backpressure");
+    assert_eq!(
+        counters.slow_consumer_disconnects, 0,
+        "clean mesh slow-consumer evictions"
+    );
+    assert_eq!(counters.dropped, 0, "clean mesh dropped server messages");
+    assert_scraped_message_conservation(&counters);
+    let metrics = fetch_prometheus_text(server.port).await;
+    assert_eq!(
+        sample_value(&metrics, "signal_fish_transport_signals_relayed_total"),
+        u64::try_from(total_signals).expect("signal total fits u64"),
+        "server accepted signal count must equal client emission ledger"
+    );
+    assert_eq!(
+        sample_value(&metrics, "signal_fish_websocket_ping_timeouts_total"),
+        0,
+        "clean mesh must not lose clients to ping timeout"
+    );
+
+    println!(
+        "H8 mesh complete: players={PLAYERS} pairs={} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
+        PLAYERS * (PLAYERS - 1) / 2,
+        peak_rss.first().copied().unwrap_or(0),
+        &peak_rss[1..]
+    );
+}

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -256,7 +256,7 @@ fn assert_exact_channel_ledger(
     );
 }
 
-fn assert_client_log(
+fn assert_client_barrier(
     client: &NativeClientProcess,
     player_id: &str,
     all_ids: &BTreeSet<&str>,
@@ -280,9 +280,6 @@ fn assert_client_log(
         events_named(&client.events, "fallback_engaged").is_empty(),
         "{who}: clean full mesh must never engage fallback"
     );
-    let exit = single_event(&client.events, "exiting", who);
-    assert_eq!(exit.get("code").and_then(Value::as_i64), Some(0));
-
     let plan = single_event(window, "session_plan", who);
     assert_eq!(string_field(plan, "topology", who), "mesh");
     assert_eq!(string_field(plan, "transport", who), "webrtc");
@@ -375,12 +372,34 @@ fn assert_client_log(
         "{who}: relay-floor sender ledger"
     );
 
-    let signal_count = events_named(&client.events, "signal_sent").len();
+    let signal_count = events_named(window, "signal_sent").len();
     assert!(
         signal_count <= signal_budget,
         "{who}: emitted {signal_count} signals, exceeding production budget {signal_budget}"
     );
     signal_count
+}
+
+fn assert_clean_client_exit(client: &NativeClientProcess, status: &std::process::ExitStatus) {
+    assert!(
+        status.success(),
+        "{} exited {status};\n{}",
+        client.name,
+        client.diagnostics()
+    );
+    assert!(
+        events_named(&client.events, "error").is_empty(),
+        "{}: errors after mesh release: {:?}",
+        client.name,
+        client.error_messages()
+    );
+    assert!(
+        events_named(&client.events, "fallback_engaged").is_empty(),
+        "{}: clean full mesh must never engage fallback",
+        client.name
+    );
+    let exit = single_event(&client.events, "exiting", &client.name);
+    assert_eq!(exit.get("code").and_then(Value::as_i64), Some(0));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -430,25 +449,6 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
     )
     .await;
     let barrier_elapsed = barrier_started.elapsed();
-    std::fs::write(&success_release_file, b"release")
-        .expect("release successful clients from the mesh barrier");
-    let statuses = join_all(
-        clients
-            .iter_mut()
-            .map(|client| client.drain_to_termination(CLIENT_EXIT_DEADLINE)),
-    )
-    .await;
-    let total_elapsed = total_started.elapsed();
-    stop_tx.send(true).expect("stop RSS sampler");
-    let peak_rss = rss_task.await.expect("RSS sampler task succeeds");
-    for (client, status) in clients.iter().zip(&statuses) {
-        assert!(
-            status.success(),
-            "{} exited {status};\n{}",
-            client.name,
-            client.diagnostics()
-        );
-    }
 
     let ids: Vec<String> = clients
         .iter()
@@ -471,7 +471,7 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
 
     let mut per_client_signals = Vec::with_capacity(PLAYERS);
     for (client, id) in clients.iter().zip(&ids) {
-        per_client_signals.push(assert_client_log(
+        per_client_signals.push(assert_client_barrier(
             client,
             id,
             &all_ids,
@@ -485,6 +485,47 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
     let signal_p50 = sorted_signals[(sorted_signals.len() - 1) / 2];
     let signal_p99 = *sorted_signals.last().expect("the matrix has clients");
 
+    let held_counters = scrape_delivery_counters(server.port).await;
+    assert_eq!(
+        held_counters.backpressure_events, 0,
+        "clean mesh backpressure"
+    );
+    assert_eq!(
+        held_counters.slow_consumer_disconnects, 0,
+        "clean mesh slow-consumer evictions"
+    );
+    assert_eq!(
+        held_counters.dropped, 0,
+        "clean mesh messages dropped before coordinated teardown"
+    );
+    assert_scraped_message_conservation(&held_counters);
+    let held_metrics = fetch_prometheus_text(server.port).await;
+    assert_eq!(
+        sample_value(&held_metrics, "signal_fish_transport_signals_relayed_total"),
+        u64::try_from(total_signals).expect("signal total fits u64"),
+        "server accepted signal count must equal client emission ledger"
+    );
+    assert_eq!(
+        sample_value(&held_metrics, "signal_fish_websocket_ping_timeouts_total"),
+        0,
+        "clean mesh must not lose clients to ping timeout"
+    );
+
+    std::fs::write(&success_release_file, b"release")
+        .expect("release successful clients from the mesh barrier");
+    let statuses = join_all(
+        clients
+            .iter_mut()
+            .map(|client| client.drain_to_termination(CLIENT_EXIT_DEADLINE)),
+    )
+    .await;
+    let total_elapsed = total_started.elapsed();
+    stop_tx.send(true).expect("stop RSS sampler");
+    let peak_rss = rss_task.await.expect("RSS sampler task succeeds");
+    for (client, status) in clients.iter().zip(&statuses) {
+        assert_clean_client_exit(client, status);
+    }
+
     wait_for_metrics_quiescence(server.port).await;
     let counters = scrape_delivery_counters(server.port).await;
     assert_eq!(counters.backpressure_events, 0, "clean mesh backpressure");
@@ -492,14 +533,8 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
         counters.slow_consumer_disconnects, 0,
         "clean mesh slow-consumer evictions"
     );
-    assert_eq!(counters.dropped, 0, "clean mesh dropped server messages");
     assert_scraped_message_conservation(&counters);
     let metrics = fetch_prometheus_text(server.port).await;
-    assert_eq!(
-        sample_value(&metrics, "signal_fish_transport_signals_relayed_total"),
-        u64::try_from(total_signals).expect("signal total fits u64"),
-        "server accepted signal count must equal client emission ledger"
-    );
     assert_eq!(
         sample_value(&metrics, "signal_fish_websocket_ping_timeouts_total"),
         0,
@@ -507,8 +542,12 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
     );
 
     println!(
-        "H8 mesh complete: players={PLAYERS} pairs={} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
+        "H8 mesh complete: players={PLAYERS} pairs={} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} coordinated_teardown_drops={} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
         PLAYERS * (PLAYERS - 1) / 2,
+        counters
+            .dropped
+            .checked_sub(held_counters.dropped)
+            .expect("server dropped-message counter is monotonic"),
         peak_rss.first().copied().unwrap_or(0),
         &peak_rss[1..]
     );

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -441,7 +441,7 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
         "H8 is registered against the real default"
     );
 
-    let server = spawn_server(mesh_server_config()).await;
+    let mut server = spawn_server(mesh_server_config()).await;
     let workdir = tempfile::tempdir().expect("create native-client workdir");
     let success_release_file = workdir.path().join("release-success");
     assert!(!success_release_file.exists());
@@ -577,4 +577,5 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
         peak_rss.first().copied().unwrap_or(0),
         &peak_rss[1..]
     );
+    server.kill_and_wait().await;
 }

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -31,8 +31,10 @@ use websocket_test_helpers::server_process::{spawn_server, ServerProcess};
 const PLAYERS: usize = 16;
 const GAME_NAME: &str = "webrtc-mesh-budget";
 const EVENT_DEADLINE: Duration = Duration::from_secs(60);
-const CLIENT_EXIT_DEADLINE: Duration = Duration::from_secs(360);
+const SUCCESS_BARRIER_DEADLINE: Duration = Duration::from_secs(360);
+const CLIENT_EXIT_DEADLINE: Duration = Duration::from_secs(30);
 const METRIC_QUIESCENCE_DEADLINE: Duration = Duration::from_secs(30);
+const CLIENT_MAX_RUNTIME_SECS: u64 = 540;
 const CHANNEL_LABELS: [&str; 2] = ["reliable", "unreliable"];
 
 fn event_name(event: &Value) -> Option<&str> {
@@ -102,7 +104,7 @@ fn client_args(
         "--run-for-secs".to_string(),
         "240".to_string(),
         "--max-runtime-secs".to_string(),
-        "300".to_string(),
+        CLIENT_MAX_RUNTIME_SECS.to_string(),
         "--success-release-file".to_string(),
         success_release_file.to_string_lossy().into_owned(),
     ];
@@ -426,6 +428,12 @@ fn assert_clean_client_exit(client: &NativeClientProcess, status: &std::process:
 #[ignore = "nightly-only (verification-nightly.yml): spawns 16 real webrtc-rs clients"]
 async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
     let total_started = tokio::time::Instant::now();
+    let maximum_bounded_pre_release_wait =
+        EVENT_DEADLINE + SUCCESS_BARRIER_DEADLINE + EVENT_DEADLINE;
+    assert!(
+        Duration::from_secs(CLIENT_MAX_RUNTIME_SECS) > maximum_bounded_pre_release_wait,
+        "client watchdog must leave headroom beyond room creation, the success barrier, and signal-ledger settlement"
+    );
     let signal_budget = usize::try_from(Config::default().rate_limit.max_signals)
         .expect("production signal budget fits usize");
     assert_eq!(
@@ -462,11 +470,9 @@ async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
     let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
     let rss_task = tokio::spawn(sample_peak_rss(pids, stop_rx));
     let barrier_started = tokio::time::Instant::now();
-    join_all(
-        clients.iter_mut().map(|client| {
-            client.await_event_count("success_criteria_met", 1, CLIENT_EXIT_DEADLINE)
-        }),
-    )
+    join_all(clients.iter_mut().map(|client| {
+        client.await_event_count("success_criteria_met", 1, SUCCESS_BARRIER_DEADLINE)
+    }))
     .await;
     let barrier_elapsed = barrier_started.elapsed();
 

--- a/tests/websocket_test_helpers/native_client_process.rs
+++ b/tests/websocket_test_helpers/native_client_process.rs
@@ -155,23 +155,29 @@ impl NativeClientProcess {
     /// Read until `count` events with this tag have been recorded in total.
     pub async fn await_event_count(&mut self, event_name: &str, count: usize, timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
-        while self.recorded_event_count(event_name) < count {
-            let context = format!(
-                "awaiting {count} `{event_name}` events (have {})",
-                self.recorded_event_count(event_name)
-            );
+        let mut observed = self.recorded_event_count(event_name);
+        while observed < count {
+            let context = format!("awaiting {count} `{event_name}` events (have {observed})");
             let event = self.next_event_before(deadline, &context).await;
+            if event
+                .as_ref()
+                .and_then(|item| item.get("event"))
+                .and_then(Value::as_str)
+                == Some(event_name)
+            {
+                observed += 1;
+            }
             assert!(
                 event.is_some(),
                 "client {}: stdout ended with {} of {count} `{event_name}` events;\n{}",
                 self.name,
-                self.recorded_event_count(event_name),
+                observed,
                 self.diagnostics()
             );
         }
     }
 
-    pub fn recorded_event_count(&self, event_name: &str) -> usize {
+    fn recorded_event_count(&self, event_name: &str) -> usize {
         self.events
             .iter()
             .filter(|event| event.get("event").and_then(Value::as_str) == Some(event_name))

--- a/tests/websocket_test_helpers/native_client_process.rs
+++ b/tests/websocket_test_helpers/native_client_process.rs
@@ -21,7 +21,7 @@ pub fn native_client_binary() -> PathBuf {
         assert!(
             path.is_file(),
             "SIGNAL_FISH_CLIENT_BIN points at {path:?}, which is not a file. Run \
-             `cargo build --manifest-path clients/native/Cargo.toml --bin \
+             `cargo build --locked --manifest-path clients/native/Cargo.toml --bin \
              signal-fish-reference-native` and point the variable at the built binary."
         );
         return path;
@@ -60,7 +60,7 @@ pub fn native_client_binary() -> PathBuf {
             assert!(
                 status.success(),
                 "building the native reference client failed ({status}); build it manually with \
-                 `cargo build --manifest-path clients/native/Cargo.toml --bin \
+                 `cargo build --locked --manifest-path clients/native/Cargo.toml --bin \
                  signal-fish-reference-native` or set SIGNAL_FISH_CLIENT_BIN"
             );
             let path = root

--- a/tests/websocket_test_helpers/native_client_process.rs
+++ b/tests/websocket_test_helpers/native_client_process.rs
@@ -1,0 +1,258 @@
+//! Shared real native-reference-client process harness.
+//!
+//! Root integration tests cannot use the standalone `clients/native` crate's
+//! test harness directly. This module owns the one root-side implementation:
+//! locate (or build) the binary, spawn it with an arbitrary CLI argument list,
+//! consume its JSONL stdout without blocking stderr, and kill it on drop.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, BufReader, Lines};
+use tokio::process::ChildStdout;
+
+/// Locate the `signal-fish-reference-native` binary: `SIGNAL_FISH_CLIENT_BIN`
+/// when set (CI pre-builds it), else a once-per-process standalone-crate build.
+pub fn native_client_binary() -> PathBuf {
+    if let Some(raw) = std::env::var_os("SIGNAL_FISH_CLIENT_BIN") {
+        let path = PathBuf::from(raw);
+        assert!(
+            path.is_file(),
+            "SIGNAL_FISH_CLIENT_BIN points at {path:?}, which is not a file. Run \
+             `cargo build --manifest-path clients/native/Cargo.toml --bin \
+             signal-fish-reference-native` and point the variable at the built binary."
+        );
+        return path;
+    }
+
+    static BUILT: OnceLock<PathBuf> = OnceLock::new();
+    BUILT
+        .get_or_init(|| {
+            let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let manifest = root.join("clients").join("native").join("Cargo.toml");
+            let mut command = std::process::Command::new(env!("CARGO"));
+            command
+                .arg("build")
+                .arg("--locked")
+                .arg("--manifest-path")
+                .arg(&manifest)
+                .args(["--bin", "signal-fish-reference-native"]);
+            // Instrumented parent cargo processes must not leak flags into the
+            // nested standalone-workspace build.
+            for var in [
+                "RUSTFLAGS",
+                "CARGO_ENCODED_RUSTFLAGS",
+                "RUSTDOCFLAGS",
+                "CARGO_TARGET_DIR",
+                "ASAN_OPTIONS",
+                "LSAN_OPTIONS",
+                "UBSAN_OPTIONS",
+                "TSAN_OPTIONS",
+                "MIRIFLAGS",
+            ] {
+                command.env_remove(var);
+            }
+            let status = command
+                .status()
+                .expect("run `cargo build` for the native reference client");
+            assert!(
+                status.success(),
+                "building the native reference client failed ({status}); build it manually with \
+                 `cargo build --manifest-path clients/native/Cargo.toml --bin \
+                 signal-fish-reference-native` or set SIGNAL_FISH_CLIENT_BIN"
+            );
+            let path = root
+                .join("clients")
+                .join("native")
+                .join("target")
+                .join("debug")
+                .join("signal-fish-reference-native");
+            assert!(
+                path.is_file(),
+                "the nested client build succeeded but {path:?} does not exist"
+            );
+            path
+        })
+        .clone()
+}
+
+/// Guard around one spawned reference-client process and its JSONL event log.
+pub struct NativeClientProcess {
+    pub name: String,
+    child: Option<tokio::process::Child>,
+    lines: Lines<BufReader<ChildStdout>>,
+    pub events: Vec<Value>,
+    stderr_path: PathBuf,
+}
+
+impl Drop for NativeClientProcess {
+    fn drop(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            if let Err(error) = child.start_kill() {
+                eprintln!("failed to kill client {} on drop: {error}", self.name);
+            }
+        }
+    }
+}
+
+/// Spawn one native reference client with the exact supplied CLI arguments.
+pub fn spawn_native_client(name: &str, args: &[String], workdir: &Path) -> NativeClientProcess {
+    let stderr_path = workdir.join(format!("client-{name}-stderr.log"));
+    let stderr_file = std::fs::File::create(&stderr_path).expect("create client stderr capture");
+
+    let mut command = tokio::process::Command::new(native_client_binary());
+    command
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::from(stderr_file))
+        .env("RUST_LOG", "info")
+        .kill_on_drop(true);
+
+    let mut child = command.spawn().expect("spawn the native reference client");
+    let stdout = child.stdout.take().expect("client stdout is piped");
+    NativeClientProcess {
+        name: name.to_string(),
+        child: Some(child),
+        lines: BufReader::new(stdout).lines(),
+        events: Vec::new(),
+        stderr_path,
+    }
+}
+
+impl NativeClientProcess {
+    /// OS pid of the still-running client (panics once reaped).
+    pub fn pid(&self) -> u32 {
+        self.child
+            .as_ref()
+            .and_then(tokio::process::Child::id)
+            .expect("client process already exited or was reaped")
+    }
+
+    /// Read events until one named event arrives.
+    pub async fn await_event(&mut self, event_name: &str, timeout: Duration) -> Value {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match self
+                .next_event_before(deadline, &format!("awaiting `{event_name}`"))
+                .await
+            {
+                Some(event) if event.get("event").and_then(Value::as_str) == Some(event_name) => {
+                    return event;
+                }
+                Some(_) => {}
+                None => panic!(
+                    "client {}: stdout ended before `{event_name}`;\n{}",
+                    self.name,
+                    self.diagnostics()
+                ),
+            }
+        }
+    }
+
+    /// Read until `count` events with this tag have been recorded in total.
+    pub async fn await_event_count(&mut self, event_name: &str, count: usize, timeout: Duration) {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while self.recorded_event_count(event_name) < count {
+            let context = format!(
+                "awaiting {count} `{event_name}` events (have {})",
+                self.recorded_event_count(event_name)
+            );
+            let event = self.next_event_before(deadline, &context).await;
+            assert!(
+                event.is_some(),
+                "client {}: stdout ended with {} of {count} `{event_name}` events;\n{}",
+                self.name,
+                self.recorded_event_count(event_name),
+                self.diagnostics()
+            );
+        }
+    }
+
+    pub fn recorded_event_count(&self, event_name: &str) -> usize {
+        self.events
+            .iter()
+            .filter(|event| event.get("event").and_then(Value::as_str) == Some(event_name))
+            .count()
+    }
+
+    async fn next_event_before(
+        &mut self,
+        deadline: tokio::time::Instant,
+        context: &str,
+    ) -> Option<Value> {
+        let read = tokio::time::timeout_at(deadline, self.lines.next_line()).await;
+        let line = read
+            .unwrap_or_else(|_elapsed| {
+                panic!(
+                    "client {}: timed out {context};\n{}",
+                    self.name,
+                    self.diagnostics()
+                )
+            })
+            .unwrap_or_else(|error| {
+                panic!(
+                    "client {}: stdout read error: {error};\n{}",
+                    self.name,
+                    self.diagnostics()
+                )
+            })?;
+        let event: Value = serde_json::from_str(&line).unwrap_or_else(|error| {
+            panic!(
+                "client {}: stdout line is not a JSON event ({error}): {line}",
+                self.name
+            )
+        });
+        self.events.push(event.clone());
+        Some(event)
+    }
+
+    /// Drain stdout to EOF, reap the child, and return its exact exit status.
+    pub async fn drain_to_termination(&mut self, timeout: Duration) -> std::process::ExitStatus {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while let Some(_event) = self
+            .next_event_before(deadline, "draining events to process exit")
+            .await
+        {}
+        let mut child = self.child.take().expect("client child already reaped");
+        tokio::time::timeout_at(deadline, child.wait())
+            .await
+            .unwrap_or_else(|_elapsed| {
+                panic!(
+                    "client {}: stdout closed but the process did not exit;\n{}",
+                    self.name,
+                    self.diagnostics()
+                )
+            })
+            .unwrap_or_else(|error| panic!("client {}: failed to reap process: {error}", self.name))
+    }
+
+    pub fn error_messages(&self) -> Vec<String> {
+        self.events
+            .iter()
+            .filter(|event| event.get("event").and_then(Value::as_str) == Some("error"))
+            .filter_map(|event| event.get("message").and_then(Value::as_str))
+            .map(str::to_string)
+            .collect()
+    }
+
+    pub fn diagnostics(&self) -> String {
+        const EVENT_TAIL: usize = 12;
+        let tail_start = self.events.len().saturating_sub(EVENT_TAIL);
+        let recent: Vec<String> = self.events[tail_start..]
+            .iter()
+            .map(Value::to_string)
+            .collect();
+        let stderr = std::fs::read_to_string(&self.stderr_path)
+            .unwrap_or_else(|error| format!("<failed to read stderr: {error}>"));
+        format!(
+            "last {} events:\n{}\n--- client {} stderr ---\n{}",
+            recent.len(),
+            recent.join("\n"),
+            self.name,
+            stderr
+        )
+    }
+}

--- a/tests/websocket_test_helpers/native_client_process.rs
+++ b/tests/websocket_test_helpers/native_client_process.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, BufReader, Lines};
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::ChildStdout;
 
 /// Locate the `signal-fish-reference-native` binary: `SIGNAL_FISH_CLIENT_BIN`
@@ -82,7 +82,7 @@ pub fn native_client_binary() -> PathBuf {
 pub struct NativeClientProcess {
     pub name: String,
     child: Option<tokio::process::Child>,
-    lines: Lines<BufReader<ChildStdout>>,
+    stdout: BufReader<ChildStdout>,
     pub events: Vec<Value>,
     stderr_path: PathBuf,
 }
@@ -116,7 +116,7 @@ pub fn spawn_native_client(name: &str, args: &[String], workdir: &Path) -> Nativ
     NativeClientProcess {
         name: name.to_string(),
         child: Some(child),
-        lines: BufReader::new(stdout).lines(),
+        stdout: BufReader::new(stdout),
         events: Vec::new(),
         stderr_path,
     }
@@ -189,8 +189,10 @@ impl NativeClientProcess {
         deadline: tokio::time::Instant,
         context: &str,
     ) -> Option<Value> {
-        let read = tokio::time::timeout_at(deadline, self.lines.next_line()).await;
-        let line = read
+        let mut bytes = Vec::new();
+        let read =
+            tokio::time::timeout_at(deadline, self.stdout.read_until(b'\n', &mut bytes)).await;
+        let bytes_read = read
             .unwrap_or_else(|_elapsed| {
                 panic!(
                     "client {}: timed out {context};\n{}",
@@ -204,15 +206,58 @@ impl NativeClientProcess {
                     self.name,
                     self.diagnostics()
                 )
-            })?;
-        let event: Value = serde_json::from_str(&line).unwrap_or_else(|error| {
-            panic!(
+            });
+        if bytes_read == 0 {
+            return None;
+        }
+        let terminated = bytes.ends_with(b"\n");
+        if terminated {
+            bytes.pop();
+            if bytes.ends_with(b"\r") {
+                bytes.pop();
+            }
+        }
+        let signaled_trailing_fragment = !terminated && self.child_exited_by_signal();
+        let line = match String::from_utf8(bytes) {
+            Ok(line) => line,
+            Err(error) if signaled_trailing_fragment => {
+                eprintln!(
+                    "client {}: ignoring trailing non-UTF-8 stdout fragment after signal: {error}",
+                    self.name
+                );
+                return None;
+            }
+            Err(error) => panic!(
+                "client {}: stdout line is not UTF-8 ({error});\n{}",
+                self.name,
+                self.diagnostics()
+            ),
+        };
+        let event: Value = match serde_json::from_str(&line) {
+            Ok(event) => event,
+            Err(_error) if signaled_trailing_fragment => {
+                eprintln!(
+                    "client {}: ignoring trailing partial JSONL after signal: {line}",
+                    self.name
+                );
+                return None;
+            }
+            Err(error) => panic!(
                 "client {}: stdout line is not a JSON event ({error}): {line}",
                 self.name
-            )
-        });
+            ),
+        };
         self.events.push(event.clone());
         Some(event)
+    }
+
+    fn child_exited_by_signal(&mut self) -> bool {
+        use std::os::unix::process::ExitStatusExt;
+
+        self.child
+            .as_mut()
+            .and_then(|child| child.try_wait().ok().flatten())
+            .is_some_and(|status| status.signal().is_some())
     }
 
     /// Drain stdout to EOF, reap the child, and return its exact exit status.

--- a/tests/websocket_test_helpers/server_process.rs
+++ b/tests/websocket_test_helpers/server_process.rs
@@ -96,6 +96,14 @@ pub struct ServerProcess {
 }
 
 impl ServerProcess {
+    /// OS process id of the live server child (for resource diagnostics).
+    pub fn pid(&self) -> u32 {
+        self.child
+            .as_ref()
+            .and_then(tokio::process::Child::id)
+            .expect("server process was already killed")
+    }
+
     /// SIGKILL the child (TerminateProcess on Windows) and reap it.
     pub async fn kill_and_wait(&mut self) {
         let mut child = self


### PR DESCRIPTION
## Summary

- add the first empirical P10.C WebRTC matrix cell: 16 real native webrtc-rs clients forming the exact 120-edge clean mesh under the production 600-signal default
- add exact reliable/unreliable payload ledgers, WebSocket relay-floor coverage, full client/server signal accounting, and wall-time/RSS diagnostics
- add a harness-only coordinated success barrier so no client can shrink another client's obligations by exiting early
- extract the native-client process harness for reuse and wire the ignored heavy test into Verification Nightly

## Scope

This closes only the clean N=16 mesh implementation slice. The registered crippled-ICE case, host topology, smaller sizes, and tc-netem fail-loud cells remain open.

## Local verification

- `cargo fmt --all`
- `git diff --check`
- `cargo test --locked --manifest-path clients/native/Cargo.toml --lib` (49 passed)
- `cargo test --locked --test webrtc_mesh_budget_e2e --test multiprocess_delivery_e2e --no-run`
- `cargo clippy --locked --all-features --test webrtc_mesh_budget_e2e --test multiprocess_delivery_e2e -- -D warnings`
- `cargo clippy --locked --manifest-path clients/native/Cargo.toml --all-targets -- -D warnings`
- `actionlint -no-color .github/workflows/verification-nightly.yml`
- `scripts/check-ci-config.sh` (passed with pre-existing advisories)
- `cargo test --locked --test ci_config_tests` (276 passed, 1 intentionally ignored)
- `scripts/check-doc-consistency.sh --changed-files ...`
- `scripts/check-markdown.sh`

The resource-heavy 16-client test was intentionally not run locally; this PR's path-triggered verification workflow is the registered execution lane.

## Exact-head CI evidence

At `47e2b3b`, all 13 applicable workflows passed (Dependabot auto-merge intentionally skipped). Verification Nightly formed all 120 WebRTC edges with exact channel/relay ledgers: 720 signals total, exactly 45 per client (p50/p99 45) against the production 600-signal limit; all clients reached the held barrier in 2.023s and the test completed in 2.513s. Bugbot found no new issues on the exact head, Copilot's actionable findings are closed, and every inline review thread is resolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native client exit/timer orchestration and WebRTC engine callbacks, but behavior is gated on an opt-in harness flag; primary risk is CI runtime/resource load from the ignored heavy suite.
> 
> **Overview**
> Adds a **nightly empirical proof** that 16 real native clients can form the full 120-edge WebRTC mesh under the production **600-signal** budget, with exact per-channel ledgers, relay-floor coverage, and server signal accounting—without early-exit teardown races.
> 
> The native reference client gains a **harness-only** `--success-release-file` path: when criteria are met it emits `success_criteria_met`, waits for every expected peer’s **ICE gathering complete** marker (signal-ledger boundary), then stays connected until the harness creates the release file. Soft `--run-for-secs` no longer forces exit during that hold; release-file checks run on `spawn_blocking`.
> 
> **`IceGatheringComplete`** is surfaced from webrtc-rs (including in crippled-ICE mode) and tracked per peer generation. Multi-process tests **share** `tests/websocket_test_helpers/native_client_process.rs` (multiprocess delivery refactored to use it). CI wires `webrtc_mesh_budget_e2e` into verification-nightly and extends nextest (`process-spawning` group + 600s slow-timeout for the mesh binary); `[profile.ci]` now `inherits = "default"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e2b3bc945bb12a976c0d8664bc8b0ecabce130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->