### PR TITLE
Complete the clean WebRTC topology and size matrix

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -48,9 +48,11 @@ filter = 'binary(v3_multiprocess_e2e) or binary(multiprocess_delivery_e2e) or bi
 test-group = 'process-spawning'
 threads-required = 4
 
-# The real 16-client mesh has a 540s watchdog per child plus startup and
-# server-metric settlement. Keep nextest's outer deadline strictly above those
-# composed bounds so the clients, rather than nextest, emit useful diagnostics.
+# Each real WebRTC matrix cell has a 540s watchdog per child plus startup and
+# server-metric settlement. Cells are independently registered and serialized
+# by the process-spawning group. Keep each nextest outer deadline strictly above
+# those composed bounds so the clients, rather than nextest, emit useful
+# diagnostics.
 [[profile.default.overrides]]
 filter = 'binary(webrtc_mesh_budget_e2e)'
 slow-timeout = { period = "300s", terminate-after = 2 }

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -23,8 +23,8 @@
 #     + REAL client processes with OS faults (SIGSTOP/SIGKILL); the two
 #     ignored child-process tests need the pre-built native reference client
 #     (SIGNAL_FISH_CLIENT_BIN), which is why they are nightly-only.
-#     The same job runs the H8 empirical 16-client WebRTC clean-budget and
-#     crippled-ICE fallback proofs.
+#     The same job runs the clean WebRTC {mesh,host} x {2,8,16} matrix and the
+#     H8 16-client crippled-ICE fallback proof.
 #   - starved-runtime: clients/native/tests/starved_runtime_e2e.rs — the
 #     --runtime current / --tick-stall-ms conformance matrix pinning the
 #     documented "continuously drive your runtime" requirement.
@@ -239,10 +239,12 @@ jobs:
   multiprocess-delivery:
     name: Multi-Process Delivery Faults
     runs-on: ubuntu-latest
-    # Generous floor: the native reference client build (full webrtc
-    # dependency graph) dominates a cold run; a too-tight timeout cancels a
-    # healthy-but-loaded build (zero-flakiness policy).
-    timeout-minutes: 60
+    # Generous floor: after the native reference client build, seven WebRTC
+    # cells run serially in the process-spawning group. Each cell has a 600s
+    # nextest ceiling above its 540s child watchdog, so the job ceiling keeps
+    # principled headroom for all cells plus the delivery-fault suite and cold
+    # compilation (zero-flakiness policy).
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
@@ -290,7 +292,7 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test multiprocess_delivery_e2e --run-ignored all \
             --success-output final 2>&1 | tee multiprocess-output.txt
-      - name: Run 16-player WebRTC mesh budget experiments
+      - name: Run WebRTC topology and size matrix
         shell: bash
         env:
           SIGNAL_FISH_CLIENT_BIN: ${{ github.workspace }}/clients/native/target/debug/signal-fish-reference-native
@@ -298,7 +300,7 @@ jobs:
           set -o pipefail
           cargo nextest run --profile ci --locked --all-features \
             --test webrtc_mesh_budget_e2e --run-ignored all \
-            --success-output final 2>&1 | tee webrtc-mesh-budget-output.txt
+            --success-output final 2>&1 | tee webrtc-matrix-output.txt
       - name: Report multi-process results to job summary
         if: always()
         shell: bash
@@ -310,10 +312,10 @@ jobs:
             tail -n 60 multiprocess-output.txt 2>/dev/null || echo "no multiprocess output captured"
             echo '```'
             echo
-            echo "### H8 16-player WebRTC mesh budget and fallback"
+            echo "### WebRTC clean topology/size matrix and H8 fallback"
             echo
             echo '```text'
-            tail -n 160 webrtc-mesh-budget-output.txt 2>/dev/null || echo "no WebRTC mesh budget output captured"
+            tail -n 260 webrtc-matrix-output.txt 2>/dev/null || echo "no WebRTC matrix output captured"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   WebSocket relay-floor ledger. Terminal peer-connection generations count as
   signal-settled for the harness barrier because they can emit no later ICE
   candidates; live generations still require their end-of-gathering marker.
+  The same held real-process harness now covers the complete clean
+  `{mesh, host} x {2, 8, 16}` topology/size grid with exact plan, signaling,
+  channel, room-wide transport-status, and relay-floor ledgers. The signal
+  budget guard accounts for the accepted `TransportStatus` report that shares
+  the 600-message control-plane bucket with WebRTC signals.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/tests/signal_budget_model.rs
+++ b/tests/signal_budget_model.rs
@@ -2,8 +2,9 @@
 //! default per-connection signal rate limit.
 //!
 //! Falsification experiment H8. Pre-registered prediction: at N=16 players in a
-//! full mesh with K=10 trickle-ICE candidates per peer, each player SENDS ~165
-//! `Signal` messages during formation, well under the default `max_signals`
+//! full mesh with K=10 trickle-ICE candidates per peer, each player consumes 166
+//! control-plane slots during formation (165 `Signal` messages plus its one
+//! `TransportStatus` report), well under the default `max_signals`
 //! budget (600 per `time_window`), i.e. ≈3.6× headroom.
 //!
 //! This is a MODEL — arithmetic over the protocol's signaling rules — not a live
@@ -25,9 +26,10 @@ use signal_fish_server::rate_limit::RateLimitConfig;
 ///   player emits one SDP message toward each of its peers — plus
 /// - `k` ICE candidates per peer (trickle),
 ///
-/// across its `n - 1` peers ⇒ `(n - 1) * (1 + k)`.
-fn mesh_signals_sent_per_player(n: u32, k: u32) -> u32 {
-    (n - 1) * (1 + k)
+/// across its `n - 1` peers, plus the one accepted `TransportStatus` state
+/// change that shares the same rate-limit bucket ⇒ `(n - 1) * (1 + k) + 1`.
+fn mesh_formation_control_messages_per_player(n: u32, k: u32) -> u32 {
+    (n - 1) * (1 + k) + 1
 }
 
 /// Representative trickle-ICE candidate count per peer for the model (host +
@@ -38,15 +40,17 @@ const TYPICAL_ICE_CANDIDATES_PER_PEER: u32 = 10;
 fn mesh_signal_budget_model_holds_and_default_config_accommodates_sixteen_players() {
     // Pin the model at representative points so any change to the formula (or to
     // the glare rule's one-SDP-per-peer assumption) is caught explicitly.
-    // (n, k, expected signals sent per player)
+    // (n, k, expected rate-limited control messages per player)
     for (n, k, expected) in [
-        (2, TYPICAL_ICE_CANDIDATES_PER_PEER, 11), // the two-player floor
-        (8, TYPICAL_ICE_CANDIDATES_PER_PEER, 77),
-        (16, TYPICAL_ICE_CANDIDATES_PER_PEER, 165), // the 16-player target
-        (16, 0, 15),                                // SDP-only (no trickle)
+        (2, TYPICAL_ICE_CANDIDATES_PER_PEER, 12), // the two-player floor
+        (8, TYPICAL_ICE_CANDIDATES_PER_PEER, 78),
+        (16, TYPICAL_ICE_CANDIDATES_PER_PEER, 166), // the 16-player target
+        (16, 0, 16),                                // SDP-only (no trickle)
+        (16, 38, 586),                              // last in-budget integer K
+        (16, 39, 601),                              // first over-budget integer K
     ] {
         assert_eq!(
-            mesh_signals_sent_per_player(n, k),
+            mesh_formation_control_messages_per_player(n, k),
             expected,
             "mesh signal model mismatch at N={n}, K={k}"
         );
@@ -69,7 +73,8 @@ fn mesh_signal_budget_model_holds_and_default_config_accommodates_sixteen_player
         budget,
         "the in-process and config-layer default max_signals must stay in sync"
     );
-    let per_player = mesh_signals_sent_per_player(16, TYPICAL_ICE_CANDIDATES_PER_PEER);
+    let per_player =
+        mesh_formation_control_messages_per_player(16, TYPICAL_ICE_CANDIDATES_PER_PEER);
 
     assert!(
         per_player < budget,
@@ -85,6 +90,6 @@ fn mesh_signal_budget_model_holds_and_default_config_accommodates_sixteen_player
 
     // Documented failure edge (comment, not a brittle assertion coupled to the
     // exact default): a 16-player mesh only exceeds the budget once trickle-ICE
-    // candidates reach K≈40 — 15*(1+K) > 600 ⇒ K ≥ 40 at today's default 600. The
-    // headroom assertion above is the robust guard; this notes where it runs out.
+    // candidates reach K≈39 — 15*(1+K)+1 > 600 ⇒ K ≥ 39 at today's default 600.
+    // The headroom assertion above is the robust guard; this notes where it runs out.
 }

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -689,11 +689,11 @@ fn assert_client_exit(client: &NativeClientProcess, status: &std::process::ExitS
 
 async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     let total_started = tokio::time::Instant::now();
-    let maximum_bounded_pre_release_wait =
-        EVENT_DEADLINE + SUCCESS_BARRIER_DEADLINE + EVENT_DEADLINE;
+    let maximum_bounded_host_release_wait =
+        EVENT_DEADLINE + SUCCESS_BARRIER_DEADLINE + EVENT_DEADLINE + CLIENT_EXIT_DEADLINE;
     assert!(
-        Duration::from_secs(CLIENT_MAX_RUNTIME_SECS) > maximum_bounded_pre_release_wait,
-        "client watchdog must leave headroom beyond room creation, the success barrier, and signal-ledger settlement"
+        Duration::from_secs(CLIENT_MAX_RUNTIME_SECS) > maximum_bounded_host_release_wait,
+        "client watchdog must leave headroom beyond room creation, the success barrier, signal-ledger settlement, and staged host teardown"
     );
     let signal_budget = usize::try_from(Config::default().rate_limit.max_signals)
         .expect("production signal budget fits usize");
@@ -714,11 +714,23 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
 
     let mut server = spawn_server(server_config(scenario.topology)).await;
     let workdir = tempfile::tempdir().expect("create native-client workdir");
-    let success_release_file = workdir.path().join("release-success");
-    assert!(!success_release_file.exists());
+    let success_release_files = match scenario.topology {
+        MatrixTopology::Mesh => {
+            let shared = workdir.path().join("release-success");
+            vec![shared; scenario.players]
+        }
+        MatrixTopology::Host => (0..scenario.players)
+            .map(|ordinal| {
+                workdir
+                    .path()
+                    .join(format!("release-success-c{ordinal:02}"))
+            })
+            .collect(),
+    };
+    assert!(success_release_files.iter().all(|path| !path.exists()));
     let mut creator = spawn_native_client(
         "c00",
-        &client_args(&server, "c00", None, &success_release_file, scenario, 0),
+        &client_args(&server, "c00", None, &success_release_files[0], scenario, 0),
         workdir.path(),
     );
     let created = creator.await_event("room_created", EVENT_DEADLINE).await;
@@ -726,7 +738,7 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
 
     let mut clients = Vec::with_capacity(scenario.players);
     clients.push(creator);
-    for ordinal in 1..scenario.players {
+    for (ordinal, success_release_file) in success_release_files.iter().enumerate().skip(1) {
         let name = format!("c{ordinal:02}");
         clients.push(spawn_native_client(
             &name,
@@ -734,7 +746,7 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
                 &server,
                 &name,
                 Some(&room_code),
-                &success_release_file,
+                success_release_file,
                 scenario,
                 ordinal,
             ),
@@ -911,14 +923,44 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
         scenario.label()
     );
 
-    std::fs::write(&success_release_file, b"release")
-        .expect("release successful clients from the WebRTC barrier");
-    let statuses = join_all(
-        clients
-            .iter_mut()
-            .map(|client| client.drain_to_termination(CLIENT_EXIT_DEADLINE)),
-    )
-    .await;
+    let statuses = match scenario.topology {
+        MatrixTopology::Mesh => {
+            std::fs::write(&success_release_files[0], b"release")
+                .expect("release successful mesh clients from the WebRTC barrier");
+            join_all(
+                clients
+                    .iter_mut()
+                    .map(|client| client.drain_to_termination(CLIENT_EXIT_DEADLINE)),
+            )
+            .await
+        }
+        MatrixTopology::Host => {
+            // Keep the elected host alive until every leaf has completed its
+            // teardown signaling and the server has causally broadcast every
+            // departure. Releasing the whole star at once can let the host
+            // leave first and turn a leaf's final signal into a genuine
+            // SignalTargetNotFound server error, obscuring the measured phase.
+            for release_file in success_release_files.iter().skip(1) {
+                std::fs::write(release_file, b"release")
+                    .expect("release successful host-topology leaf client");
+            }
+            let (host, leaves) = clients
+                .split_first_mut()
+                .expect("the scenario always has a creator");
+            let leaf_terminations = join_all(
+                leaves
+                    .iter_mut()
+                    .map(|client| client.drain_to_termination(CLIENT_EXIT_DEADLINE)),
+            );
+            let host_departure_barrier =
+                host.await_event_count("player_left", scenario.players - 1, CLIENT_EXIT_DEADLINE);
+            let (leaf_statuses, ()) = tokio::join!(leaf_terminations, host_departure_barrier);
+            std::fs::write(&success_release_files[0], b"release")
+                .expect("release successful host-topology creator client");
+            let host_status = host.drain_to_termination(CLIENT_EXIT_DEADLINE).await;
+            std::iter::once(host_status).chain(leaf_statuses).collect()
+        }
+    };
     let total_elapsed = total_started.elapsed();
     stop_tx.send(true).expect("stop RSS sampler");
     let peak_rss = rss_task.await.expect("RSS sampler task succeeds");

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -1,12 +1,13 @@
-//! P10.H8 empirical 16-player native WebRTC mesh signal-budget experiments.
+//! P10.C empirical native WebRTC topology/size and H8 signal-budget experiments.
 //!
-//! The model test proves the arithmetic. These nightly real-process experiments
-//! prove both the complete clean mesh and a partial partition: one client with
-//! deterministic crippled ICE falls back to the WebSocket relay while the
-//! other 15 retain their exact 105-edge WebRTC submesh. Both stay under the
-//! production 600-signal per-connection budget and preserve exact relay-floor
-//! delivery. They are ignored because running 16 real webrtc-rs stacks is
-//! intentionally outside the PR machine's cheap local test budget.
+//! The nightly real-process matrix covers clean mesh and host topologies at
+//! N=2/8/16. The H8 fault variant additionally proves a partial partition: one
+//! client with deterministic crippled ICE falls back to the WebSocket relay
+//! while the other 15 retain their exact 105-edge WebRTC submesh. Every cell
+//! stays under the production 600-signal per-connection budget and preserves
+//! exact WebRTC-channel and relay-floor ledgers. The tests are ignored because
+//! running up to 16 real webrtc-rs stacks is intentionally outside the PR
+//! machine's cheap local test budget.
 
 #![cfg(unix)]
 
@@ -29,8 +30,7 @@ use websocket_test_helpers::prometheus_scrape::{
 };
 use websocket_test_helpers::server_process::{spawn_server, ServerProcess};
 
-const PLAYERS: usize = 16;
-const GAME_NAME: &str = "webrtc-mesh-budget";
+const H8_PLAYERS: usize = 16;
 const EVENT_DEADLINE: Duration = Duration::from_secs(60);
 const SUCCESS_BARRIER_DEADLINE: Duration = Duration::from_secs(360);
 const CLIENT_EXIT_DEADLINE: Duration = Duration::from_secs(30);
@@ -38,38 +38,71 @@ const METRIC_QUIESCENCE_DEADLINE: Duration = Duration::from_secs(30);
 const CLIENT_MAX_RUNTIME_SECS: u64 = 540;
 const CHANNEL_LABELS: [&str; 2] = ["reliable", "unreliable"];
 
-#[derive(Clone, Copy, Debug)]
-enum MeshScenario {
-    Clean,
-    OneCrippled { ordinal: usize },
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MatrixTopology {
+    Mesh,
+    Host,
 }
 
-impl MeshScenario {
-    fn label(self) -> &'static str {
+impl MatrixTopology {
+    const fn label(self) -> &'static str {
         match self {
-            Self::Clean => "clean",
-            Self::OneCrippled { .. } => "one-crippled",
+            Self::Mesh => "mesh",
+            Self::Host => "host",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct WebRtcScenario {
+    topology: MatrixTopology,
+    players: usize,
+    crippled_ordinal: Option<usize>,
+}
+
+impl WebRtcScenario {
+    const fn clean(topology: MatrixTopology, players: usize) -> Self {
+        Self {
+            topology,
+            players,
+            crippled_ordinal: None,
         }
     }
 
-    fn crippled_ordinal(self) -> Option<usize> {
-        match self {
-            Self::Clean => None,
-            Self::OneCrippled { ordinal } => Some(ordinal),
+    const fn one_crippled_mesh(players: usize, ordinal: usize) -> Self {
+        Self {
+            topology: MatrixTopology::Mesh,
+            players,
+            crippled_ordinal: Some(ordinal),
         }
     }
 
-    fn p2p_timeout_secs(self) -> u64 {
-        match self {
-            Self::Clean => 180,
-            Self::OneCrippled { .. } => 30,
+    fn label(self) -> String {
+        let fault = if self.crippled_ordinal.is_some() {
+            "one-crippled"
+        } else {
+            "clean"
+        };
+        format!("{}-n{}-{fault}", self.topology.label(), self.players)
+    }
+
+    const fn crippled_ordinal(self) -> Option<usize> {
+        self.crippled_ordinal
+    }
+
+    const fn p2p_timeout_secs(self) -> u64 {
+        if self.crippled_ordinal.is_some() {
+            30
+        } else {
+            180
         }
     }
 
-    fn run_for_secs(self) -> u64 {
-        match self {
-            Self::Clean => 240,
-            Self::OneCrippled { .. } => 90,
+    const fn run_for_secs(self) -> u64 {
+        if self.crippled_ordinal.is_some() {
+            90
+        } else {
+            240
         }
     }
 }
@@ -116,28 +149,33 @@ fn success_window<'a>(events: &'a [Value], who: &str) -> &'a [Value] {
     &events[..=end]
 }
 
+fn held_window<'a>(events: &'a [Value], who: &str) -> &'a [Value] {
+    let _success_prefix = success_window(events, who);
+    events
+}
+
 fn client_args(
     server: &ServerProcess,
     name: &str,
     room_code: Option<&str>,
     success_release_file: &Path,
-    scenario: MeshScenario,
+    scenario: WebRtcScenario,
     ordinal: usize,
 ) -> Vec<String> {
     let mut args = vec![
         "--server-url".to_string(),
         format!("ws://127.0.0.1:{}/v3/ws", server.port),
         "--game-name".to_string(),
-        GAME_NAME.to_string(),
+        format!("webrtc-{}", scenario.label()),
         "--player-name".to_string(),
         name.to_string(),
         "--peers".to_string(),
-        PLAYERS.to_string(),
+        scenario.players.to_string(),
         "--exchange".to_string(),
         "--relay-payload".to_string(),
         format!("relay-from-{name}"),
         "--supported-topologies".to_string(),
-        "mesh".to_string(),
+        scenario.topology.label().to_string(),
         "--p2p-timeout-secs".to_string(),
         scenario.p2p_timeout_secs().to_string(),
         "--run-for-secs".to_string(),
@@ -157,10 +195,10 @@ fn client_args(
     args
 }
 
-fn mesh_server_config() -> Value {
+fn server_config(topology: MatrixTopology) -> Value {
     json!({
         "session": {
-            "default_topology": "mesh",
+            "default_topology": topology.label(),
             "enable_webrtc": true
         },
         "turn": {
@@ -320,18 +358,126 @@ fn assert_exact_channel_ledger(
     );
 }
 
+fn assert_exact_signal_ledger(
+    clients: &[NativeClientProcess],
+    ids: &[String],
+    all_ids: &BTreeSet<&str>,
+    host_id: &str,
+    topology: MatrixTopology,
+) {
+    let mut sent = BTreeMap::<(String, String, String), usize>::new();
+    let mut received = BTreeMap::<(String, String, String), usize>::new();
+
+    for (client, player_id) in clients.iter().zip(ids) {
+        let expected_peers = expected_planned_peers(player_id, all_ids, host_id, topology);
+        for event in events_named(held_window(&client.events, &client.name), "signal_sent") {
+            let to = string_field(event, "to", &client.name);
+            let kind = string_field(event, "kind", &client.name);
+            assert!(
+                expected_peers.contains(to),
+                "{}: sent off-graph {kind} signal to {to}",
+                client.name
+            );
+            assert_ne!(kind, "other", "{}: emitted opaque signal kind", client.name);
+            *sent
+                .entry((player_id.clone(), to.to_string(), kind.to_string()))
+                .or_default() += 1;
+        }
+        for event in events_named(held_window(&client.events, &client.name), "signal_received") {
+            let from = string_field(event, "from", &client.name);
+            let kind = string_field(event, "kind", &client.name);
+            assert!(
+                expected_peers.contains(from),
+                "{}: received off-graph {kind} signal from {from}",
+                client.name
+            );
+            assert_ne!(
+                kind, "other",
+                "{}: received opaque signal kind",
+                client.name
+            );
+            *received
+                .entry((from.to_string(), player_id.clone(), kind.to_string()))
+                .or_default() += 1;
+        }
+    }
+
+    assert_eq!(
+        received,
+        sent,
+        "{}: every outbound signal must arrive exactly once at its intended peer",
+        topology.label()
+    );
+
+    for (left_index, left) in ids.iter().enumerate() {
+        for right in ids.iter().skip(left_index + 1) {
+            if !expected_planned_peers(left, all_ids, host_id, topology).contains(right.as_str()) {
+                continue;
+            }
+            let kind_count = |kind: &str| {
+                sent.get(&(left.clone(), right.clone(), kind.to_string()))
+                    .copied()
+                    .unwrap_or_default()
+                    + sent
+                        .get(&(right.clone(), left.clone(), kind.to_string()))
+                        .copied()
+                        .unwrap_or_default()
+            };
+            assert_eq!(
+                kind_count("offer"),
+                1,
+                "{} edge {left}<->{right}: exact offer ledger",
+                topology.label()
+            );
+            assert_eq!(
+                kind_count("answer"),
+                1,
+                "{} edge {left}<->{right}: exact answer ledger",
+                topology.label()
+            );
+            assert!(
+                kind_count("ice_candidate") > 0,
+                "{} edge {left}<->{right}: at least one trickle-ICE candidate",
+                topology.label()
+            );
+        }
+    }
+}
+
+fn expected_planned_peers<'a>(
+    player_id: &'a str,
+    all_ids: &BTreeSet<&'a str>,
+    host_id: &'a str,
+    topology: MatrixTopology,
+) -> BTreeSet<&'a str> {
+    match topology {
+        MatrixTopology::Mesh => all_ids
+            .iter()
+            .copied()
+            .filter(|candidate| *candidate != player_id)
+            .collect(),
+        MatrixTopology::Host if player_id == host_id => all_ids
+            .iter()
+            .copied()
+            .filter(|candidate| *candidate != player_id)
+            .collect(),
+        MatrixTopology::Host => BTreeSet::from([host_id]),
+    }
+}
+
 fn expected_connected_peers<'a>(
     player_id: &'a str,
     all_ids: &BTreeSet<&'a str>,
+    host_id: &'a str,
+    topology: MatrixTopology,
     crippled_id: Option<&'a str>,
 ) -> BTreeSet<&'a str> {
     if crippled_id == Some(player_id) {
         return BTreeSet::new();
     }
-    all_ids
-        .iter()
-        .copied()
-        .filter(|candidate| *candidate != player_id && Some(*candidate) != crippled_id)
+    expected_planned_peers(player_id, all_ids, host_id, topology)
+        .into_iter()
+        .filter(|candidate| Some(*candidate) != crippled_id)
         .collect()
 }
 
@@ -339,24 +485,29 @@ fn assert_client_barrier(
     client: &NativeClientProcess,
     player_id: &str,
     all_ids: &BTreeSet<&str>,
-    names_by_id: &BTreeMap<&str, &str>,
+    names_by_id: &BTreeMap<&str, String>,
     signal_budget: usize,
+    host_id: &str,
+    scenario: WebRtcScenario,
     crippled_id: Option<&str>,
 ) -> usize {
     let who = &client.name;
-    let window = success_window(&client.events, who);
-    let expected_peers: BTreeSet<&str> = all_ids
+    let window = held_window(&client.events, who);
+    let room_peers: BTreeSet<&str> = all_ids
         .iter()
         .copied()
         .filter(|candidate| *candidate != player_id)
         .collect();
-    let expected_connected_peers = expected_connected_peers(player_id, all_ids, crippled_id);
-    let expected_connected = !expected_connected_peers.is_empty();
+    let expected_peers = expected_planned_peers(player_id, all_ids, host_id, scenario.topology);
+    let expected_connections =
+        expected_connected_peers(player_id, all_ids, host_id, scenario.topology, crippled_id);
+    let expected_connected = !expected_connections.is_empty();
 
     let barrier_errors = events_named(window, "error");
     assert!(
         barrier_errors.is_empty(),
-        "{who}: errors before the successful mesh barrier: {barrier_errors:?}"
+        "{who}: errors before the successful {} barrier: {barrier_errors:?}",
+        scenario.label()
     );
     assert_eq!(
         events_named(window, "fallback_engaged").len(),
@@ -364,10 +515,20 @@ fn assert_client_barrier(
         "{who}: fallback count must match its WebRTC connectivity"
     );
     let plan = single_event(window, "session_plan", who);
-    assert_eq!(string_field(plan, "topology", who), "mesh");
+    assert_eq!(
+        string_field(plan, "topology", who),
+        scenario.topology.label()
+    );
     assert_eq!(string_field(plan, "transport", who), "webrtc");
     assert_eq!(string_field(plan, "fallback", who), "relay");
-    assert!(plan.get("host").is_some_and(Value::is_null));
+    match scenario.topology {
+        MatrixTopology::Mesh => assert!(plan.get("host").is_some_and(Value::is_null)),
+        MatrixTopology::Host => assert_eq!(
+            plan.get("host").and_then(Value::as_str),
+            Some(host_id),
+            "{who}: every host plan must name the creator"
+        ),
+    }
     assert_eq!(
         plan.get("ice_servers_count").and_then(Value::as_u64),
         Some(0),
@@ -377,7 +538,11 @@ fn assert_client_barrier(
         .get("peers")
         .and_then(Value::as_array)
         .unwrap_or_else(|| panic!("{who}: session plan lacks peers: {plan}"));
-    assert_eq!(peers.len(), PLAYERS - 1, "{who}: session-plan peer count");
+    assert_eq!(
+        peers.len(),
+        expected_peers.len(),
+        "{who}: session-plan peer count"
+    );
     let mut planned = BTreeSet::new();
     let self_uuid = Uuid::parse_str(player_id).expect("player id is a UUID");
     for peer in peers {
@@ -386,40 +551,52 @@ fn assert_client_barrier(
             planned.insert(peer_id),
             "{who}: duplicate planned peer {peer_id}"
         );
-        let peer_uuid = Uuid::parse_str(peer_id).expect("planned peer id is a UUID");
+        let expected_initiate = match scenario.topology {
+            MatrixTopology::Mesh => {
+                let peer_uuid = Uuid::parse_str(peer_id).expect("planned peer id is a UUID");
+                self_uuid < peer_uuid
+            }
+            MatrixTopology::Host => player_id != host_id,
+        };
         assert_eq!(
             peer.get("initiate").and_then(Value::as_bool),
-            Some(self_uuid < peer_uuid),
-            "{who}: glare role for {peer_id} must follow UUID ordering"
+            Some(expected_initiate),
+            "{who}: glare role for {peer_id} in {}",
+            scenario.topology.label()
         );
     }
-    assert_eq!(planned, expected_peers, "{who}: exact mesh plan peer set");
+    assert_eq!(
+        planned,
+        expected_peers,
+        "{who}: exact {} plan peer set",
+        scenario.topology.label()
+    );
 
     assert_exact_peer_events(
         window,
         "p2p_pair_connected",
         "peer",
-        &expected_connected_peers,
+        &expected_connections,
         who,
     );
     assert_exact_channel_ledger(
         window,
         "channel_open",
-        &expected_connected_peers,
+        &expected_connections,
         player_id,
         who,
     );
     assert_exact_channel_ledger(
         window,
         "channel_message_sent",
-        &expected_connected_peers,
+        &expected_connections,
         player_id,
         who,
     );
     assert_exact_channel_ledger(
         window,
         "channel_message",
-        &expected_connected_peers,
+        &expected_connections,
         player_id,
         who,
     );
@@ -439,12 +616,11 @@ fn assert_client_barrier(
             "{who}: peer status transport"
         );
         let peer = string_field(peer_status, "peer", who);
-        assert!(
-            expected_peers.contains(peer),
-            "{who}: stray peer status {peer}"
-        );
+        assert!(room_peers.contains(peer), "{who}: stray peer status {peer}");
         *peer_status_counts.entry(peer).or_default() += 1;
-        let expected_peer_connected = Some(peer) != crippled_id;
+        let expected_peer_connected =
+            !expected_connected_peers(peer, all_ids, host_id, scenario.topology, crippled_id)
+                .is_empty();
         assert_eq!(
             peer_status.get("connected").and_then(Value::as_bool),
             Some(expected_peer_connected),
@@ -453,7 +629,7 @@ fn assert_client_barrier(
     }
     assert_eq!(
         peer_status_counts.keys().copied().collect::<BTreeSet<_>>(),
-        expected_peers,
+        room_peers,
         "{who}: exact peer transport-status set"
     );
     for (peer, count) in peer_status_counts {
@@ -472,8 +648,8 @@ fn assert_client_barrier(
             .unwrap_or_else(|| panic!("{who}: relay event lacks relay_msg: {event}"));
         let sender_name = names_by_id
             .get(from)
-            .copied()
-            .unwrap_or_else(|| panic!("{who}: relay sender {from} is outside the mesh"));
+            .map(String::as_str)
+            .unwrap_or_else(|| panic!("{who}: relay sender {from} is outside the room"));
         assert_eq!(payload, format!("relay-from-{sender_name}"));
         assert!(
             relay_ledger.insert(from, payload).is_none(),
@@ -482,14 +658,14 @@ fn assert_client_barrier(
     }
     assert_eq!(
         relay_ledger.keys().copied().collect::<BTreeSet<_>>(),
-        expected_peers,
+        room_peers,
         "{who}: relay-floor sender ledger"
     );
 
     let signal_count = events_named(window, "signal_sent").len();
     assert!(
-        signal_count <= signal_budget,
-        "{who}: emitted {signal_count} signals, exceeding production budget {signal_budget}"
+        signal_count < signal_budget,
+        "{who}: emitted {signal_count} signals plus one TransportStatus, exceeding production control-plane budget {signal_budget}"
     );
     signal_count
 }
@@ -503,7 +679,7 @@ fn assert_client_exit(client: &NativeClientProcess, status: &std::process::ExitS
     );
     assert!(
         events_named(&client.events, "error").is_empty(),
-        "{}: errors after mesh release: {:?}",
+        "{}: errors after WebRTC release: {:?}",
         client.name,
         client.error_messages()
     );
@@ -511,7 +687,7 @@ fn assert_client_exit(client: &NativeClientProcess, status: &std::process::ExitS
     assert_eq!(exit.get("code").and_then(Value::as_i64), Some(0));
 }
 
-async fn run_mesh_scenario(scenario: MeshScenario) {
+async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     let total_started = tokio::time::Instant::now();
     let maximum_bounded_pre_release_wait =
         EVENT_DEADLINE + SUCCESS_BARRIER_DEADLINE + EVENT_DEADLINE;
@@ -526,10 +702,17 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
         "H8 is registered against the real default"
     );
     if let Some(ordinal) = scenario.crippled_ordinal() {
-        assert!(ordinal < PLAYERS, "crippled ordinal must name a client");
+        assert!(
+            ordinal < scenario.players,
+            "crippled ordinal must name a client"
+        );
     }
+    assert!(
+        scenario.players >= 2,
+        "WebRTC cells require at least two clients"
+    );
 
-    let mut server = spawn_server(mesh_server_config()).await;
+    let mut server = spawn_server(server_config(scenario.topology)).await;
     let workdir = tempfile::tempdir().expect("create native-client workdir");
     let success_release_file = workdir.path().join("release-success");
     assert!(!success_release_file.exists());
@@ -541,9 +724,9 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
     let created = creator.await_event("room_created", EVENT_DEADLINE).await;
     let room_code = string_field(&created, "room_code", "c00").to_string();
 
-    let mut clients = Vec::with_capacity(PLAYERS);
+    let mut clients = Vec::with_capacity(scenario.players);
     clients.push(creator);
-    for ordinal in 1..PLAYERS {
+    for ordinal in 1..scenario.players {
         let name = format!("c{ordinal:02}");
         clients.push(spawn_native_client(
             &name,
@@ -583,17 +766,70 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
         })
         .collect();
     let all_ids: BTreeSet<&str> = ids.iter().map(String::as_str).collect();
-    assert_eq!(all_ids.len(), PLAYERS, "all player ids must be distinct");
-    let names_by_id: BTreeMap<&str, &str> = ids
+    assert_eq!(
+        all_ids.len(),
+        scenario.players,
+        "all player ids must be distinct"
+    );
+    let names_by_id: BTreeMap<&str, String> = ids
         .iter()
         .zip(&clients)
-        .map(|(id, client)| (id.as_str(), client.name.as_str()))
+        .map(|(id, client)| (id.as_str(), client.name.clone()))
         .collect();
     let crippled_id = scenario
         .crippled_ordinal()
         .map(|ordinal| ids[ordinal].as_str());
+    let host_id = ids[0].as_str();
 
-    let mut per_client_signals = Vec::with_capacity(PLAYERS);
+    // Mesh clients already wait for every room peer's status because every
+    // peer is a pairing obligation. Host leaves wait only for the host, so a
+    // sibling leaf's room-wide fan-out may still be buffered after the global
+    // success barrier. Settle that exact full-room ledger while the clients
+    // remain held. In parallel, settle the server signal metric against the
+    // signal events frozen causally before each success marker.
+    let barrier_signal_counts: Vec<usize> = clients
+        .iter()
+        .map(|client| {
+            events_named(success_window(&client.events, &client.name), "signal_sent").len()
+        })
+        .collect();
+    let barrier_total_signals: usize = barrier_signal_counts.iter().sum();
+    let id_indexes: BTreeMap<&str, usize> = ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| (id.as_str(), index))
+        .collect();
+    let mut expected_inbound_signals = vec![0; scenario.players];
+    for client in &clients {
+        for event in events_named(success_window(&client.events, &client.name), "signal_sent") {
+            let to = string_field(event, "to", &client.name);
+            let target_index = id_indexes.get(to).copied().unwrap_or_else(|| {
+                panic!("{}: signal target {to} is outside the room", client.name)
+            });
+            expected_inbound_signals[target_index] += 1;
+        }
+    }
+    let event_settlement = join_all(clients.iter_mut().zip(expected_inbound_signals).map(
+        |(client, inbound_signals)| async move {
+            let mut expected = vec![("peer_transport_status", scenario.players - 1)];
+            if scenario.crippled_ordinal().is_none() {
+                expected.push(("signal_received", inbound_signals));
+            }
+            client.await_event_counts(&expected, EVENT_DEADLINE).await;
+        },
+    ));
+    let signal_settlement = wait_for_exact_signal_ledger(
+        server.port,
+        u64::try_from(barrier_total_signals).expect("signal total fits u64"),
+    );
+    let ((), ()) = tokio::join!(
+        async {
+            event_settlement.await;
+        },
+        signal_settlement
+    );
+
+    let mut per_client_signals = Vec::with_capacity(scenario.players);
     for (client, id) in clients.iter().zip(&ids) {
         per_client_signals.push(assert_client_barrier(
             client,
@@ -601,9 +837,17 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
             &all_ids,
             &names_by_id,
             signal_budget,
+            host_id,
+            scenario,
             crippled_id,
         ));
     }
+    assert_eq!(
+        per_client_signals,
+        barrier_signal_counts,
+        "{}: signal ledger changed after the success barrier",
+        scenario.label()
+    );
     let total_signals: usize = per_client_signals.iter().sum();
     let mut sorted_signals = per_client_signals.clone();
     sorted_signals.sort_unstable();
@@ -614,50 +858,61 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
     assert_eq!(
         held_counters.backpressure_events,
         0,
-        "{} mesh backpressure",
+        "{} backpressure",
         scenario.label()
     );
     assert_eq!(
         held_counters.slow_consumer_disconnects,
         0,
-        "{} mesh slow-consumer evictions",
+        "{} slow-consumer evictions",
         scenario.label()
     );
     assert_eq!(
         held_counters.dropped,
         0,
-        "{} mesh messages dropped before coordinated teardown",
+        "{} messages dropped before coordinated teardown",
         scenario.label()
     );
     assert_scraped_message_conservation(&held_counters);
-    wait_for_exact_signal_ledger(
-        server.port,
-        u64::try_from(total_signals).expect("signal total fits u64"),
-    )
-    .await;
+    assert_eq!(
+        total_signals,
+        barrier_total_signals,
+        "{}: settled signal total",
+        scenario.label()
+    );
+    if crippled_id.is_none() {
+        assert_exact_signal_ledger(&clients, &ids, &all_ids, host_id, scenario.topology);
+    }
     let held_metrics = fetch_prometheus_text(server.port).await;
-    let expected_fallbacks = u64::from(scenario.crippled_ordinal().is_some());
+    let expected_connected_clients = ids
+        .iter()
+        .filter(|id| {
+            !expected_connected_peers(id, &all_ids, host_id, scenario.topology, crippled_id)
+                .is_empty()
+        })
+        .count();
+    let expected_fallbacks = scenario.players - expected_connected_clients;
     assert_eq!(
         sample_value(&held_metrics, "signal_fish_transport_p2p_established_total"),
-        u64::try_from(PLAYERS).expect("player count fits u64") - expected_fallbacks,
-        "{} mesh P2P-established client count",
+        u64::try_from(expected_connected_clients).expect("player count fits u64"),
+        "{} P2P-established client count",
         scenario.label()
     );
     assert_eq!(
         sample_value(&held_metrics, "signal_fish_transport_relay_fallback_total"),
-        expected_fallbacks,
-        "{} mesh relay-fallback client count",
+        u64::try_from(expected_fallbacks).expect("fallback count fits u64"),
+        "{} relay-fallback client count",
         scenario.label()
     );
     assert_eq!(
         sample_value(&held_metrics, "signal_fish_websocket_ping_timeouts_total"),
         0,
-        "{} mesh must not lose clients to ping timeout",
+        "{} must not lose clients to ping timeout",
         scenario.label()
     );
 
     std::fs::write(&success_release_file, b"release")
-        .expect("release successful clients from the mesh barrier");
+        .expect("release successful clients from the WebRTC barrier");
     let statuses = join_all(
         clients
             .iter_mut()
@@ -676,13 +931,13 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
     assert_eq!(
         counters.backpressure_events,
         0,
-        "{} mesh backpressure",
+        "{} backpressure",
         scenario.label()
     );
     assert_eq!(
         counters.slow_consumer_disconnects,
         0,
-        "{} mesh slow-consumer evictions",
+        "{} slow-consumer evictions",
         scenario.label()
     );
     assert_scraped_message_conservation(&counters);
@@ -690,15 +945,26 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
     assert_eq!(
         sample_value(&metrics, "signal_fish_websocket_ping_timeouts_total"),
         0,
-        "{} mesh must not lose clients to ping timeout",
+        "{} must not lose clients to ping timeout",
         scenario.label()
     );
 
-    let connected_players = PLAYERS - usize::from(scenario.crippled_ordinal().is_some());
-    let connected_pairs = connected_players * (connected_players - 1) / 2;
+    let directed_connected_edges: usize = ids
+        .iter()
+        .map(|id| {
+            expected_connected_peers(id, &all_ids, host_id, scenario.topology, crippled_id).len()
+        })
+        .sum();
+    assert_eq!(
+        directed_connected_edges % 2,
+        0,
+        "the expected WebRTC graph must be symmetric"
+    );
+    let connected_pairs = directed_connected_edges / 2;
     println!(
-        "H8 mesh complete: scenario={} players={PLAYERS} connected_pairs={connected_pairs} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} coordinated_teardown_drops={} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
+        "WebRTC matrix cell complete: scenario={} players={} connected_pairs={connected_pairs} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} coordinated_teardown_drops={} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
         scenario.label(),
+        scenario.players,
         counters
             .dropped
             .checked_sub(held_counters.dropped)
@@ -710,35 +976,76 @@ async fn run_mesh_scenario(scenario: MeshScenario) {
 }
 
 #[test]
-fn connectivity_oracle_preserves_clean_and_partial_mesh_graphs() {
+fn connectivity_oracle_preserves_mesh_and_host_graphs() {
     let all = BTreeSet::from(["a", "b", "c"]);
     assert_eq!(
-        expected_connected_peers("b", &all, None),
+        expected_connected_peers("b", &all, "a", MatrixTopology::Mesh, None),
         BTreeSet::from(["a", "c"]),
         "clean mesh connects every other peer"
     );
     assert_eq!(
-        expected_connected_peers("b", &all, Some("c")),
+        expected_connected_peers("b", &all, "a", MatrixTopology::Mesh, Some("c")),
         BTreeSet::from(["a"]),
         "healthy peer excludes the crippled member"
     );
     assert!(
-        expected_connected_peers("c", &all, Some("c")).is_empty(),
+        expected_connected_peers("c", &all, "a", MatrixTopology::Mesh, Some("c")).is_empty(),
         "crippled member forms no WebRTC edges"
+    );
+    assert_eq!(
+        expected_connected_peers("a", &all, "a", MatrixTopology::Host, None),
+        BTreeSet::from(["b", "c"]),
+        "host connects to every client"
+    );
+    assert_eq!(
+        expected_connected_peers("b", &all, "a", MatrixTopology::Host, None),
+        BTreeSet::from(["a"]),
+        "each client connects only to the host"
     );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "nightly-only (verification-nightly.yml): spawns 16 real webrtc-rs clients"]
 async fn sixteen_native_clients_form_complete_mesh_within_signal_budget() {
-    run_mesh_scenario(MeshScenario::Clean).await;
+    run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Mesh, H8_PLAYERS)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "nightly-only (verification-nightly.yml): spawns 16 real webrtc-rs clients"]
 async fn one_crippled_ice_client_falls_back_without_breaking_healthy_submesh() {
-    run_mesh_scenario(MeshScenario::OneCrippled {
-        ordinal: PLAYERS - 1,
-    })
+    run_webrtc_scenario(WebRtcScenario::one_crippled_mesh(
+        H8_PLAYERS,
+        H8_PLAYERS - 1,
+    ))
     .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 2 real webrtc-rs clients"]
+async fn clean_mesh_n2_has_exact_graph_and_ledgers() {
+    run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Mesh, 2)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 8 real webrtc-rs clients"]
+async fn clean_mesh_n8_has_exact_graph_and_ledgers() {
+    run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Mesh, 8)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 2 real webrtc-rs clients"]
+async fn clean_host_n2_has_exact_graph_and_ledgers() {
+    run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Host, 2)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 8 real webrtc-rs clients"]
+async fn clean_host_n8_has_exact_graph_and_ledgers() {
+    run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Host, 8)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 16 real webrtc-rs clients"]
+async fn clean_host_n16_has_exact_graph_and_ledgers() {
+    run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Host, 16)).await;
 }

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -506,7 +506,7 @@ fn assert_client_barrier(
     let barrier_errors = events_named(window, "error");
     assert!(
         barrier_errors.is_empty(),
-        "{who}: errors before the successful {} barrier: {barrier_errors:?}",
+        "{who}: errors in the held {} event window: {barrier_errors:?}",
         scenario.label()
     );
     assert_eq!(

--- a/tests/websocket_test_helpers/native_client_process.rs
+++ b/tests/websocket_test_helpers/native_client_process.rs
@@ -154,24 +154,46 @@ impl NativeClientProcess {
 
     /// Read until `count` events with this tag have been recorded in total.
     pub async fn await_event_count(&mut self, event_name: &str, count: usize, timeout: Duration) {
+        self.await_event_counts(&[(event_name, count)], timeout)
+            .await;
+    }
+
+    /// Read until every `(tag, total count)` requirement is satisfied against
+    /// one absolute deadline. This lets held-process barriers settle concurrent
+    /// event streams without accidentally granting one full timeout per tag.
+    pub async fn await_event_counts(&mut self, expected: &[(&str, usize)], timeout: Duration) {
         let deadline = tokio::time::Instant::now() + timeout;
-        let mut observed = self.recorded_event_count(event_name);
-        while observed < count {
-            let context = format!("awaiting {count} `{event_name}` events (have {observed})");
+        let mut observed: Vec<usize> = expected
+            .iter()
+            .map(|(event_name, _count)| self.recorded_event_count(event_name))
+            .collect();
+        while observed
+            .iter()
+            .zip(expected)
+            .any(|(seen, (_event_name, count))| seen < count)
+        {
+            let context = expected
+                .iter()
+                .zip(&observed)
+                .map(|((event_name, count), seen)| format!("{seen}/{count} `{event_name}` events"))
+                .collect::<Vec<_>>()
+                .join(", ");
             let event = self.next_event_before(deadline, &context).await;
-            if event
+            if let Some(event_name) = event
                 .as_ref()
                 .and_then(|item| item.get("event"))
                 .and_then(Value::as_str)
-                == Some(event_name)
             {
-                observed += 1;
+                for ((expected_name, _count), seen) in expected.iter().zip(&mut observed) {
+                    if event_name == *expected_name {
+                        *seen += 1;
+                    }
+                }
             }
             assert!(
                 event.is_some(),
-                "client {}: stdout ended with {} of {count} `{event_name}` events;\n{}",
+                "client {}: stdout ended before all event counts settled ({context});\n{}",
                 self.name,
-                observed,
                 self.diagnostics()
             );
         }


### PR DESCRIPTION
## What changed

- generalize the real-process WebRTC harness across mesh and host topologies at N=2/8/16
- enforce exact plan, graph, signaling, two-channel, room-wide status, and relay-floor ledgers
- reserve the accepted TransportStatus report in the shared 600-message control-plane budget
- settle held client event streams against one absolute deadline to avoid host-star races
- independently bound and serialize all seven WebRTC experiments in nightly verification

## Why

P10.C registered a clean `{mesh, host} x {2, 8, 16}` WebRTC grid. The repository already proved mesh N=16 and its crippled-ICE variant; this closes the five remaining clean host/size cells without weakening the exact H8 oracle. The privileged `tc netem` loss lane remains a separate follow-up with a fault-specific unreliable-channel recovery oracle.

## Local verification

- `cargo fmt --all`
- targeted Clippy with `-D warnings`
- `cargo test --locked --test signal_budget_model`
- targeted graph-oracle test and `webrtc_mesh_budget_e2e --no-run`
- `cargo test --locked --test ci_config_tests` (276 passed, 1 intentional ignore)
- actionlint, cargo-deny/CI config, workflow hygiene, tooling parity, doc consistency
- pre-commit and pre-push hooks

The seven resource-heavy real WebRTC cells are intentionally executed by Verification Nightly, not on the local machine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to tests, test helpers, CI timeouts, and docs; no production signaling or rate-limit behavior is modified in this diff.
> 
> **Overview**
> Extends the nightly real-process WebRTC harness from mesh-only N=16 (plus the H8 crippled-ICE case) to the full clean **`{mesh, host} × {2, 8, 16}`** grid, with five new ignored matrix cells alongside the existing H8 proofs.
> 
> The shared **`run_webrtc_scenario`** path now parameterizes topology and player count, checks **exact** session plans, peer graphs, signaling (offer/answer/ICE), dual data channels, room-wide **`PeerTransportStatus`**, and relay-floor ledgers, and uses **staged host teardown** (leaves exit before the creator) so teardown does not mask real signal errors. **`native_client_process`** gains **`await_event_counts`** so multiple JSONL event streams settle under one deadline—important for host topology where status fan-out can lag the success barrier.
> 
> The PR-lane **signal budget model** counts each player’s accepted **`TransportStatus`** in the same 600-message control-plane bucket as WebRTC signals (**`(n−1)(1+k)+1`**), and the e2e harness asserts **`signal_sent` &lt; budget** with that reservation. **Nightly CI** documents seven serialized WebRTC cells, raises the multiprocess-delivery job ceiling to **120 minutes**, and renames the workflow step/output to a topology/size matrix; **nextest** comments reflect per-cell watchdog bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41cc92ee10acf6e2a4f5638924e3b7de9568eb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->