### PR TITLE
Complete the WebRTC loss matrix

### DIFF
--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -239,8 +239,9 @@ jobs:
   multiprocess-delivery:
     name: Multi-Process Delivery Faults
     runs-on: ubuntu-latest
-    # Generous floor: after the native reference client build, seven WebRTC
-    # cells run serially in the process-spawning group. Each cell has a 600s
+    # Generous floor: after the native reference client build, eleven WebRTC
+    # cells run serially in the process-spawning group (seven clean/H8 plus
+    # four privileged 1%-loss cells). Each cell has a 600s
     # nextest ceiling above its 540s child watchdog, so the job ceiling keeps
     # principled headroom for all cells plus the delivery-fault suite and cold
     # compilation (zero-flakiness policy).
@@ -292,7 +293,7 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test multiprocess_delivery_e2e --run-ignored all \
             --success-output final 2>&1 | tee multiprocess-output.txt
-      - name: Run WebRTC topology and size matrix
+      - name: Run clean WebRTC topology and size matrix
         shell: bash
         env:
           SIGNAL_FISH_CLIENT_BIN: ${{ github.workspace }}/clients/native/target/debug/signal-fish-reference-native
@@ -300,7 +301,45 @@ jobs:
           set -o pipefail
           cargo nextest run --profile ci --locked --all-features \
             --test webrtc_mesh_budget_e2e --run-ignored all \
+            -E 'not test(one_percent_loss)' \
+            --no-tests fail \
             --success-output final 2>&1 | tee webrtc-matrix-output.txt
+      - name: Run fail-loud WebRTC netem loss matrix
+        shell: bash
+        env:
+          SIGNAL_FISH_CLIENT_BIN: ${{ github.workspace }}/clients/native/target/debug/signal-fish-reference-native
+          SF_NETEM_ACTIVE: "1"
+        run: |
+          set -o pipefail
+          cleanup_netem() {
+            sudo -n tc qdisc del dev lo root 2>/dev/null || true
+          }
+          for test_name in \
+            one_percent_loss_mesh_n2_recovers_exact_ledgers_after_fault_lift \
+            one_percent_loss_mesh_n8_recovers_exact_ledgers_after_fault_lift \
+            one_percent_loss_host_n2_recovers_exact_ledgers_after_fault_lift \
+            one_percent_loss_host_n8_recovers_exact_ledgers_after_fault_lift
+          do
+            cleanup_netem
+            trap cleanup_netem EXIT
+            cargo nextest run --profile ci --locked --all-features \
+              --test webrtc_mesh_budget_e2e --run-ignored all \
+              -E "test($test_name)" \
+              --no-tests fail \
+              --success-output final 2>&1 | tee -a webrtc-matrix-output.txt
+            cleanup_netem
+            trap - EXIT
+          done
+      - name: Remove WebRTC network fault state
+        if: always()
+        shell: bash
+        run: |
+          sudo -n tc qdisc del dev lo root 2>/dev/null || true
+          if tc qdisc show dev lo | grep -q netem; then
+            echo "ERROR: netem remained active after the WebRTC matrix"
+            tc qdisc show dev lo
+            exit 1
+          fi
       - name: Report multi-process results to job summary
         if: always()
         shell: bash
@@ -312,7 +351,7 @@ jobs:
             tail -n 60 multiprocess-output.txt 2>/dev/null || echo "no multiprocess output captured"
             echo '```'
             echo
-            echo "### WebRTC clean topology/size matrix and H8 fallback"
+            echo "### WebRTC clean/loss topology-size matrix and H8 fallback"
             echo
             echo '```text'
             tail -n 260 webrtc-matrix-output.txt 2>/dev/null || echo "no WebRTC matrix output captured"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{mesh, host} x {2, 8, 16}` topology/size grid with exact plan, signaling,
   channel, room-wide transport-status, and relay-floor ledgers. The signal
   budget guard accounts for the accepted `TransportStatus` report that shares
-  the 600-message control-plane bucket with WebRTC signals.
+  the 600-message control-plane bucket with WebRTC signals. Four additional
+  `{mesh, host} x {2, 8}` cells form every planned pair under verified 1%
+  loopback packet loss, then lift the fault before releasing the exact channel
+  exchange. The native client's new harness-only exchange release file emits
+  `exchange_ready` after pair formation and ICE gathering; ordinary exchange
+  behavior remains unchanged when the flag is omitted.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -56,6 +56,7 @@ Exactly one of `--create-room` / `--join-code` is required; everything else has 
 | `--app-id <ID>` | `reference-native-app` | `Authenticate.app_id` (interop servers run with WebSocket auth disabled) |
 | `--platform <P>` | `reference-native` | `Authenticate.platform` |
 | `--exchange` | off | When a P2P pair fully opens, send exactly one text message per channel and require the symmetric receives (see success criteria) |
+| `--exchange-release-file <PATH>` | — | Test harness only; requires `--exchange`. Establish every planned pair and finish local ICE gathering, emit `exchange_ready`, then hold the exact channel exchange until PATH exists. Normal exchange behavior is unchanged when omitted |
 | `--relay-payload <TEXT>` | — | After `GameStarting` (+250 ms settle), send one `GameData {"relay_msg": TEXT}` over the WebSocket relay floor and require the other `--peers - 1` members' payloads. A late joiner (entry into a finalized room) arms the send on entry instead — `GameStarting` pre-dates the join — and its receive requirement is waived: payloads sent before the join are never replayed |
 | `--cripple-ice` | off | Deterministically break ICE: reject every interface during gathering AND drop all outbound/inbound `IceCandidate` signals (SDP offer/answer still flows). Forces the relay fallback |
 | `--p2p-timeout-secs <S>` | `15` | Window for WebRTC pair establishment before the overall transport status resolves |
@@ -123,6 +124,7 @@ process continues to its normal bounded exit.
 | `channel_message_sent` | `peer`, `label`, `text` | An `--exchange` message was sent |
 | `channel_message` | `peer`, `label`, `text` | A data-channel text message arrived |
 | `p2p_pair_connected` | `peer` | BOTH channels toward `peer` are open |
+| `exchange_ready` | — | Harness-only barrier: every planned pair is open and local ICE gathering is complete, while `--exchange-release-file` still holds application exchange |
 | `transport_status_sent` | `transport`, `connected` | An overall `TransportStatus` state change went out (Appendix G) |
 | `peer_transport_status` | `peer`, `transport`, `connected` | A same-room peer's reported state changed (server fan-out) |
 | `game_data_sent` | — | The `--relay-payload` GameData was sent |

--- a/clients/native/src/cli.rs
+++ b/clients/native/src/cli.rs
@@ -80,6 +80,12 @@ pub struct Cli {
     #[arg(long)]
     pub exchange: bool,
 
+    /// Test-harness coordination: when --exchange is enabled, wait until this
+    /// path exists before sending the exact per-channel exchange. Channel and
+    /// pair establishment continue while held.
+    #[arg(long, requires = "exchange")]
+    pub exchange_release_file: Option<PathBuf>,
+
     /// After GameStarting (plus a short settle), send one GameData message with
     /// payload {"relay_msg": <text>} over the WebSocket relay floor.
     #[arg(long)]
@@ -269,6 +275,7 @@ mod tests {
         assert_eq!(cli.runtime.as_str(), "multi");
         assert_eq!(cli.tick_stall_ms, 0, "fault injection is off by default");
         assert_eq!(cli.success_release_file, None);
+        assert_eq!(cli.exchange_release_file, None);
         assert_eq!(
             cli.topologies(),
             vec![Topology::Relay, Topology::Host, Topology::Mesh]
@@ -355,6 +362,37 @@ mod tests {
         assert_eq!(
             cli.success_release_file.as_deref(),
             Some(std::path::Path::new("/tmp/signal-fish-release"))
+        );
+    }
+
+    #[test]
+    fn exchange_release_file_parses() {
+        let cli = Cli::parse_from([
+            "signal-fish-reference-native",
+            "--server-url",
+            "ws://127.0.0.1:9000/v3/ws",
+            "--create-room",
+            "--exchange",
+            "--exchange-release-file",
+            "/tmp/signal-fish-exchange-release",
+        ]);
+        assert!(cli.exchange);
+        assert_eq!(
+            cli.exchange_release_file.as_deref(),
+            Some(std::path::Path::new("/tmp/signal-fish-exchange-release"))
+        );
+
+        let without_exchange = Cli::try_parse_from([
+            "signal-fish-reference-native",
+            "--server-url",
+            "ws://127.0.0.1:9000/v3/ws",
+            "--create-room",
+            "--exchange-release-file",
+            "/tmp/signal-fish-exchange-release",
+        ]);
+        assert!(
+            without_exchange.is_err(),
+            "the exchange gate is meaningless without --exchange"
         );
     }
 

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -202,6 +202,9 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         peer_status_from: BTreeSet::new(),
         sent_labels: BTreeMap::new(),
         received_labels: BTreeMap::new(),
+        exchange_released: cli.exchange_release_file.is_none(),
+        exchange_ready_reported: false,
+        exchange_release_poll_at: None,
         pending_signals: BTreeMap::new(),
         run_deadline,
         linger_until: None,
@@ -615,6 +618,12 @@ struct Orchestrator<'a> {
     /// Exchange bookkeeping: channel labels sent/received per peer.
     sent_labels: BTreeMap<PlayerId, BTreeSet<String>>,
     received_labels: BTreeMap<PlayerId, BTreeSet<String>>,
+    /// Whether an optional harness gate has released the application exchange.
+    exchange_released: bool,
+    /// Whether the stable all-planned-pairs-open barrier event was emitted.
+    exchange_ready_reported: bool,
+    /// Next poll for `--exchange-release-file` while application traffic is held.
+    exchange_release_poll_at: Option<Instant>,
     /// Signals that arrived before their peer was paired (defensive: server
     /// FIFO ordering makes this unreachable in the documented flows).
     pending_signals: BTreeMap<PlayerId, VecDeque<serde_json::Value>>,
@@ -757,6 +766,9 @@ impl Orchestrator<'_> {
         if let Some(at) = self.success_release_poll_at {
             wake = wake.min(at);
         }
+        if let Some(at) = self.exchange_release_poll_at {
+            wake = wake.min(at);
+        }
         wake = wake.min(self.next_ping_at);
         if let Some(at) = self.pong_deadline {
             wake = wake.min(at);
@@ -807,6 +819,8 @@ impl Orchestrator<'_> {
             self.resolve_transport_status().await?;
             self.p2p_deadline = None;
         }
+
+        self.process_exchange_gate(now).await?;
 
         self.arm_success_linger(now).await?;
         if self.linger_until.is_some_and(|at| now >= at) {
@@ -872,22 +886,111 @@ impl Orchestrator<'_> {
     }
 
     async fn success_release_pending(&self) -> Result<bool, FatalError> {
-        let Some(path) = &self.cli.success_release_file else {
+        Self::release_file_pending(
+            self.cli.success_release_file.as_deref(),
+            "--success-release-file",
+        )
+        .await
+    }
+
+    async fn exchange_release_pending(&self) -> Result<bool, FatalError> {
+        Self::release_file_pending(
+            self.cli.exchange_release_file.as_deref(),
+            "--exchange-release-file",
+        )
+        .await
+    }
+
+    async fn release_file_pending(
+        path: Option<&std::path::Path>,
+        flag: &'static str,
+    ) -> Result<bool, FatalError> {
+        let Some(path) = path else {
             return Ok(false);
         };
-        let path = path.clone();
+        let path = path.to_path_buf();
         let display = path.display().to_string();
         tokio::task::spawn_blocking(move || path.try_exists())
             .await
             .map_err(|error| {
                 FatalError::connection(format!(
-                    "inspect --success-release-file {display}: metadata task failed: {error}"
+                    "inspect {flag} {display}: metadata task failed: {error}"
                 ))
             })?
             .map(|exists| !exists)
-            .map_err(|error| {
-                FatalError::connection(format!("inspect --success-release-file {display}: {error}"))
+            .map_err(|error| FatalError::connection(format!("inspect {flag} {display}: {error}")))
+    }
+
+    async fn process_exchange_gate(&mut self, now: Instant) -> Result<(), FatalError> {
+        if !self.cli.exchange
+            || self.exchange_released
+            || !self.exchange_gate_ready()
+            || self
+                .exchange_release_poll_at
+                .is_some_and(|poll_at| now < poll_at)
+        {
+            return Ok(());
+        }
+        if !self.exchange_ready_reported {
+            emit(&Event::ExchangeReady);
+            self.exchange_ready_reported = true;
+        }
+        if self.exchange_release_pending().await? {
+            self.exchange_release_poll_at = Some(now + SUCCESS_RELEASE_POLL);
+            return Ok(());
+        }
+
+        self.exchange_released = true;
+        self.exchange_release_poll_at = None;
+        let peers: Vec<PlayerId> = self.connected_pairs.iter().copied().collect();
+        for peer in peers {
+            self.send_exchange(peer).await?;
+        }
+        Ok(())
+    }
+
+    fn exchange_gate_ready(&self) -> bool {
+        self.all_expected_pairs_connected()
+            && self.expected_peers.iter().all(|peer| {
+                !needs_ice_gathering_marker(
+                    self.engine.is_paired(*peer),
+                    self.ice_gathering_complete.contains(peer),
+                )
             })
+    }
+
+    async fn send_exchange(&mut self, peer: PlayerId) -> Result<(), FatalError> {
+        for label in [RELIABLE_LABEL, UNRELIABLE_LABEL] {
+            if self
+                .sent_labels
+                .get(&peer)
+                .is_some_and(|labels| labels.contains(label))
+            {
+                continue;
+            }
+            let Some(channel) = self.engine.channel(peer, label) else {
+                return Err(FatalError::connection(format!(
+                    "open pair with {peer} is missing channel {label}"
+                )));
+            };
+            let text = format!(
+                r#"{{"from":"{}","channel":"{}","seq":0}}"#,
+                self.my_id, label
+            );
+            channel.send_text(text.clone()).await.map_err(|error| {
+                FatalError::connection(format!("send on {label} to {peer} failed: {error}"))
+            })?;
+            self.sent_labels
+                .entry(peer)
+                .or_default()
+                .insert(label.to_string());
+            emit(&Event::ChannelMessageSent {
+                peer,
+                label: label.to_string(),
+                text,
+            });
+        }
+        Ok(())
     }
 
     async fn handle_server_message(&mut self, message: ServerMessage) -> Result<(), FatalError> {
@@ -1413,37 +1516,8 @@ impl Orchestrator<'_> {
     async fn on_pair_connected(&mut self, peer: PlayerId) -> Result<(), FatalError> {
         self.connected_pairs.insert(peer);
         emit(&Event::P2pPairConnected { peer });
-        if self.cli.exchange {
-            for label in [RELIABLE_LABEL, UNRELIABLE_LABEL] {
-                let Some(channel) = self.engine.channel(peer, label) else {
-                    return Err(FatalError::connection(format!(
-                        "open pair with {peer} is missing channel {label}"
-                    )));
-                };
-                // The exact documented exchange payload (stable field order).
-                let text = format!(
-                    r#"{{"from":"{}","channel":"{}","seq":0}}"#,
-                    self.my_id, label
-                );
-                match channel.send_text(text.clone()).await {
-                    Ok(_bytes_sent) => {
-                        self.sent_labels
-                            .entry(peer)
-                            .or_default()
-                            .insert(label.to_string());
-                        emit(&Event::ChannelMessageSent {
-                            peer,
-                            label: label.to_string(),
-                            text,
-                        });
-                    }
-                    Err(error) => {
-                        return Err(FatalError::connection(format!(
-                            "send on {label} to {peer} failed: {error}"
-                        )));
-                    }
-                }
-            }
+        if self.cli.exchange && self.exchange_released {
+            self.send_exchange(peer).await?;
         }
         // Initial resolution waits for all pairs; after any prior resolution,
         // one late pair is enough to change the overall any-pair state.

--- a/clients/native/src/events.rs
+++ b/clients/native/src/events.rs
@@ -79,6 +79,9 @@ pub enum Event {
     },
     /// Both channels (`reliable` + `unreliable`) are open toward `peer`.
     P2pPairConnected { peer: PlayerId },
+    /// Every planned pair is open and local ICE gathering is complete, but
+    /// `--exchange-release-file` still holds the exact application exchange.
+    ExchangeReady,
     /// An overall `TransportStatus` state change was sent (Appendix G).
     TransportStatusSent {
         transport: Transport,
@@ -227,6 +230,7 @@ mod tests {
             ),
             (Event::GameDataSent, "game_data_sent"),
             (Event::FallbackEngaged, "fallback_engaged"),
+            (Event::ExchangeReady, "exchange_ready"),
             (Event::SuccessCriteriaMet, "success_criteria_met"),
             (Event::Exiting { code: 0 }, "exiting"),
         ];

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -120,7 +120,9 @@ impl WebRtcScenario {
     }
 
     const fn run_for_secs(self) -> u64 {
-        if self.crippled_ordinal.is_some() {
+        if self.netem_loss {
+            480
+        } else if self.crippled_ordinal.is_some() {
             90
         } else {
             240
@@ -874,6 +876,13 @@ fn assert_client_exit(client: &NativeClientProcess, status: &std::process::ExitS
 
 async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     let total_started = tokio::time::Instant::now();
+    if scenario.uses_netem() {
+        let maximum_pre_success_wait = EVENT_DEADLINE + SUCCESS_BARRIER_DEADLINE;
+        assert!(
+            Duration::from_secs(scenario.run_for_secs()) > maximum_pre_success_wait,
+            "loss-client soft deadline must exceed room creation plus the shared fault-formation/recovery barrier"
+        );
+    }
     let maximum_bounded_host_release_wait =
         EVENT_DEADLINE + SUCCESS_BARRIER_DEADLINE + EVENT_DEADLINE + CLIENT_EXIT_DEADLINE;
     assert!(

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -1,13 +1,15 @@
 //! P10.C empirical native WebRTC topology/size and H8 signal-budget experiments.
 //!
 //! The nightly real-process matrix covers clean mesh and host topologies at
-//! N=2/8/16. The H8 fault variant additionally proves a partial partition: one
-//! client with deterministic crippled ICE falls back to the WebSocket relay
-//! while the other 15 retain their exact 105-edge WebRTC submesh. Every cell
-//! stays under the production 600-signal per-connection budget and preserves
-//! exact WebRTC-channel and relay-floor ledgers. The tests are ignored because
-//! running up to 16 real webrtc-rs stacks is intentionally outside the PR
-//! machine's cheap local test budget.
+//! N=2/8/16 plus fail-loud 1% `tc netem` loss at N=2/8. Loss stays active
+//! through ICE/channel formation; exact channel exchange is released only
+//! after fault lift. The H8 fault variant additionally proves a partial
+//! partition: one client with deterministic crippled ICE falls back to the
+//! WebSocket relay while the other 15 retain their exact 105-edge WebRTC
+//! submesh. Every cell stays under the production 600-signal per-connection
+//! budget and preserves exact WebRTC-channel and relay-floor ledgers. The tests
+//! are ignored because running real webrtc-rs stacks and privileged network
+//! faults is intentionally outside the PR machine's cheap local test budget.
 
 #![cfg(unix)]
 
@@ -17,6 +19,7 @@ mod websocket_test_helpers;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
+use std::process::Command;
 use std::time::Duration;
 
 use futures_util::future::join_all;
@@ -58,6 +61,7 @@ struct WebRtcScenario {
     topology: MatrixTopology,
     players: usize,
     crippled_ordinal: Option<usize>,
+    netem_loss: bool,
 }
 
 impl WebRtcScenario {
@@ -66,6 +70,7 @@ impl WebRtcScenario {
             topology,
             players,
             crippled_ordinal: None,
+            netem_loss: false,
         }
     }
 
@@ -74,12 +79,24 @@ impl WebRtcScenario {
             topology: MatrixTopology::Mesh,
             players,
             crippled_ordinal: Some(ordinal),
+            netem_loss: false,
+        }
+    }
+
+    const fn netem_loss(topology: MatrixTopology, players: usize) -> Self {
+        Self {
+            topology,
+            players,
+            crippled_ordinal: None,
+            netem_loss: true,
         }
     }
 
     fn label(self) -> String {
         let fault = if self.crippled_ordinal.is_some() {
             "one-crippled"
+        } else if self.netem_loss {
+            "loss-1pct"
         } else {
             "clean"
         };
@@ -88,6 +105,10 @@ impl WebRtcScenario {
 
     const fn crippled_ordinal(self) -> Option<usize> {
         self.crippled_ordinal
+    }
+
+    const fn uses_netem(self) -> bool {
+        self.netem_loss
     }
 
     const fn p2p_timeout_secs(self) -> u64 {
@@ -159,6 +180,7 @@ fn client_args(
     name: &str,
     room_code: Option<&str>,
     success_release_file: &Path,
+    exchange_release_file: Option<&Path>,
     scenario: WebRtcScenario,
     ordinal: usize,
 ) -> Vec<String> {
@@ -188,11 +210,169 @@ fn client_args(
     if scenario.crippled_ordinal() == Some(ordinal) {
         args.push("--cripple-ice".to_string());
     }
+    if let Some(path) = exchange_release_file {
+        args.extend([
+            "--exchange-release-file".to_string(),
+            path.to_string_lossy().into_owned(),
+        ]);
+    }
     match room_code {
         Some(code) => args.extend(["--join-code".to_string(), code.to_string()]),
         None => args.push("--create-room".to_string()),
     }
     args
+}
+
+struct NetemGuard {
+    active: bool,
+    baseline_drops: u64,
+}
+
+impl NetemGuard {
+    fn activate() -> Self {
+        assert_eq!(
+            std::env::var("SF_NETEM_ACTIVE").as_deref(),
+            Ok("1"),
+            "netem loss cells require SF_NETEM_ACTIVE=1; refusing to run a silent clean substitute"
+        );
+
+        Self::replace_loss("100%");
+        Self::assert_loss("100%");
+        let before = Self::dropped_packets();
+        let receiver = std::net::UdpSocket::bind("127.0.0.1:0")
+            .expect("bind deterministic netem probe receiver");
+        let sender = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind netem probe sender");
+        for _ in 0..8 {
+            sender
+                .send_to(
+                    b"signal-fish-netem-probe",
+                    receiver.local_addr().expect("probe addr"),
+                )
+                .expect("send deterministic netem probe");
+        }
+        let after = Self::dropped_packets();
+        assert!(
+            after > before,
+            "100% netem probe did not increment qdisc drops (before={before}, after={after}); packet fault injection is not operational"
+        );
+
+        Self::replace_loss("1%");
+        Self::assert_loss("1%");
+        Self {
+            active: true,
+            baseline_drops: Self::dropped_packets(),
+        }
+    }
+
+    fn verify_active(&self) {
+        assert!(self.active, "netem guard was already released");
+        Self::assert_loss("1%");
+    }
+
+    fn release(mut self) -> u64 {
+        self.verify_active();
+        let drops = Self::dropped_packets().saturating_sub(self.baseline_drops);
+        Self::delete();
+        self.active = false;
+        let qdisc = Self::show(false);
+        assert!(
+            !qdisc.contains("netem"),
+            "netem remained active after fault lift: {qdisc}"
+        );
+        drops
+    }
+
+    fn replace_loss(loss: &str) {
+        let output = Command::new("sudo")
+            .args([
+                "-n", "tc", "qdisc", "replace", "dev", "lo", "root", "netem", "loss", "random",
+                loss,
+            ])
+            .output()
+            .expect("execute sudo tc netem setup");
+        assert!(
+            output.status.success(),
+            "failed to install netem loss {loss}; status={} stdout={} stderr={} (the runner needs passwordless sudo/CAP_NET_ADMIN)",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn delete() {
+        let output = Command::new("sudo")
+            .args(["-n", "tc", "qdisc", "del", "dev", "lo", "root"])
+            .output()
+            .expect("execute sudo tc netem cleanup");
+        assert!(
+            output.status.success(),
+            "failed to remove netem qdisc; status={} stdout={} stderr={}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn assert_loss(expected: &str) {
+        let qdisc = Self::show(false);
+        assert!(
+            qdisc.contains("qdisc netem") && qdisc.contains(&format!("loss {expected}")),
+            "requested netem loss {expected} is absent: {qdisc}"
+        );
+    }
+
+    fn dropped_packets() -> u64 {
+        let qdisc = Self::show(true);
+        let marker = "dropped ";
+        let start = qdisc
+            .find(marker)
+            .unwrap_or_else(|| panic!("tc statistics lack dropped counter: {qdisc}"))
+            + marker.len();
+        let digits: String = qdisc[start..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        digits
+            .parse()
+            .unwrap_or_else(|error| panic!("invalid tc dropped counter {digits:?}: {error}"))
+    }
+
+    fn show(statistics: bool) -> String {
+        let mut command = Command::new("tc");
+        if statistics {
+            command.arg("-s");
+        }
+        let output = command
+            .args(["qdisc", "show", "dev", "lo"])
+            .output()
+            .expect("inspect loopback qdisc");
+        assert!(
+            output.status.success(),
+            "tc qdisc inspection failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).expect("tc qdisc output is UTF-8")
+    }
+}
+
+impl Drop for NetemGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let output = Command::new("sudo")
+                .args(["-n", "tc", "qdisc", "del", "dev", "lo", "root"])
+                .output();
+            if let Err(error) = output {
+                eprintln!("failed to execute emergency netem cleanup: {error}");
+            } else if let Ok(output) = output {
+                if !output.status.success() {
+                    eprintln!(
+                        "emergency netem cleanup failed: {}",
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn server_config(topology: MatrixTopology) -> Value {
@@ -514,6 +694,11 @@ fn assert_client_barrier(
         usize::from(!expected_connected),
         "{who}: fallback count must match its WebRTC connectivity"
     );
+    assert_eq!(
+        events_named(window, "exchange_ready").len(),
+        usize::from(scenario.uses_netem()),
+        "{who}: fault-gated exchange barrier count"
+    );
     let plan = single_event(window, "session_plan", who);
     assert_eq!(
         string_field(plan, "topology", who),
@@ -728,9 +913,27 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
             .collect(),
     };
     assert!(success_release_files.iter().all(|path| !path.exists()));
+    let exchange_release_file = scenario
+        .uses_netem()
+        .then(|| workdir.path().join("release-exchange-after-netem"));
+    assert!(
+        exchange_release_file
+            .as_ref()
+            .is_none_or(|path| !path.exists()),
+        "exchange fault-release path must start absent"
+    );
+    let mut netem_guard = scenario.uses_netem().then(NetemGuard::activate);
     let mut creator = spawn_native_client(
         "c00",
-        &client_args(&server, "c00", None, &success_release_files[0], scenario, 0),
+        &client_args(
+            &server,
+            "c00",
+            None,
+            &success_release_files[0],
+            exchange_release_file.as_deref(),
+            scenario,
+            0,
+        ),
         workdir.path(),
     );
     let created = creator.await_event("room_created", EVENT_DEADLINE).await;
@@ -747,6 +950,7 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
                 &name,
                 Some(&room_code),
                 success_release_file,
+                exchange_release_file.as_deref(),
                 scenario,
                 ordinal,
             ),
@@ -760,8 +964,38 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
     let rss_task = tokio::spawn(sample_peak_rss(pids, stop_rx));
     let barrier_started = tokio::time::Instant::now();
+    let barrier_deadline = barrier_started + SUCCESS_BARRIER_DEADLINE;
+    let netem_drops = if scenario.uses_netem() {
+        join_all(clients.iter_mut().map(|client| {
+            client.await_event_count(
+                "exchange_ready",
+                1,
+                barrier_deadline.saturating_duration_since(tokio::time::Instant::now()),
+            )
+        }))
+        .await;
+        let guard = netem_guard
+            .take()
+            .expect("netem scenario owns an active qdisc guard");
+        guard.verify_active();
+        let drops = guard.release();
+        std::fs::write(
+            exchange_release_file
+                .as_ref()
+                .expect("netem scenario owns an exchange release file"),
+            b"release",
+        )
+        .expect("release exact data-channel exchange after lifting netem");
+        Some(drops)
+    } else {
+        None
+    };
     join_all(clients.iter_mut().map(|client| {
-        client.await_event_count("success_criteria_met", 1, SUCCESS_BARRIER_DEADLINE)
+        client.await_event_count(
+            "success_criteria_met",
+            1,
+            barrier_deadline.saturating_duration_since(tokio::time::Instant::now()),
+        )
     }))
     .await;
     let barrier_elapsed = barrier_started.elapsed();
@@ -1004,7 +1238,7 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     );
     let connected_pairs = directed_connected_edges / 2;
     println!(
-        "WebRTC matrix cell complete: scenario={} players={} connected_pairs={connected_pairs} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} coordinated_teardown_drops={} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
+        "WebRTC matrix cell complete: scenario={} players={} connected_pairs={connected_pairs} netem_qdisc_drops={netem_drops:?} total_signals={total_signals} signals_per_client={per_client_signals:?} signal_p50={signal_p50} signal_p99={signal_p99} all_clients_at_success_barrier={barrier_elapsed:?} total_elapsed={total_elapsed:?} coordinated_teardown_drops={} post_spawn_server_peak_rss_kib={} post_spawn_client_peak_rss_kib={:?}",
         scenario.label(),
         scenario.players,
         counters
@@ -1090,4 +1324,28 @@ async fn clean_host_n8_has_exact_graph_and_ledgers() {
 #[ignore = "nightly-only (verification-nightly.yml): spawns 16 real webrtc-rs clients"]
 async fn clean_host_n16_has_exact_graph_and_ledgers() {
     run_webrtc_scenario(WebRtcScenario::clean(MatrixTopology::Host, 16)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): requires privileged tc netem"]
+async fn one_percent_loss_mesh_n2_recovers_exact_ledgers_after_fault_lift() {
+    run_webrtc_scenario(WebRtcScenario::netem_loss(MatrixTopology::Mesh, 2)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): requires privileged tc netem"]
+async fn one_percent_loss_mesh_n8_recovers_exact_ledgers_after_fault_lift() {
+    run_webrtc_scenario(WebRtcScenario::netem_loss(MatrixTopology::Mesh, 8)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): requires privileged tc netem"]
+async fn one_percent_loss_host_n2_recovers_exact_ledgers_after_fault_lift() {
+    run_webrtc_scenario(WebRtcScenario::netem_loss(MatrixTopology::Host, 2)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): requires privileged tc netem"]
+async fn one_percent_loss_host_n8_recovers_exact_ledgers_after_fault_lift() {
+    run_webrtc_scenario(WebRtcScenario::netem_loss(MatrixTopology::Host, 8)).await;
 }


### PR DESCRIPTION
## What changed

- add fail-loud `{mesh, host} x {2, 8}` native WebRTC cells under verified `tc netem loss 1%`
- hold the exact reliable/unreliable exchange until every pair forms, ICE gathering completes, and the fault is verified and removed
- isolate every privileged cell with Rust unwind cleanup plus per-invocation shell cleanup
- retain the existing exact graph, glare, signal, status, relay-floor, budget, conservation, teardown, and RSS oracles

## Why

P10.C's clean topology/size grid is complete, but its registered privileged loss lane remained open. A one-shot unreliable payload cannot be an exact oracle while random loss is active, so the client now exposes a harness-only exchange barrier: formation happens under loss and exact application recovery happens after fault lift. Ordinary client exchange behavior and all server/wire behavior remain unchanged.

## Validation

- native CLI/event unit suites (15 focused tests)
- real clean mesh N=2 process cell with exact ledgers
- focused root/native Clippy with warnings denied
- `ci_config_tests` (276 passed, 1 intentional ignore)
- actionlint, cargo-deny/CI config, workflow hygiene, tooling parity, doc consistency
- pre-commit and pre-push hooks

The four privileged cells intentionally run on GitHub's Ubuntu runner; the local container lacks `CAP_NET_ADMIN` and fails loudly rather than skipping.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are mostly nightly E2E and harness-only client flags, but privileged `tc netem` on loopback and serial CI steps can leave network state or extend job runtime if cleanup fails.
> 
> **Overview**
> Completes the P10.C **1% packet-loss** WebRTC verification lane for `{mesh, host} × {N=2, N=8}` by separating **formation under loss** from **exact channel exchange after fault lift**.
> 
> The native reference client gains **`--exchange-release-file`** (requires `--exchange`): pairs and ICE gathering finish normally, the harness sees **`exchange_ready`**, then reliable/unreliable exchange waits until the release path exists. Default exchange behavior is unchanged when the flag is omitted; release-file polling is shared with the existing success-release helper.
> 
> **`webrtc_mesh_budget_e2e`** adds a **`NetemGuard`** (`tc netem` on `lo`, gated by **`SF_NETEM_ACTIVE=1`** with a 100% probe so silent clean runs are refused), longer run budgets for loss cells, and four ignored tests that lift netem before writing the exchange release file. **`verification-nightly.yml`** runs clean/H8 matrix cells separately from the four privileged loss tests (per-test netem cleanup + always-on qdisc verification) and updates job timeout commentary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f3a51239f631debee2131dc6c3a0364378ea04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->