### PR TITLE
Rate-limit mixed-encoding fallback advisories

### DIFF
--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -33,6 +33,8 @@
 #     backgrounded-tab profile (multi-second absorbed pauses + eviction).
 #     The same job runs tests/sixteen_player_matrix_e2e.rs, adding the twelve
 #     per-client jitter/throttle and burst-pause relay matrix cells.
+#     It also runs the H14 mixed-encoding amplification experiment: exact
+#     unsupported-format reports under a bandwidth-constrained JSON fallback.
 #   - split-brain-catalog: tests/split_brain_two_instances_e2e.rs — two real
 #     server processes pin the unsupported multi-instance failure catalog used
 #     by the deployment doctrine.
@@ -63,6 +65,7 @@ on:
       - "tests/webrtc_mesh_budget_e2e.rs"
       - "tests/scenario_realworld_e2e.rs"
       - "tests/sixteen_player_matrix_e2e.rs"
+      - "tests/mixed_encoding_relay_e2e.rs"
       - "tests/split_brain_two_instances_e2e.rs"
       - "tests/websocket_test_helpers/**"
       - "clients/native/**"
@@ -461,6 +464,13 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test sixteen_player_matrix_e2e --run-ignored all \
             --success-output final 2>&1 | tee relay-matrix-output.txt
+      - name: Run mixed-encoding amplification experiment
+        shell: bash
+        run: |
+          set -o pipefail
+          cargo nextest run --profile ci --locked --all-features \
+            --test mixed_encoding_relay_e2e --run-ignored ignored-only \
+            --success-output final 2>&1 | tee mixed-encoding-output.txt
       - name: Report scenario results to job summary
         if: always()
         shell: bash
@@ -476,6 +486,12 @@ jobs:
             echo
             echo '```text'
             tail -n 60 relay-matrix-output.txt 2>/dev/null || echo "no relay matrix output captured"
+            echo '```'
+            echo
+            echo "### Mixed-encoding amplification"
+            echo
+            echo '```text'
+            tail -n 60 mixed-encoding-output.txt 2>/dev/null || echo "no mixed-encoding output captured"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -78,6 +78,18 @@ cargo fmt && cargo clippy --all-targets --all-features && cargo test --all-featu
 
 **Zero warnings policy** -- all linters enforce strict compliance.
 
+### GitHub Access (Required Fallback)
+
+- Use local `git` for branch management, staging, commits, and pushes.
+- Prefer the connected VS Code GitHub extension / GitHub app for pull-request
+  creation, metadata, comments, reviewer requests, and review inspection.
+- Do not block repository delivery solely because `gh auth status` is
+  unauthenticated when the connected GitHub extension/app is available and the
+  Git remote can push successfully.
+- Use `gh` only for capabilities the connector cannot supply (notably detailed
+  GitHub Actions logs or GraphQL review-thread operations), and only when an
+  authenticated CLI session is available.
+
 ### Hook Reliability Rules (Required)
 
 - Git hooks are last-resort guards and must stay cross-platform (`pwsh` + `git` only) and sub-second.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rate-limit protocol-v3 unsupported-format advisory errors per sender and
+  recipient while preserving an exact `DeliveryReport` for every omitted
+  sequence. Mixed-encoding malformed payloads can no longer double each relay
+  into an unbounded report/error stream; later advisories include the number
+  suppressed since the prior notice.
+
 ### Added
 
 - Add a harness-only native reference-client success barrier and a nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Rate-limit protocol-v3 unsupported-format advisory errors per sender and
-  recipient while preserving an exact `DeliveryReport` for every omitted
-  sequence. Mixed-encoding malformed payloads can no longer double each relay
-  into an unbounded report/error stream; later advisories include the number
-  suppressed since the prior notice.
-
 ### Added
 
 - Add a harness-only native reference-client success barrier and a nightly
@@ -973,6 +965,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rate-limit protocol-v3 unsupported-format advisory errors per sender and
+  recipient while preserving an exact `DeliveryReport` for every omitted
+  sequence. Mixed-encoding malformed payloads can no longer double each relay
+  into an unbounded report/error stream; later advisories include the number
+  suppressed since the prior notice.
 - **Consolidated the pre-release protocol into a single v3.** The
   delivery-reliability features that were briefly developed behind a separate
   `protocol_version: 4` (server-stamped `GameData.seq` + incarnation `epoch`, and

--- a/clients/browser/README.md
+++ b/clients/browser/README.md
@@ -68,7 +68,9 @@ before applying relayed data. It retains ranges across bounded rollover reports
 only when their non-overlapping, causally prior union covers every missing
 sequence. `RelayStats`, totals, and supplemental errors are diagnostics only.
 RelayStats snapshots are checked for a positive stable interval and monotonic
-cumulative counters. V2 mode remains reliable FIFO, and raw binary data is
+cumulative counters. Unsupported-format errors are optional rate-limited
+advisories: when present they require a prior causal exact report, but need not
+be adjacent to it. V2 mode remains reliable FIFO, and raw binary data is
 always reliable. This runtime negotiates `game_data_format: "json"`, so an
 incoming binary frame or text `GameDataBinary` is a protocol error. The strict
 MessagePack decoder is kept as a tested protocol utility for binary-capable

--- a/clients/browser/src/page/accountability.test.ts
+++ b/clients/browser/src/page/accountability.test.ts
@@ -1051,18 +1051,23 @@ test('snapshot baseline validates only the recipient-visible tail', () => {
   );
 });
 
-test('unsupported report requires its immediate error or a terminal close', () => {
+test('unsupported advisory requires a prior report but not adjacency', () => {
   const report = { per_class: countersWithUnsupported(1), gaps: [unsupportedGap(1)] };
 
   const paired = joinedState();
   paired.recordReport(report);
+  paired.observeServerMessage(false);
   paired.observeServerMessage(true);
   paired.observeServerMessage(false);
-  expectViolation(() => paired.observeServerMessage(true), 'lacked an immediately preceding');
+  expectViolation(() => paired.observeServerMessage(true), 'lacked a prior causal');
 
-  const missing = joinedState();
-  missing.recordReport(report);
-  expectViolation(() => missing.observeServerMessage(false), 'not immediately followed');
+  const rollover = joinedState();
+  rollover.recordReport(report);
+  rollover.recordReport({
+    per_class: countersWithUnsupported(2),
+    gaps: [unsupportedGap(2)],
+  });
+  rollover.observeServerMessage(true);
 
   const terminal = joinedState();
   terminal.recordReport(report);
@@ -1268,7 +1273,7 @@ test('the JSON-negotiated runtime rejects physical and text GameDataBinary frame
   }
 });
 
-test('binary envelopes are strict and retain arrival-order adjacency', () => {
+test('binary envelopes are strict and preserve deferred advisory accountability', () => {
   const report = {
     type: 'DeliveryReport',
     data: { per_class: countersWithUnsupported(1), gaps: [unsupportedGap(1)] },
@@ -1287,10 +1292,8 @@ test('binary envelopes are strict and retain arrival-order adjacency', () => {
   }
   const buffered = joinedState();
   dispatchClassifiedFrame(buffered, handoff[0] as ServerFrame);
-  expectViolation(
-    () => dispatchClassifiedFrame(buffered, handoff[1] as ServerFrame),
-    'not immediately followed',
-  );
+  dispatchClassifiedFrame(buffered, handoff[1] as ServerFrame);
+  dispatchClassifiedFrame(buffered, handoff[2] as ServerFrame);
 
   const binary = encode({
     from_player: BINARY_SENDER_BYTES,
@@ -1309,10 +1312,8 @@ test('binary envelopes are strict and retain arrival-order adjacency', () => {
   }
   const live = joinedState();
   dispatchClassifiedFrame(live, liveFrames[0] as ServerFrame);
-  expectViolation(
-    () => dispatchClassifiedFrame(live, liveFrames[1] as ServerFrame),
-    'not immediately followed',
-  );
+  dispatchClassifiedFrame(live, liveFrames[1] as ServerFrame);
+  dispatchClassifiedFrame(live, liveFrames[2] as ServerFrame);
 
   const canonicalEntries = binaryEnvelopeEntries();
   const canonical = encodeMessagePackMap(canonicalEntries);

--- a/clients/browser/src/page/accountability.test.ts
+++ b/clients/browser/src/page/accountability.test.ts
@@ -1069,6 +1069,11 @@ test('unsupported advisory requires a prior report but not adjacency', () => {
   });
   rollover.observeServerMessage(true);
 
+  const roomReset = joinedState();
+  roomReset.recordReport(report);
+  roomReset.resetRoom();
+  expectViolation(() => roomReset.observeServerMessage(true), 'lacked a prior causal');
+
   const terminal = joinedState();
   terminal.recordReport(report);
   terminal.observeTerminal();

--- a/clients/browser/src/page/accountability.ts
+++ b/clients/browser/src/page/accountability.ts
@@ -68,7 +68,7 @@ export class DeliveryAccountability {
   private readonly staleSenders = new Set<string>();
   private readonly departedSenders = new Map<string, Map<number, DepartedSender>>();
   private readonly pendingGaps = new Map<string, ParsedGap[]>();
-  private pendingUnsupportedError: ParsedGap | null = null;
+  private unadvisedUnsupportedGap: ParsedGap | null = null;
   private counters: number[] | null = null;
   private lastRelayStats: RelayStatsSnapshot | null = null;
 
@@ -88,7 +88,7 @@ export class DeliveryAccountability {
   /** Start accountability for a new physical connection. */
   resetConnection(): void {
     this.resetRoom();
-    this.pendingUnsupportedError = null;
+    this.unadvisedUnsupportedGap = null;
     this.counters = null;
     this.lastRelayStats = null;
   }
@@ -235,26 +235,16 @@ export class DeliveryAccountability {
     if (!this.protocolV3) {
       return;
     }
-    if (this.pendingUnsupportedError !== null) {
-      if (isUnsupportedFormatError) {
-        this.pendingUnsupportedError = null;
-        return;
-      }
-      const gap = this.pendingUnsupportedError;
-      violation(
-        `unsupported-format report for ${gap.fromPlayer} epoch ${gap.epoch}, seq ` +
-          `${gap.fromSeq} was not immediately followed by Error(UnsupportedGameDataFormat)`,
-      );
-    }
     if (isUnsupportedFormatError) {
-      violation(
-        'Error(UnsupportedGameDataFormat) lacked an immediately preceding causal DeliveryReport',
-      );
+      if (this.unadvisedUnsupportedGap === null) {
+        violation('Error(UnsupportedGameDataFormat) lacked a prior causal DeliveryReport');
+      }
+      this.unadvisedUnsupportedGap = null;
     }
   }
 
   observeTerminal(): void {
-    this.pendingUnsupportedError = null;
+    this.unadvisedUnsupportedGap = null;
   }
 
   /** Validate one connection-cumulative relay statistics snapshot. */
@@ -335,11 +325,6 @@ export class DeliveryAccountability {
   recordReport(reportValue: unknown): void {
     if (!this.protocolV3) {
       violation('v2 connection received DeliveryReport');
-    }
-    if (this.pendingUnsupportedError !== null) {
-      violation(
-        'unsupported-format DeliveryReport was not immediately followed by its supplemental Error',
-      );
     }
     const report = asRecord(reportValue, 'DeliveryReport.data');
     const nextCounters = parseCounters(report['per_class']);
@@ -424,7 +409,7 @@ export class DeliveryAccountability {
       this.pendingGaps.set(key, pending);
     }
     if (unsupportedSeen) {
-      this.pendingUnsupportedError = gaps[0] ?? null;
+      this.unadvisedUnsupportedGap = gaps[0] ?? null;
     }
     this.counters = nextCounters;
     for (const gap of gaps) {

--- a/clients/browser/src/page/accountability.ts
+++ b/clients/browser/src/page/accountability.ts
@@ -83,6 +83,7 @@ export class DeliveryAccountability {
     this.staleSenders.clear();
     this.departedSenders.clear();
     this.pendingGaps.clear();
+    this.unadvisedUnsupportedGap = null;
   }
 
   /** Start accountability for a new physical connection. */

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -78,7 +78,9 @@ retains ranges across reports (one frame carries at most 256) until their
 non-overlapping union covers a later sequence hole. Aggregate counters,
 `RelayStats`, and supplemental errors never authorize a gap. RelayStats
 snapshots are checked for a positive stable interval and monotonic cumulative
-counters. V2 mode rejects all v3 stamps/reports and remains reliable FIFO; raw
+counters. Unsupported-format errors are optional rate-limited advisories: when
+present they require a prior causal exact report, but need not be adjacent to
+it. V2 mode rejects all v3 stamps/reports and remains reliable FIFO; raw
 binary game data is always reliable. This runtime negotiates
 `game_data_format: "json"`, so an incoming binary frame or text
 `GameDataBinary` is a protocol error. The strict MessagePack decoder remains a

--- a/clients/native/src/accountability.rs
+++ b/clients/native/src/accountability.rs
@@ -79,6 +79,7 @@ impl DeliveryAccountability {
         self.stale_senders.clear();
         self.departed_senders.clear();
         self.pending_gaps.clear();
+        self.unadvised_unsupported_gap = None;
     }
 
     /// Start accountability for a new physical connection.
@@ -1579,6 +1580,12 @@ mod tests {
             })
             .unwrap();
         rollover.observe_server_message(true).unwrap();
+
+        let mut room_reset = DeliveryAccountability::default();
+        room_reset.note_player_joined(&player(sender, 1)).unwrap();
+        room_reset.record_report(&report).unwrap();
+        room_reset.reset_room();
+        assert!(room_reset.observe_server_message(true).is_err());
 
         let mut terminal = DeliveryAccountability::default();
         terminal.note_player_joined(&player(sender, 1)).unwrap();

--- a/clients/native/src/accountability.rs
+++ b/clients/native/src/accountability.rs
@@ -45,7 +45,7 @@ pub struct DeliveryAccountability {
     stale_senders: BTreeSet<PlayerId>,
     departed_senders: BTreeMap<(PlayerId, u32), DepartedSender>,
     pending_gaps: BTreeMap<(PlayerId, u32), Vec<DeliveryGap>>,
-    pending_unsupported_error: Option<DeliveryGap>,
+    unadvised_unsupported_gap: Option<DeliveryGap>,
     counters: Option<DeliveryCountersByClass>,
     last_relay_stats: Option<RelayStatsSnapshot>,
 }
@@ -65,7 +65,7 @@ impl DeliveryAccountability {
             stale_senders: BTreeSet::new(),
             departed_senders: BTreeMap::new(),
             pending_gaps: BTreeMap::new(),
-            pending_unsupported_error: None,
+            unadvised_unsupported_gap: None,
             counters: None,
             last_relay_stats: None,
         }
@@ -84,7 +84,7 @@ impl DeliveryAccountability {
     /// Start accountability for a new physical connection.
     pub fn reset_connection(&mut self) {
         self.reset_room();
-        self.pending_unsupported_error = None;
+        self.unadvised_unsupported_gap = None;
         self.counters = None;
         self.last_relay_stats = None;
     }
@@ -306,8 +306,9 @@ impl DeliveryAccountability {
         self.try_retire_departed(player_id, epoch)
     }
 
-    /// Enforce the inline unsupported-format replacement pair on the next
-    /// server frame. The boolean identifies Error(UnsupportedGameDataFormat).
+    /// Accept an optional rate-limited unsupported-format advisory only after
+    /// a causal exact report. The boolean identifies
+    /// Error(UnsupportedGameDataFormat).
     pub fn observe_server_message(
         &mut self,
         is_unsupported_format_error: bool,
@@ -315,27 +316,16 @@ impl DeliveryAccountability {
         if !self.protocol_v3 {
             return Ok(());
         }
-        match (
-            self.pending_unsupported_error.as_ref(),
-            is_unsupported_format_error,
-        ) {
-            (Some(_gap), true) => {
-                self.pending_unsupported_error = None;
-                Ok(())
-            }
-            (Some(gap), false) => Err(format!(
-                "delivery accountability violation: unsupported-format report for {} epoch {}, seq {} was not immediately followed by Error(UnsupportedGameDataFormat)",
-                gap.from_player, gap.epoch, gap.from_seq
-            )),
-            (None, true) => Err("delivery accountability violation: Error(UnsupportedGameDataFormat) lacked an immediately preceding causal DeliveryReport".to_string()),
-            (None, false) => Ok(()),
+        if is_unsupported_format_error && self.unadvised_unsupported_gap.take().is_none() {
+            return Err("delivery accountability violation: Error(UnsupportedGameDataFormat) lacked a prior causal DeliveryReport".to_string());
         }
+        Ok(())
     }
 
     /// A terminal socket outcome ends the observable stream, so no
     /// supplemental error is required after the final report.
     pub fn observe_terminal(&mut self) {
-        self.pending_unsupported_error = None;
+        self.unadvised_unsupported_gap = None;
     }
 
     pub fn record_relay_stats(
@@ -448,9 +438,6 @@ impl DeliveryAccountability {
                     .to_string(),
             );
         }
-        if self.pending_unsupported_error.is_some() {
-            return Err("delivery accountability violation: unsupported-format DeliveryReport was not immediately followed by its supplemental Error".to_string());
-        }
         if report.gaps.len() > DELIVERY_REPORT_MAX_GAPS {
             return Err(format!(
                 "delivery accountability violation: DeliveryReport contains {} gap ranges, limit is {DELIVERY_REPORT_MAX_GAPS}",
@@ -547,7 +534,7 @@ impl DeliveryAccountability {
             gaps.sort_unstable_by_key(|candidate| candidate.from_seq);
         }
         if unsupported_seen {
-            self.pending_unsupported_error = report.gaps.first().cloned();
+            self.unadvised_unsupported_gap = report.gaps.first().cloned();
         }
         self.counters = Some(report.per_class);
         for gap in &report.gaps {
@@ -1567,7 +1554,7 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_report_requires_the_immediate_error_or_terminal() {
+    fn unsupported_advisory_requires_a_prior_report_but_not_adjacency() {
         let sender = id(9);
         let report = DeliveryReportPayload {
             per_class: counters_with_unsupported(1),
@@ -1577,14 +1564,21 @@ mod tests {
         let mut paired = DeliveryAccountability::default();
         paired.note_player_joined(&player(sender, 1)).unwrap();
         paired.record_report(&report).unwrap();
+        paired.observe_server_message(false).unwrap();
         paired.observe_server_message(true).unwrap();
         paired.observe_server_message(false).unwrap();
         assert!(paired.observe_server_message(true).is_err());
 
-        let mut missing = DeliveryAccountability::default();
-        missing.note_player_joined(&player(sender, 1)).unwrap();
-        missing.record_report(&report).unwrap();
-        assert!(missing.observe_server_message(false).is_err());
+        let mut rollover = DeliveryAccountability::default();
+        rollover.note_player_joined(&player(sender, 1)).unwrap();
+        rollover.record_report(&report).unwrap();
+        rollover
+            .record_report(&DeliveryReportPayload {
+                per_class: counters_with_unsupported(2),
+                gaps: vec![unsupported_gap(sender, 2)],
+            })
+            .unwrap();
+        rollover.observe_server_message(true).unwrap();
 
         let mut terminal = DeliveryAccountability::default();
         terminal.note_player_joined(&player(sender, 1)).unwrap();

--- a/docs/features.md
+++ b/docs/features.md
@@ -590,6 +590,12 @@ tag for the payload bytes. The server advertises its accepted formats in
 `UNSUPPORTED_GAME_DATA_FORMAT` and falls back to JSON. V2 binary wire shapes
 remain byte-identical and unstamped.
 
+If an opaque binary payload cannot be converted for a differently encoded
+recipient, protocol v3 emits an exact `DeliveryReport` for every omitted
+sequence. Supplemental `UNSUPPORTED_GAME_DATA_FORMAT` prose errors are limited
+to one per sender per second so a malformed stream cannot amplify advisory
+traffic; clients use the reports, not those advisory errors, for gap accounting.
+
 ## CORS Support
 
 Configure allowed origins:

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1715,9 +1715,12 @@ Gap-bearing reports are event-driven even when
 `websocket.delivery_stats_interval_secs` is zero. Queue-policy reports for
 `latest` / `volatile` travel on the active generation's strict-priority control
 lane and are committed atomically with the omission. An unsupported-format
-report is written inline immediately before the server attempts its best-effort
-supplemental `Error`. Both paths publish the exact range before later data can
-reveal the gap; if a supplemental error write fails, the stream disconnects.
+report is written inline before later data can reveal the gap. The supplemental
+`UNSUPPORTED_GAME_DATA_FORMAT` prose `Error` is rate-limited to at most one per
+sender per second for each recipient; a later notice reports how many similar
+advisories were suppressed. Clients MUST use the unthrottled exact reports—not
+advisory errors—to account sequence gaps. If either an exact report or a chosen
+supplemental error write fails, the stream disconnects.
 Counter-only snapshots may be periodic. If exact reporting cannot be preserved,
 the server closes the connection with `4002 slow_consumer` before exposing
 later data.

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -365,9 +365,10 @@ impl UnsupportedNoticeLimiter {
                 .senders
                 .iter()
                 .min_by_key(|(_, state)| state.last_emitted)
-                .map(|(sender, _)| *sender)
-                .expect("nonempty limiter at capacity");
-            self.senders.remove(&oldest);
+                .map(|(sender, _)| *sender);
+            if let Some(oldest) = oldest {
+                self.senders.remove(&oldest);
+            }
         }
         self.senders.insert(
             sender,

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -6,12 +6,12 @@
 //! capacity before changing the data queue, so every observable sequence gap
 //! has a causally prior exact report.
 
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::atomic::{AtomicU16, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use tokio::sync::Notify;
-use tokio::time::Instant;
+use tokio::time::{Duration, Instant};
 
 use crate::protocol::{
     DeliveryClass, DeliveryCountersByClass, DeliveryGap, DeliveryGapReason, DeliveryReportPayload,
@@ -328,9 +328,56 @@ struct SharedQueue {
     capacity_available: Notify,
     protocol_version: AtomicU16,
     game_data_format: AtomicU8,
+    unsupported_notices: Mutex<UnsupportedNoticeLimiter>,
     data_capacity: usize,
     control_capacity: usize,
     metrics: Option<Arc<crate::metrics::ServerMetrics>>,
+}
+
+const UNSUPPORTED_NOTICE_INTERVAL: Duration = Duration::from_secs(1);
+const MAX_UNSUPPORTED_NOTICE_SENDERS: usize = 256;
+
+#[derive(Debug, Default)]
+struct UnsupportedNoticeLimiter {
+    senders: BTreeMap<PlayerId, UnsupportedNoticeState>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct UnsupportedNoticeState {
+    last_emitted: Instant,
+    suppressed: u64,
+}
+
+impl UnsupportedNoticeLimiter {
+    fn observe(&mut self, sender: PlayerId, now: Instant) -> Option<u64> {
+        if let Some(state) = self.senders.get_mut(&sender) {
+            if now.duration_since(state.last_emitted) < UNSUPPORTED_NOTICE_INTERVAL {
+                state.suppressed = state.suppressed.saturating_add(1);
+                return None;
+            }
+            let suppressed = std::mem::take(&mut state.suppressed);
+            state.last_emitted = now;
+            return Some(suppressed);
+        }
+
+        if self.senders.len() >= MAX_UNSUPPORTED_NOTICE_SENDERS {
+            let oldest = self
+                .senders
+                .iter()
+                .min_by_key(|(_, state)| state.last_emitted)
+                .map(|(sender, _)| *sender)
+                .expect("nonempty limiter at capacity");
+            self.senders.remove(&oldest);
+        }
+        self.senders.insert(
+            sender,
+            UnsupportedNoticeState {
+                last_emitted: now,
+                suppressed: 0,
+            },
+        );
+        Some(0)
+    }
 }
 
 impl SharedQueue {
@@ -475,6 +522,7 @@ fn channel_inner(
         capacity_available: Notify::new(),
         protocol_version: AtomicU16::new(crate::config::SERVER_MIN_PROTOCOL_VERSION),
         game_data_format: AtomicU8::new(encoding_tag(GameDataEncoding::Json)),
+        unsupported_notices: Mutex::new(UnsupportedNoticeLimiter::default()),
         data_capacity,
         control_capacity,
         metrics,
@@ -1221,6 +1269,17 @@ impl OutboundReceiver {
 
     pub(crate) fn game_data_format(&self) -> GameDataEncoding {
         encoding_from_tag(self.shared.game_data_format.load(Ordering::Acquire))
+    }
+
+    /// Decide whether this recipient should receive the supplemental
+    /// unsupported-format advisory for `sender`. Exact `DeliveryReport` gaps
+    /// are never throttled; only the redundant prose `Error` is rate-limited.
+    pub(crate) fn unsupported_notice(&self, sender: PlayerId) -> Option<u64> {
+        self.shared
+            .unsupported_notices
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .observe(sender, Instant::now())
     }
 
     /// Receive the next item. Pre-v3 traffic stays FIFO; after v3 negotiation,
@@ -2766,6 +2825,42 @@ mod tests {
         assert_eq!(
             report.gaps,
             vec![metadata.gap(DeliveryGapReason::UnsupportedFormat)]
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unsupported_notice_limiter_is_per_sender_and_reports_suppression() {
+        let (_tx, rx) = channel(1, 1);
+        let first = PlayerId::from_u128(1);
+        let second = PlayerId::from_u128(2);
+
+        assert_eq!(rx.unsupported_notice(first), Some(0));
+        assert_eq!(rx.unsupported_notice(first), None);
+        assert_eq!(rx.unsupported_notice(second), Some(0));
+        tokio::time::advance(UNSUPPORTED_NOTICE_INTERVAL - Duration::from_millis(1)).await;
+        assert_eq!(rx.unsupported_notice(first), None);
+        tokio::time::advance(Duration::from_millis(1)).await;
+        assert_eq!(rx.unsupported_notice(first), Some(2));
+        assert_eq!(rx.unsupported_notice(first), None);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unsupported_notice_limiter_bounds_sender_state() {
+        let (_tx, rx) = channel(1, 1);
+        for ordinal in 0..=MAX_UNSUPPORTED_NOTICE_SENDERS {
+            assert_eq!(
+                rx.unsupported_notice(PlayerId::from_u128(ordinal as u128 + 1)),
+                Some(0)
+            );
+        }
+        assert_eq!(
+            rx.shared
+                .unsupported_notices
+                .lock()
+                .expect("notice limiter poisoned")
+                .senders
+                .len(),
+            MAX_UNSUPPORTED_NOTICE_SENDERS
         );
     }
 }

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -294,6 +294,10 @@ impl<'a> SendAccounting<'a> {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
     }
+
+    fn unsupported_notice(&self, sender: PlayerId) -> Option<u64> {
+        self.receiver.unsupported_notice(sender)
+    }
 }
 
 impl Drop for SendAccounting<'_> {
@@ -380,15 +384,22 @@ async fn notify_or_close_on_fallback_failure(
                 let report = ServerMessage::DeliveryReport(Box::new(report));
                 send_text_message(sender, &report, player_id).await?;
             }
-            let notice = ServerMessage::Error {
-                message: format!(
-                    "Undeliverable game data from player {from_player} \
-                     ({} payload cannot be converted for this connection): {reason}",
-                    encoding.as_wire_str()
-                ),
-                error_code: Some(ErrorCode::UnsupportedGameDataFormat),
-            };
-            send_text_message(sender, &notice, player_id).await?;
+            if let Some(suppressed) = accounting.unsupported_notice(from_player) {
+                let suppressed = if suppressed == 0 {
+                    String::new()
+                } else {
+                    format!("; {suppressed} similar advisories suppressed since the last notice")
+                };
+                let notice = ServerMessage::Error {
+                    message: format!(
+                        "Undeliverable game data from player {from_player} \
+                         ({} payload cannot be converted for this connection): {reason}{suppressed}",
+                        encoding.as_wire_str()
+                    ),
+                    error_code: Some(ErrorCode::UnsupportedGameDataFormat),
+                };
+                send_text_message(sender, &notice, player_id).await?;
+            }
             Ok(SendDisposition::AccountedDrop)
         }
     }

--- a/tests/mixed_encoding_relay_e2e.rs
+++ b/tests/mixed_encoding_relay_e2e.rs
@@ -1,0 +1,549 @@
+//! P10.C H14: mixed JSON/MessagePack rooms over real WebSockets.
+//!
+//! The pre-registered concern was that one incompatible recipient could turn
+//! every binary relay into an `UNSUPPORTED_GAME_DATA_FORMAT` error and amplify
+//! a stream into a slow-consumer eviction. Negotiated MessagePack is, however,
+//! losslessly convertible to JSON. This test pins that boundary: same-format
+//! recipients receive binary frames, JSON recipients receive text fallbacks,
+//! and neither path emits an unsupported-format report or loses accountability.
+
+mod test_helpers;
+mod websocket_test_helpers;
+
+use std::collections::BTreeMap;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use signal_fish_server::config::ProtocolConfig;
+use signal_fish_server::protocol::{
+    ClientMessage, GameDataEncoding, PlayerId, ServerMessage, V3BinaryGameDataFrame,
+};
+use signal_fish_server::websocket::create_router;
+use tokio_tungstenite::tungstenite::Message;
+
+use test_helpers::{create_test_server_with_config, test_server_config, RunningTestServer};
+use websocket_test_helpers::chaos_proxy::{ChaosProxy, Direction};
+use websocket_test_helpers::conformance::{ConformanceAuditor, ReceiverProtocolMode};
+use websocket_test_helpers::delivery_ledger::{ReceiverExpectation, SenderExpectation};
+use websocket_test_helpers::room16::{authenticate_with_encoding, connect, try_join};
+
+const MESSAGES_PER_SENDER: u64 = 128;
+const FRAME_DEADLINE: Duration = Duration::from_secs(30);
+
+fn encode_game_data(encoding: GameDataEncoding, sender: &str, seq: u64) -> Message {
+    let data = serde_json::json!({
+        "ledger_sender": sender,
+        "seq": seq,
+        "payload": "mixed-encoding-fallback",
+    });
+    match encoding {
+        GameDataEncoding::Json => Message::Text(
+            serde_json::to_string(&ClientMessage::GameData {
+                data,
+                class: None,
+                key: None,
+            })
+            .expect("serialize JSON GameData")
+            .into(),
+        ),
+        GameDataEncoding::MessagePack => Message::Binary(
+            rmp_serde::to_vec_named(&data)
+                .expect("serialize MessagePack GameData")
+                .into(),
+        ),
+        GameDataEncoding::Rkyv => panic!("rkyv is reserved and cannot be negotiated"),
+    }
+}
+
+fn decode_message_pack(frame: &V3BinaryGameDataFrame) -> serde_json::Value {
+    assert_eq!(frame.encoding, GameDataEncoding::MessagePack);
+    rmp_serde::from_slice(&frame.payload).expect("decode relayed MessagePack payload")
+}
+
+async fn drain_join_lifecycle(
+    receiver: &str,
+    ws: &mut websocket_test_helpers::WsStream,
+    expected_later_joiners: usize,
+    auditor: &ConformanceAuditor,
+) {
+    let deadline = tokio::time::Instant::now() + FRAME_DEADLINE;
+    let mut joined = 0usize;
+    while joined < expected_later_joiners {
+        let frame = tokio::time::timeout_at(deadline, ws.next())
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "{receiver} timed out after {joined}/{expected_later_joiners} join lifecycle frames"
+                )
+            })
+            .unwrap_or_else(|| panic!("{receiver} closed while draining join lifecycle"))
+            .unwrap_or_else(|error| {
+                panic!("{receiver} WebSocket failed while draining join lifecycle: {error}")
+            });
+        match frame {
+            Message::Text(text) => match auditor.record_text_frame(receiver, &text) {
+                ServerMessage::PlayerJoined { .. } => joined += 1,
+                ServerMessage::LobbyStateChanged { .. } => {}
+                other => panic!("{receiver} observed unexpected join setup message: {other:?}"),
+            },
+            Message::Ping(_) | Message::Pong(_) => {}
+            Message::Binary(bytes) => {
+                panic!("{receiver} observed unexpected binary join frame: {bytes:?}")
+            }
+            Message::Close(reason) => {
+                panic!("{receiver} closed while draining join lifecycle: {reason:?}")
+            }
+            Message::Frame(frame) => {
+                panic!("{receiver} observed unexpected raw join frame: {frame:?}")
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn mixed_json_and_message_pack_relay_without_error_amplification() {
+    let mut protocol = ProtocolConfig::default();
+    protocol.sdk_compatibility.enforce = false;
+    let server = create_test_server_with_config(test_server_config(), protocol).await;
+    let metrics = server.metrics();
+    let router = create_router("http://localhost:3000").with_state(server.clone());
+    let running_server = RunningTestServer::spawn(server, router).await;
+
+    // P0 is JSON; P1/P2 are MessagePack. This produces all meaningful paths:
+    // JSON -> MessagePack recipient stays text, MessagePack -> JSON falls back
+    // to text, and MessagePack -> MessagePack remains binary.
+    let encodings = [
+        GameDataEncoding::Json,
+        GameDataEncoding::MessagePack,
+        GameDataEncoding::MessagePack,
+    ];
+    let mut players = Vec::with_capacity(encodings.len());
+    for (ordinal, encoding) in encodings.into_iter().enumerate() {
+        let mut ws = connect(running_server.addr()).await;
+        authenticate_with_encoding(&mut ws, 3, Some(encoding)).await;
+        let player = try_join(
+            ws,
+            "mixed_encoding",
+            "MIXED1",
+            Some(3),
+            &format!("P{ordinal}"),
+        )
+        .await
+        .unwrap_or_else(|(reason, code)| {
+            panic!("P{ordinal} failed to join mixed-encoding room: {reason} ({code:?})")
+        });
+        players.push(player);
+    }
+
+    let identities: Arc<BTreeMap<PlayerId, (String, GameDataEncoding)>> = Arc::new(
+        players
+            .iter()
+            .enumerate()
+            .map(|(ordinal, player)| {
+                (
+                    player.player_id,
+                    (format!("P{ordinal}"), encodings[ordinal]),
+                )
+            })
+            .collect(),
+    );
+    let auditor = Arc::new(ConformanceAuditor::new(ReceiverProtocolMode::V3));
+
+    let expected_per_receiver = (encodings.len() - 1)
+        * usize::try_from(MESSAGES_PER_SENDER).expect("message count fits usize");
+    let mut writers = Vec::with_capacity(players.len());
+    let mut readers = Vec::with_capacity(players.len());
+    for (ordinal, player) in players.into_iter().enumerate() {
+        let name = format!("P{ordinal}");
+        auditor.record_message(
+            &name,
+            &ServerMessage::RoomJoined(Box::new(player.room_joined)),
+        );
+
+        let expected_later_joiners = encodings.len() - player.room_player_count;
+        let sender_encoding = encodings[ordinal];
+        let (mut sink, mut stream) = player.ws.split();
+        let writer_name = name.clone();
+        writers.push(tokio::spawn(async move {
+            for seq in 0..MESSAGES_PER_SENDER {
+                sink.send(encode_game_data(sender_encoding, &writer_name, seq))
+                    .await
+                    .unwrap_or_else(|error| {
+                        panic!("{writer_name} failed to send mixed frame {seq}: {error}")
+                    });
+            }
+            sink
+        }));
+
+        let reader_auditor = Arc::clone(&auditor);
+        let reader_identities = Arc::clone(&identities);
+        let receiver_encoding = encodings[ordinal];
+        readers.push(tokio::spawn(async move {
+            let deadline = tokio::time::Instant::now() + FRAME_DEADLINE;
+            let mut delivered = 0usize;
+            let mut later_joiners = 0usize;
+            let mut text_deliveries = 0usize;
+            let mut binary_deliveries = 0usize;
+            while delivered < expected_per_receiver {
+                let frame = tokio::time::timeout_at(deadline, stream.next())
+                    .await
+                    .unwrap_or_else(|_| {
+                        panic!(
+                            "{name} timed out after {delivered}/{expected_per_receiver} mixed deliveries"
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{name} closed after {delivered}/{expected_per_receiver} mixed deliveries"
+                        )
+                    })
+                    .unwrap_or_else(|error| panic!("{name} WebSocket read failed: {error}"));
+
+                let (from_player, data, physical_binary) = match frame {
+                    Message::Text(text) => match reader_auditor.record_text_frame(&name, &text) {
+                        ServerMessage::PlayerJoined { .. } => {
+                            later_joiners += 1;
+                            assert!(
+                                later_joiners <= expected_later_joiners,
+                                "{name} observed too many PlayerJoined frames"
+                            );
+                            continue;
+                        }
+                        ServerMessage::LobbyStateChanged { .. } => continue,
+                        ServerMessage::GameData {
+                            from_player, data, ..
+                        } => (from_player, data, false),
+                        ServerMessage::Error { message, error_code } => panic!(
+                            "{name} observed mixed-encoding error {error_code:?}: {message}"
+                        ),
+                        other => panic!("{name} observed unexpected text message: {other:?}"),
+                    },
+                    Message::Binary(bytes) => {
+                        let frame = reader_auditor.record_binary_frame(&name, &bytes);
+                        let from_player = frame.from_player;
+                        (from_player, decode_message_pack(&frame), true)
+                    }
+                    Message::Ping(_) | Message::Pong(_) => continue,
+                    Message::Close(reason) => panic!(
+                        "{name} closed after {delivered}/{expected_per_receiver} mixed deliveries: {reason:?}"
+                    ),
+                    Message::Frame(frame) => {
+                        panic!("{name} received unexpected raw frame: {frame:?}")
+                    }
+                };
+
+                let (sender, sender_encoding) = reader_identities
+                    .get(&from_player)
+                    .unwrap_or_else(|| panic!("{name} received data from unknown {from_player}"));
+                let expected_binary = *sender_encoding == GameDataEncoding::MessagePack
+                    && receiver_encoding == GameDataEncoding::MessagePack;
+                assert_eq!(
+                    physical_binary, expected_binary,
+                    "{name} received {sender}'s {:?} payload in the wrong physical frame",
+                    sender_encoding
+                );
+                assert_eq!(
+                    data.get("ledger_sender").and_then(serde_json::Value::as_str),
+                    Some(sender.as_str()),
+                    "{name} received a fallback with changed payload identity"
+                );
+                if physical_binary {
+                    binary_deliveries += 1;
+                } else {
+                    text_deliveries += 1;
+                }
+                delivered += 1;
+            }
+            assert_eq!(
+                later_joiners, expected_later_joiners,
+                "{name} data overtook an expected join lifecycle"
+            );
+            (stream, text_deliveries, binary_deliveries)
+        }));
+    }
+
+    let mut sinks = Vec::with_capacity(encodings.len());
+    let mut streams = Vec::with_capacity(encodings.len());
+    let mut text_deliveries = 0usize;
+    let mut binary_deliveries = 0usize;
+    for writer in writers {
+        sinks.push(writer.await.expect("mixed-encoding writer task panicked"));
+    }
+    for reader in readers {
+        let (stream, text, binary) = reader.await.expect("mixed-encoding reader task panicked");
+        streams.push(stream);
+        text_deliveries += text;
+        binary_deliveries += binary;
+    }
+
+    let expectations: Vec<_> = (0..encodings.len())
+        .map(|receiver| ReceiverExpectation {
+            receiver: format!("P{receiver}"),
+            senders: (0..encodings.len())
+                .filter(|sender| *sender != receiver)
+                .map(|sender| SenderExpectation {
+                    sender: format!("P{sender}"),
+                    total_sent: MESSAGES_PER_SENDER,
+                })
+                .collect(),
+        })
+        .collect();
+    auditor.assert_conformance(&metrics, &expectations).await;
+
+    let per_sender = usize::try_from(MESSAGES_PER_SENDER).expect("message count fits usize");
+    assert_eq!(text_deliveries, 4 * per_sender);
+    assert_eq!(binary_deliveries, 2 * per_sender);
+    let delivery = metrics.delivery_metrics_by_class();
+    assert_eq!(delivery.reliable.unsupported_format, 0);
+    assert_eq!(delivery.latest.unsupported_format, 0);
+    assert_eq!(delivery.volatile.unsupported_format, 0);
+    assert_eq!(
+        metrics.websocket_messages_dropped.load(Ordering::Relaxed),
+        0
+    );
+    assert_eq!(
+        metrics
+            .websocket_backpressure_events
+            .load(Ordering::Relaxed),
+        0
+    );
+    assert_eq!(
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        0
+    );
+
+    drop(sinks);
+    drop(streams);
+    running_server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+#[ignore = "nightly-only (verification-nightly.yml): throttled unsupported-format amplification"]
+async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
+    const BURST: u64 = 5_000;
+    const THROTTLE_BYTES_PER_SEC: u64 = 32 * 1_024;
+    const EXPERIMENT_DEADLINE: Duration = Duration::from_secs(90);
+
+    let mut config = test_server_config();
+    // Isolate delivery-sojourn behavior from transport-probe timeouts. The
+    // production delivery queue, 15-second max sojourn, and 5-second full-queue
+    // timeout remain unchanged.
+    config.websocket_config.server_ping_interval_secs = 0;
+    let mut protocol = ProtocolConfig::default();
+    protocol.sdk_compatibility.enforce = false;
+    let server = create_test_server_with_config(config, protocol).await;
+    let metrics = server.metrics();
+    let router = create_router("http://localhost:3000").with_state(server.clone());
+    let running_server = RunningTestServer::spawn(server, router).await;
+
+    let compatible_proxy = ChaosProxy::spawn(running_server.addr()).await;
+    let fallback_proxy = ChaosProxy::spawn(running_server.addr()).await;
+    let endpoints = [
+        running_server.addr(),
+        compatible_proxy.addr(),
+        fallback_proxy.addr(),
+    ];
+    let encodings = [
+        GameDataEncoding::MessagePack,
+        GameDataEncoding::MessagePack,
+        GameDataEncoding::Json,
+    ];
+    let auditor = Arc::new(ConformanceAuditor::new(ReceiverProtocolMode::V3));
+    let mut players = Vec::with_capacity(encodings.len());
+    for ordinal in 0..encodings.len() {
+        let mut ws = connect(endpoints[ordinal]).await;
+        authenticate_with_encoding(&mut ws, 3, Some(encodings[ordinal])).await;
+        let player = try_join(
+            ws,
+            "mixed_encoding",
+            "MIXED2",
+            Some(3),
+            &format!("P{ordinal}"),
+        )
+        .await
+        .unwrap_or_else(|(reason, code)| {
+            panic!("P{ordinal} failed to join amplification room: {reason} ({code:?})")
+        });
+        auditor.record_message(
+            &format!("P{ordinal}"),
+            &ServerMessage::RoomJoined(Box::new(player.room_joined.clone())),
+        );
+        players.push(player);
+    }
+    for (ordinal, player) in players.iter_mut().enumerate() {
+        drain_join_lifecycle(
+            &format!("P{ordinal}"),
+            &mut player.ws,
+            encodings.len() - player.room_player_count,
+            &auditor,
+        )
+        .await;
+    }
+
+    compatible_proxy.throttle(Direction::ServerToClient, Some(THROTTLE_BYTES_PER_SEC));
+    fallback_proxy.throttle(Direction::ServerToClient, Some(THROTTLE_BYTES_PER_SEC));
+
+    let mut sender = players.remove(0).ws;
+    let compatible = players.remove(0).ws;
+    let fallback = players.remove(0).ws;
+
+    let compatible_auditor = Arc::clone(&auditor);
+    let compatible_reader = tokio::spawn(async move {
+        let (_, mut stream) = compatible.split();
+        let deadline = tokio::time::Instant::now() + EXPERIMENT_DEADLINE;
+        let mut delivered = 0u64;
+        let mut player_left = 0u64;
+        while delivered < BURST {
+            let frame = tokio::time::timeout_at(deadline, stream.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("compatible recipient timed out after {delivered}/{BURST} binary frames")
+                })
+                .unwrap_or_else(|| {
+                    panic!("compatible recipient closed after {delivered}/{BURST} binary frames")
+                })
+                .unwrap_or_else(|error| panic!("compatible recipient read failed: {error}"));
+            match frame {
+                Message::Binary(bytes) => {
+                    let relayed = compatible_auditor.record_binary_frame("P1", &bytes);
+                    assert_eq!(relayed.encoding, GameDataEncoding::MessagePack);
+                    assert_eq!(relayed.payload.as_slice(), [0xc1]);
+                    delivered += 1;
+                }
+                Message::Ping(_) | Message::Pong(_) => {}
+                Message::Text(text) => match compatible_auditor.record_text_frame("P1", &text) {
+                    ServerMessage::PlayerLeft { .. } => player_left += 1,
+                    other => panic!("compatible recipient expected binary delivery, got {other:?}"),
+                },
+                Message::Close(reason) => {
+                    panic!("compatible recipient was evicted after {delivered}/{BURST}: {reason:?}")
+                }
+                Message::Frame(frame) => {
+                    panic!("compatible recipient observed raw frame: {frame:?}")
+                }
+            }
+        }
+        (stream, player_left)
+    });
+
+    let fallback_auditor = Arc::clone(&auditor);
+    let fallback_reader = tokio::spawn(async move {
+        let (_, mut stream) = fallback.split();
+        let deadline = tokio::time::Instant::now() + EXPERIMENT_DEADLINE;
+        let mut reports = 0u64;
+        let mut errors = 0u64;
+        while reports < BURST {
+            let frame = tokio::time::timeout_at(deadline, stream.next())
+                .await
+                .unwrap_or_else(|_| {
+                    panic!("fallback recipient timed out after {reports} reports/{errors} errors")
+                })
+                .unwrap_or_else(|| {
+                    panic!("fallback recipient closed without a semantic close frame")
+                })
+                .unwrap_or_else(|error| panic!("fallback recipient read failed: {error}"));
+            match frame {
+                Message::Text(text) => match fallback_auditor.record_text_frame("P2", &text) {
+                    ServerMessage::DeliveryReport(_) => reports += 1,
+                    ServerMessage::Error { error_code, .. } => {
+                        assert_eq!(
+                            error_code,
+                            Some(
+                                signal_fish_server::protocol::ErrorCode::UnsupportedGameDataFormat
+                            )
+                        );
+                        errors += 1;
+                    }
+                    other => panic!("fallback recipient observed unexpected message: {other:?}"),
+                },
+                Message::Close(reason) => {
+                    let reason = reason.expect("fallback close must carry code and reason");
+                    let code = u16::from(reason.code);
+                    fallback_auditor.record_close("P2", code, &reason.reason);
+                    return (
+                        stream,
+                        reports,
+                        errors,
+                        Some((code, reason.reason.to_string())),
+                    );
+                }
+                Message::Ping(_) | Message::Pong(_) => {}
+                Message::Binary(bytes) => {
+                    panic!("JSON fallback recipient received unconvertible binary bytes: {bytes:?}")
+                }
+                Message::Frame(frame) => {
+                    panic!("fallback recipient observed raw frame: {frame:?}")
+                }
+            }
+        }
+        (stream, reports, errors, None)
+    });
+
+    for _ in 0..BURST {
+        // 0xc1 is MessagePack's reserved/invalid marker. The server correctly
+        // treats binary game data as opaque for same-format peers, while a JSON
+        // recipient cannot convert it and needs explicit gap accountability.
+        sender
+            .send(Message::Binary(vec![0xc1].into()))
+            .await
+            .expect("send unconvertible MessagePack payload");
+    }
+
+    let (fallback_stream, reports, errors, close) = fallback_reader
+        .await
+        .expect("fallback recipient task panicked");
+    compatible_proxy.throttle(Direction::ServerToClient, None);
+    fallback_proxy.throttle(Direction::ServerToClient, None);
+
+    let (compatible_stream, compatible_player_left) = compatible_reader
+        .await
+        .expect("compatible recipient task panicked");
+
+    // This is the pre-registered falsification oracle. A RED result here means
+    // the per-message advisory doubles the fallback stream enough to evict a
+    // recipient that survives the same throttle on compact binary delivery.
+    assert!(
+        close.is_none(),
+        "unsupported-format amplification evicted only the JSON fallback recipient after \
+         {reports} reports/{errors} rate-limited errors ({close:?})"
+    );
+    assert_eq!(
+        reports, BURST,
+        "every omitted sequence needs an exact report"
+    );
+    assert!(
+        errors > 0,
+        "the first supplemental advisory must be visible"
+    );
+    assert!(
+        errors < reports / 100,
+        "advisory rate limiting was ineffective: {errors} errors for {reports} reports"
+    );
+    assert_eq!(
+        compatible_player_left, 0,
+        "compatible recipient observed fallback-recipient eviction"
+    );
+    assert_eq!(
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        0
+    );
+    auditor.assert_conformance(&metrics, &[]).await;
+    eprintln!(
+        "mixed-encoding H14: exact_reports={reports} advisory_errors={errors} \
+         compatible_deliveries={BURST} slow_consumer_evictions=0"
+    );
+
+    drop(sender);
+    drop(compatible_stream);
+    drop(fallback_stream);
+    drop(compatible_proxy);
+    drop(fallback_proxy);
+    running_server.shutdown().await;
+}

--- a/tests/websocket_test_helpers/conformance.rs
+++ b/tests/websocket_test_helpers/conformance.rs
@@ -748,6 +748,7 @@ impl ConformanceAuditor {
         receiver_state.senders.clear();
         receiver_state.membership_history.clear();
         receiver_state.pending_gaps.clear();
+        receiver_state.unadvised_unsupported_gap = None;
         for player in current_players {
             assert!(
                 receiver_state.membership_history.insert(player.id),
@@ -813,6 +814,7 @@ impl ConformanceAuditor {
         receiver_state.senders.clear();
         receiver_state.membership_history.clear();
         receiver_state.pending_gaps.clear();
+        receiver_state.unadvised_unsupported_gap = None;
     }
 
     fn record_lifecycle_epoch(

--- a/tests/websocket_test_helpers/conformance.rs
+++ b/tests/websocket_test_helpers/conformance.rs
@@ -693,9 +693,9 @@ impl ConformanceAuditor {
                 .or_insert(self.default_mode);
             let receiver_state = state.receivers.entry(receiver.to_string()).or_default();
             Self::assert_receiver_active(receiver, receiver_state);
-            // The report is the causal accountability record. A failed write
-            // of the supplemental Error may terminate the socket immediately;
-            // only a continuing stream must show Error as its next frame.
+            // The report is the causal accountability record. The supplemental
+            // Error is optional and may be absent when rate-limited or when
+            // its write is overtaken by terminal disconnect.
             receiver_state.unadvised_unsupported_gap = None;
             receiver_state.disconnect_cause = Some(cause);
         }

--- a/tests/websocket_test_helpers/conformance.rs
+++ b/tests/websocket_test_helpers/conformance.rs
@@ -54,7 +54,7 @@ struct ReceiverState {
     last_delivery_counters: Option<DeliveryCountersByClass>,
     disconnect_cause: Option<ReceiverDisconnectCause>,
     last_relay_stats: Option<RelayStatsSnapshot>,
-    pending_unsupported_error: Option<DeliveryGap>,
+    unadvised_unsupported_gap: Option<DeliveryGap>,
     ledger_payloads: u64,
     observed_delivered: DeliveryCountersByClass,
     abandoned_requires_disconnect: bool,
@@ -533,10 +533,6 @@ impl ConformanceAuditor {
             let state = self.state.lock().expect("conformance auditor poisoned");
             for (receiver, receiver_state) in &state.receivers {
                 assert!(
-                    receiver_state.pending_unsupported_error.is_none(),
-                    "{receiver}: DeliveryReport was not followed by its unsupported-format Error"
-                );
-                assert!(
                     !receiver_state.abandoned_requires_disconnect
                         || receiver_state.disconnect_cause.is_some(),
                     "{receiver}: DeliveryReport exposed abandoned deliveries but the stream continued without a terminal disconnect"
@@ -566,30 +562,6 @@ impl ConformanceAuditor {
         let receiver_state = state.receivers.entry(receiver.to_string()).or_default();
         Self::assert_receiver_active(receiver, receiver_state);
 
-        if let Some(gap) = receiver_state.pending_unsupported_error.take() {
-            assert!(
-                matches!(
-                    message,
-                    ServerMessage::Error {
-                        error_code: Some(signal_fish_server::protocol::ErrorCode::UnsupportedGameDataFormat),
-                        ..
-                    }
-                ),
-                "{receiver} <- {}: unsupported-format DeliveryReport for epoch {}, seq {} must be immediately followed by Error(UnsupportedGameDataFormat), got {message:?}",
-                gap.from_player,
-                gap.epoch,
-                gap.from_seq
-            );
-            if receiver_state.abandoned_requires_disconnect {
-                assert!(
-                    !receiver_state.abandoned_advisory_seen,
-                    "{receiver}: unsupported-format Error duplicated the terminal advisory after abandoned deliveries"
-                );
-                receiver_state.abandoned_advisory_seen = true;
-            }
-            return;
-        }
-
         if receiver_state.abandoned_requires_disconnect {
             assert!(
                 !receiver_state.abandoned_advisory_seen
@@ -599,16 +571,20 @@ impl ConformanceAuditor {
             receiver_state.abandoned_advisory_seen = true;
         }
 
-        assert!(
-            !matches!(
-                message,
-                ServerMessage::Error {
-                    error_code: Some(signal_fish_server::protocol::ErrorCode::UnsupportedGameDataFormat),
-                    ..
-                }
-            ),
-            "{receiver}: unsupported-format Error lacked an immediately preceding causal DeliveryReport"
-        );
+        if matches!(
+            message,
+            ServerMessage::Error {
+                error_code: Some(
+                    signal_fish_server::protocol::ErrorCode::UnsupportedGameDataFormat
+                ),
+                ..
+            }
+        ) {
+            assert!(
+                receiver_state.unadvised_unsupported_gap.take().is_some(),
+                "{receiver}: unsupported-format Error lacked a prior causal DeliveryReport"
+            );
+        }
 
         if mode == ReceiverProtocolMode::V2 {
             assert!(
@@ -626,10 +602,6 @@ impl ConformanceAuditor {
             .or_insert(self.default_mode);
         let receiver_state = state.receivers.entry(receiver.to_string()).or_default();
         Self::assert_receiver_active(receiver, receiver_state);
-        assert!(
-            receiver_state.pending_unsupported_error.is_none(),
-            "{receiver}: unsupported-format DeliveryReport must be followed by Error, not {frame}"
-        );
         assert!(
             !receiver_state.abandoned_requires_disconnect,
             "{receiver}: {frame} continued after DeliveryReport exposed abandoned deliveries"
@@ -724,7 +696,7 @@ impl ConformanceAuditor {
             // The report is the causal accountability record. A failed write
             // of the supplemental Error may terminate the socket immediately;
             // only a continuing stream must show Error as its next frame.
-            receiver_state.pending_unsupported_error = None;
+            receiver_state.unadvised_unsupported_gap = None;
             receiver_state.disconnect_cause = Some(cause);
         }
         self.ledger
@@ -1270,7 +1242,9 @@ impl ConformanceAuditor {
             "{receiver}: unsupported-format counter delta must equal newly reported exact gaps"
         );
 
-        receiver_state.pending_unsupported_error = unsupported_gap;
+        if unsupported_gap.is_some() {
+            receiver_state.unadvised_unsupported_gap = unsupported_gap;
+        }
         receiver_state.abandoned_requires_disconnect = report.per_class.reliable.abandoned > 0
             || report.per_class.latest.abandoned > 0
             || report.per_class.volatile.abandoned > 0;
@@ -1732,7 +1706,7 @@ fn receiver_state_is_reconnect_preface(state: &ReceiverState) -> bool {
         && state.last_relay_stats.is_none_or(|stats| {
             stats.sent_to_you == 0 && stats.dropped_for_you == 0 && stats.backpressure_events == 0
         })
-        && state.pending_unsupported_error.is_none()
+        && state.unadvised_unsupported_gap.is_none()
         && state.ledger_payloads == 0
         && state.observed_delivered == DeliveryCountersByClass::default()
         && !state.abandoned_requires_disconnect

--- a/tests/websocket_test_helpers_tests.rs
+++ b/tests/websocket_test_helpers_tests.rs
@@ -730,7 +730,7 @@ fn conformance_modes_enforce_delivery_class_key_and_epoch_shapes() {
 }
 
 #[test]
-fn conformance_gap_counters_are_causal_and_unsupported_error_is_adjacent() {
+fn conformance_gap_counters_are_causal_with_rate_limited_unsupported_advisories() {
     type Mutate = fn(&mut DeliveryCountersByClass);
     let mismatches: &[(&str, DeliveryGapReason, Mutate)] = &[
         (
@@ -778,12 +778,12 @@ fn conformance_gap_counters_are_causal_and_unsupported_error_is_adjacent() {
         );
     }
 
-    let out_of_order = ConformanceAuditor::new(ReceiverProtocolMode::V3);
+    let deferred = ConformanceAuditor::new(ReceiverProtocolMode::V3);
     let sender = id(72);
-    out_of_order.record_message("receiver", &room_joined(sender, 1));
+    deferred.record_message("receiver", &room_joined(sender, 1));
     let mut counters = DeliveryCountersByClass::default();
     counters.reliable.unsupported_format = 1;
-    out_of_order.record_message(
+    deferred.record_message(
         "receiver",
         &delivery_report(
             counters,
@@ -796,9 +796,8 @@ fn conformance_gap_counters_are_causal_and_unsupported_error_is_adjacent() {
             }],
         ),
     );
-    assert!(panics(
-        || out_of_order.record_message("receiver", &ServerMessage::Pong)
-    ));
+    deferred.record_message("receiver", &ServerMessage::Pong);
+    deferred.record_message("receiver", &format_error());
 
     let terminal = ConformanceAuditor::new(ReceiverProtocolMode::V3);
     terminal.record_message("receiver", &room_joined(sender, 1));
@@ -2042,7 +2041,7 @@ fn conformance_v3_rejects_unenveloped_binary_passthrough() {
 }
 
 #[test]
-fn conformance_binary_entrypoints_cannot_bypass_report_error_adjacency() {
+fn conformance_binary_entrypoints_allow_rate_limited_advisory_after_exact_report() {
     let sender = id(95);
     for encoding in [
         GameDataEncoding::Json,
@@ -2074,13 +2073,50 @@ fn conformance_binary_entrypoints_cannot_bypass_report_error_adjacency() {
             epoch: 1,
         };
         let wire = rmp_serde::to_vec_named(&fixture).expect("serialize binary frame");
-        assert!(
-            panics(|| {
-                auditor.record_binary_frame("receiver", &wire);
-            }),
+        assert_eq!(
+            auditor.record_binary_frame("receiver", &wire),
+            fixture,
             "encoding={encoding:?}"
         );
+        auditor.record_message("receiver", &format_error());
     }
+}
+
+#[test]
+fn conformance_unsupported_advisory_requires_prior_report_but_not_adjacency() {
+    let sender = id(96);
+    let unmatched = ConformanceAuditor::new(ReceiverProtocolMode::V3);
+    unmatched.record_message("receiver", &room_joined(sender, 1));
+    assert!(
+        panics(|| unmatched.record_message("receiver", &format_error())),
+        "an unsupported-format advisory cannot invent an omission"
+    );
+
+    let deferred = ConformanceAuditor::new(ReceiverProtocolMode::V3);
+    deferred.record_message("receiver", &room_joined(sender, 1));
+    let mut counters = DeliveryCountersByClass::default();
+    counters.reliable.unsupported_format = 1;
+    deferred.record_message(
+        "receiver",
+        &delivery_report(
+            counters,
+            [DeliveryGap {
+                from_player: sender,
+                epoch: 1,
+                from_seq: 1,
+                to_seq: 1,
+                reason: DeliveryGapReason::UnsupportedFormat,
+            }],
+        ),
+    );
+    deferred.record_message(
+        "receiver",
+        &ServerMessage::Error {
+            message: "terminal delivery failure".to_string(),
+            error_code: Some(ErrorCode::SlowConsumer),
+        },
+    );
+    deferred.record_close("receiver", 4002, "slow_consumer");
 }
 
 #[test]

--- a/tests/websocket_test_helpers_tests.rs
+++ b/tests/websocket_test_helpers_tests.rs
@@ -2117,6 +2117,27 @@ fn conformance_unsupported_advisory_requires_prior_report_but_not_adjacency() {
         },
     );
     deferred.record_close("receiver", 4002, "slow_consumer");
+
+    let room_reset = ConformanceAuditor::new(ReceiverProtocolMode::V3);
+    room_reset.record_message("receiver", &room_joined(sender, 1));
+    room_reset.record_message(
+        "receiver",
+        &delivery_report(
+            counters,
+            [DeliveryGap {
+                from_player: sender,
+                epoch: 1,
+                from_seq: 1,
+                to_seq: 1,
+                reason: DeliveryGapReason::UnsupportedFormat,
+            }],
+        ),
+    );
+    room_reset.record_message("receiver", &ServerMessage::RoomLeft);
+    assert!(
+        panics(|| room_reset.record_message("receiver", &format_error())),
+        "an advisory cannot use a report from a prior room lifecycle"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add the P10.C H14 mixed JSON/MessagePack real-socket falsification suite
- rate-limit supplemental `UNSUPPORTED_GAME_DATA_FORMAT` prose errors per recipient and sender while preserving every exact `DeliveryReport`
- bound advisory limiter state and report suppressed advisory counts
- update conformance auditing, protocol documentation, changelog, nightly CI, and repository GitHub-access guidance

## Why

An unconvertible MessagePack stream could produce one exact report plus one prose error for every omitted sequence. Under identical 32 KiB/s downstream constraints, that amplification evicted the JSON fallback recipient while the compact MessagePack recipient survived. The exact report is the authoritative gap record; repeating the supplemental prose advisory per message adds bandwidth without improving accountability.

## Behavior

The first advisory is emitted immediately. Further advisories from the same sender to the same recipient are suppressed for one second, and the next emitted advisory includes the suppressed count. Exact per-sequence reports remain unthrottled. Protocol-v2 wire shapes are unchanged.

## Validation

- focused Clippy over the library and affected integration targets with warnings denied
- outbound notice-limiter tests
- 38-test ConformanceAuditor suite
- mixed-encoding representable relay test
- H14 5,000-message throttled experiment (68.67s): all exact reports and compatible binary deliveries complete, advisory count below 1% of reports, zero slow-consumer evictions
- timeout and loud-failure policy scans
- documentation consistency and workflow hygiene/toolchain checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes v3 delivery accountability semantics and outbound WebSocket behavior on mixed-encoding fallback paths; mitigated by extensive e2e/conformance tests and unchanged exact-report guarantees.
> 
> **Overview**
> **Protocol v3** still emits an exact `DeliveryReport` for every undeliverable sequence when binary cannot be converted for a recipient, but **supplemental** `UNSUPPORTED_GAME_DATA_FORMAT` prose errors are now **rate-limited** to at most one per sender per recipient per second. Suppressed advisories are counted and surfaced on the next emitted notice. Exact reports are never throttled.
> 
> **Server:** `OutboundReceiver::unsupported_notice` and a per-connection limiter in `outbound_queue` gate whether `sending.rs` writes the advisory after the mandatory report.
> 
> **Clients & auditors:** Browser and native `DeliveryAccountability` no longer require report–error **adjacency**; an advisory only needs a prior causal exact report. Conformance auditing and unit tests match that contract.
> 
> **Verification:** New `mixed_encoding_relay_e2e` (representable mixed JSON/MessagePack relay plus nightly H14 burst under throttle) and nightly CI wiring. Docs, changelog, and `.llm/context.md` GitHub-access guidance updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 522c9c6ba10f171957f49abda434d3c37425748d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->