### PR TITLE
Prove directional partition recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Document bidirectional WebSocket liveness under symmetric and one-way
+  partitions. The client and operator guides now distinguish reliable-delivery
+  close `4002 slow_consumer` from transport-liveness close `4003
+  activity_timeout`, describe the default protocol-Ping detection bound, and
+  require clients to reconnect instead of treating one-way progress as a
+  healthy connection. Real-socket fault experiments pin both close mechanisms
+  and prove room relay recovery after each eviction.
 - Add a harness-only native reference-client success barrier and a nightly
   16-player WebRTC mesh experiment. The client can emit
   `success_criteria_met` and remain connected until a release file appears,

--- a/docs/architecture/scaling.md
+++ b/docs/architecture/scaling.md
@@ -83,8 +83,34 @@ reconnect token routable and does not establish room affinity by itself.
   process; see the [TURN deployment guide](../deployment-turn.md).
 
 These are operational starting points, not measured saturation guarantees. The
-P10.F2 sizing table remains pending the planned 16-player knee and partition
-experiments.
+P10.F2 throughput knee table remains pending the planned 16-player saturation
+experiment.
+
+## Directional partition detection
+
+A WebSocket can fail in only one direction. Do not use successful inbound or
+outbound application traffic as proof that the reverse path is healthy. The
+server has two independent fail-loud mechanisms:
+
+| Fault | What may still work | Default detection path | Authoritative result |
+| --- | --- | --- | --- |
+| client → server blackhole | The client can keep receiving room traffic and RFC 6455 Ping frames | The matching Pong cannot return; the next probe plus its deadline is roughly bounded by `server_ping_interval_secs + pong_timeout_secs` (10 + 5 seconds by default) | close `4003 activity_timeout`; `signal_fish_websocket_ping_timeouts_total` increments |
+| server → client blackhole, otherwise idle | The server can keep receiving application `Ping` and game traffic | The client never receives the next protocol Ping, so no matching Pong returns; the same probe bound applies | close `4003 activity_timeout` |
+| server → client blackhole under reliable relay pressure | Client writes can still reach the server while its outbound socket/data queue stops draining | Queue/socket fill plus `slow_consumer_timeout_ms` (5 seconds by default), or `max_sojourn_ms` (15 seconds by default); a socket probe can win first depending on probe phase | close `4002 slow_consumer` when delivery pressure wins, otherwise `4003 activity_timeout` |
+| symmetric blackhole | Neither direction carries new traffic | The next protocol probe cannot complete | close `4003 activity_timeout` |
+
+The close code describes the mechanism that won, not the physical direction of
+the fault. In particular, application Pings crossing client → server do not
+make a blocked server → client path healthy. Keep protocol Ping handling enabled
+in the WebSocket stack, treat `4002` and `4003` as terminal for that physical
+connection, and reconnect according to the client contract.
+
+The directional real-socket experiments use shortened probe/grace values and
+prove all three distinct cases: the unaffected direction carries traffic,
+exactly the expected close metric fires, the surviving member observes
+`PlayerLeft`, and a replacement member can join and receive relayed data. The
+same suite confirms that E4's probe bound supersedes the older activity-reaper
+estimate for these socket partitions.
 
 ## Related documents
 

--- a/docs/guides/building-a-client.md
+++ b/docs/guides/building-a-client.md
@@ -232,6 +232,13 @@ Worked v3 sessions: [mesh + WebRTC](../scenarios/v3-mesh-webrtc.md),
   accountability can all produce the close.
 - **Keep the connection alive.** Send `Ping` on an interval or you will be
   dropped with `CONNECTION_IDLE_TIMEOUT`.
+- **Liveness is bidirectional.** Receiving room traffic does not prove that
+  your writes or automatic RFC 6455 Pong replies reach the server; sending
+  application `Ping` does not prove that the server-to-client path drains.
+  Keep reading and writing the socket, let the WebSocket stack answer protocol
+  Pings, and treat close `4002 slow_consumer` or `4003 activity_timeout` as a
+  terminal physical connection that must be reconnected. See the
+  [directional partition table](../architecture/scaling.md#directional-partition-detection).
 - **Authenticate first.** Any other message before `Authenticate` is an error.
 - **Rejoining by code re-creates a vanished room — carry your original
   `max_players`.** If a room no longer exists (the server restarted, or every
@@ -266,6 +273,10 @@ A client is conformant when it passes these scenarios:
       [error code reference](../reference/error-codes.md).
 - [ ] **Heartbeat:** the connection survives an idle period because `Ping` is
       sent.
+- [ ] **Directional liveness:** independently block client → server and server
+      → client traffic; confirm the unaffected direction can still carry data,
+      then surface `4003 activity_timeout` or `4002 slow_consumer` and reconnect
+      instead of treating one-way progress as a healthy connection.
 - [ ] **Reconnect (if implemented):** drop and `Reconnect` with the join
       `auth_token`, replay control-only `missed_events`, resync gameplay state
       at the application layer, and for v3 apply `sender_watermarks` as

--- a/tests/partition_scenarios_e2e.rs
+++ b/tests/partition_scenarios_e2e.rs
@@ -224,8 +224,12 @@ async fn complete_while_servicing_healthy<T>(
     tokio::pin!(operation);
     loop {
         tokio::select! {
-            output = &mut operation => return output,
+            // If recovery and a socket frame become ready in the same poll,
+            // consume the frame first. In particular, never return while a
+            // ready protocol Ping is still waiting for its Pong.
+            biased;
             frame = healthy.next() => service_healthy_frame(healthy, frame, context).await,
+            output = &mut operation => return output,
         }
     }
 }

--- a/tests/partition_scenarios_e2e.rs
+++ b/tests/partition_scenarios_e2e.rs
@@ -1,0 +1,473 @@
+//! P10.C directional-partition experiments over real WebSockets.
+//!
+//! A connection being "up" is not a single fact under an asymmetric network
+//! fault. These tests pin which side can still make progress, the semantic
+//! close that makes the failure loud, and the room's recovery after eviction.
+
+mod test_helpers;
+mod websocket_test_helpers;
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt};
+use signal_fish_server::config::{ProtocolConfig, WebSocketConfig};
+use signal_fish_server::protocol::{ClientMessage, PlayerId, RoomJoinedPayload, ServerMessage};
+use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
+use signal_fish_server::websocket::create_router;
+use test_helpers::{create_test_server_with_config, RunningTestServer};
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use websocket_test_helpers::chaos_proxy::{ChaosProxy, Direction};
+
+type WsStream =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+const EVENT_DEADLINE: tokio::time::Duration = tokio::time::Duration::from_secs(30);
+const GAME: &str = "partition_scenarios";
+
+#[derive(Debug, Default)]
+struct CloseObservation {
+    code: Option<u16>,
+    reason: Option<String>,
+    saw_application_pong: bool,
+    #[cfg(windows)]
+    transport_reset_after_cause: bool,
+}
+
+async fn start_server(
+    ping_interval_secs: u64,
+    pong_timeout_secs: u64,
+    slow_consumer_timeout_ms: u64,
+) -> (RunningTestServer, Arc<EnhancedGameServer>) {
+    let config = ServerConfig {
+        // Keep the legacy activity reaper out of these E4 transport-probe
+        // experiments. The socket-level Ping/Pong task owns 4003 here.
+        ping_timeout: std::time::Duration::from_secs(600),
+        heartbeat_throttle: std::time::Duration::ZERO,
+        websocket_config: WebSocketConfig {
+            send_queue_capacity: 8,
+            slow_consumer_timeout_ms,
+            server_ping_interval_secs: ping_interval_secs,
+            pong_timeout_secs,
+            ..WebSocketConfig::default()
+        },
+        ..ServerConfig::default()
+    };
+    let server = create_test_server_with_config(config, ProtocolConfig::default()).await;
+    let router = create_router("http://localhost:3000").with_state(server.clone());
+    let running = RunningTestServer::spawn(server.clone(), router).await;
+    (running, server)
+}
+
+async fn connect(addr: std::net::SocketAddr) -> WsStream {
+    let url = format!("ws://{addr}/ws");
+    let (ws, _) = tokio::time::timeout(EVENT_DEADLINE, connect_async(url))
+        .await
+        .expect("websocket connect timed out")
+        .expect("websocket connect failed");
+    ws
+}
+
+async fn join_room(ws: &mut WsStream, room: &str, player_name: &str) -> Box<RoomJoinedPayload> {
+    let join = ClientMessage::JoinRoom {
+        game_name: GAME.to_string(),
+        room_code: Some(room.to_string()),
+        player_name: player_name.to_string(),
+        max_players: Some(4),
+        supports_authority: Some(false),
+        relay_transport: None,
+    };
+    send_client_message(ws, &join).await;
+
+    loop {
+        match read_server_message(ws, "joining room").await {
+            ServerMessage::RoomJoined(payload) => return payload,
+            ServerMessage::RoomJoinFailed { reason, error_code } => {
+                panic!("room join failed for {player_name}: {reason} ({error_code:?})")
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn send_client_message(ws: &mut WsStream, message: &ClientMessage) {
+    let json = serde_json::to_string(message).expect("serialize client message");
+    ws.send(Message::Text(json.into()))
+        .await
+        .expect("send client message");
+}
+
+async fn read_server_message(ws: &mut WsStream, context: &str) -> ServerMessage {
+    loop {
+        let frame = tokio::time::timeout(EVENT_DEADLINE, ws.next())
+            .await
+            .unwrap_or_else(|_| panic!("{context}: timed out waiting for server message"))
+            .unwrap_or_else(|| panic!("{context}: connection closed"))
+            .unwrap_or_else(|error| panic!("{context}: websocket read failed: {error}"));
+        if let Message::Text(text) = frame {
+            return serde_json::from_str(&text)
+                .unwrap_or_else(|error| panic!("{context}: invalid server message: {error}"));
+        }
+    }
+}
+
+async fn poll_until(context: &str, mut condition: impl FnMut() -> bool) {
+    let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
+    while !condition() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "{context}: condition never held within {EVENT_DEADLINE:?}"
+        );
+        tokio::task::yield_now().await;
+    }
+}
+
+async fn wait_for_player_left(ws: &mut WsStream, departed: PlayerId, context: &str) {
+    loop {
+        match read_server_message(ws, context).await {
+            ServerMessage::PlayerLeft { player_id, .. } if player_id == departed => return,
+            ServerMessage::Error {
+                message,
+                error_code,
+            } => panic!("{context}: unexpected server error: {message} ({error_code:?})"),
+            _ => {}
+        }
+    }
+}
+
+async fn wait_for_ping_timeout_while_servicing_healthy(
+    server: &EnhancedGameServer,
+    healthy: &mut WsStream,
+    departed: PlayerId,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
+    let mut saw_player_left = false;
+    loop {
+        let timeout_count = server
+            .metrics()
+            .websocket_ping_timeouts
+            .load(Ordering::Relaxed);
+        if timeout_count == 1 {
+            return saw_player_left;
+        }
+        assert_eq!(timeout_count, 0, "partition timed out more than once");
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "partition never produced its expected Ping timeout"
+        );
+
+        match tokio::time::timeout(tokio::time::Duration::from_millis(50), healthy.next()).await {
+            Ok(Some(Ok(Message::Ping(payload)))) => healthy
+                .send(Message::Pong(payload))
+                .await
+                .expect("healthy peer sends matching Pong"),
+            Ok(Some(Ok(Message::Text(text)))) => {
+                let message: ServerMessage =
+                    serde_json::from_str(&text).expect("decode healthy peer server message");
+                if matches!(
+                    message,
+                    ServerMessage::PlayerLeft { player_id, .. } if player_id == departed
+                ) {
+                    saw_player_left = true;
+                }
+            }
+            Ok(Some(Ok(_))) | Err(_) => {}
+            Ok(Some(Err(error))) => panic!("healthy peer websocket failed: {error}"),
+            Ok(None) => panic!("healthy peer closed during another client's partition"),
+        }
+    }
+}
+
+async fn wait_for_marker(ws: &mut WsStream, marker: &str) {
+    loop {
+        if let ServerMessage::GameData { data, .. } =
+            read_server_message(ws, "waiting for traffic across one-way partition").await
+        {
+            if data.get("marker").and_then(serde_json::Value::as_str) == Some(marker) {
+                return;
+            }
+        }
+    }
+}
+
+async fn observe_until_close(ws: &mut WsStream) -> CloseObservation {
+    let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
+    let mut observation = CloseObservation::default();
+    loop {
+        let next = tokio::time::timeout_at(deadline, ws.next())
+            .await
+            .expect("timed out waiting for semantic partition close")
+            .expect("partitioned connection ended without a close frame");
+        let frame = match next {
+            Ok(frame) => frame,
+            #[cfg(windows)]
+            Err(tokio_tungstenite::tungstenite::Error::Io(error))
+                if error.kind() == std::io::ErrorKind::ConnectionReset =>
+            {
+                // ChaosProxy deliberately tears down both pumps when either
+                // half observes EOF. Windows may surface WSAECONNRESET before
+                // tungstenite exposes the already-forwarded close frame (the
+                // same platform behavior covered by server_ping_e2e). Every
+                // caller has already observed the authoritative server cause
+                // metric before resuming the paused direction.
+                observation.transport_reset_after_cause = true;
+                return observation;
+            }
+            Err(error) => panic!("partitioned websocket failed before its close frame: {error}"),
+        };
+        match frame {
+            Message::Close(Some(frame)) => {
+                observation.code = Some(frame.code.into());
+                observation.reason = Some(frame.reason.to_string());
+                return observation;
+            }
+            Message::Close(None) => panic!("partitioned connection received a bare close frame"),
+            Message::Text(text) => {
+                let message: ServerMessage =
+                    serde_json::from_str(&text).expect("decode partition server message");
+                if matches!(message, ServerMessage::Pong) {
+                    observation.saw_application_pong = true;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn assert_room_healed(
+    healthy: &mut WsStream,
+    healthy_id: PlayerId,
+    departed_id: PlayerId,
+    server_addr: std::net::SocketAddr,
+    room: &str,
+    departed_already_observed: bool,
+) {
+    if !departed_already_observed {
+        wait_for_player_left(
+            healthy,
+            departed_id,
+            "waiting for partitioned peer to leave",
+        )
+        .await;
+    }
+
+    let mut replacement = connect(server_addr).await;
+    let snapshot = join_room(&mut replacement, room, "Replacement").await;
+    assert!(
+        snapshot
+            .current_players
+            .iter()
+            .any(|player| player.id == healthy_id),
+        "replacement snapshot must retain the healthy room member"
+    );
+
+    let marker = format!("healed-{departed_id}");
+    send_client_message(
+        healthy,
+        &ClientMessage::GameData {
+            data: serde_json::json!({ "marker": marker }),
+            class: None,
+            key: None,
+        },
+    )
+    .await;
+    loop {
+        if let ServerMessage::GameData {
+            from_player, data, ..
+        } = read_server_message(&mut replacement, "proving healed room relay").await
+        {
+            if from_player == healthy_id
+                && data.get("marker").and_then(serde_json::Value::as_str) == Some(marker.as_str())
+            {
+                break;
+            }
+        }
+    }
+}
+
+fn assert_close(observation: &CloseObservation, code: u16, reason: &str) {
+    #[cfg(windows)]
+    if observation.transport_reset_after_cause {
+        assert_eq!(observation.code, None);
+        assert_eq!(observation.reason, None);
+        return;
+    }
+    assert_eq!(
+        observation.code,
+        Some(code),
+        "partition close must use semantic code {code}: {observation:?}"
+    );
+    assert_eq!(observation.reason.as_deref(), Some(reason));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn symmetric_blackhole_closes_4003_and_room_heals() {
+    let (running, server) = start_server(1, 1, 500).await;
+    let proxy = ChaosProxy::spawn(running.addr()).await;
+    let mut healthy = connect(running.addr()).await;
+    let mut partitioned = connect(proxy.addr()).await;
+    let healthy_id = join_room(&mut healthy, "CAPSYM", "Healthy").await.player_id;
+    let partitioned_id = join_room(&mut partitioned, "CAPSYM", "Partitioned")
+        .await
+        .player_id;
+
+    proxy.pause(Direction::ClientToServer);
+    proxy.pause(Direction::ServerToClient);
+    let saw_player_left =
+        wait_for_ping_timeout_while_servicing_healthy(&server, &mut healthy, partitioned_id).await;
+    proxy.resume(Direction::ServerToClient);
+    proxy.resume(Direction::ClientToServer);
+
+    let observation = observe_until_close(&mut partitioned).await;
+    assert_close(&observation, 4003, "activity_timeout");
+    assert_eq!(
+        server
+            .metrics()
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        0,
+        "an idle symmetric blackhole must be a liveness timeout, not queue pressure"
+    );
+    assert_room_healed(
+        &mut healthy,
+        healthy_id,
+        partitioned_id,
+        running.addr(),
+        "CAPSYM",
+        saw_player_left,
+    )
+    .await;
+    running.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn server_to_client_blackhole_closes_4002_while_inbound_ping_is_live() {
+    // Put the first socket-level probe beyond this short pressure experiment:
+    // this cell isolates reliable delivery's response to a one-way receive
+    // outage. The symmetric/client->server cells exercise the E4 probe path.
+    let (running, server) = start_server(30, 5, 300).await;
+    let proxy = ChaosProxy::spawn(running.addr()).await;
+    let mut sender = connect(running.addr()).await;
+    let mut partitioned = connect(proxy.addr()).await;
+    let sender_id = join_room(&mut sender, "CAPS2C", "Sender").await.player_id;
+    let partitioned_id = join_room(&mut partitioned, "CAPS2C", "Partitioned")
+        .await
+        .player_id;
+
+    proxy.pause(Direction::ServerToClient);
+    let heartbeat_before = server.metrics().heartbeat_updates.load(Ordering::Relaxed);
+    send_client_message(&mut partitioned, &ClientMessage::Ping).await;
+    poll_until("client Ping crosses the server-to-client blackhole", || {
+        server.metrics().heartbeat_updates.load(Ordering::Relaxed) > heartbeat_before
+    })
+    .await;
+
+    let padding = "x".repeat(32 * 1_024);
+    let pressure = async {
+        while server
+            .metrics()
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed)
+            == 0
+        {
+            send_client_message(
+                &mut sender,
+                &ClientMessage::GameData {
+                    data: serde_json::json!({ "padding": padding.as_str() }),
+                    class: None,
+                    key: None,
+                },
+            )
+            .await;
+        }
+    };
+    tokio::time::timeout(EVENT_DEADLINE, pressure)
+        .await
+        .expect("server-to-client pressure never evicted the blocked receiver");
+    proxy.resume(Direction::ServerToClient);
+
+    let observation = observe_until_close(&mut partitioned).await;
+    assert_close(&observation, 4002, "slow_consumer");
+    assert!(
+        observation.saw_application_pong,
+        "a Pong queued before eviction must prove client-to-server traffic stayed live"
+    );
+    assert_eq!(
+        server
+            .metrics()
+            .websocket_ping_timeouts
+            .load(Ordering::Relaxed),
+        0,
+        "the isolated receive outage must be attributed to reliable queue pressure"
+    );
+    assert_room_healed(
+        &mut sender,
+        sender_id,
+        partitioned_id,
+        running.addr(),
+        "CAPS2C",
+        false,
+    )
+    .await;
+    running.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+async fn client_to_server_blackhole_receives_data_then_closes_4003() {
+    let (running, server) = start_server(1, 1, 500).await;
+    let proxy = ChaosProxy::spawn(running.addr()).await;
+    let mut sender = connect(running.addr()).await;
+    let mut partitioned = connect(proxy.addr()).await;
+    let sender_id = join_room(&mut sender, "CAPC2S", "Sender").await.player_id;
+    let partitioned_id = join_room(&mut partitioned, "CAPC2S", "Partitioned")
+        .await
+        .player_id;
+
+    proxy.pause(Direction::ClientToServer);
+    send_client_message(
+        &mut sender,
+        &ClientMessage::GameData {
+            data: serde_json::json!({ "marker": "received-during-client-blackhole" }),
+            class: None,
+            key: None,
+        },
+    )
+    .await;
+
+    wait_for_marker(&mut partitioned, "received-during-client-blackhole").await;
+    let saw_player_left =
+        wait_for_ping_timeout_while_servicing_healthy(&server, &mut sender, partitioned_id).await;
+    proxy.resume(Direction::ClientToServer);
+
+    let observation = observe_until_close(&mut partitioned).await;
+    assert_close(&observation, 4003, "activity_timeout");
+    assert_eq!(
+        server
+            .metrics()
+            .websocket_ping_timeouts
+            .load(Ordering::Relaxed),
+        1,
+        "the unreachable automatic Pong must time out exactly once"
+    );
+    assert_eq!(
+        server
+            .metrics()
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+        0,
+        "a client-to-server outage must not masquerade as a slow reader"
+    );
+    assert_room_healed(
+        &mut sender,
+        sender_id,
+        partitioned_id,
+        running.addr(),
+        "CAPC2S",
+        saw_player_left,
+    )
+    .await;
+    running.shutdown().await;
+}

--- a/tests/partition_scenarios_e2e.rs
+++ b/tests/partition_scenarios_e2e.rs
@@ -104,9 +104,16 @@ async fn read_server_message(ws: &mut WsStream, context: &str) -> ServerMessage 
             .unwrap_or_else(|_| panic!("{context}: timed out waiting for server message"))
             .unwrap_or_else(|| panic!("{context}: connection closed"))
             .unwrap_or_else(|error| panic!("{context}: websocket read failed: {error}"));
-        if let Message::Text(text) = frame {
-            return serde_json::from_str(&text)
-                .unwrap_or_else(|error| panic!("{context}: invalid server message: {error}"));
+        match frame {
+            Message::Ping(payload) => ws
+                .send(Message::Pong(payload))
+                .await
+                .unwrap_or_else(|error| panic!("{context}: failed to answer server Ping: {error}")),
+            Message::Text(text) => {
+                return serde_json::from_str(&text)
+                    .unwrap_or_else(|error| panic!("{context}: invalid server message: {error}"));
+            }
+            _ => {}
         }
     }
 }
@@ -190,6 +197,39 @@ async fn wait_for_marker(ws: &mut WsStream, marker: &str) {
     }
 }
 
+async fn service_healthy_frame(
+    healthy: &mut WsStream,
+    frame: Option<Result<Message, tokio_tungstenite::tungstenite::Error>>,
+    context: &str,
+) {
+    match frame {
+        Some(Ok(Message::Ping(payload))) => healthy
+            .send(Message::Pong(payload))
+            .await
+            .unwrap_or_else(|error| panic!("{context}: failed to answer healthy Ping: {error}")),
+        Some(Ok(Message::Close(frame))) => {
+            panic!("{context}: healthy peer closed during recovery: {frame:?}")
+        }
+        Some(Ok(_)) => {}
+        Some(Err(error)) => panic!("{context}: healthy peer websocket failed: {error}"),
+        None => panic!("{context}: healthy peer ended during recovery"),
+    }
+}
+
+async fn complete_while_servicing_healthy<T>(
+    healthy: &mut WsStream,
+    operation: impl std::future::Future<Output = T>,
+    context: &str,
+) -> T {
+    tokio::pin!(operation);
+    loop {
+        tokio::select! {
+            output = &mut operation => return output,
+            frame = healthy.next() => service_healthy_frame(healthy, frame, context).await,
+        }
+    }
+}
+
 async fn observe_until_close(ws: &mut WsStream) -> CloseObservation {
     let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
     let mut observation = CloseObservation::default();
@@ -251,8 +291,16 @@ async fn assert_room_healed(
         .await;
     }
 
-    let mut replacement = connect(server_addr).await;
-    let snapshot = join_room(&mut replacement, room, "Replacement").await;
+    let replacement = connect(server_addr);
+    let mut replacement =
+        complete_while_servicing_healthy(healthy, replacement, "connecting replacement").await;
+    let replacement_join = join_room(&mut replacement, room, "Replacement");
+    let snapshot = complete_while_servicing_healthy(
+        healthy,
+        replacement_join,
+        "joining replacement to healed room",
+    )
+    .await;
     assert!(
         snapshot
             .current_players
@@ -271,18 +319,22 @@ async fn assert_room_healed(
         },
     )
     .await;
-    loop {
-        if let ServerMessage::GameData {
-            from_player, data, ..
-        } = read_server_message(&mut replacement, "proving healed room relay").await
-        {
-            if from_player == healthy_id
-                && data.get("marker").and_then(serde_json::Value::as_str) == Some(marker.as_str())
+    let relay_proof = async {
+        loop {
+            if let ServerMessage::GameData {
+                from_player, data, ..
+            } = read_server_message(&mut replacement, "proving healed room relay").await
             {
-                break;
+                if from_player == healthy_id
+                    && data.get("marker").and_then(serde_json::Value::as_str)
+                        == Some(marker.as_str())
+                {
+                    break;
+                }
             }
         }
-    }
+    };
+    complete_while_servicing_healthy(healthy, relay_proof, "proving healed room relay").await;
 }
 
 fn assert_close(observation: &CloseObservation, code: u16, reason: &str) {
@@ -298,6 +350,20 @@ fn assert_close(observation: &CloseObservation, code: u16, reason: &str) {
         "partition close must use semantic code {code}: {observation:?}"
     );
     assert_eq!(observation.reason.as_deref(), Some(reason));
+}
+
+fn assert_application_pong_or_windows_reset(observation: &CloseObservation) {
+    #[cfg(windows)]
+    assert!(
+        observation.saw_application_pong || observation.transport_reset_after_cause,
+        "the processed application Ping must either yield its Pong or hit the documented \
+         Windows teardown reset: {observation:?}"
+    );
+    #[cfg(not(windows))]
+    assert!(
+        observation.saw_application_pong,
+        "a Pong queued before eviction must prove client-to-server traffic stayed live"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -390,10 +456,7 @@ async fn server_to_client_blackhole_closes_4002_while_inbound_ping_is_live() {
 
     let observation = observe_until_close(&mut partitioned).await;
     assert_close(&observation, 4002, "slow_consumer");
-    assert!(
-        observation.saw_application_pong,
-        "a Pong queued before eviction must prove client-to-server traffic stayed live"
-    );
+    assert_application_pong_or_windows_reset(&observation);
     assert_eq!(
         server
             .metrics()

--- a/tests/partition_scenarios_e2e.rs
+++ b/tests/partition_scenarios_e2e.rs
@@ -29,7 +29,6 @@ const GAME: &str = "partition_scenarios";
 struct CloseObservation {
     code: Option<u16>,
     reason: Option<String>,
-    saw_application_pong: bool,
     #[cfg(windows)]
     transport_reset_after_cause: bool,
 }
@@ -266,13 +265,6 @@ async fn observe_until_close(ws: &mut WsStream) -> CloseObservation {
                 return observation;
             }
             Message::Close(None) => panic!("partitioned connection received a bare close frame"),
-            Message::Text(text) => {
-                let message: ServerMessage =
-                    serde_json::from_str(&text).expect("decode partition server message");
-                if matches!(message, ServerMessage::Pong) {
-                    observation.saw_application_pong = true;
-                }
-            }
             _ => {}
         }
     }
@@ -356,20 +348,6 @@ fn assert_close(observation: &CloseObservation, code: u16, reason: &str) {
     assert_eq!(observation.reason.as_deref(), Some(reason));
 }
 
-fn assert_application_pong_or_windows_reset(observation: &CloseObservation) {
-    #[cfg(windows)]
-    assert!(
-        observation.saw_application_pong || observation.transport_reset_after_cause,
-        "the processed application Ping must either yield its Pong or hit the documented \
-         Windows teardown reset: {observation:?}"
-    );
-    #[cfg(not(windows))]
-    assert!(
-        observation.saw_application_pong,
-        "a Pong queued before eviction must prove client-to-server traffic stayed live"
-    );
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial_test::serial]
 async fn symmetric_blackhole_closes_4003_and_room_heals() {
@@ -433,6 +411,10 @@ async fn server_to_client_blackhole_closes_4002_while_inbound_ping_is_live() {
         server.metrics().heartbeat_updates.load(Ordering::Relaxed) > heartbeat_before
     })
     .await;
+    // This server-side counter advances while routing the decoded inbound
+    // Ping, before pressure begins. Do not require its application Pong: that
+    // reply uses the deliberately blocked server-to-client queue and may be
+    // abandoned when SlowConsumer eviction wins.
 
     let padding = "x".repeat(32 * 1_024);
     let pressure = async {
@@ -460,7 +442,6 @@ async fn server_to_client_blackhole_closes_4002_while_inbound_ping_is_live() {
 
     let observation = observe_until_close(&mut partitioned).await;
     assert_close(&observation, 4002, "slow_consumer");
-    assert_application_pong_or_windows_reset(&observation);
     assert_eq!(
         server
             .metrics()


### PR DESCRIPTION
## Summary

- add real-WebSocket symmetric, server-to-client, and client-to-server partition experiments over `ChaosProxy`
- pin exact `4002 slow_consumer` versus `4003 activity_timeout` attribution and prove room relay recovery through a replacement client
- document bidirectional client liveness and operator detection bounds, correcting the pre-E4 30–90 second estimate

## Why

A WebSocket can remain usable in only one direction. Successful application traffic in one direction must not be treated as proof that the reverse path is healthy. These experiments make the CP/fail-loud behavior observable and turn the results into client/operator guidance.

## Impact

Runtime behavior and wire contracts are unchanged. Clients and operators now have evidence-backed guidance for one-way failures and the close mechanism that wins. C-partition remains open only for the planned true pairwise WebRTC `--drop-ice-from` refinement.

## Verification

- `cargo clippy --locked --all-features --test partition_scenarios_e2e -- -D warnings`
- `cargo test --locked --test partition_scenarios_e2e blackhole -- --nocapture` (3 passed; stress-repeated three additional times)
- `cargo fmt --check`
- `scripts/check-markdown.sh`
- `scripts/check-doc-consistency.sh --changed-files CHANGELOG.md docs/architecture/scaling.md docs/guides/building-a-client.md tests/partition_scenarios_e2e.rs`
- hook readiness plus worktree pre-commit/pre-push checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes; production WebSocket handling and contracts are unchanged.
> 
> **Overview**
> Adds **real-WebSocket partition experiments** (`tests/partition_scenarios_e2e.rs`) that drive one-way and symmetric blackholes through the existing `ChaosProxy`, without changing server behavior.
> 
> The suite pins **which close wins** (`4002 slow_consumer` vs `4003 activity_timeout`) and the matching metrics for symmetric outage, server→client blackhole under reliable relay pressure (while inbound app `Ping` still reaches the server), and client→server blackhole (partitioned peer can still receive relayed `GameData` before liveness fails). Each case asserts **`PlayerLeft` on survivors** and **room relay recovery** via a replacement client.
> 
> **Docs** add a directional-partition table and E4 probe bounds in `docs/architecture/scaling.md`, bidirectional liveness guidance and a client testing checklist item in `docs/guides/building-a-client.md`, and a matching **CHANGELOG** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9bb974394dee28c70fb4fa384335c21e49c253e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->