### PR TITLE
Prove pairwise WebRTC partition recovery

### DIFF
--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -23,8 +23,8 @@
 #     + REAL client processes with OS faults (SIGSTOP/SIGKILL); the two
 #     ignored child-process tests need the pre-built native reference client
 #     (SIGNAL_FISH_CLIENT_BIN), which is why they are nightly-only.
-#     The same job runs the clean WebRTC {mesh,host} x {2,8,16} matrix and the
-#     H8 16-client crippled-ICE fallback proof.
+#     The same job runs the clean WebRTC {mesh,host} x {2,8,16} matrix, the H8
+#     16-client crippled-ICE fallback proof, and the N=3 pairwise ICE partition.
 #   - starved-runtime: clients/native/tests/starved_runtime_e2e.rs — the
 #     --runtime current / --tick-stall-ms conformance matrix pinning the
 #     documented "continuously drive your runtime" requirement.
@@ -242,13 +242,13 @@ jobs:
   multiprocess-delivery:
     name: Multi-Process Delivery Faults
     runs-on: ubuntu-latest
-    # Generous floor: after the native reference client build, eleven WebRTC
-    # cells run serially in the process-spawning group (seven clean/H8 plus
-    # four privileged 1%-loss cells). Each cell has a 600s
+    # Generous floor: after the native reference client build, twelve WebRTC
+    # cells run serially in the process-spawning group (eight clean/H8/
+    # deterministic-partition plus four privileged 1%-loss cells). Each has a 600s
     # nextest ceiling above its 540s child watchdog, so the job ceiling keeps
     # principled headroom for all cells plus the delivery-fault suite and cold
     # compilation (zero-flakiness policy).
-    timeout-minutes: 120
+    timeout-minutes: 150
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
@@ -296,7 +296,7 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test multiprocess_delivery_e2e --run-ignored all \
             --success-output final 2>&1 | tee multiprocess-output.txt
-      - name: Run clean WebRTC topology and size matrix
+      - name: Run WebRTC topology, size, and deterministic partition matrix
         shell: bash
         env:
           SIGNAL_FISH_CLIENT_BIN: ${{ github.workspace }}/clients/native/target/debug/signal-fish-reference-native
@@ -354,7 +354,7 @@ jobs:
             tail -n 60 multiprocess-output.txt 2>/dev/null || echo "no multiprocess output captured"
             echo '```'
             echo
-            echo "### WebRTC clean/loss topology-size matrix and H8 fallback"
+            echo "### WebRTC clean/loss topology-size matrix and deterministic partitions"
             echo
             echo '```text'
             tail -n 260 webrtc-matrix-output.txt 2>/dev/null || echo "no WebRTC matrix output captured"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loopback packet loss, then lift the fault before releasing the exact channel
   exchange. The native client's new harness-only exchange release file emits
   `exchange_ready` after pair formation and ICE gathering; ordinary exchange
-  behavior remains unchanged when the flag is omitted.
+  behavior remains unchanged when the flag is omitted. A final N=3 pairwise
+  partition cell reciprocally drops ICE candidates on exactly one planned edge,
+  proves the other two WebRTC edges and the all-to-all WebSocket relay floor
+  remain complete, and records every injected drop in the client's JSONL event
+  stream. Normal candidate handling is unchanged unless the harness-only
+  `--drop-ice-from` flag is supplied.
 - Add canonical release identity across the annotated Git tag, crates.io,
   GitHub Release, and multi-architecture GHCR image. Manual releases now invoke
   container publication directly, publish matching `vX.Y.Z`, `X.Y.Z`, and

--- a/clients/browser/README.md
+++ b/clients/browser/README.md
@@ -113,7 +113,8 @@ Byte-identical to the native client's for the shared CLI surface — see the
 [canonical contract](../native/README.md#jsonl-event-contract) and
 [exit codes](../native/README.md#exit-codes). The same Rust harness asserts over native and browser
 processes interchangeably. The native-only `--drop-ice-from` fault may additionally emit
-`ice_candidate_dropped`; browser/shared-flag runs never do. EPIPE handling matches too: a failed stdout write is logged to stderr once and
+`ice_candidate_dropped`; browser/shared-flag runs never do. EPIPE handling matches too: a failed stdout
+write is logged to stderr once and
 latches suppression; the run continues to its bounded exit. Usage errors exit `2` before the event stream
 starts (no `exiting` event), matching the documented clap behavior.
 

--- a/clients/browser/README.md
+++ b/clients/browser/README.md
@@ -87,7 +87,7 @@ accounting lifetime from `sender_watermarks`. Thus the shared
 
 ## CLI reference
 
-The flag surface mirrors the native client's ([canonical reference](../native/README.md#cli-reference)):
+The shared flag surface mirrors the native client's ([canonical reference](../native/README.md#cli-reference)):
 `--server-url`, `--create-room`/`--join-code`, `--peers`, `--expect-total-peers`, `--leave-on-game-start`,
 `--game-name`, `--player-name`, `--app-id`, `--platform`, `--exchange`, `--relay-payload`, `--cripple-ice`,
 `--p2p-timeout-secs`, `--run-for-secs`, `--max-runtime-secs`, `--protocol-version`,
@@ -103,15 +103,17 @@ Browser-specific additions and deviations:
 |-----------------|---------|
 | `--mdns-obfuscation` | Leave Chromium's DEFAULT mDNS host-candidate obfuscation ON (candidates become opaque `<uuid>.local` names — the PLAN P7 `.local` trap). Default OFF: Chromium is launched with `--disable-features=WebRtcHideLocalIpsWithMdns` for deterministic loopback host candidates |
 | `--cripple-ice` (browser flavor) | The browser cannot filter network interfaces the way the native engine does; determinism comes from dropping ALL outbound candidates AND ignoring all inbound ones (`signal_received` is still emitted). With zero remote candidates on both sides, no ICE check pair ever forms |
+| Native `--drop-ice-from` | Not exposed by the browser client. It is a native-only matrix-harness fault for isolating one webrtc-rs peer edge; shared interop and `--cripple-ice` behavior remain identical |
 | `--run-for-secs` measurement | The soft window still measures from PROCESS start: the CLI passes the Chromium-launch time already spent into the page engine, which subtracts it |
 | Chromium launch failure | Local infrastructure failures (browser launch, page bridge) exit `4`, mirroring the native client's runtime-start failure path |
 
 ## JSONL event contract and exit codes
 
-Byte-identical to the native client's — see the
+Byte-identical to the native client's for the shared CLI surface — see the
 [canonical contract](../native/README.md#jsonl-event-contract) and
 [exit codes](../native/README.md#exit-codes). The same Rust harness asserts over native and browser
-processes interchangeably. EPIPE handling matches too: a failed stdout write is logged to stderr once and
+processes interchangeably. The native-only `--drop-ice-from` fault may additionally emit
+`ice_candidate_dropped`; browser/shared-flag runs never do. EPIPE handling matches too: a failed stdout write is logged to stderr once and
 latches suppression; the run continues to its bounded exit. Usage errors exit `2` before the event stream
 starts (no `exiting` event), matching the documented clap behavior.
 

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -59,6 +59,7 @@ Exactly one of `--create-room` / `--join-code` is required; everything else has 
 | `--exchange-release-file <PATH>` | — | Test harness only; requires `--exchange`. Establish every planned pair and finish local ICE gathering, emit `exchange_ready`, then hold the exact channel exchange until PATH exists. Normal exchange behavior is unchanged when omitted |
 | `--relay-payload <TEXT>` | — | After `GameStarting` (+250 ms settle), send one `GameData {"relay_msg": TEXT}` over the WebSocket relay floor and require the other `--peers - 1` members' payloads. A late joiner (entry into a finalized room) arms the send on entry instead — `GameStarting` pre-dates the join — and its receive requirement is waived: payloads sent before the join are never replayed |
 | `--cripple-ice` | off | Deterministically break ICE: reject every interface during gathering AND drop all outbound/inbound `IceCandidate` signals (SDP offer/answer still flows). Forces the relay fallback |
+| `--drop-ice-from <N>` | — | Matrix-harness fault injection: drop inbound `IceCandidate` signals from the planned peer named `cNN`, while preserving offer/answer signaling, every other P2P edge, and the relay floor. The flag fails loudly if the ordinal does not resolve to exactly one planned peer |
 | `--p2p-timeout-secs <S>` | `15` | Window for WebRTC pair establishment before the overall transport status resolves |
 | `--run-for-secs <S>` | `30` | Soft cap: exit 1 if the flag-driven success criteria are still unmet |
 | `--max-runtime-secs <S>` | `60` | Hard watchdog: abort with exit 4 no matter what (the no-hang guarantee) |
@@ -121,6 +122,7 @@ process continues to its normal bounded exit.
 | `new_peer` | `peer_id`, `you_initiate` | Compatible incremental pairing directive (the universal server uses full plans) |
 | `signal_sent` | `to`, `kind` | Outbound `Signal` relayed (`kind` ∈ `offer`/`answer`/`ice_candidate`/`other`) |
 | `signal_received` | `from`, `kind` | Inbound `Signal` arrived (emitted even when `--cripple-ice` then drops it) |
+| `ice_candidate_dropped` | `from` | Native-only `--drop-ice-from` discarded this peer's inbound candidate after `signal_received` made the signaling hop observable. The older shared `--cripple-ice` contract remains unchanged and does not emit this event |
 | `pc_state` | `peer`, `state` | RTCPeerConnection state transition (informational) |
 | `channel_open` | `peer`, `label` | One data channel reached open (`label` ∈ `reliable`/`unreliable`) |
 | `channel_message_sent` | `peer`, `label`, `text` | An `--exchange` message was sent |
@@ -194,6 +196,7 @@ client processes (loopback only; the interop server config disables TURN with ze
 | Mesh N=3 full WebRTC + live relay floor | ✅ `mesh_n3_full_webrtc_session_with_live_relay_floor` | ✅ `mixed_mesh_n3_full_webrtc_with_browser` |
 | Host star N=3 | ✅ `host_star_n3_webrtc` | ✅ `host_star_n3_browser_client` |
 | Crippled-ICE relay fallback | ✅ `mesh_n3_partial_ice_cripple_relay_fallback` | ✅ `mesh_n3_browser_crippled_ice_fallback` |
+| Pairwise ICE partition with healthy partial mesh + relay floor | ✅ nightly `pairwise_ice_partition_preserves_partial_mesh_and_relay_floor` | — |
 | Late join (authoritative full-plan seat fill) | ✅ `late_join_authoritative_replan_real_webrtc_n3` | — (native-only cell) |
 | Mixed v2/v3 relay floor | ✅ `mixed_v2_v3_n3_relay_floor_with_reference_client` | ✅ `mixed_v2_browser_v3_native_relay_floor` |
 | Browser ↔ browser mesh (Chromium↔Chromium pair) | n/a | ✅ `browser_pair_mesh_n3` |

--- a/clients/native/src/cli.rs
+++ b/clients/native/src/cli.rs
@@ -97,6 +97,12 @@ pub struct Cli {
     #[arg(long)]
     pub cripple_ice: bool,
 
+    /// FAULT INJECTION (matrix harness only): discard inbound trickle-ICE
+    /// candidates from the planned peer named `cNN`, where NN is this ordinal.
+    /// Offer/answer signaling, other peer links, and the relay floor stay live.
+    #[arg(long)]
+    pub drop_ice_from: Option<usize>,
+
     /// Seconds allowed for WebRTC pair establishment before the overall
     /// transport status resolves (true iff >= 1 pair connected at resolution).
     #[arg(long, default_value_t = 15)]
@@ -274,6 +280,7 @@ mod tests {
         assert_eq!(cli.runtime, RuntimeFlavor::Multi);
         assert_eq!(cli.runtime.as_str(), "multi");
         assert_eq!(cli.tick_stall_ms, 0, "fault injection is off by default");
+        assert_eq!(cli.drop_ice_from, None);
         assert_eq!(cli.success_release_file, None);
         assert_eq!(cli.exchange_release_file, None);
         assert_eq!(
@@ -347,6 +354,19 @@ mod tests {
         assert_eq!(cli.runtime, RuntimeFlavor::Current);
         assert_eq!(cli.runtime.as_str(), "current");
         assert_eq!(cli.tick_stall_ms, 750);
+    }
+
+    #[test]
+    fn per_peer_ice_fault_target_ordinal_parses() {
+        let cli = Cli::parse_from([
+            "signal-fish-reference-native",
+            "--server-url",
+            "ws://127.0.0.1:9000/v3/ws",
+            "--create-room",
+            "--drop-ice-from",
+            "12",
+        ]);
+        assert_eq!(cli.drop_ice_from, Some(12));
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -206,6 +206,7 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         exchange_ready_reported: false,
         exchange_release_poll_at: None,
         pending_signals: BTreeMap::new(),
+        drop_ice_from: None,
         run_deadline,
         linger_until: None,
         success_criteria_reported: false,
@@ -627,6 +628,9 @@ struct Orchestrator<'a> {
     /// Signals that arrived before their peer was paired (defensive: server
     /// FIFO ordering makes this unreachable in the documented flows).
     pending_signals: BTreeMap<PlayerId, VecDeque<serde_json::Value>>,
+    /// Runtime UUID resolved from the harness-only `--drop-ice-from` ordinal
+    /// when an authoritative plan supplies its `cNN` peer name.
+    drop_ice_from: Option<PlayerId>,
     /// `--run-for-secs` soft cap.
     run_deadline: Instant,
     /// Set once all criteria are met; exit 0 when it elapses.
@@ -1091,6 +1095,9 @@ impl Orchestrator<'_> {
             ServerMessage::SessionPlan(plan) => {
                 self.initial_session_plan_pending = false;
                 self.pending_membership_plans.clear();
+                self.drop_ice_from =
+                    resolve_drop_ice_from(self.cli.drop_ice_from, self.my_id, &plan.peers)
+                        .map_err(FatalError::protocol)?;
                 emit(&Event::SessionPlan {
                     topology: plan.topology,
                     transport: plan.transport,
@@ -1487,10 +1494,14 @@ impl Orchestrator<'_> {
                 None => Err(anyhow::anyhow!("Answer payload is not a string")),
             },
             SignalKind::IceCandidate => {
-                if self.cli.cripple_ice {
+                let pairwise_drop = self.drop_ice_from == Some(from);
+                if self.cli.cripple_ice || pairwise_drop {
                     // Belt and braces with the engine's interface filter:
-                    // inbound candidates are dropped, never applied.
-                    tracing::debug!(%from, "cripple-ice: dropping inbound candidate");
+                    // selected inbound candidates are dropped, never applied.
+                    tracing::debug!(%from, "fault injection: dropping inbound ICE candidate");
+                    if pairwise_drop {
+                        emit(&Event::IceCandidateDropped { from });
+                    }
                     Ok(())
                 } else {
                     match signal.get("IceCandidate").and_then(|c| c.as_str()) {
@@ -1773,6 +1784,35 @@ fn needs_ice_gathering_marker(is_current_generation: bool, gathering_complete: b
     is_current_generation && !gathering_complete
 }
 
+fn resolve_drop_ice_from(
+    ordinal: Option<usize>,
+    my_id: PlayerId,
+    peers: &[signal_fish_server::protocol::SessionPeer],
+) -> Result<Option<PlayerId>, String> {
+    let Some(ordinal) = ordinal else {
+        return Ok(None);
+    };
+    let target_name = format!("c{ordinal:02}");
+    let mut matches = peers
+        .iter()
+        .filter(|peer| peer.player_name == target_name)
+        .map(|peer| peer.player_id);
+    let target = matches.next().ok_or_else(|| {
+        format!("--drop-ice-from {ordinal} did not resolve to planned peer {target_name:?}")
+    })?;
+    if matches.next().is_some() {
+        return Err(format!(
+            "--drop-ice-from {ordinal} ambiguously matched multiple planned peers named {target_name:?}"
+        ));
+    }
+    if target == my_id {
+        return Err(format!(
+            "--drop-ice-from {ordinal} resolved to this client instead of a peer"
+        ));
+    }
+    Ok(Some(target))
+}
+
 fn harness_aware_base_wake(
     run_deadline: Instant,
     success_release_poll_at: Option<Instant>,
@@ -1806,10 +1846,10 @@ mod tests {
         connection_targets_for_plan, consume_join_accountability_preface, harness_aware_base_wake,
         is_terminal_peer_connection_state, needs_ice_gathering_marker, negotiated_version_from,
         next_handshake_message, require_finalized_membership_plan,
-        requires_authoritative_finalization_plan, restore_reconnected_member,
-        should_buffer_signal_for_unpaired_peer, should_defer_success_at_run_deadline,
-        should_resolve_connected_pair, validate_json_negotiated_server_message,
-        EXIT_PROTOCOL_ERROR,
+        requires_authoritative_finalization_plan, resolve_drop_ice_from,
+        restore_reconnected_member, should_buffer_signal_for_unpaired_peer,
+        should_defer_success_at_run_deadline, should_resolve_connected_pair,
+        validate_json_negotiated_server_message, EXIT_PROTOCOL_ERROR,
     };
     use tokio_tungstenite::tungstenite::{Bytes, Message};
     use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
@@ -1834,6 +1874,42 @@ mod tests {
         assert!(!should_defer_success_at_run_deadline(false, true, false));
         assert!(!should_defer_success_at_run_deadline(true, false, false));
         assert!(!should_defer_success_at_run_deadline(false, false, true));
+    }
+
+    #[test]
+    fn per_peer_ice_fault_resolves_harness_ordinal_and_rejects_missing_target() {
+        let me = PlayerId::new_v4();
+        let target = PlayerId::new_v4();
+        let peers = vec![signal_fish_server::protocol::SessionPeer {
+            player_id: target,
+            player_name: "c01".to_string(),
+            is_authority: false,
+            initiate: true,
+        }];
+
+        assert_eq!(resolve_drop_ice_from(None, me, &peers), Ok(None));
+        assert_eq!(resolve_drop_ice_from(Some(1), me, &peers), Ok(Some(target)));
+        assert!(resolve_drop_ice_from(Some(2), me, &peers)
+            .expect_err("an absent target must fail loud")
+            .contains("did not resolve"));
+
+        let duplicate = signal_fish_server::protocol::SessionPeer {
+            player_id: PlayerId::new_v4(),
+            ..peers[0].clone()
+        };
+        assert!(
+            resolve_drop_ice_from(Some(1), me, &[peers[0].clone(), duplicate])
+                .expect_err("duplicate harness names must fail loud")
+                .contains("ambiguously matched")
+        );
+
+        let self_target = signal_fish_server::protocol::SessionPeer {
+            player_id: me,
+            ..peers[0].clone()
+        };
+        assert!(resolve_drop_ice_from(Some(1), me, &[self_target])
+            .expect_err("self-targeting must fail loud")
+            .contains("this client"));
     }
 
     #[test]

--- a/clients/native/src/events.rs
+++ b/clients/native/src/events.rs
@@ -61,6 +61,9 @@ pub enum Event {
     SignalSent { to: PlayerId, kind: SignalKind },
     /// An inbound `Signal` envelope arrived from `from`.
     SignalReceived { from: PlayerId, kind: SignalKind },
+    /// A configured ICE fault discarded this peer's inbound candidate after
+    /// the signaling envelope was observed.
+    IceCandidateDropped { from: PlayerId },
     /// RTCPeerConnection state transition (`new`/`connecting`/`connected`/...).
     PcState { peer: PlayerId, state: String },
     /// One data channel reached the open state.
@@ -351,5 +354,14 @@ mod tests {
             SignalKind::Other
         );
         assert_eq!(SignalKind::classify(&json!({})), SignalKind::Other);
+    }
+
+    #[test]
+    fn candidate_drop_event_names_the_faulted_sender() {
+        let from = PlayerId::new_v4();
+        let value = serde_json::to_value(Event::IceCandidateDropped { from })
+            .expect("event serialization succeeds");
+        assert_eq!(value["event"], "ice_candidate_dropped");
+        assert_eq!(value["from"], from.to_string());
     }
 }

--- a/clients/native/tests/interop_e2e.rs
+++ b/clients/native/tests/interop_e2e.rs
@@ -776,6 +776,7 @@ async fn mesh_n3_partial_ice_cripple_relay_fallback() {
         "channel_open",
         "channel_message",
         "channel_message_sent",
+        "ice_candidate_dropped",
     ] {
         assert!(
             events_named(crippled_log, name).is_empty(),

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -1,12 +1,15 @@
 //! P10.C empirical native WebRTC topology/size and H8 signal-budget experiments.
 //!
 //! The nightly real-process matrix covers clean mesh and host topologies at
-//! N=2/8/16 plus fail-loud 1% `tc netem` loss at N=2/8. Loss stays active
+//! N=2/8/16, one exact N=3 pairwise ICE partition, and fail-loud 1% `tc netem`
+//! loss at N=2/8. Loss stays active
 //! through ICE/channel formation; exact channel exchange is released only
 //! after fault lift. The H8 fault variant additionally proves a partial
 //! partition: one client with deterministic crippled ICE falls back to the
 //! WebSocket relay while the other 15 retain their exact 105-edge WebRTC
-//! submesh. Every cell stays under the production 600-signal per-connection
+//! submesh. The pairwise cell removes only one edge while all three clients
+//! retain WebRTC connectivity and the complete relay floor. Every cell stays
+//! under the production 600-signal per-connection
 //! budget and preserves exact WebRTC-channel and relay-floor ledgers. The tests
 //! are ignored because running real webrtc-rs stacks and privileged network
 //! faults is intentionally outside the PR machine's cheap local test budget.
@@ -47,6 +50,12 @@ enum MatrixTopology {
     Host,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct ConnectivityFault<'a> {
+    crippled_id: Option<&'a str>,
+    partition_pair: Option<(&'a str, &'a str)>,
+}
+
 impl MatrixTopology {
     const fn label(self) -> &'static str {
         match self {
@@ -61,6 +70,7 @@ struct WebRtcScenario {
     topology: MatrixTopology,
     players: usize,
     crippled_ordinal: Option<usize>,
+    partition_pair: Option<(usize, usize)>,
     netem_loss: bool,
 }
 
@@ -70,6 +80,7 @@ impl WebRtcScenario {
             topology,
             players,
             crippled_ordinal: None,
+            partition_pair: None,
             netem_loss: false,
         }
     }
@@ -79,6 +90,17 @@ impl WebRtcScenario {
             topology: MatrixTopology::Mesh,
             players,
             crippled_ordinal: Some(ordinal),
+            partition_pair: None,
+            netem_loss: false,
+        }
+    }
+
+    const fn pairwise_partition_mesh(players: usize, left: usize, right: usize) -> Self {
+        Self {
+            topology: MatrixTopology::Mesh,
+            players,
+            crippled_ordinal: None,
+            partition_pair: Some((left, right)),
             netem_loss: false,
         }
     }
@@ -88,11 +110,19 @@ impl WebRtcScenario {
             topology,
             players,
             crippled_ordinal: None,
+            partition_pair: None,
             netem_loss: true,
         }
     }
 
     fn label(self) -> String {
+        if let Some((left, right)) = self.partition_pair {
+            return format!(
+                "{}-n{}-partition-c{left:02}-c{right:02}",
+                self.topology.label(),
+                self.players
+            );
+        }
         let fault = if self.crippled_ordinal.is_some() {
             "one-crippled"
         } else if self.netem_loss {
@@ -107,12 +137,16 @@ impl WebRtcScenario {
         self.crippled_ordinal
     }
 
+    const fn partition_pair(self) -> Option<(usize, usize)> {
+        self.partition_pair
+    }
+
     const fn uses_netem(self) -> bool {
         self.netem_loss
     }
 
     const fn p2p_timeout_secs(self) -> u64 {
-        if self.crippled_ordinal.is_some() {
+        if self.crippled_ordinal.is_some() || self.partition_pair.is_some() {
             30
         } else {
             180
@@ -122,7 +156,7 @@ impl WebRtcScenario {
     const fn run_for_secs(self) -> u64 {
         if self.netem_loss {
             480
-        } else if self.crippled_ordinal.is_some() {
+        } else if self.crippled_ordinal.is_some() || self.partition_pair.is_some() {
             90
         } else {
             240
@@ -211,6 +245,18 @@ fn client_args(
     ];
     if scenario.crippled_ordinal() == Some(ordinal) {
         args.push("--cripple-ice".to_string());
+    }
+    if let Some((left, right)) = scenario.partition_pair() {
+        let target = if ordinal == left {
+            Some(right)
+        } else if ordinal == right {
+            Some(left)
+        } else {
+            None
+        };
+        if let Some(target) = target {
+            args.extend(["--drop-ice-from".to_string(), target.to_string()]);
+        }
     }
     if let Some(path) = exchange_release_file {
         args.extend([
@@ -626,6 +672,58 @@ fn assert_exact_signal_ledger(
     }
 }
 
+fn assert_pairwise_candidate_drop_ledger(
+    clients: &[NativeClientProcess],
+    ids: &[String],
+    pair: (usize, usize),
+) {
+    for (ordinal, client) in clients.iter().enumerate() {
+        let expected_from = if ordinal == pair.0 {
+            Some(ids[pair.1].as_str())
+        } else if ordinal == pair.1 {
+            Some(ids[pair.0].as_str())
+        } else {
+            None
+        };
+        let window = held_window(&client.events, &client.name);
+        let dropped = events_named(window, "ice_candidate_dropped");
+        match expected_from {
+            Some(expected_from) => {
+                assert!(
+                    !dropped.is_empty(),
+                    "{}: candidate fault was vacuous",
+                    client.name
+                );
+                assert!(
+                    dropped.iter().all(|event| {
+                        string_field(event, "from", &client.name) == expected_from
+                    }),
+                    "{}: candidate drop escaped the selected edge: {dropped:?}",
+                    client.name
+                );
+                let received_from_target = events_named(window, "signal_received")
+                    .into_iter()
+                    .filter(|event| {
+                        string_field(event, "from", &client.name) == expected_from
+                            && string_field(event, "kind", &client.name) == "ice_candidate"
+                    })
+                    .count();
+                assert_eq!(
+                    dropped.len(),
+                    received_from_target,
+                    "{}: every selected inbound candidate is dropped exactly once",
+                    client.name
+                );
+            }
+            None => assert!(
+                dropped.is_empty(),
+                "{}: uninvolved client must not drop ICE candidates: {dropped:?}",
+                client.name
+            ),
+        }
+    }
+}
+
 fn expected_planned_peers<'a>(
     player_id: &'a str,
     all_ids: &BTreeSet<&'a str>,
@@ -652,14 +750,20 @@ fn expected_connected_peers<'a>(
     all_ids: &BTreeSet<&'a str>,
     host_id: &'a str,
     topology: MatrixTopology,
-    crippled_id: Option<&'a str>,
+    fault: ConnectivityFault<'a>,
 ) -> BTreeSet<&'a str> {
-    if crippled_id == Some(player_id) {
+    if fault.crippled_id == Some(player_id) {
         return BTreeSet::new();
     }
     expected_planned_peers(player_id, all_ids, host_id, topology)
         .into_iter()
-        .filter(|candidate| Some(*candidate) != crippled_id)
+        .filter(|candidate| {
+            Some(*candidate) != fault.crippled_id
+                && !fault.partition_pair.is_some_and(|(left, right)| {
+                    (player_id == left && *candidate == right)
+                        || (player_id == right && *candidate == left)
+                })
+        })
         .collect()
 }
 
@@ -671,7 +775,7 @@ fn assert_client_barrier(
     signal_budget: usize,
     host_id: &str,
     scenario: WebRtcScenario,
-    crippled_id: Option<&str>,
+    fault: ConnectivityFault<'_>,
 ) -> usize {
     let who = &client.name;
     let window = held_window(&client.events, who);
@@ -682,7 +786,7 @@ fn assert_client_barrier(
         .collect();
     let expected_peers = expected_planned_peers(player_id, all_ids, host_id, scenario.topology);
     let expected_connections =
-        expected_connected_peers(player_id, all_ids, host_id, scenario.topology, crippled_id);
+        expected_connected_peers(player_id, all_ids, host_id, scenario.topology, fault);
     let expected_connected = !expected_connections.is_empty();
 
     let barrier_errors = events_named(window, "error");
@@ -806,8 +910,7 @@ fn assert_client_barrier(
         assert!(room_peers.contains(peer), "{who}: stray peer status {peer}");
         *peer_status_counts.entry(peer).or_default() += 1;
         let expected_peer_connected =
-            !expected_connected_peers(peer, all_ids, host_id, scenario.topology, crippled_id)
-                .is_empty();
+            !expected_connected_peers(peer, all_ids, host_id, scenario.topology, fault).is_empty();
         assert_eq!(
             peer_status.get("connected").and_then(Value::as_bool),
             Some(expected_peer_connected),
@@ -899,6 +1002,22 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
         assert!(
             ordinal < scenario.players,
             "crippled ordinal must name a client"
+        );
+    }
+    if let Some((left, right)) = scenario.partition_pair() {
+        assert!(
+            left < scenario.players,
+            "left partition ordinal must name a client"
+        );
+        assert!(
+            right < scenario.players,
+            "right partition ordinal must name a client"
+        );
+        assert_ne!(left, right, "pairwise partition endpoints must be distinct");
+        assert_eq!(
+            scenario.topology,
+            MatrixTopology::Mesh,
+            "pairwise partition is registered against the partial-mesh contract"
         );
     }
     assert!(
@@ -1034,6 +1153,13 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     let crippled_id = scenario
         .crippled_ordinal()
         .map(|ordinal| ids[ordinal].as_str());
+    let partition_pair = scenario
+        .partition_pair()
+        .map(|(left, right)| (ids[left].as_str(), ids[right].as_str()));
+    let fault = ConnectivityFault {
+        crippled_id,
+        partition_pair,
+    };
     let host_id = ids[0].as_str();
 
     // Mesh clients already wait for every room peer's status because every
@@ -1094,7 +1220,7 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
             signal_budget,
             host_id,
             scenario,
-            crippled_id,
+            fault,
         ));
     }
     assert_eq!(
@@ -1138,12 +1264,14 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
     if crippled_id.is_none() {
         assert_exact_signal_ledger(&clients, &ids, &all_ids, host_id, scenario.topology);
     }
+    if let Some(pair) = scenario.partition_pair() {
+        assert_pairwise_candidate_drop_ledger(&clients, &ids, pair);
+    }
     let held_metrics = fetch_prometheus_text(server.port).await;
     let expected_connected_clients = ids
         .iter()
         .filter(|id| {
-            !expected_connected_peers(id, &all_ids, host_id, scenario.topology, crippled_id)
-                .is_empty()
+            !expected_connected_peers(id, &all_ids, host_id, scenario.topology, fault).is_empty()
         })
         .count();
     let expected_fallbacks = scenario.players - expected_connected_clients;
@@ -1236,9 +1364,7 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
 
     let directed_connected_edges: usize = ids
         .iter()
-        .map(|id| {
-            expected_connected_peers(id, &all_ids, host_id, scenario.topology, crippled_id).len()
-        })
+        .map(|id| expected_connected_peers(id, &all_ids, host_id, scenario.topology, fault).len())
         .sum();
     assert_eq!(
         directed_connected_edges % 2,
@@ -1264,28 +1390,64 @@ async fn run_webrtc_scenario(scenario: WebRtcScenario) {
 fn connectivity_oracle_preserves_mesh_and_host_graphs() {
     let all = BTreeSet::from(["a", "b", "c"]);
     assert_eq!(
-        expected_connected_peers("b", &all, "a", MatrixTopology::Mesh, None),
+        expected_connected_peers(
+            "b",
+            &all,
+            "a",
+            MatrixTopology::Mesh,
+            ConnectivityFault::default(),
+        ),
         BTreeSet::from(["a", "c"]),
         "clean mesh connects every other peer"
     );
+    let crippled = ConnectivityFault {
+        crippled_id: Some("c"),
+        partition_pair: None,
+    };
     assert_eq!(
-        expected_connected_peers("b", &all, "a", MatrixTopology::Mesh, Some("c")),
+        expected_connected_peers("b", &all, "a", MatrixTopology::Mesh, crippled),
         BTreeSet::from(["a"]),
         "healthy peer excludes the crippled member"
     );
     assert!(
-        expected_connected_peers("c", &all, "a", MatrixTopology::Mesh, Some("c")).is_empty(),
+        expected_connected_peers("c", &all, "a", MatrixTopology::Mesh, crippled).is_empty(),
         "crippled member forms no WebRTC edges"
     );
     assert_eq!(
-        expected_connected_peers("a", &all, "a", MatrixTopology::Host, None),
+        expected_connected_peers(
+            "a",
+            &all,
+            "a",
+            MatrixTopology::Host,
+            ConnectivityFault::default(),
+        ),
         BTreeSet::from(["b", "c"]),
         "host connects to every client"
     );
     assert_eq!(
-        expected_connected_peers("b", &all, "a", MatrixTopology::Host, None),
+        expected_connected_peers(
+            "b",
+            &all,
+            "a",
+            MatrixTopology::Host,
+            ConnectivityFault::default(),
+        ),
         BTreeSet::from(["a"]),
         "each client connects only to the host"
+    );
+    let pairwise = ConnectivityFault {
+        crippled_id: None,
+        partition_pair: Some(("a", "b")),
+    };
+    assert_eq!(
+        expected_connected_peers("a", &all, "a", MatrixTopology::Mesh, pairwise),
+        BTreeSet::from(["c"]),
+        "a pairwise partition removes only the selected edge"
+    );
+    assert_eq!(
+        expected_connected_peers("c", &all, "a", MatrixTopology::Mesh, pairwise),
+        BTreeSet::from(["a", "b"]),
+        "the uninvolved peer retains both mesh edges"
     );
 }
 
@@ -1303,6 +1465,12 @@ async fn one_crippled_ice_client_falls_back_without_breaking_healthy_submesh() {
         H8_PLAYERS - 1,
     ))
     .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "nightly-only (verification-nightly.yml): spawns 3 real webrtc-rs clients"]
+async fn pairwise_ice_partition_preserves_partial_mesh_and_relay_floor() {
+    run_webrtc_scenario(WebRtcScenario::pairwise_partition_mesh(3, 0, 1)).await;
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## What changed

- add a harness-only native `--drop-ice-from <ordinal>` fault that resolves the authoritative plan's `cNN` peer and records selected inbound candidate drops
- add an N=3 reciprocal pairwise ICE-partition cell to the existing exact-ledger WebRTC matrix
- prove the other two WebRTC edges, all signaling envelopes, every room-wide status, and the complete WebSocket relay floor remain intact
- preserve the shared native/browser `--cripple-ice` JSONL contract and document the native-only fault/event deviation
- include the new twelfth serialized WebRTC cell in Verification Nightly with a composed 150-minute job bound

## Why

C-partition's last open facet required a true partial mesh rather than globally crippling one client. Reciprocal candidate filtering prevents peer-reflexive ICE from healing the selected edge while leaving both endpoints connected through the third member.

## Evidence

- focused real-process pairwise run: 2/3 connected edges, 12 exact relayed signals (4/client), 30.193s barrier, 31.249s total, zero teardown drops
- native library: 54 tests passed
- existing native crippled-ICE real-process regression passed
- root WebRTC connectivity oracle passed
- native and root focused Clippy passed with warnings denied
- CI policy suite: 276 passed, 1 intentionally ignored
- doc consistency, workflow hygiene, cargo-deny/CI config, formatting, and hook preflights passed
- independent post-implementation adversarial review: SHIP, zero findings

## Compatibility

No server or protocol wire behavior changes. Normal reference-client behavior is unchanged unless the harness-only flag is supplied.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Harness-only native client and e2e changes; no server or wire protocol changes, and normal clients are unaffected unless the flag is set.
> 
> **Overview**
> Adds a **native-only, harness-only** `--drop-ice-from <ordinal>` flag that resolves the authoritative plan peer `cNN` and drops inbound trickle-ICE from that peer only (offer/answer and other edges unchanged). Each dropped candidate is observable as JSONL `ice_candidate_dropped` after `signal_received`; shared `--cripple-ice` behavior is unchanged.
> 
> Extends the nightly WebRTC matrix with an **N=3 pairwise partition** cell: both endpoints of one planned edge reciprocally filter the other’s candidates so the edge stays down while the third peer’s two WebRTC links and the full relay floor remain complete, with ledger checks tying drops to received ICE signals.
> 
> **CI/docs:** Verification Nightly’s multiprocess job counts twelve serialized WebRTC cells, raises the job timeout to 150 minutes, and updates changelog and client READMEs (browser explicitly does not expose `--drop-ice-from`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ecc3bd03267fbd661fe2b662af025d5353c073a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->