### PR TITLE
Close RST chaos flake and standardize GitHub agent policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,5 +4,7 @@ See [Context](../.llm/context.md) for all AI agent guidelines.
 
 For GitHub work, use local `git` for branches, commits, and pushes, and use the
 connected VS Code GitHub extension / GitHub app for PRs, comments, reviewers,
-and review state. An unauthenticated `gh` CLI must not block that workflow when
-the extension and Git remote are available.
+review state, and other supported GitHub operations. Fall back to an
+authenticated `gh` CLI only when the extension/app does not expose a required
+capability (for example, detailed Actions logs). An unauthenticated `gh` CLI
+must not block the workflow when the extension/app and Git remote are available.

--- a/.github/test-fixtures/test-doc-consistency.sh
+++ b/.github/test-fixtures/test-doc-consistency.sh
@@ -133,6 +133,7 @@ INTERNAL_PATHS=(
     "Cargo.lock"
     "PLAN.md"
     "AGENTS.md"
+    "CLAUDE.md"
     "pre-push.txt"
     "logs_2025.zip"
     # Linter/tool config (glob patterns)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
                 docs/ci-cd-*|docs/test-*|docs/git-hooks-*|docs/hooks-*|docs/pre-commit-*|docs/development.md|docs/quickstart.md) ;;
                 .markdownlint*|.lychee.toml|.lycheecache|.typos.toml|.yamllint.yml) ;;
                 .gitignore|.dockerignore) ;;
-                PLAN.md|AGENTS.md|pre-push.txt) ;;
+                PLAN.md|AGENTS.md|CLAUDE.md|pre-push.txt) ;;
                 logs_*.zip) ;;
                 Dockerfile|README.md) ;;
                 clippy.toml|deny.toml|tarpaulin.toml|rust-toolchain.toml|mkdocs.yml|requirements-docs.txt) ;;

--- a/.llm/context.md
+++ b/.llm/context.md
@@ -83,14 +83,15 @@ cargo fmt && cargo clippy --all-targets --all-features && cargo test --all-featu
 - This policy applies to every repository agent entrypoint (Codex, Claude, and
   GitHub Copilot).
 - Use local `git` for branch management, staging, commits, and pushes.
-- Prefer the connected VS Code GitHub extension / GitHub app for pull-request
-  creation, metadata, comments, reviewer requests, and review inspection.
+- Use the connected VS Code GitHub extension / GitHub app for pull-request
+  creation, metadata, comments, reviewer requests, review inspection, and every
+  other GitHub operation it supports.
 - Do not block repository delivery solely because `gh auth status` is
   unauthenticated when the connected GitHub extension/app is available and the
   Git remote can push successfully.
-- Use `gh` only for capabilities the connector cannot supply (notably detailed
-  GitHub Actions logs or GraphQL review-thread operations), and only when an
-  authenticated CLI session is available.
+- Fall back to `gh` only for a required capability the extension/app cannot
+  supply (notably detailed GitHub Actions logs or GraphQL review-thread
+  operations), and only when an authenticated CLI session is available.
 
 ### Hook Reliability Rules (Required)
 

--- a/.llm/skills/mandatory-workflow.md
+++ b/.llm/skills/mandatory-workflow.md
@@ -109,15 +109,15 @@ complete workflow after confirming the intended diff:
    changes.
 2. Create a terse, intentional commit.
 3. Push the current topic branch with local `git`.
-4. Create and inspect the pull request with an available GitHub or VS Code
-   connector.
+4. Create and inspect the pull request with the connected VS Code GitHub
+   extension / GitHub app.
 5. Monitor required checks and continue fixing in-scope failures until the PR is
    green.
 
 GitHub CLI (`gh`) is an optional fallback, not a prerequisite. Its absence is not
-a blocker when the Git remote accepts pushes and an authenticated connector can
-create and inspect pull requests and checks. Use `gh` only when the connector
-cannot perform a required operation.
+a blocker when the Git remote accepts pushes and the connected VS Code GitHub
+extension / GitHub app can perform the operation. Use an authenticated `gh` only
+when the extension/app cannot perform a required operation.
 
 Suggested commit message format:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,5 +4,7 @@ See [`.llm/context.md`](.llm/context.md) for all AI agent guidelines.
 
 For GitHub work, use local `git` for branches, commits, and pushes, and use the
 connected VS Code GitHub extension / GitHub app for PRs, comments, reviewers,
-and review state. An unauthenticated `gh` CLI must not block that workflow when
-the extension and Git remote are available.
+review state, and other supported GitHub operations. Fall back to an
+authenticated `gh` CLI only when the extension/app does not expose a required
+capability (for example, detailed Actions logs). An unauthenticated `gh` CLI
+must not block the workflow when the extension/app and Git remote are available.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,7 @@ See [`.llm/context.md`](.llm/context.md) for all AI agent guidelines.
 
 For GitHub work, use local `git` for branches, commits, and pushes, and use the
 connected VS Code GitHub extension / GitHub app for PRs, comments, reviewers,
-and review state. An unauthenticated `gh` CLI must not block that workflow when
-the extension and Git remote are available.
+review state, and other supported GitHub operations. Fall back to an
+authenticated `gh` CLI only when the extension/app does not expose a required
+capability (for example, detailed Actions logs). An unauthenticated `gh` CLI
+must not block the workflow when the extension/app and Git remote are available.

--- a/scripts/check-doc-consistency.sh
+++ b/scripts/check-doc-consistency.sh
@@ -541,7 +541,7 @@ is_internal_path() {
         docs/ci-cd-*|docs/test-*|docs/git-hooks-*|docs/hooks-*|docs/pre-commit-*|docs/development.md)
             return 0
             ;;
-        Cargo.lock|PLAN.md|AGENTS.md|pre-push.txt|pre-commit.txt|logs_*.zip)
+        Cargo.lock|PLAN.md|AGENTS.md|CLAUDE.md|pre-push.txt|pre-commit.txt|logs_*.zip)
             return 0
             ;;
         .markdownlint*|.lychee.toml|.lycheecache|.typos.toml|.yamllint.yml)

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -21085,6 +21085,47 @@ fn test_ci_dep_detect_is_actor_agnostic_for_dependency_only_skips() {
     );
 }
 
+#[test]
+fn test_agent_github_access_policy_is_extension_first() {
+    let root = repo_root();
+    let policy_files = [
+        "AGENTS.md",
+        "CLAUDE.md",
+        ".github/copilot-instructions.md",
+        ".llm/context.md",
+        ".llm/skills/mandatory-workflow.md",
+    ];
+
+    for relative_path in policy_files {
+        let policy = read_file(&root.join(relative_path));
+        let normalized = policy.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            normalized.contains("local `git`"),
+            "{relative_path} must reserve branches, commits, and pushes for local git"
+        );
+        assert!(
+            normalized.contains("VS Code GitHub") && normalized.contains("GitHub app"),
+            "{relative_path} must make the connected VS Code GitHub extension/app primary"
+        );
+        assert!(
+            normalized.contains("fallback") || normalized.contains("Fall back"),
+            "{relative_path} must describe gh as a fallback"
+        );
+        assert!(
+            normalized.contains("authenticated"),
+            "{relative_path} must allow gh fallback only through an authenticated session"
+        );
+        let capability_limited = normalized.contains("only when")
+            && (normalized.contains("cannot")
+                || normalized.contains("does not expose")
+                || normalized.contains("lacks"));
+        assert!(
+            capability_limited,
+            "{relative_path} must limit gh fallback to capabilities the extension/app cannot perform"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Internal Path Classification Tests
 //
@@ -21131,6 +21172,7 @@ const SHARED_INTERNAL_PATH_PATTERNS: &[&str] = &[
     ".dockerignore",
     "PLAN.md",
     "AGENTS.md",
+    "CLAUDE.md",
     "pre-push.txt",
     "logs_*.zip",
     "clippy.toml",

--- a/tests/doc_consistency_policy_tests.rs
+++ b/tests/doc_consistency_policy_tests.rs
@@ -157,6 +157,7 @@ fn test_ci_dep_detect_internal_paths_match_script() {
         "Cargo.lock",
         "PLAN.md",
         "AGENTS.md",
+        "CLAUDE.md",
         "pre-push.txt",
         ".gitignore",
         ".dockerignore",

--- a/tests/relay_chaos_e2e.rs
+++ b/tests/relay_chaos_e2e.rs
@@ -63,6 +63,22 @@ async fn connect(addr: std::net::SocketAddr) -> (WsSink, WsReceiver) {
     stream.split()
 }
 
+/// Receive the next frame before one absolute phase deadline.
+///
+/// Server protocol Pings and other unrelated frames must not restart a relative
+/// timeout: doing so can turn a missing expected message into an unbounded wait.
+async fn next_frame_before(
+    receiver: &mut WsReceiver,
+    deadline: tokio::time::Instant,
+    context: &str,
+) -> Message {
+    tokio::time::timeout_at(deadline, receiver.next())
+        .await
+        .unwrap_or_else(|_elapsed| panic!("{context}: timed out before the phase deadline"))
+        .unwrap_or_else(|| panic!("{context}: connection closed"))
+        .unwrap_or_else(|error| panic!("{context}: websocket error: {error}"))
+}
+
 /// Join `room` and return the server-assigned player id.
 async fn join_room(
     sink: &mut WsSink,
@@ -83,12 +99,9 @@ async fn join_room(
         .await
         .expect("send JoinRoom");
 
+    let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
     loop {
-        let frame = tokio::time::timeout(EVENT_DEADLINE, receiver.next())
-            .await
-            .expect("timed out waiting for RoomJoined")
-            .expect("connection closed while joining room")
-            .expect("websocket error while joining room");
+        let frame = next_frame_before(receiver, deadline, "waiting for RoomJoined").await;
         let Message::Text(text) = frame else {
             continue;
         };
@@ -192,8 +205,10 @@ async fn rst_during_relay_heals_room_and_conserves() {
         ledger.record_consumed_v2_room_snapshot("Watcher", &[sender_id, watcher_id]);
         ledger.record_consumed_v2_room_snapshot("Victim", &[sender_id, watcher_id, victim_id]);
 
-        // The victim drains through the proxy until the RST severs it, then
-        // records its own (gap-free-prefix) disconnect.
+        // The victim drains through the proxy while the link is live. The
+        // proxy unit test independently proves that `rst_all` terminates the
+        // client-facing socket on every platform; this relay test proves the
+        // complementary server-facing contract through PlayerLeft below.
         let victim_ledger = Arc::clone(&ledger);
         let victim_drain = tokio::spawn(async move {
             loop {
@@ -205,7 +220,6 @@ async fn rst_during_relay_heals_room_and_conserves() {
                     Some(Ok(_)) => continue,
                 }
             }
-            victim_ledger.note_injected_fault("Victim", "tcp-rst mid-relay");
         });
 
         let mut payload = LedgerPayload::new("Sender", PAYLOAD_PADDING_BYTES);
@@ -219,6 +233,17 @@ async fn rst_during_relay_heals_room_and_conserves() {
         })
         .await;
         proxy.rst_all();
+        // Freeze the victim's already-proven prefix before recording the
+        // terminal fault. Otherwise an already-buffered pre-RST frame can
+        // race the terminal marker and correctly trip the auditor's
+        // no-frames-after-disconnect invariant.
+        victim_drain.abort();
+        match victim_drain.await {
+            Ok(()) => {}
+            Err(error) if error.is_cancelled() => {}
+            Err(error) => panic!("victim drain panicked: {error}"),
+        }
+        ledger.note_injected_fault("Victim", "tcp-rst mid-relay");
 
         send_burst(&mut sender_sink, &mut payload, POST_RST_MESSAGES).await;
         let total_sent = payload.sent();
@@ -226,12 +251,14 @@ async fn rst_during_relay_heals_room_and_conserves() {
         // The watcher must observe the complete stream AND the victim's
         // PlayerLeft (the room healing around the dead connection).
         let mut saw_victim_leave = false;
+        let watcher_deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
         while ledger.received_count("Watcher", "Sender") < total_sent || !saw_victim_leave {
-            let frame = tokio::time::timeout(EVENT_DEADLINE, watcher_rx.next())
-                .await
-                .expect("watcher timed out waiting for the post-RST stream")
-                .expect("watcher connection closed mid-stream")
-                .expect("watcher websocket error mid-stream");
+            let frame = next_frame_before(
+                &mut watcher_rx,
+                watcher_deadline,
+                "watcher waiting for the post-RST stream and PlayerLeft",
+            )
+            .await;
             let Message::Text(text) = frame else {
                 continue;
             };
@@ -239,8 +266,11 @@ async fn rst_during_relay_heals_room_and_conserves() {
                 saw_victim_leave = true;
             }
         }
+        // Keep the client-side sink alive until PlayerLeft proves that the
+        // server observed the proxy's upstream RST rather than a local client
+        // drop racing the injected fault.
+        drop(victim_sink);
 
-        victim_drain.await.expect("victim drain panicked");
         (ledger, total_sent)
     };
     let (ledger, total_sent) = tokio::time::timeout(tokio::time::Duration::from_secs(60), chaos)
@@ -453,22 +483,26 @@ async fn reconnect_churn_leaks_nothing() {
 
             // Both sides must observe the full exchange BEFORE the kill, so
             // the terminal ledger is exact (nothing was in flight).
+            let persistent_relay_deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
             while ledger.received_count("Persistent", &churn_name) < MESSAGES_FROM_CHURN {
-                let frame = tokio::time::timeout(EVENT_DEADLINE, persistent_rx.next())
-                    .await
-                    .expect("persistent client timed out draining churn relay")
-                    .expect("persistent connection closed mid-churn")
-                    .expect("persistent websocket error mid-churn");
+                let frame = next_frame_before(
+                    &mut persistent_rx,
+                    persistent_relay_deadline,
+                    "persistent client draining churn relay",
+                )
+                .await;
                 if let Message::Text(text) = frame {
                     let _player_left = record_frame(&ledger, "Persistent", &text);
                 }
             }
+            let churn_relay_deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
             while ledger.received_count(&churn_name, &persistent_sender) < MESSAGES_TO_CHURN {
-                let frame = tokio::time::timeout(EVENT_DEADLINE, churn_rx.next())
-                    .await
-                    .expect("churn client timed out draining persistent relay")
-                    .expect("churn connection closed before its kill")
-                    .expect("churn websocket error before its kill");
+                let frame = next_frame_before(
+                    &mut churn_rx,
+                    churn_relay_deadline,
+                    "churn client draining persistent relay",
+                )
+                .await;
                 if let Message::Text(text) = frame {
                     let _player_left = record_frame(&ledger, &churn_name, &text);
                 }
@@ -479,12 +513,14 @@ async fn reconnect_churn_leaks_nothing() {
             proxy.rst_all();
             ledger.note_injected_fault(&churn_name, "tcp-rst churn kill");
             let mut saw_churn_leave = false;
+            let player_left_deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
             while !saw_churn_leave {
-                let frame = tokio::time::timeout(EVENT_DEADLINE, persistent_rx.next())
-                    .await
-                    .expect("persistent client timed out waiting for churn PlayerLeft")
-                    .expect("persistent connection closed awaiting PlayerLeft")
-                    .expect("persistent websocket error awaiting PlayerLeft");
+                let frame = next_frame_before(
+                    &mut persistent_rx,
+                    player_left_deadline,
+                    "persistent client waiting for churn PlayerLeft",
+                )
+                .await;
                 if let Message::Text(text) = frame {
                     saw_churn_leave = record_frame(&ledger, "Persistent", &text) == Some(churn_id);
                 }


### PR DESCRIPTION
## What changed

- make relay-chaos multi-frame waits use one absolute deadline so protocol Ping frames cannot refresh a missing-condition timeout
- stop and join the victim observer before its terminal fault marker while keeping the victim sink alive until server-side `PlayerLeft` proves the injected upstream RST
- sweep the same deadline pattern through reconnect churn
- make all agent policy surfaces prefer local Git plus the connected VS Code GitHub extension/app, with authenticated `gh` only for capabilities the app lacks
- classify `CLAUDE.md` as internal policy in both local and CI changelog gates, with data-driven parity coverage

## Historical CI failures closed

- [macOS Nextest timeout](https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/29443472699/job/87448487806): exact RST regression now uses deterministic phase deadlines and passed 20/20 locally
- [AddressSanitizer leak](https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/29384512989/job/87254883205): later registered-shutdown scheduling-margin fix is proven by current-main full x86 ASan run 29475624432

## Local verification

- focused all-feature Clippy with `-D warnings`
- exact RST test 20/20 plus RST proxy and reconnect-churn siblings
- async timeout policy scan
- GitHub policy and CI/doc-classification Rust tests
- 73-case shell doc-consistency fixture
- doc consistency, workflow hygiene, CI config, tooling parity, actionlint, yamllint
- profiled pre-commit 761 ms; pre-push 566 ms

## Remaining PLAN operation

P10 is complete. P11 still requires dispatching Docker Publish with `release_tag=v0.4.0`; anonymous GHCR inventory still lacks `v0.4.0` and `0.4.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relay e2e timing and fault-ordering changes affect CI signal for transport failure behavior; incorrect ordering could hide regressions, while doc and changelog-classification updates are low blast radius.
> 
> **Overview**
> **Relay chaos e2e** hardens timing so CI stops flaking on macOS Nextest timeouts. Multi-frame waits now use a single absolute phase deadline via `next_frame_before`, so protocol Ping frames cannot reset a relative timeout and stall forever. The mid-RST scenario aborts the victim receive loop before recording the injected fault (avoiding a race with buffered pre-RST frames vs. the auditor’s disconnect invariant), keeps the victim WebSocket sink open until `PlayerLeft` proves the server saw the upstream RST, and applies the same deadline pattern in reconnect churn.
> 
> **Agent GitHub policy** is aligned across `AGENTS.md`, `CLAUDE.md`, Copilot instructions, `.llm/context.md`, and mandatory workflow: local `git` for branches/commits/pushes; the connected VS Code GitHub extension/app for PRs and other supported GitHub work; authenticated `gh` only when the app lacks a required capability (e.g. detailed Actions logs). A new `ci_config_tests` check enforces that wording on all policy surfaces.
> 
> **Changelog gates** treat `CLAUDE.md` as an internal path in `check-doc-consistency.sh`, CI dep-detect, fixtures, and parity tests so agent-doc-only edits do not require `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dccd35443c3715c497b9deeafd212a57c6bfed42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->