### PR TITLE
Automate two-phase release preparation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -81,6 +81,22 @@ jobs:
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false
 
+      - name: Read Rust toolchain
+        id: toolchain
+        shell: bash
+        run: |
+          channel=$(bash scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
+          if [ -z "$channel" ]; then
+            echo "ERROR: Could not extract channel from rust-toolchain.toml." >&2
+            exit 1
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.channel }}
+
       - name: Prepare release files
         env:
           BUMP: ${{ inputs.bump }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,228 @@
+# Prepares a reviewed release commit; publication remains release.yml's job.
+#
+# The workflow uses an installation token from the organization's auto-commit
+# GitHub App. Unlike GITHUB_TOKEN, that token lets the generated pull request
+# trigger the repository's normal pull_request CI workflows.
+
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Semantic-version component to increment"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      dry_run:
+        description: "Validate and print the release diff without opening a pull request"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release pull request
+    if: github.repository == 'Ambiguous-Interactive/signal-fish-server'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Require default branch dispatch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+            echo "ERROR: Prepare Release must run from ${DEFAULT_BRANCH}; got ${GITHUB_REF}." >&2
+            exit 1
+          fi
+
+      - name: Check auto-commit GitHub App credentials
+        env:
+          AUTO_COMMIT_APP_ID: ${{ secrets.AUTO_COMMIT_APP_ID }}
+          AUTO_COMMIT_APP_PRIVATE_KEY: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          if [ -n "${AUTO_COMMIT_APP_ID:-}" ] && [ -n "${AUTO_COMMIT_APP_PRIVATE_KEY:-}" ]; then
+            exit 0
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "WARNING: AUTO_COMMIT_APP_* secrets are missing; dry-run can continue." >&2
+            exit 0
+          fi
+          echo "ERROR: AUTO_COMMIT_APP_ID and AUTO_COMMIT_APP_PRIVATE_KEY are required." >&2
+          echo "The App must have repository Contents and Pull requests read/write permissions." >&2
+          exit 1
+
+      - name: Generate auto-commit GitHub App token
+        id: app-token
+        if: ${{ !inputs.dry_run }}
+        uses: actions/create-github-app-token@v3.2.0
+        with:
+          app-id: ${{ secrets.AUTO_COMMIT_APP_ID }}
+          private-key: ${{ secrets.AUTO_COMMIT_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Checkout default branch
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || github.token }}
+          persist-credentials: false
+
+      - name: Prepare release files
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: bash scripts/prepare-release.sh --bump "$BUMP"
+
+      - name: Validate prepared diff scope
+        run: |
+          set -euo pipefail
+          git diff --check
+
+          expected=$(mktemp)
+          actual=$(mktemp)
+          printf '%s\n' \
+            .llm/context.md \
+            CHANGELOG.md \
+            Cargo.lock \
+            Cargo.toml \
+            clients/native/Cargo.lock \
+            docs/library-usage.md \
+            | sort > "$expected"
+          git diff --name-only | sort > "$actual"
+          if ! diff -u "$expected" "$actual"; then
+            echo "ERROR: Release preparation changed an unexpected file set." >&2
+            exit 1
+          fi
+
+      - name: Resolve prepared release identity
+        id: release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+        run: |
+          set -euo pipefail
+          version=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "ERROR: Prepared Cargo.toml version is not strict X.Y.Z semver: $version" >&2
+            exit 1
+          fi
+          branch="release/v${version}"
+          tag="v${version}"
+
+          set +e
+          tag_result=$(git ls-remote --exit-code --tags origin "refs/tags/${tag}" 2>&1)
+          tag_status=$?
+          branch_result=$(git ls-remote --exit-code --heads origin "refs/heads/${branch}" 2>&1)
+          branch_status=$?
+          set -e
+
+          if [ "$tag_status" -eq 0 ]; then
+            echo "ERROR: Release tag ${tag} already exists." >&2
+            exit 1
+          elif [ "$tag_status" -ne 2 ]; then
+            echo "ERROR: Failed to check release tag ${tag}: ${tag_result}" >&2
+            exit "$tag_status"
+          fi
+          if [ "$branch_status" -eq 0 ]; then
+            echo "ERROR: Release branch ${branch} already exists." >&2
+            exit 1
+          elif [ "$branch_status" -ne 2 ]; then
+            echo "ERROR: Failed to check release branch ${branch}: ${branch_result}" >&2
+            exit "$branch_status"
+          fi
+
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "branch=$branch"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create recovery patch
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/release-prepare
+          git diff --binary > "artifacts/release-prepare/release-${VERSION}.patch"
+          git diff --stat > "artifacts/release-prepare/release-${VERSION}.stat.txt"
+
+      - name: Print dry-run diff
+        if: ${{ inputs.dry_run }}
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          BRANCH: ${{ steps.release.outputs.branch }}
+        run: |
+          set -euo pipefail
+          echo "Dry run: would push ${BRANCH} and open a release PR for ${VERSION}."
+          git --no-pager diff --
+
+      - name: Push release branch and open pull request
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ steps.release.outputs.version }}
+          TAG: ${{ steps.release.outputs.tag }}
+          BRANCH: ${{ steps.release.outputs.branch }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add \
+            .llm/context.md \
+            CHANGELOG.md \
+            Cargo.lock \
+            Cargo.toml \
+            clients/native/Cargo.lock \
+            docs/library-usage.md
+          git commit -m "release: ${VERSION}"
+
+          auth_header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            push origin "HEAD:refs/heads/${BRANCH}"
+
+          body_file=$(mktemp)
+          {
+            echo "Automated release preparation for Signal Fish Server ${VERSION}."
+            echo
+            echo "## Checklist"
+            echo
+            echo "- [ ] \`Cargo.toml\` and path-package lockfiles identify \`${VERSION}\`."
+            echo "- [ ] \`CHANGELOG.md\` release notes and date are reviewed."
+            echo "- [ ] All required checks pass on this exact release commit."
+            echo
+            echo "## After merge"
+            echo
+            echo "Run **Release - Publish Crate** from \`${DEFAULT_BRANCH}\` with \`release_version=${VERSION}\`."
+            echo "That workflow creates or verifies annotated tag \`${TAG}\`, then publishes crates.io and GHCR."
+            echo "It creates the GitHub Release and attaches the SBOM and platform archives."
+          } > "$body_file"
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$DEFAULT_BRANCH" \
+            --head "$BRANCH" \
+            --title "release: ${VERSION}" \
+            --body-file "$body_file"
+
+      - name: Upload release preparation recovery patch
+        if: ${{ failure() && !inputs.dry_run }}
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: release-prepare-recovery-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/release-prepare/
+          if-no-files-found: ignore

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -137,11 +137,14 @@ jobs:
           fi
           branch="release/v${version}"
           tag="v${version}"
+          auth_header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
 
           set +e
-          tag_result=$(git ls-remote --exit-code --tags origin "refs/tags/${tag}" 2>&1)
+          tag_result=$(git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            ls-remote --exit-code --tags origin "refs/tags/${tag}" 2>&1)
           tag_status=$?
-          branch_result=$(git ls-remote --exit-code --heads origin "refs/heads/${branch}" 2>&1)
+          branch_result=$(git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            ls-remote --exit-code --heads origin "refs/heads/${branch}" 2>&1)
           branch_status=$?
           set -e
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Checkout default branch
         uses: actions/checkout@v7.0.0
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token || github.token }}
           persist-credentials: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add a manual **Prepare Release** workflow with a `patch` / `minor` / `major`
+  dropdown and optional dry run. It deterministically bumps the root crate and
+  path-package lockfiles, synchronizes public version references, cuts the
+  dated Keep a Changelog section and comparison links, validates the prepared
+  tree, and opens a `release/vX.Y.Z` pull request using an installation token so
+  normal PR CI runs. The existing **Release - Publish Crate** workflow remains
+  the reviewed second phase and publishes crates.io, the canonical annotated
+  GitHub release/tag, verified GHCR images, SBOM, and platform archives.
 - Add the browser completion cell for the Fortress Rollback issue-242 gate.
   The exact released Fortress 0.10.0 and Signal Fish Rust client 0.8.0 graph now
   runs inside two independent Godot 4.5 no-thread WASM exports in Chromium,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,12 +6,31 @@ resolve to the same tagged commit.
 
 ## Prepare the Release Commit
 
-1. Set `[package].version` in `Cargo.toml` and refresh `Cargo.lock`.
-2. Move the release notes from `[Unreleased]` to an exact
-   `## [X.Y.Z] - YYYY-MM-DD` section in `CHANGELOG.md` and update its comparison
-   links.
-3. Push the release commit to the default branch and wait for the required CI
-   and documentation workflows to pass on that commit.
+Run the **Prepare Release** workflow from the default branch:
+
+1. Choose `patch`, `minor`, or `major` from the `bump` dropdown. Use `dry_run`
+   first when you only want to validate and inspect the generated diff.
+2. The workflow computes the next version from `Cargo.toml`, updates the root
+   package and every tracked lockfile that embeds it, synchronizes public dependency
+   examples and project metadata, and moves `[Unreleased]` into an exact
+   `## [X.Y.Z] - YYYY-MM-DD` changelog section with corrected comparison links.
+3. Review and merge the generated `release/vX.Y.Z` pull request only after its
+   normal CI and documentation workflows pass on the exact release commit.
+
+The non-dry-run path requires the repository secrets `AUTO_COMMIT_APP_ID` and
+`AUTO_COMMIT_APP_PRIVATE_KEY`. The installed GitHub App needs read/write access
+to repository contents and pull requests. The workflow deliberately uses its
+installation token when pushing the branch and opening the pull request so the
+generated `pull_request` event starts normal CI; GitHub suppresses new workflow
+runs for equivalent writes made with the built-in `GITHUB_TOKEN`.
+
+For local recovery or troubleshooting, run the same deterministic transformer
+from a clean default-branch checkout, inspect the diff, and open the release PR
+normally:
+
+```bash
+bash scripts/prepare-release.sh --bump patch
+```
 
 Do not create or move the version tag by hand for the normal manual path. Run
 the **Release - Publish Crate** workflow with `release_version=X.Y.Z`. It creates

--- a/progress/session-051-issue-155-release-automation.md
+++ b/progress/session-051-issue-155-release-automation.md
@@ -1,0 +1,36 @@
+# Session 051 — Issue 155 Release Automation
+
+## Objective
+
+Complete issue 155's two-phase manual release flow: prepare a reviewed release
+commit from a semantic-version dropdown, then publish the crate, GitHub Release,
+and packaged artifacts.
+
+## Design
+
+- Reused the already-merged P11 publication path in `.github/workflows/release.yml`.
+  It already owns the canonical annotated tag, crates.io publication, verified
+  multi-architecture GHCR image, GitHub Release, SBOM, and platform archives.
+- Added `.github/workflows/prepare-release.yml` as the missing first phase. It
+  accepts `patch`, `minor`, or `major`, supports a no-write dry run, requires a
+  default-branch dispatch, validates exact tag/branch nonexistence, and opens a
+  `release/vX.Y.Z` pull request.
+- The real PR path uses the organization's auto-commit GitHub App installation
+  token. A PR created with `GITHUB_TOKEN` would not start normal pull-request
+  workflows, so silently falling back would leave the release commit without
+  the repository's required CI evidence.
+- Added `scripts/prepare-release.sh` as the deterministic local and workflow
+  implementation. It updates `Cargo.toml`, all tracked lockfiles containing the
+  root path package, public dependency examples, `.llm/context.md`, and the dated
+  changelog section/link graph; it then validates locked Cargo metadata and the
+  repository documentation policy.
+
+## Verification
+
+- Data-driven tests cover all three bump choices and every synchronized output.
+- Negative tests cover invalid input, invalid dates, empty release notes,
+  duplicate release sections, missing lockfile identity, and arithmetic
+  overflow.
+- CI policy tests pin the workflow choice input, non-cancellable concurrency,
+  least privilege, GitHub App token, branch/tag collision checks, recovery
+  artifact, PR creation, and handoff to the publication workflow.

--- a/progress/session-051-issue-155-release-automation.md
+++ b/progress/session-051-issue-155-release-automation.md
@@ -43,3 +43,8 @@ The validator now performs strict Gregorian calendar checks in Bash, including
 century leap-year rules, so release preparation has identical behavior on the
 Linux, macOS, and Windows CI runners. The regression matrix includes a valid
 leap day plus invalid leap-day, range, and year-zero cases.
+
+Bugbot also identified that the workflow invoked locked Cargo metadata without
+first installing the repository's pinned Rust toolchain. Prepare Release now
+reads `rust-toolchain.toml` after checkout and installs that exact toolchain
+before running the transformer; a policy-ordering test prevents regression.

--- a/progress/session-051-issue-155-release-automation.md
+++ b/progress/session-051-issue-155-release-automation.md
@@ -61,3 +61,10 @@ only when they had dated changelog sections. It now also accepts an exact local
 `vX.Y.Z` Git tag, preserving typo detection while supporting this repository's
 real `v0.3.0` and `v0.4.0` releases. A Git-backed fixture proves an absent tag
 still fails and an existing immutable tag passes.
+
+The replacement macOS lane then found one last fixture-only assumption: the
+test seams hard-coded Linux's `/bin/true`, while macOS provides
+`/usr/bin/true`. They now invoke `true` through `PATH`, matching every required
+runner. The same head's ASan suite passed all tests before reproducing the
+repository's known process-exit leak signature (29 allocations, about 39.8 KiB),
+so that job is classified for an exact-head retry rather than a code change.

--- a/progress/session-051-issue-155-release-automation.md
+++ b/progress/session-051-issue-155-release-automation.md
@@ -34,3 +34,12 @@ and packaged artifacts.
 - CI policy tests pin the workflow choice input, non-cancellable concurrency,
   least privilege, GitHub App token, branch/tag collision checks, recovery
   artifact, PR creation, and handoff to the publication workflow.
+
+## Exact-head CI follow-up
+
+The first PR-head macOS Nextest run exposed a platform-specific date-validation
+bug: `prepare-release.sh` used GNU `date -d`, which BSD `date` does not provide.
+The validator now performs strict Gregorian calendar checks in Bash, including
+century leap-year rules, so release preparation has identical behavior on the
+Linux, macOS, and Windows CI runners. The regression matrix includes a valid
+leap day plus invalid leap-day, range, and year-zero cases.

--- a/progress/session-051-issue-155-release-automation.md
+++ b/progress/session-051-issue-155-release-automation.md
@@ -68,3 +68,9 @@ test seams hard-coded Linux's `/bin/true`, while macOS provides
 runner. The same head's ASan suite passed all tests before reproducing the
 repository's known process-exit leak signature (29 allocations, about 39.8 KiB),
 so that job is classified for an exact-head retry rather than a code change.
+
+Bugbot's next pass found a queued-dispatch race: checkout without an explicit
+`ref` uses the SHA captured when the workflow was requested, which can be stale
+by the time non-cancellable release preparation starts. Checkout now resolves
+the repository's current default-branch ref at job execution, and the workflow
+policy test pins that requirement.

--- a/progress/session-051-issue-155-release-automation.md
+++ b/progress/session-051-issue-155-release-automation.md
@@ -48,3 +48,16 @@ Bugbot also identified that the workflow invoked locked Cargo metadata without
 first installing the repository's pinned Rust toolchain. Prepare Release now
 reads `rust-toolchain.toml` after checkout and installs that exact toolchain
 before running the transformer; a policy-ordering test prevents regression.
+
+A later review caught that the generated release comparison used the newest
+dated changelog section instead of the actual pre-bump package identity. Since
+the repository has `v0.3.0` and `v0.4.0` tags but no matching dated sections,
+that would have skipped both tags. The comparison now always starts at the
+pre-bump `Cargo.toml` version; the fixture intentionally keeps an older dated
+section to prove the two identities cannot be confused again.
+
+The existing documentation checker originally recognized compare endpoints
+only when they had dated changelog sections. It now also accepts an exact local
+`vX.Y.Z` Git tag, preserving typo detection while supporting this repository's
+real `v0.3.0` and `v0.4.0` releases. A Git-backed fixture proves an absent tag
+still fails and an existing immutable tag passes.

--- a/scripts/check-doc-consistency.sh
+++ b/scripts/check-doc-consistency.sh
@@ -369,7 +369,11 @@ validate_changelog() {
         if [[ "$release_ref" =~ /compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.v${version}([#?].*)?$ ]]; then
             local previous_version
             previous_version="${BASH_REMATCH[1]}"
-            if ! grep -Fxq "$previous_version" <<< "$versions"; then
+            # A legitimate prior tag can predate changelog section backfills.
+            # Accept that immutable release identity, but still reject typos and
+            # nonexistent compare endpoints when neither evidence source exists.
+            if ! grep -Fxq "$previous_version" <<< "$versions" \
+                && ! git rev-parse --verify --quiet "refs/tags/v$previous_version" >/dev/null; then
                 action_error "[$version] compare link references unknown previous version v$previous_version (link: $release_ref)"
             fi
             continue

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -176,15 +176,6 @@ if ! grep -Eq '^### (Added|Changed|Deprecated|Removed|Fixed|Security)$' <<< "$UN
     exit 1
 fi
 
-LATEST_RELEASE=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' CHANGELOG.md \
-    | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/' \
-    | sort -V \
-    | tail -n 1)
-if [ -z "$LATEST_RELEASE" ]; then
-    echo "ERROR: CHANGELOG.md has no dated release section to compare from." >&2
-    exit 1
-fi
-
 replace_root_package_version() {
     local file="$1"
     local next_version="$2"
@@ -344,7 +335,7 @@ for lockfile in Cargo.lock clients/native/Cargo.lock; do
 done
 replace_documented_version docs/library-usage.md "$CURRENT_VERSION" "$NEXT_VERSION"
 replace_context_version .llm/context.md "$CURRENT_VERSION" "$NEXT_VERSION"
-cut_changelog_release CHANGELOG.md "$NEXT_VERSION" "$RELEASE_DATE" "$LATEST_RELEASE"
+cut_changelog_release CHANGELOG.md "$NEXT_VERSION" "$RELEASE_DATE" "$CURRENT_VERSION"
 
 if [ "$(read_package_version)" != "$NEXT_VERSION" ]; then
     echo "ERROR: Cargo.toml version update did not persist." >&2

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,344 @@
+#!/usr/bin/env bash
+# Prepare one Signal Fish Server release commit from the current source tree.
+#
+# The script is intentionally deterministic and side-effect free outside the
+# checked-out worktree: it updates the root package version, every tracked
+# lockfile that embeds that path package, synchronized public version references,
+# and the Keep a Changelog release boundary. Publishing remains release.yml's job.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/prepare-release.sh --bump <major|minor|patch> [--date YYYY-MM-DD]
+
+Options:
+  --bump  Required semantic-version component to increment.
+  --date  UTC release date. Defaults to today's UTC date.
+USAGE
+}
+
+BUMP=""
+RELEASE_DATE=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --bump)
+            [ "$#" -ge 2 ] || {
+                echo "ERROR: --bump requires a value." >&2
+                usage >&2
+                exit 2
+            }
+            BUMP="$2"
+            shift 2
+            ;;
+        --date)
+            [ "$#" -ge 2 ] || {
+                echo "ERROR: --date requires a value." >&2
+                usage >&2
+                exit 2
+            }
+            RELEASE_DATE="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$BUMP" in
+    major|minor|patch) ;;
+    *)
+        echo "ERROR: --bump must be one of: major, minor, patch." >&2
+        exit 2
+        ;;
+esac
+
+if [ -z "$RELEASE_DATE" ]; then
+    RELEASE_DATE=$(date -u +%F)
+fi
+if [[ ! "$RELEASE_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
+    || [ "$(date -u -d "$RELEASE_DATE" +%F 2>/dev/null || true)" != "$RELEASE_DATE" ]; then
+    echo "ERROR: --date must be a real calendar date in YYYY-MM-DD form." >&2
+    exit 2
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "ERROR: prepare-release.sh must run inside a Git worktree." >&2
+    exit 1
+}
+cd "$REPO_ROOT"
+
+for required in \
+    Cargo.toml Cargo.lock CHANGELOG.md .llm/context.md docs/library-usage.md \
+    clients/native/Cargo.lock scripts/check-doc-consistency.sh; do
+    if [ ! -f "$required" ]; then
+        echo "ERROR: Required release file is missing: $required" >&2
+        exit 1
+    fi
+done
+
+read_package_version() {
+    awk '
+        BEGIN { in_package = 0 }
+        /^\[package\][[:space:]]*$/ { in_package = 1; next }
+        /^\[[^]]+\][[:space:]]*$/ { if (in_package == 1) in_package = 0 }
+        in_package == 1 && /^[[:space:]]*version[[:space:]]*=[[:space:]]*"/ {
+            line = $0
+            sub(/^[[:space:]]*version[[:space:]]*=[[:space:]]*"/, "", line)
+            sub(/".*$/, "", line)
+            print line
+            exit
+        }
+    ' Cargo.toml
+}
+
+CURRENT_VERSION=$(read_package_version)
+if [[ ! "$CURRENT_VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "ERROR: Cargo.toml [package].version is not strict X.Y.Z semver: $CURRENT_VERSION" >&2
+    exit 1
+fi
+
+IFS=. read -r CURRENT_MAJOR CURRENT_MINOR CURRENT_PATCH <<< "$CURRENT_VERSION"
+
+# Bash arithmetic is signed 64-bit on the supported runners. Fail closed before
+# incrementing instead of wrapping a syntactically valid (but extreme) semver.
+increment_component() {
+    local value="$1"
+    local max_incrementable="9223372036854775806"
+    # Equal-width decimal strings are intentionally compared lexicographically.
+    # shellcheck disable=SC2071
+    if [ "${#value}" -gt "${#max_incrementable}" ] \
+        || { [ "${#value}" -eq "${#max_incrementable}" ] && [[ "$value" > "$max_incrementable" ]]; }; then
+        echo "ERROR: Cannot safely increment semver component '$value'." >&2
+        exit 1
+    fi
+    printf '%s\n' "$((value + 1))"
+}
+
+case "$BUMP" in
+    major)
+        NEXT_VERSION="$(increment_component "$CURRENT_MAJOR").0.0"
+        ;;
+    minor)
+        NEXT_VERSION="$CURRENT_MAJOR.$(increment_component "$CURRENT_MINOR").0"
+        ;;
+    patch)
+        NEXT_VERSION="$CURRENT_MAJOR.$CURRENT_MINOR.$(increment_component "$CURRENT_PATCH")"
+        ;;
+esac
+
+if grep -Eq "^## \\[${NEXT_VERSION//./\\.}\\]([[:space:]]|$)" CHANGELOG.md; then
+    echo "ERROR: CHANGELOG.md already contains a release section for $NEXT_VERSION." >&2
+    exit 1
+fi
+
+UNRELEASED_BODY=$(awk '
+    /^## \[Unreleased\]$/ { in_unreleased = 1; next }
+    in_unreleased && /^## \[/ { exit }
+    in_unreleased { print }
+' CHANGELOG.md)
+if ! grep -Eq '^### (Added|Changed|Deprecated|Removed|Fixed|Security)$' <<< "$UNRELEASED_BODY" \
+    || ! grep -Eq '^[[:space:]]*[-*][[:space:]]+' <<< "$UNRELEASED_BODY"; then
+    echo "ERROR: CHANGELOG.md [Unreleased] must contain categorized release notes before preparation." >&2
+    exit 1
+fi
+
+LATEST_RELEASE=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' CHANGELOG.md \
+    | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/' \
+    | sort -V \
+    | tail -n 1)
+if [ -z "$LATEST_RELEASE" ]; then
+    echo "ERROR: CHANGELOG.md has no dated release section to compare from." >&2
+    exit 1
+fi
+
+replace_root_package_version() {
+    local file="$1"
+    local next_version="$2"
+    local output count_file
+    output=$(mktemp)
+    count_file=$(mktemp)
+    awk -v next_version="$next_version" -v count_file="$count_file" '
+        BEGIN { in_package = 0; changed = 0 }
+        /^\[package\][[:space:]]*$/ { in_package = 1; print; next }
+        /^\[[^]]+\][[:space:]]*$/ { if (in_package == 1) in_package = 0 }
+        in_package == 1 && /^[[:space:]]*version[[:space:]]*=[[:space:]]*"/ {
+            indent = $0
+            sub(/[^[:space:]].*$/, "", indent)
+            print indent "version = \"" next_version "\""
+            changed++
+            next
+        }
+        { print }
+        END { print changed > count_file }
+    ' "$file" > "$output"
+    if [ "$(cat "$count_file")" -ne 1 ]; then
+        echo "ERROR: Expected exactly one [package].version in $file." >&2
+        rm -f "$output" "$count_file"
+        exit 1
+    fi
+    mv "$output" "$file"
+    rm -f "$count_file"
+}
+
+replace_locked_path_package_version() {
+    local file="$1"
+    local next_version="$2"
+    local output count_file
+    output=$(mktemp)
+    count_file=$(mktemp)
+    awk -v next_version="$next_version" -v count_file="$count_file" '
+        BEGIN { target = 0; changed = 0 }
+        /^\[\[package\]\]$/ { target = 0 }
+        /^name = "signal-fish-server"$/ { target = 1 }
+        target == 1 && /^version = "/ {
+            print "version = \"" next_version "\""
+            changed++
+            target = 0
+            next
+        }
+        { print }
+        END { print changed > count_file }
+    ' "$file" > "$output"
+    if [ "$(cat "$count_file")" -ne 1 ]; then
+        echo "ERROR: Expected exactly one signal-fish-server package entry in $file." >&2
+        rm -f "$output" "$count_file"
+        exit 1
+    fi
+    mv "$output" "$file"
+    rm -f "$count_file"
+}
+
+replace_documented_version() {
+    local file="$1"
+    local current_version="$2"
+    local next_version="$3"
+    local output count_file
+    output=$(mktemp)
+    count_file=$(mktemp)
+    awk -v current_version="$current_version" -v next_version="$next_version" -v count_file="$count_file" '
+        BEGIN { changed = 0 }
+        function replace_all(text, needle, replacement,    result, position) {
+            result = ""
+            replacements = 0
+            while ((position = index(text, needle)) != 0) {
+                result = result substr(text, 1, position - 1) replacement
+                text = substr(text, position + length(needle))
+                replacements++
+            }
+            return result text
+        }
+        /signal-fish-server[[:space:]]*=[[:space:]]*["{]/ {
+            $0 = replace_all($0, current_version, next_version)
+            changed += replacements
+        }
+        { print }
+        END { print changed > count_file }
+    ' "$file" > "$output"
+    if [ "$(cat "$count_file")" -lt 1 ]; then
+        echo "ERROR: No $current_version dependency examples were updated in $file." >&2
+        rm -f "$output" "$count_file"
+        exit 1
+    fi
+    mv "$output" "$file"
+    rm -f "$count_file"
+}
+
+replace_context_version() {
+    local file="$1"
+    local current_version="$2"
+    local next_version="$3"
+    local output count_file
+    output=$(mktemp)
+    count_file=$(mktemp)
+    awk -v current="- **Version:** $current_version" -v replacement="- **Version:** $next_version" -v count_file="$count_file" '
+        BEGIN { changed = 0 }
+        $0 == current { print replacement; changed++; next }
+        { print }
+        END { print changed > count_file }
+    ' "$file" > "$output"
+    if [ "$(cat "$count_file")" -ne 1 ]; then
+        echo "ERROR: Expected one exact project version line in $file." >&2
+        rm -f "$output" "$count_file"
+        exit 1
+    fi
+    mv "$output" "$file"
+    rm -f "$count_file"
+}
+
+cut_changelog_release() {
+    local file="$1"
+    local next_version="$2"
+    local release_date="$3"
+    local latest_release="$4"
+    local output count_file
+    output=$(mktemp)
+    count_file=$(mktemp)
+    awk \
+        -v next_version="$next_version" \
+        -v release_date="$release_date" \
+        -v latest_release="$latest_release" \
+        -v count_file="$count_file" '
+        BEGIN { heading = 0; link = 0 }
+        /^## \[Unreleased\]$/ {
+            print
+            print ""
+            print "## [" next_version "] - " release_date
+            heading++
+            next
+        }
+        /^\[Unreleased\]:[[:space:]]*/ {
+            print "[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v" next_version "...HEAD"
+            print "[" next_version "]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v" latest_release "...v" next_version
+            link++
+            next
+        }
+        { print }
+        END { print heading ":" link > count_file }
+    ' "$file" > "$output"
+    if [ "$(cat "$count_file")" != "1:1" ]; then
+        echo "ERROR: Expected one [Unreleased] heading and link in $file." >&2
+        rm -f "$output" "$count_file"
+        exit 1
+    fi
+    mv "$output" "$file"
+    rm -f "$count_file"
+}
+
+replace_root_package_version Cargo.toml "$NEXT_VERSION"
+for lockfile in Cargo.lock clients/native/Cargo.lock; do
+    replace_locked_path_package_version "$lockfile" "$NEXT_VERSION"
+done
+replace_documented_version docs/library-usage.md "$CURRENT_VERSION" "$NEXT_VERSION"
+replace_context_version .llm/context.md "$CURRENT_VERSION" "$NEXT_VERSION"
+cut_changelog_release CHANGELOG.md "$NEXT_VERSION" "$RELEASE_DATE" "$LATEST_RELEASE"
+
+if [ "$(read_package_version)" != "$NEXT_VERSION" ]; then
+    echo "ERROR: Cargo.toml version update did not persist." >&2
+    exit 1
+fi
+
+# These two overrides are narrow test seams. Production and the workflow use
+# the real commands, while isolated fixture tests can validate transformations
+# without resolving the repository's dependency graph.
+PREPARE_RELEASE_CARGO_BIN=${PREPARE_RELEASE_CARGO_BIN:-cargo}
+PREPARE_RELEASE_DOC_CHECK=${PREPARE_RELEASE_DOC_CHECK:-scripts/check-doc-consistency.sh}
+
+for manifest in Cargo.toml clients/native/Cargo.toml; do
+    "$PREPARE_RELEASE_CARGO_BIN" metadata --locked --no-deps --format-version 1 \
+        --manifest-path "$manifest" >/dev/null
+done
+"$PREPARE_RELEASE_DOC_CHECK" --changed-files \
+    Cargo.toml Cargo.lock clients/native/Cargo.lock \
+    CHANGELOG.md docs/library-usage.md .llm/context.md
+
+printf 'Prepared Signal Fish Server %s -> %s (%s).\n' \
+    "$CURRENT_VERSION" "$NEXT_VERSION" "$RELEASE_DATE"

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -64,8 +64,33 @@ esac
 if [ -z "$RELEASE_DATE" ]; then
     RELEASE_DATE=$(date -u +%F)
 fi
-if [[ ! "$RELEASE_DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] \
-    || [ "$(date -u -d "$RELEASE_DATE" +%F 2>/dev/null || true)" != "$RELEASE_DATE" ]; then
+
+# Validate Gregorian calendar dates in Bash instead of relying on GNU `date -d`,
+# which is unavailable on the macOS runners used by the required CI matrix.
+is_real_calendar_date() {
+    local candidate="$1"
+    local year month day max_day
+
+    [[ "$candidate" =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})$ ]] || return 1
+    year=$((10#${BASH_REMATCH[1]}))
+    month=$((10#${BASH_REMATCH[2]}))
+    day=$((10#${BASH_REMATCH[3]}))
+
+    ((year >= 1 && month >= 1 && month <= 12 && day >= 1)) || return 1
+    case "$month" in
+        2)
+            max_day=28
+            if ((year % 400 == 0 || (year % 4 == 0 && year % 100 != 0))); then
+                max_day=29
+            fi
+            ;;
+        4|6|9|11) max_day=30 ;;
+        *) max_day=31 ;;
+    esac
+    ((day <= max_day))
+}
+
+if ! is_real_calendar_date "$RELEASE_DATE"; then
     echo "ERROR: --date must be a real calendar date in YYYY-MM-DD form." >&2
     exit 2
 fi

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4067,7 +4067,7 @@ fn test_prepare_release_script_updates_every_canonical_release_input() {
         "docs/library-usage.md",
         ".llm/context.md",
         "Unreleased",
-        "sort -V",
+        "cut_changelog_release CHANGELOG.md \"$NEXT_VERSION\" \"$RELEASE_DATE\" \"$CURRENT_VERSION\"",
         "metadata --locked --no-deps --format-version 1",
         "scripts/check-doc-consistency.sh",
     ] {

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4036,6 +4036,8 @@ fn test_prepare_release_script_updates_every_canonical_release_input() {
     for required in [
         "major|minor|patch",
         "date -u +%F",
+        "is_real_calendar_date",
+        "year % 400 == 0",
         "Cargo.toml",
         "Cargo.lock",
         "clients/native/Cargo.lock",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4012,8 +4012,9 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
         "bash scripts/prepare-release.sh --bump \"$BUMP\"",
         "git diff --check",
         "branch=\"release/v${version}\"",
-        "git ls-remote --exit-code --tags",
-        "git ls-remote --exit-code --heads",
+        "auth_header=$(printf 'x-access-token:%s' \"$GH_TOKEN\" | base64 | tr -d '\\n')",
+        "ls-remote --exit-code --tags",
+        "ls-remote --exit-code --heads",
         "push origin \"HEAD:refs/heads/${BRANCH}\"",
         "gh pr create",
         "Release - Publish Crate",
@@ -4029,6 +4030,19 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
         prepare.contains("GH_TOKEN: ${{ steps.app-token.outputs.token }}"),
         "The release PR must be created with the installation token so normal pull_request CI \
          runs; workflow-created PRs made with GITHUB_TOKEN do not trigger new workflows."
+    );
+
+    assert_eq!(
+        prepare
+            .matches(
+                "git -c \"http.https://github.com/.extraheader=AUTHORIZATION: basic \
+                 ${auth_header}\""
+            )
+            .count(),
+        3,
+        "Every remote git operation (tag probe, branch probe, and branch push) must use the \
+         installation-token authorization header; unauthenticated probes can fail on private \
+         repositories or anonymous rate limits."
     );
 
     let checkout = prepare

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4005,6 +4005,9 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
         "actions/create-github-app-token@v3.2.0",
         "permission-contents: write",
         "permission-pull-requests: write",
+        "Read Rust toolchain",
+        "dtolnay/rust-toolchain@v1",
+        "toolchain: ${{ steps.toolchain.outputs.channel }}",
         "bash scripts/prepare-release.sh --bump \"$BUMP\"",
         "git diff --check",
         "branch=\"release/v${version}\"",
@@ -4025,6 +4028,26 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
         prepare.contains("GH_TOKEN: ${{ steps.app-token.outputs.token }}"),
         "The release PR must be created with the installation token so normal pull_request CI \
          runs; workflow-created PRs made with GITHUB_TOKEN do not trigger new workflows."
+    );
+
+    let checkout = prepare
+        .find("Checkout default branch")
+        .expect("prepare job must check out the repository");
+    let read_toolchain = prepare
+        .find("Read Rust toolchain")
+        .expect("prepare job must read the pinned Rust toolchain");
+    let install_toolchain = prepare
+        .find("Install Rust toolchain")
+        .expect("prepare job must install the pinned Rust toolchain");
+    let prepare_files = prepare
+        .find("Prepare release files")
+        .expect("prepare job must run the release transformer");
+    assert!(
+        checkout < read_toolchain
+            && read_toolchain < install_toolchain
+            && install_toolchain < prepare_files,
+        "The pinned Rust toolchain must be installed after checkout and before release \
+         preparation invokes Cargo."
     );
 }
 

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4005,6 +4005,7 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
         "actions/create-github-app-token@v3.2.0",
         "permission-contents: write",
         "permission-pull-requests: write",
+        "ref: ${{ github.event.repository.default_branch }}",
         "Read Rust toolchain",
         "dtolnay/rust-toolchain@v1",
         "toolchain: ${{ steps.toolchain.outputs.channel }}",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1353,6 +1353,10 @@ const REQUIRED_WORKFLOW_FILES: &[(&str, &str)] = &[
         "Release automation (crates.io + GitHub release)",
     ),
     (
+        "prepare-release.yml",
+        "Manual release preparation (semver bump + changelog release PR)",
+    ),
+    (
         "ci-safety.yml",
         "Advanced safety analysis (Miri, AddressSanitizer — staged)",
     ),
@@ -3966,6 +3970,95 @@ FROM chef AS builder";
         !strip_comment_lines(jsonc_commented).contains("docker-outside-of-docker"),
         "a guard asserting the LIVE view must reject a `//`-commented JSONC feature line"
     );
+}
+
+#[test]
+fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
+    let root = repo_root();
+    let workflow = read_live_file(&root.join(".github/workflows/prepare-release.yml"));
+    let permissions = extract_yaml_mapping_block(&workflow, "permissions", 0)
+        .expect("prepare-release.yml must define workflow-level permissions");
+    let prepare = extract_workflow_job_block(&workflow, "prepare")
+        .expect("prepare-release.yml must define the prepare job");
+
+    assert!(workflow.contains("name: Prepare Release"));
+    assert!(workflow.contains("workflow_dispatch:"));
+    for required in [
+        "bump:",
+        "type: choice",
+        "- patch",
+        "- minor",
+        "- major",
+        "dry_run:",
+        "cancel-in-progress: false",
+    ] {
+        assert!(
+            workflow.contains(required),
+            "prepare-release.yml must contain `{required}` so a maintainer can choose a safe, \
+             non-cancellable semantic-version preparation run."
+        );
+    }
+
+    assert_eq!(permissions.trim(), "contents: read");
+    for required in [
+        "Require default branch dispatch",
+        "actions/create-github-app-token@v3.2.0",
+        "permission-contents: write",
+        "permission-pull-requests: write",
+        "bash scripts/prepare-release.sh --bump \"$BUMP\"",
+        "git diff --check",
+        "branch=\"release/v${version}\"",
+        "git ls-remote --exit-code --tags",
+        "git ls-remote --exit-code --heads",
+        "push origin \"HEAD:refs/heads/${BRANCH}\"",
+        "gh pr create",
+        "Release - Publish Crate",
+        "actions/upload-artifact@v7.0.1",
+    ] {
+        assert!(
+            prepare.contains(required),
+            "prepare-release.yml prepare job must contain `{required}`.\nJob block:\n{prepare}"
+        );
+    }
+
+    assert!(
+        prepare.contains("GH_TOKEN: ${{ steps.app-token.outputs.token }}"),
+        "The release PR must be created with the installation token so normal pull_request CI \
+         runs; workflow-created PRs made with GITHUB_TOKEN do not trigger new workflows."
+    );
+}
+
+#[test]
+fn test_prepare_release_script_updates_every_canonical_release_input() {
+    let root = repo_root();
+    let script = read_live_file(&root.join("scripts/prepare-release.sh"));
+
+    for required in [
+        "major|minor|patch",
+        "date -u +%F",
+        "Cargo.toml",
+        "Cargo.lock",
+        "clients/native/Cargo.lock",
+        "docs/library-usage.md",
+        ".llm/context.md",
+        "Unreleased",
+        "sort -V",
+        "metadata --locked --no-deps --format-version 1",
+        "scripts/check-doc-consistency.sh",
+    ] {
+        assert!(
+            script.contains(required),
+            "prepare-release.sh must contain live `{required}` handling so version, lockfile, \
+             changelog, and documented release identities cannot drift."
+        );
+    }
+
+    for manifest in ["Cargo.toml", "clients/native/Cargo.toml"] {
+        assert!(
+            script.contains(manifest),
+            "prepare-release.sh must validate {manifest} with locked Cargo metadata."
+        );
+    }
 }
 
 #[test]

--- a/tests/doc_consistency_script_tests.rs
+++ b/tests/doc_consistency_script_tests.rs
@@ -4,6 +4,7 @@ mod common;
 
 use common::{bash_command, repo_root, unique_temp_dir, write_file};
 use std::fs;
+use std::process::Command;
 use std::thread;
 
 use regex::RegexBuilder;
@@ -113,6 +114,15 @@ fn run_checker_with_fixture(
     extra_files: &[(&str, &str)],
     args: &[&str],
 ) -> (i32, String) {
+    run_checker_with_fixture_and_tags(overrides, extra_files, args, &[])
+}
+
+fn run_checker_with_fixture_and_tags(
+    overrides: &[(&str, &str)],
+    extra_files: &[(&str, &str)],
+    args: &[&str],
+    tags: &[&str],
+) -> (i32, String) {
     let temp_root = unique_temp_dir("doc-consistency");
     let script_src = repo_root().join("scripts/check-doc-consistency.sh");
     let script_dst = temp_root.path().join("scripts/check-doc-consistency.sh");
@@ -131,6 +141,31 @@ fn run_checker_with_fixture(
 
     for (path, content) in extra_files {
         write_file(&temp_root.path().join(path), content);
+    }
+
+    if !tags.is_empty() {
+        for arguments in [
+            vec!["init", "--quiet"],
+            vec!["config", "user.name", "Fixture"],
+            vec!["config", "user.email", "fixture@example.invalid"],
+            vec!["add", "."],
+            vec!["commit", "--quiet", "-m", "fixture"],
+        ] {
+            let status = Command::new("git")
+                .args(arguments)
+                .current_dir(temp_root.path())
+                .status()
+                .expect("run fixture Git command");
+            assert!(status.success(), "fixture Git setup failed");
+        }
+        for tag in tags {
+            let status = Command::new("git")
+                .args(["tag", tag])
+                .current_dir(temp_root.path())
+                .status()
+                .expect("create fixture release tag");
+            assert!(status.success(), "fixture tag creation failed for {tag}");
+        }
     }
 
     let mut command = bash_command();
@@ -156,6 +191,26 @@ fn run_checker_with_fixture(
         output.status.code().unwrap_or(-1),
         combined.replace("\r\n", "\n"),
     )
+}
+
+#[test]
+fn test_release_compare_accepts_existing_tag_without_dated_section() {
+    let changelog = "# Changelog\n\n\
+        The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n\
+        ## [Unreleased]\n\n### Changed\n- Pending.\n\n\
+        ## [0.2.0] - 2026-02-24\n\n### Added\n- Release notes.\n\n\
+        ## [0.1.0] - 2026-02-15\n\n### Added\n- Initial release.\n\n\
+        [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.2.0...HEAD\n\
+        [0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.1...v0.2.0\n\
+        [0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0\n";
+
+    let (exit_code, output) =
+        run_checker_with_fixture_and_tags(&[("CHANGELOG.md", changelog)], &[], &[], &["v0.1.1"]);
+    assert_eq!(
+        exit_code, 0,
+        "An existing immutable release tag is a valid compare endpoint even when its dated \
+         changelog section has not been backfilled.\nOutput:\n{output}"
+    );
 }
 
 #[derive(Debug)]

--- a/tests/release_prepare_tests.rs
+++ b/tests/release_prepare_tests.rs
@@ -61,11 +61,11 @@ impl Fixture {
              - Ship the release preparation workflow.\n\n\
              ### Fixed\n\n\
              - Preserve categorized notes.\n\n\
-             ## [1.2.3] - 2026-07-01\n\n\
+             ## [1.1.0] - 2026-07-01\n\n\
              ### Added\n\n\
              - Previous release.\n\n\
-             [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v1.2.3...HEAD\n\
-             [1.2.3]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v1.2.3\n",
+             [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v1.1.0...HEAD\n\
+             [1.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v1.1.0\n",
         );
         write(
             &root.join("scripts/check-doc-consistency.sh"),
@@ -194,8 +194,8 @@ fn prepare_release_fails_closed_on_empty_notes_existing_version_or_lock_drift() 
 
     let duplicate = Fixture::new("1.2.3");
     let changelog = read(duplicate.root.join("CHANGELOG.md")).replace(
-        "## [1.2.3] - 2026-07-01",
-        "## [1.2.4] - 2026-07-10\n\n### Fixed\n\n- Already cut.\n\n## [1.2.3] - 2026-07-01",
+        "## [1.1.0] - 2026-07-01",
+        "## [1.2.4] - 2026-07-10\n\n### Fixed\n\n- Already cut.\n\n## [1.1.0] - 2026-07-01",
     );
     write(&duplicate.root.join("CHANGELOG.md"), &changelog);
     let output = duplicate.run(&["--bump", "patch", "--date", RELEASE_DATE]);

--- a/tests/release_prepare_tests.rs
+++ b/tests/release_prepare_tests.rs
@@ -88,8 +88,8 @@ impl Fixture {
             .arg(script)
             .args(arguments)
             .current_dir(&self.root)
-            .env("PREPARE_RELEASE_CARGO_BIN", "/bin/true")
-            .env("PREPARE_RELEASE_DOC_CHECK", "/bin/true")
+            .env("PREPARE_RELEASE_CARGO_BIN", "true")
+            .env("PREPARE_RELEASE_DOC_CHECK", "true")
             .output()
             .expect("run prepare-release.sh")
     }

--- a/tests/release_prepare_tests.rs
+++ b/tests/release_prepare_tests.rs
@@ -1,0 +1,213 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use tempfile::TempDir;
+
+const RELEASE_DATE: &str = "2026-07-17";
+
+struct Fixture {
+    _temp: TempDir,
+    root: PathBuf,
+}
+
+impl Fixture {
+    fn new(version: &str) -> Self {
+        let temp = tempfile::tempdir().expect("create release fixture");
+        let root = temp.path().to_path_buf();
+        for directory in [".llm", "clients/native", "docs", "fuzz", "scripts"] {
+            fs::create_dir_all(root.join(directory)).expect("create fixture directory");
+        }
+
+        write(
+            &root.join("Cargo.toml"),
+            &format!(
+                "[package]\nname = \"signal-fish-server\"\nversion = \"{version}\"\n\n\
+                 [dependencies]\nexample = {{ version = \"9.9.9\" }}\n"
+            ),
+        );
+        for lock in ["Cargo.lock", "clients/native/Cargo.lock"] {
+            write(
+                &root.join(lock),
+                &format!(
+                    "version = 4\n\n[[package]]\nname = \"example\"\nversion = \"9.9.9\"\n\n\
+                     [[package]]\nname = \"signal-fish-server\"\nversion = \"{version}\"\n"
+                ),
+            );
+        }
+        write(
+            &root.join("clients/native/Cargo.toml"),
+            "[package]\nname = \"native\"\nversion = \"0.1.0\"\n",
+        );
+        write(
+            &root.join("docs/library-usage.md"),
+            &format!(
+                "```toml\nsignal-fish-server = \"{version}\"\n\
+                 signal-fish-server = {{ version = \"{version}\", features = [\"tls\"] }}\n```\n"
+            ),
+        );
+        write(
+            &root.join(".llm/context.md"),
+            &format!("# Context\n\n- **Version:** {version}\n"),
+        );
+        write(
+            &root.join("CHANGELOG.md"),
+            "# Changelog\n\n\
+             The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n\
+             ## [Unreleased]\n\n\
+             ### Added\n\n\
+             - Ship the release preparation workflow.\n\n\
+             ### Fixed\n\n\
+             - Preserve categorized notes.\n\n\
+             ## [1.2.3] - 2026-07-01\n\n\
+             ### Added\n\n\
+             - Previous release.\n\n\
+             [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v1.2.3...HEAD\n\
+             [1.2.3]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v1.2.3\n",
+        );
+        write(
+            &root.join("scripts/check-doc-consistency.sh"),
+            "#!/usr/bin/env bash\nexit 0\n",
+        );
+
+        let status = Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&root)
+            .status()
+            .expect("initialize fixture worktree");
+        assert!(status.success(), "git init failed for release fixture");
+
+        Self { _temp: temp, root }
+    }
+
+    fn run(&self, arguments: &[&str]) -> Output {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/prepare-release.sh");
+        Command::new("bash")
+            .arg(script)
+            .args(arguments)
+            .current_dir(&self.root)
+            .env("PREPARE_RELEASE_CARGO_BIN", "/bin/true")
+            .env("PREPARE_RELEASE_DOC_CHECK", "/bin/true")
+            .output()
+            .expect("run prepare-release.sh")
+    }
+}
+
+fn write(path: &Path, content: &str) {
+    fs::write(path, content).unwrap_or_else(|error| panic!("write {}: {error}", path.display()));
+}
+
+fn read(path: impl AsRef<Path>) -> String {
+    let path = path.as_ref();
+    fs::read_to_string(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+#[test]
+fn prepare_release_applies_every_semver_bump_and_synchronizes_release_files() {
+    for (bump, expected) in [("patch", "1.2.4"), ("minor", "1.3.0"), ("major", "2.0.0")] {
+        let fixture = Fixture::new("1.2.3");
+        let output = fixture.run(&["--bump", bump, "--date", RELEASE_DATE]);
+        assert!(
+            output.status.success(),
+            "{bump} preparation failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let cargo_toml = read(fixture.root.join("Cargo.toml"));
+        assert!(cargo_toml.contains(&format!("version = \"{expected}\"")));
+        assert!(cargo_toml.contains("example = { version = \"9.9.9\" }"));
+
+        for lock in ["Cargo.lock", "clients/native/Cargo.lock"] {
+            let contents = read(fixture.root.join(lock));
+            assert!(
+                contents.contains(&format!(
+                    "name = \"signal-fish-server\"\nversion = \"{expected}\""
+                )),
+                "{lock} did not receive {expected}:\n{contents}"
+            );
+            assert!(contents.contains("name = \"example\"\nversion = \"9.9.9\""));
+        }
+
+        let docs = read(fixture.root.join("docs/library-usage.md"));
+        assert_eq!(docs.matches(expected).count(), 2);
+        assert!(!docs.contains("1.2.3"));
+        assert_eq!(
+            read(fixture.root.join(".llm/context.md")),
+            format!("# Context\n\n- **Version:** {expected}\n")
+        );
+
+        let changelog = read(fixture.root.join("CHANGELOG.md"));
+        assert!(changelog.contains(&format!(
+            "## [Unreleased]\n\n## [{expected}] - {RELEASE_DATE}\n\n### Added"
+        )));
+        assert!(changelog.contains("- Preserve categorized notes."));
+        assert!(changelog.contains(&format!(
+            "[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v{expected}...HEAD"
+        )));
+        assert!(changelog.contains(&format!(
+            "[{expected}]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v1.2.3...v{expected}"
+        )));
+    }
+}
+
+#[test]
+fn prepare_release_rejects_invalid_inputs_before_mutating_files() {
+    for arguments in [
+        vec!["--bump", "prerelease"],
+        vec!["--bump", "patch", "--date", "2026-02-30"],
+        vec!["--date", RELEASE_DATE],
+    ] {
+        let fixture = Fixture::new("1.2.3");
+        let before = read(fixture.root.join("Cargo.toml"));
+        let output = fixture.run(&arguments);
+        assert!(
+            !output.status.success(),
+            "invalid arguments unexpectedly passed"
+        );
+        assert_eq!(read(fixture.root.join("Cargo.toml")), before);
+    }
+}
+
+#[test]
+fn prepare_release_fails_closed_on_empty_notes_existing_version_or_lock_drift() {
+    let empty = Fixture::new("1.2.3");
+    write(
+        &empty.root.join("CHANGELOG.md"),
+        "# Changelog\n\nKeep a Changelog\n\n## [Unreleased]\n\n\
+         ## [1.2.3] - 2026-07-01\n\n### Added\n\n- Previous.\n\n\
+         [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v1.2.3...HEAD\n\
+         [1.2.3]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v1.2.3\n",
+    );
+    let output = empty.run(&["--bump", "patch", "--date", RELEASE_DATE]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("categorized release notes"));
+
+    let duplicate = Fixture::new("1.2.3");
+    let changelog = read(duplicate.root.join("CHANGELOG.md")).replace(
+        "## [1.2.3] - 2026-07-01",
+        "## [1.2.4] - 2026-07-10\n\n### Fixed\n\n- Already cut.\n\n## [1.2.3] - 2026-07-01",
+    );
+    write(&duplicate.root.join("CHANGELOG.md"), &changelog);
+    let output = duplicate.run(&["--bump", "patch", "--date", RELEASE_DATE]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("already contains"));
+
+    let lock_drift = Fixture::new("1.2.3");
+    write(
+        &lock_drift.root.join("clients/native/Cargo.lock"),
+        "version = 4\n\n[[package]]\nname = \"different-package\"\nversion = \"1.2.3\"\n",
+    );
+    let output = lock_drift.run(&["--bump", "patch", "--date", RELEASE_DATE]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("exactly one signal-fish-server"));
+}
+
+#[test]
+fn prepare_release_rejects_semver_arithmetic_overflow() {
+    let fixture = Fixture::new("9223372036854775807.0.0");
+    let output = fixture.run(&["--bump", "major", "--date", RELEASE_DATE]);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Cannot safely increment"));
+}

--- a/tests/release_prepare_tests.rs
+++ b/tests/release_prepare_tests.rs
@@ -106,9 +106,13 @@ fn read(path: impl AsRef<Path>) -> String {
 
 #[test]
 fn prepare_release_applies_every_semver_bump_and_synchronizes_release_files() {
-    for (bump, expected) in [("patch", "1.2.4"), ("minor", "1.3.0"), ("major", "2.0.0")] {
+    for (bump, expected, release_date) in [
+        ("patch", "1.2.4", RELEASE_DATE),
+        ("minor", "1.3.0", RELEASE_DATE),
+        ("major", "2.0.0", "2028-02-29"),
+    ] {
         let fixture = Fixture::new("1.2.3");
-        let output = fixture.run(&["--bump", bump, "--date", RELEASE_DATE]);
+        let output = fixture.run(&["--bump", bump, "--date", release_date]);
         assert!(
             output.status.success(),
             "{bump} preparation failed:\n{}",
@@ -140,7 +144,7 @@ fn prepare_release_applies_every_semver_bump_and_synchronizes_release_files() {
 
         let changelog = read(fixture.root.join("CHANGELOG.md"));
         assert!(changelog.contains(&format!(
-            "## [Unreleased]\n\n## [{expected}] - {RELEASE_DATE}\n\n### Added"
+            "## [Unreleased]\n\n## [{expected}] - {release_date}\n\n### Added"
         )));
         assert!(changelog.contains("- Preserve categorized notes."));
         assert!(changelog.contains(&format!(
@@ -157,6 +161,10 @@ fn prepare_release_rejects_invalid_inputs_before_mutating_files() {
     for arguments in [
         vec!["--bump", "prerelease"],
         vec!["--bump", "patch", "--date", "2026-02-30"],
+        vec!["--bump", "patch", "--date", "2025-02-29"],
+        vec!["--bump", "patch", "--date", "0000-01-01"],
+        vec!["--bump", "patch", "--date", "2026-13-01"],
+        vec!["--bump", "patch", "--date", "2026-01-00"],
         vec!["--date", RELEASE_DATE],
     ] {
         let fixture = Fixture::new("1.2.3");


### PR DESCRIPTION
Closes #155.

## Summary

- add a manual **Prepare Release** workflow with `patch`, `minor`, and `major` choices plus a no-write dry run
- add a deterministic release transformer that updates the root crate, tracked path-package lockfiles, synchronized version references, and the dated changelog boundary
- open the prepared `release/vX.Y.Z` pull request with an installation token so normal PR CI runs, then hand off publication to the existing P11-hardened **Release - Publish Crate** workflow
- document the GitHub App prerequisite and complete two-phase release runbook
- add data-driven positive and fail-closed tests plus workflow policy guards

## Validation

- fresh-checkout `0.4.0 -> 0.4.1` preparation with repository consistency checks
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- workflow hygiene, YAML lint, actionlint, doc consistency, hook readiness, pre-commit, and pre-push gates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and version/changelog identity across the repo; mistakes could open bad release PRs or skew compare links, though dry-run, diff-scope checks, collision guards, and tests reduce that risk.
> 
> **Overview**
> Adds the **first phase** of the release process: a manual **Prepare Release** workflow and a shared `scripts/prepare-release.sh` transformer, while **Release - Publish Crate** (`release.yml`) stays the reviewed publish step.
> 
> Dispatch **patch** / **minor** / **major** (optional **dry run**) from the default branch. The script bumps `Cargo.toml`, path-package lockfiles, public version docs, and cuts `[Unreleased]` into a dated changelog with compare links anchored to the **pre-bump** version (not the newest dated section). The workflow enforces an exact allowed file set, installs the pinned Rust toolchain before Cargo checks, refuses existing `release/vX.Y.Z` branches and `vX.Y.Z` tags, and opens a `release/vX.Y.Z` PR using a **GitHub App installation token** so normal PR CI runs (not `GITHUB_TOKEN`).
> 
> `docs/releasing.md` documents the two-phase runbook and App secrets. `check-doc-consistency.sh` now accepts changelog compare bases backed by local `vX.Y.Z` tags when dated sections were never backfilled. Regression coverage includes `tests/release_prepare_tests.rs`, doc-consistency fixtures, and CI policy tests on the workflow shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d7c40488dd1386f3f837c27ec033d92070409a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->