### PR TITLE
Fix historical GHCR backfill tooling

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,11 @@
-# GitHub Actions supports `concurrency.queue: max`, but actionlint 1.7.12 does
-# not yet include that schema key. Keep this exception path- and message-scoped
-# until the repository's pinned actionlint release recognizes it.
+# GitHub Actions supports `concurrency.queue: max` and the reusable-workflow
+# `job.workflow_repository` / `job.workflow_sha` contexts, but actionlint 1.7.12
+# does not yet include those schema fields. Keep these exceptions path- and
+# message-scoped until the repository's pinned actionlint release recognizes
+# them.
 paths:
   .github/workflows/docker-publish.yml:
     ignore:
       - 'unexpected key "queue" for "concurrency" section'
+      - 'property "workflow_repository" is not defined in object type'
+      - 'property "workflow_sha" is not defined in object type'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,11 +71,25 @@ jobs:
       image_version: ${{ steps.identity.outputs.image_version }}
       is_backfill: ${{ steps.identity.outputs.is_backfill }}
     steps:
+      - name: Checkout publication tooling
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: publication-tools
+          sparse-checkout: |
+            scripts/read-toml-string.sh
+            scripts/reuse-verified-image.sh
+            scripts/verify-release-image.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Checkout exact source
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_ref || inputs.release_tag || github.ref }}
+          path: source
 
       - name: Resolve and validate source identity
         id: identity
@@ -87,8 +101,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          source_revision=$(git rev-parse "HEAD^{commit}")
-          cargo_version=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
+          source_revision=$(git -C source rev-parse "HEAD^{commit}")
+          cargo_version=$(bash publication-tools/scripts/read-toml-string.sh source/Cargo.toml version package || true)
           if [ -z "$cargo_version" ]; then
             echo "ERROR: Could not extract [package].version from Cargo.toml." >&2
             exit 1
@@ -141,18 +155,18 @@ jobs:
               echo "ERROR: Release version is not canonical semantic version text: $release_version" >&2
               exit 1
             fi
-            git fetch --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
-            if [ "$(git cat-file -t "refs/tags/${release_tag}" 2>/dev/null || true)" != "tag" ]; then
+            git -C source fetch --no-tags origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            if [ "$(git -C source cat-file -t "refs/tags/${release_tag}" 2>/dev/null || true)" != "tag" ]; then
               echo "ERROR: $release_tag must exist as an annotated Git tag before container publication." >&2
               exit 1
             fi
-            tag_revision=$(git rev-parse "refs/tags/${release_tag}^{commit}")
+            tag_revision=$(git -C source rev-parse "refs/tags/${release_tag}^{commit}")
             if [ "$tag_revision" != "$source_revision" ]; then
               echo "ERROR: $release_tag resolves to $tag_revision, not checked-out commit $source_revision." >&2
               exit 1
             fi
             escaped_version=${release_version//./\\.}
-            if [ "$is_backfill" != "true" ] && ! grep -Eq "^## \\[${escaped_version}\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
+            if [ "$is_backfill" != "true" ] && ! grep -Eq "^## \\[${escaped_version}\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" source/CHANGELOG.md; then
               echo "ERROR: CHANGELOG.md has no ## [${release_version}] release section, with or without a date." >&2
               exit 1
             fi
@@ -193,10 +207,24 @@ jobs:
     outputs:
       digest: ${{ steps.verify.outputs.digest || steps.rolling-digest.outputs.digest }}
     steps:
+      - name: Checkout publication tooling
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: publication-tools
+          sparse-checkout: |
+            scripts/read-toml-string.sh
+            scripts/reuse-verified-image.sh
+            scripts/verify-release-image.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Checkout exact source
         uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.resolve.outputs.source_revision }}
+          path: source
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4.2.0
@@ -232,7 +260,8 @@ jobs:
           IMAGE_VERSION: ${{ needs.resolve.outputs.image_version }}
           IS_RELEASE: ${{ needs.resolve.outputs.is_release }}
           IS_BACKFILL: ${{ needs.resolve.outputs.is_backfill }}
-        run: bash scripts/reuse-verified-image.sh
+          VERIFY_RELEASE_IMAGE_SCRIPT: ${{ github.workspace }}/publication-tools/scripts/verify-release-image.sh
+        run: bash publication-tools/scripts/reuse-verified-image.sh
 
       - name: Prepare Docker metadata
         id: meta
@@ -253,8 +282,8 @@ jobs:
           set -euo pipefail
 
           image_title=${GITHUB_REPOSITORY#*/}
-          image_description=$(bash scripts/read-toml-string.sh Cargo.toml description package)
-          image_licenses=$(bash scripts/read-toml-string.sh Cargo.toml license package)
+          image_description=$(bash publication-tools/scripts/read-toml-string.sh source/Cargo.toml description package)
+          image_licenses=$(bash publication-tools/scripts/read-toml-string.sh source/Cargo.toml license package)
           image_url="https://github.com/${GITHUB_REPOSITORY}"
           image_created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           for value_name in image_title image_description image_licenses image_url image_created; do
@@ -317,7 +346,7 @@ jobs:
         if: steps.existing.outputs.reuse != 'true'
         uses: docker/build-push-action@v7.3.0
         with:
-          context: .
+          context: source
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -361,7 +390,7 @@ jobs:
           if [ "$VERIFY_SHA" != "false" ]; then
             tags+=("$SHA_TAG")
           fi
-          bash scripts/verify-release-image.sh \
+          bash publication-tools/scripts/verify-release-image.sh \
             "$IMAGE" "$SOURCE_REVISION" "$RELEASE_VERSION" "${tags[@]}"
 
       - name: Record rolling image digest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Make historical GHCR backfills load publication helpers from the exact
-  workflow revision while building only the tagged source checkout. Releases
-  that predate the helper scripts no longer fail before the container build,
-  and current workflow tooling cannot alter the historical build context.
-
 ### Added
 
 - Add a manual **Prepare Release** workflow with a `patch` / `minor` / `major`
@@ -797,6 +790,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make historical GHCR backfills load publication helpers from the exact
+  workflow revision while building only the tagged source checkout. Releases
+  that predate the helper scripts no longer fail before the container build,
+  and current workflow tooling cannot alter the historical build context.
 - Fixed negotiated lossy delivery under a slow-but-draining TCP downstream.
   A bounded, configurable TCP send buffer (`websocket.socket_send_buffer_bytes`,
   default 65536; `0` restores the platform default) prevents megabytes of data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make historical GHCR backfills load publication helpers from the exact
+  workflow revision while building only the tagged source checkout. Releases
+  that predate the helper scripts no longer fail before the container build,
+  and current workflow tooling cannot alter the historical build context.
+
 ### Added
 
 - Add a manual **Prepare Release** workflow with a `patch` / `minor` / `major`

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4335,6 +4335,74 @@ fn test_container_publish_supports_release_and_backfill_entry_points() {
 }
 
 #[test]
+fn test_container_publish_bootstraps_tools_from_workflow_revision() {
+    let root = repo_root();
+    let docker = read_live_file(&root.join(".github/workflows/docker-publish.yml"));
+
+    for job_name in ["resolve", "docker-publish"] {
+        let job = extract_workflow_job_block(&docker, job_name)
+            .unwrap_or_else(|| panic!("docker-publish.yml must define {job_name}"));
+        let tooling_position = job
+            .find("- name: Checkout publication tooling")
+            .unwrap_or_else(|| panic!("{job_name} must check out publication tooling"));
+        let source_position = job
+            .find("- name: Checkout exact source")
+            .unwrap_or_else(|| panic!("{job_name} must check out exact source"));
+
+        assert!(
+            tooling_position < source_position,
+            "{job_name} must load current publication tooling before checking out historical source."
+        );
+        for required in [
+            "repository: ${{ job.workflow_repository }}",
+            "ref: ${{ job.workflow_sha }}",
+            "path: publication-tools",
+            "scripts/read-toml-string.sh",
+            "scripts/reuse-verified-image.sh",
+            "scripts/verify-release-image.sh",
+            "sparse-checkout-cone-mode: false",
+            "persist-credentials: false",
+        ] {
+            assert!(
+                job.contains(required),
+                "{job_name} tooling checkout must contain `{required}` so a tagged source that predates publication helpers remains releasable.\nJob block:\n{job}"
+            );
+        }
+
+        let source_step = extract_named_workflow_step(&job, "Checkout exact source")
+            .unwrap_or_else(|| panic!("{job_name} must define its exact-source checkout"));
+        assert!(
+            source_step.contains("path: source"),
+            "{job_name} must isolate exact source from workflow tooling.\nStep:\n{source_step}"
+        );
+    }
+
+    for required in [
+        "source_revision=$(git -C source rev-parse",
+        "publication-tools/scripts/read-toml-string.sh source/Cargo.toml",
+        "VERIFY_RELEASE_IMAGE_SCRIPT: ${{ github.workspace }}/publication-tools/scripts/verify-release-image.sh",
+        "run: bash publication-tools/scripts/reuse-verified-image.sh",
+        "bash publication-tools/scripts/verify-release-image.sh",
+        "context: source",
+    ] {
+        assert!(
+            docker.contains(required),
+            "docker-publish.yml must consume isolated source/tooling through `{required}`."
+        );
+    }
+    for forbidden in [
+        "run: bash scripts/reuse-verified-image.sh",
+        "bash scripts/verify-release-image.sh \\",
+        "context: .",
+    ] {
+        assert!(
+            !docker.contains(forbidden),
+            "docker-publish.yml must not use ambiguous checkout-relative publication path `{forbidden}`."
+        );
+    }
+}
+
+#[test]
 fn test_release_identity_fails_closed_across_artifacts() {
     let root = repo_root();
     let release = read_live_file(&root.join(".github/workflows/release.yml"));
@@ -4363,8 +4431,8 @@ fn test_release_identity_fails_closed_across_artifacts() {
             &docker,
             vec![
                 "Cargo.toml version package",
-                "git fetch --no-tags origin \"refs/tags/${release_tag}:refs/tags/${release_tag}\"",
-                "git cat-file -t \"refs/tags/${release_tag}\"",
+                "git -C source fetch --no-tags origin \"refs/tags/${release_tag}:refs/tags/${release_tag}\"",
+                "git -C source cat-file -t \"refs/tags/${release_tag}\"",
                 "escaped_version=${release_version//./\\\\.}",
                 "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
                 "org.opencontainers.image.revision=",
@@ -4414,7 +4482,8 @@ fn test_release_retries_reuse_digest_and_record_verification() {
         "IMAGE_VERSION: ${{ needs.resolve.outputs.image_version }}",
         "IS_RELEASE: ${{ needs.resolve.outputs.is_release }}",
         "IS_BACKFILL: ${{ needs.resolve.outputs.is_backfill }}",
-        "run: bash scripts/reuse-verified-image.sh",
+        "VERIFY_RELEASE_IMAGE_SCRIPT: ${{ github.workspace }}/publication-tools/scripts/verify-release-image.sh",
+        "run: bash publication-tools/scripts/reuse-verified-image.sh",
     ] {
         assert!(
             existing.contains(required),
@@ -4491,6 +4560,8 @@ fn test_release_retries_reuse_digest_and_record_verification() {
     for required in [
         ".github/workflows/docker-publish.yml:",
         "unexpected key \"queue\" for \"concurrency\" section",
+        "property \"workflow_repository\" is not defined in object type",
+        "property \"workflow_sha\" is not defined in object type",
     ] {
         assert!(
             actionlint_config.contains(required),


### PR DESCRIPTION
## Summary

- check out publication helpers from the exact workflow revision in both Docker Publish jobs
- isolate the immutable release source under `source/` and pass only that directory to Buildx
- pin the historical-checkout contract, current helper paths, and narrow Actionlint compatibility exceptions with CI policy tests

## Root cause

The canonical `v0.4.0` backfill run [29595222223](https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/29595222223) resolved the annotated tag and source commit correctly, then failed with exit 127 because the historical checkout predates `scripts/reuse-verified-image.sh`. The later verification helper would have had the same failure mode.

Publication policy must come from the workflow being executed, while the bytes being built must come from the immutable tagged source. The workflow now uses GitHub's `job.workflow_repository` and `job.workflow_sha` contexts for a sparse `publication-tools/` checkout and keeps the exact release source in `source/`.

## Validation

- `cargo test --locked --test ci_config_tests` — 283 passed, 1 intentionally ignored
- `cargo clippy --locked --test ci_config_tests -- -D warnings`
- focused container publication policy/state-transition tests — 3 passed
- Actionlint and YAML validation
- `scripts/check-ci-config.sh`
- `scripts/check-workflow-hygiene.sh`
- `scripts/check-tooling-parity.sh`
- `scripts/check-doc-consistency.sh --changed-files ...`
- hook readiness, pre-commit, and pre-push worktree preflights

## Operational proof

The corrected workflow completed [backfill run 29602078436](https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/29602078436) from this fully green, reviewed commit. Independent registry verification confirmed:

- `v0.4.0`, `0.4.0`, and `0.4` share digest `sha256:09b127664e8572b67ec9d9cbb84da30092c7721d3638b4b383bd2c41f7772389`
- runtime platforms are exactly `linux/amd64`, `linux/arm64`, and `linux/arm/v7`
- each runtime manifest carries revision `50b28a9a13dc2b99d301bfb2482c5fd6f768a2e8` and version `0.4.0`
- historical `sha-50b28a9` remains unchanged at `sha256:8d9f52aa6c95eba858825ce3f238f9f7b92eecaea89f50c25662b81b8fbbbdd3` with its original `latest` metadata

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to GitHub Actions publication wiring, actionlint suppressions, and CI tests; runtime server behavior is unchanged.
> 
> **Overview**
> **Docker Publish** now uses two checkouts: publication scripts come from the **workflow revision** (`job.workflow_repository` / `job.workflow_sha` into `publication-tools/`), while the **tagged release source** lives under `source/` and is the only Buildx context. Identity resolution, metadata, reuse/verify steps, and `git` tag checks run against those paths so historical backfills (e.g. tags that predate the helper scripts) no longer fail with missing `scripts/*.sh` before the image build.
> 
> **Actionlint** exceptions are extended for the reusable-workflow `workflow_repository` / `workflow_sha` contexts. **CI policy tests** lock the tooling-before-source order, isolated paths, and forbid ambiguous root-relative script invocations. **CHANGELOG** documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ac04490edbbaf64144c066a3ee1ce7d2f4b16f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->