### PR TITLE
Harden release preparation and WebSocket liveness

### DIFF
--- a/.llm/skills/shell-scripting-patterns.md
+++ b/.llm/skills/shell-scripting-patterns.md
@@ -194,6 +194,10 @@ done
 **Docker RUN commands and POSIX scripts use `/bin/sh` (dash on Debian), not bash.**
 Bash-specific features silently fail or behave differently under `/bin/sh`.
 
+macOS still supplies Bash 3.2. With `set -u`, it can reject `"${items[@]}"`
+when `items=()` is empty; cardinality-guard the expansion and keep a macOS CI
+lane for scripts that use arrays.
+
 ### Brace Expansion Does Not Work in `/bin/sh`
 
 ```bash
@@ -274,6 +278,7 @@ use that when adding `--quiet` or deciding which messages must still print on wa
 - [ ] `IFS` uses single-character delimiter (not multi-char like `:::`)
 - [ ] Shellcheck passes; tested locally before pushing to CI
 - [ ] No bash-isms in `/bin/sh` scripts or Dockerfile `RUN` commands
+- [ ] Empty Bash arrays are guarded before expansion under `set -u`
 - [ ] `find` commands use `-type f` when targeting files
 - [ ] Log messages match actual search scope (recursive vs. non-recursive)
 - [ ] `--quiet` suppresses banner, info, success, and summary — never errors or warnings

--- a/.llm/skills/version-sync-and-changelog-gates.md
+++ b/.llm/skills/version-sync-and-changelog-gates.md
@@ -17,6 +17,26 @@
 3. `CHANGELOG.md` must remain Keep a Changelog compliant.
 4. If non-internal files change, `CHANGELOG.md` must be updated in the same change.
 
+## Release History Invariants
+
+Changelog validity is file-backed and must be identical in a tagless/shallow
+checkout and a full clone. Never use a fetched Git tag as a substitute for a
+missing dated release section.
+
+- Keep exactly one `[Unreleased]` section first.
+- Keep unique, strictly descending `X.Y.Z` release headings with real dates.
+- Point `[Unreleased]` from the newest dated release to `HEAD`.
+- Link every release to the immediately adjacent older section; only the oldest
+  release uses a direct tag link.
+- Before preparing a release, require `Cargo.toml` to equal the newest dated
+  release and require its annotated `vX.Y.Z` tag to resolve to an ancestor of
+  `HEAD`. Reject an existing target section or local target tag before mutation.
+
+Run `scripts/prepare-release.sh` only from this valid released baseline. Its
+preflight and postflight checks are intentional atomicity boundaries; do not
+weaken them by widening CI checkout depth or by making correctness conditional
+on repository topology.
+
 ## Version Scan Scope
 
 `scripts/check-doc-consistency.sh` scans first-party Markdown for

--- a/.llm/skills/websocket-protocol-patterns.md
+++ b/.llm/skills/websocket-protocol-patterns.md
@@ -81,29 +81,22 @@ async fn authenticate(
 
 ### Heartbeat / Ping-Pong
 
-```rust
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15);
-const CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
+Server transport probes are idle-only. Maintain one bounded/coalescing activity
+generation and at most one active unpredictable nonce:
 
-async fn connection_loop(mut sender: SplitSink<WebSocket, Message>, mut receiver: SplitStream<WebSocket>) {
-    let mut heartbeat = interval(HEARTBEAT_INTERVAL);
-    let mut last_pong = Instant::now();
+1. Immediately after decoding any non-Pong frame, publish transport activity
+   before parsing, metrics, or awaited application handling.
+2. At a scheduled tick, skip the probe if the generation changed during the
+   preceding interval.
+3. Recheck the generation when the writer begins, because the Ping command may
+   have waited behind another socket write.
+4. Once written, accept only the exact matching Pong. A decoded non-Pong frame
+   cancels the probe as fresh activity; wrong, stale, or unsolicited Pongs do
+   neither. Silence through the deadline closes `4003 activity_timeout`.
 
-    loop {
-        tokio::select! {
-            msg = receiver.next() => match msg {
-                Some(Ok(Message::Pong(_))) => last_pong = Instant::now(),
-                Some(Ok(msg)) => handle_message(msg).await,
-                Some(Err(_)) | None => break,
-            },
-            _ = heartbeat.tick() => {
-                if last_pong.elapsed() > CLIENT_TIMEOUT { break; }
-                if sender.send(Message::Ping(vec![].into())).await.is_err() { break; }
-            }
-        }
-    }
-}
-```
+Use O(1) watch/state-machine storage, keep application handling sequential, and
+never insert an unbounded transport-to-application queue. Awaiting application
+work in the receive loop is safe only because activity is published first.
 
 ### Graceful Disconnection
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (delivery classes, epoch, reconnect watermarks, drain, and WebSocket pings),
   including the rejected/deferred feature cut list.
 
+### Fixed
+
+- Make historical GHCR backfills load publication helpers from the exact
+  workflow revision while building only the tagged source checkout. Releases
+  that predate the helper scripts no longer fail before the container build,
+  and current workflow tooling cannot alter the historical build context.
+- Fixed negotiated lossy delivery under a slow-but-draining TCP downstream.
+  A bounded, configurable TCP send buffer (`websocket.socket_send_buffer_bytes`,
+  default 65536; `0` restores the platform default) prevents megabytes of data
+  already accepted by the kernel from burying later WebSocket Pings and exact
+  `DeliveryReport` frames. Writer sojourn deadlines are now class-aware:
+  reliable traffic retains its oldest reliable queue-plus-write ceiling,
+  control traffic owns its enqueue deadline, and latest/volatile traffic gets a
+  bounded write-progress deadline without inheriting unrelated queue age. The
+  same progress deadline now covers exact reports for deterministic
+  writer-discovered format failures: those payloads have already reached an
+  accounted unsupported terminal outcome and no longer inherit the age of
+  unresolved reliable data. Valid cross-encoding fallbacks reuse the preflight
+  decode rather than parsing the payload twice. The
+  nightly 256-kbps asymmetric experiment now keeps a 90-KiB/s volatile stream
+  connected for 60 seconds with production Pings enabled and every observed
+  sequence gap covered by a causally prior exact report; reliable traffic still
+  fails loudly with `4002 slow_consumer` and reconnects with rotated wire tokens.
+  Registered shutdown waiting also includes scheduling margin after its three
+  bounded close writes, so a handler completing at the final write deadline is
+  not mistaken for a leaked socket under sanitizer or production shutdown load.
+
+### Changed
+
+- Rate-limit protocol-v3 unsupported-format advisory errors per sender and
+  recipient while preserving an exact `DeliveryReport` for every omitted
+  sequence. Mixed-encoding malformed payloads can no longer double each relay
+  into an unbounded report/error stream; later advisories include the number
+  suppressed since the prior notice.
+
+## [0.4.0] - 2026-07-12
+
+### Added
+
 - Add server-initiated RFC 6455 liveness probes (P10.E4). By default each
   connection receives a transport-level Ping every 10 seconds and must return
   the matching Pong within 5 seconds or close with `4003 activity_timeout`.
@@ -375,6 +414,109 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `test_release_workflow_builds_all_platform_binaries`,
   `test_release_workflow_attaches_binaries_with_checksums`) so the container manifest and
   release-binary matrix can never silently regress to a single platform again.
+
+### Fixed
+
+- Fixed a room-lifecycle GC bug where every room was deleted a fixed interval after **creation**
+  regardless of activity (default `inactive_room_timeout` = 1 h) — `Room.last_activity` was
+  written only at creation and never refreshed (both refresher methods had zero call sites), so a
+  session over an hour old was reaped with players still in it, and a long-lived room that emptied
+  was deleted immediately, collapsing the reconnection window (reconnects failed `RoomNotFound`
+  with still-valid tokens). `last_activity` is now refreshed on join, on a real leave/disconnect,
+  and once per inbound message on the throttled liveness path — covering pings, relayed `GameData`
+  (JSON and binary), and WebRTC `Signal` traffic uniformly; the empty-room clock keys off
+  `last_activity` (not `created_at`) so both cleanup paths agree; and room GC never deletes a room
+  that still holds an unexpired reconnection record
+  (`ReconnectionManager::rooms_with_active_reconnections`). Startup validation additionally rejects
+  `server.heartbeat_throttle_secs >= server.inactive_room_timeout`, so the throttled refresh can
+  never lag the reaper and re-open the bug by misconfiguration.
+- Fixed a config timeout-inversion where a legal combination evicted a **healthy** sender: with
+  `websocket.slow_consumer_timeout_ms ≥ server.ping_timeout · 1000`, a sender parked on the
+  broadcast fan-out for a slow recipient could outlast the activity-reaper deadline and be closed
+  `4003` before its slow recipient was ever disconnected. Startup validation now rejects that
+  combination (cross-field check, guarded on `ping_timeout > 0`).
+- Fixed `game_data_messages` (`signal_fish_game_data_messages_total`) reading a permanent `0`: the
+  metric was exported to Prometheus but never incremented. It is now counted once per relayed
+  `GameData` message at the relay funnel.
+- Fixed an orphaned reconnection replay buffer (found by the new `fuzz_reconnect_tokens` fuzz
+  target): a player re-registering a disconnect from a NEW room replaced its pending record and
+  left the old room's replay ring alive forever — capturing control events and replaying ghosts
+  for a room with nobody pending.
+- Fixed a send-task race (found by the close-code e2e suite) where a connection's write loop
+  ending in the same instant a close reason was requested could lose the reason — and with it
+  the semantic close code — because the unbiased `select!` took the loop-ended arm; terminal
+  paths now re-check the close listener non-blockingly.
+- Fixed [#131](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/131): the relay
+  silently dropped `GameData` under burst — each connection's outbound queue was a small bounded
+  channel (`batch_size * 4` = 40 messages) written with a fire-and-forget `try_send`, so a burst
+  that outpaced one recipient's drain rate discarded messages with only a metric to show for it.
+  The server no longer silently drops reliable delivery: the fast path is a
+  non-waiting try-enqueue, but a full reliable queue makes delivery wait (true backpressure) for up to
+  `websocket.slow_consumer_timeout_ms`, and only a recipient that stays full past that timeout is
+  disconnected as a slow consumer (metrics + warning log + best-effort `SLOW_CONSUMER` error
+  frame, then the close). Room senders are paced to their slowest healthy recipient; a dead
+  recipient costs reliable senders at most one timeout window before it is evicted. Protocol-v3
+  `latest` / `volatile` omissions are instead explicit in `DeliveryReport`. Covered end to end by
+  `tests/relay_backpressure_e2e.rs`; delivery semantics are documented in `docs/protocol.md`.
+- Undeliverable binary game data is no longer silently dropped by the send path: a payload that
+  cannot be converted for a recipient (e.g. an internal binary encoding relayed to a JSON-only
+  client) now surfaces an explicit `Error` frame with code `UNSUPPORTED_GAME_DATA_FORMAT` to that
+  recipient in place of each undeliverable payload. A v3 recipient first receives an exact
+  `DeliveryReport` gap; the aggregate drop metric still increments.
+- Hardened release and documentation validation: `release.yml` now skips binary
+  attachment with a clear diagnostic when no `release-binary-*` artifacts exist,
+  uses an existing `actions/download-artifact` tag, and the workflow hygiene job
+  can verify pinned GitHub Action tags exist upstream. Documentation version
+  scans now prune vendored `third_party/` Markdown while rejecting unsyncable
+  versionless `signal-fish-server` dependency examples.
+- Fixed [#122](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/122): the
+  published `ghcr.io/ambiguous-interactive/signal-fish-server` image was built only for
+  `linux/amd64`, so pulling it on ARM64 Linux (AWS Graviton, Ampere, Raspberry Pi, Apple Silicon
+  under Docker) failed with `no matching manifest for linux/arm64/v8`. `docker-publish.yml` now
+  builds a single multi-architecture manifest covering `linux/amd64`, `linux/arm64`, and
+  `linux/arm/v7`. The Rust binary is cross-compiled natively on the build runner (the heavy
+  compile never runs under emulation; only the trivial runtime-image setup does), and the
+  `Dockerfile` resolves the cross toolchain per target arch (build-host-agnostic via
+  `$BUILDARCH`).
+
+### Changed
+
+- **Consolidated the pre-release protocol into a single v3.** The
+  delivery-reliability features that were briefly developed behind a separate
+  `protocol_version: 4` (server-stamped `GameData.seq` + incarnation `epoch`, and
+  the opt-in `RelayStats` frame) now negotiate under **v3** — there is no v4. v3
+  is the single unshipped/mutable "current" version (WebRTC signaling AND
+  delivery reliability), additive over the frozen v2 floor.
+  `SERVER_MAX_PROTOCOL_VERSION` and the `protocol.max_protocol_version` default
+  are now **3**; a client that still advertises `4`/`5` is clamped to 3. v2
+  remains byte-frozen (the pre-v3 forms are unchanged). Net effect for consumers:
+  a client obtains the reliability surface by negotiating v3 rather than v4. The
+  `[Unreleased]` entries that referenced "v4" describe these same features as
+  they now ship — under v3.
+- The activity reaper (`ConnectionManager::collect_expired_clients`) and the heartbeat-update
+  throttle (`ConnectionManager::should_update_last_seen`) now read the Tokio runtime clock
+  (`tokio::time::Instant`) instead of `std::time::Instant`. Production behavior is unchanged —
+  outside a paused runtime `tokio::time::Instant` wraps the same monotonic std clock — but tests
+  can now drive these windows deterministically with `tokio::time::advance()` under
+  `#[tokio::test(start_paused = true)]` at zero wall-clock cost. The `heartbeat.rs` reaper test
+  that previously relied on a real 25 ms sleep is now paused-clock and instant.
+- Raised `security.max_connections_per_ip` default `10` → `24`. Ten silently refused the 11th
+  concurrent connection from one IP, so a 16-player session behind a single NAT (LAN party,
+  office, venue) could not connect. `24` covers 16 players plus spectators and reconnect churn.
+  (The per-room player count is bounded separately by that room's `max_players`, default `8`.)
+- SDK platform/version enforcement (`protocol.sdk_compatibility.enforce`) now defaults to
+  `false` (opt-in): with the old default the prepopulated platform list made a default-config
+  server reject every client that did not claim to be a known engine — including
+  `platform: None` and custom/Rust clients. Deployments shipping engine SDKs re-enable it
+  explicitly.
+- `protocol.max_protocol_version` now defaults to `4`.
+- The `PlayerReconnected` notification fan-out is concurrent (bounded by the slowest recipient)
+  instead of serial per recipient.
+
+## [0.3.0] - 2026-06-20
+
+### Added
+
 - Added `tests/docs_site_consistency.rs`, a documentation-accuracy regression guard that ties the
   published docs to source: it asserts `docs/reference/error-codes.md` documents every `ErrorCode`
   variant, `docs/protocol.md` documents every `ClientMessage` / `ServerMessage` variant and the
@@ -790,91 +932,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Make historical GHCR backfills load publication helpers from the exact
-  workflow revision while building only the tagged source checkout. Releases
-  that predate the helper scripts no longer fail before the container build,
-  and current workflow tooling cannot alter the historical build context.
-- Fixed negotiated lossy delivery under a slow-but-draining TCP downstream.
-  A bounded, configurable TCP send buffer (`websocket.socket_send_buffer_bytes`,
-  default 65536; `0` restores the platform default) prevents megabytes of data
-  already accepted by the kernel from burying later WebSocket Pings and exact
-  `DeliveryReport` frames. Writer sojourn deadlines are now class-aware:
-  reliable traffic retains its oldest reliable queue-plus-write ceiling,
-  control traffic owns its enqueue deadline, and latest/volatile traffic gets a
-  bounded write-progress deadline without inheriting unrelated queue age. The
-  same progress deadline now covers exact reports for deterministic
-  writer-discovered format failures: those payloads have already reached an
-  accounted unsupported terminal outcome and no longer inherit the age of
-  unresolved reliable data. Valid cross-encoding fallbacks reuse the preflight
-  decode rather than parsing the payload twice. The
-  nightly 256-kbps asymmetric experiment now keeps a 90-KiB/s volatile stream
-  connected for 60 seconds with production Pings enabled and every observed
-  sequence gap covered by a causally prior exact report; reliable traffic still
-  fails loudly with `4002 slow_consumer` and reconnects with rotated wire tokens.
-  Registered shutdown waiting also includes scheduling margin after its three
-  bounded close writes, so a handler completing at the final write deadline is
-  not mistaken for a leaked socket under sanitizer or production shutdown load.
-- Fixed a room-lifecycle GC bug where every room was deleted a fixed interval after **creation**
-  regardless of activity (default `inactive_room_timeout` = 1 h) — `Room.last_activity` was
-  written only at creation and never refreshed (both refresher methods had zero call sites), so a
-  session over an hour old was reaped with players still in it, and a long-lived room that emptied
-  was deleted immediately, collapsing the reconnection window (reconnects failed `RoomNotFound`
-  with still-valid tokens). `last_activity` is now refreshed on join, on a real leave/disconnect,
-  and once per inbound message on the throttled liveness path — covering pings, relayed `GameData`
-  (JSON and binary), and WebRTC `Signal` traffic uniformly; the empty-room clock keys off
-  `last_activity` (not `created_at`) so both cleanup paths agree; and room GC never deletes a room
-  that still holds an unexpired reconnection record
-  (`ReconnectionManager::rooms_with_active_reconnections`). Startup validation additionally rejects
-  `server.heartbeat_throttle_secs >= server.inactive_room_timeout`, so the throttled refresh can
-  never lag the reaper and re-open the bug by misconfiguration.
-- Fixed a config timeout-inversion where a legal combination evicted a **healthy** sender: with
-  `websocket.slow_consumer_timeout_ms ≥ server.ping_timeout · 1000`, a sender parked on the
-  broadcast fan-out for a slow recipient could outlast the activity-reaper deadline and be closed
-  `4003` before its slow recipient was ever disconnected. Startup validation now rejects that
-  combination (cross-field check, guarded on `ping_timeout > 0`).
-- Fixed `game_data_messages` (`signal_fish_game_data_messages_total`) reading a permanent `0`: the
-  metric was exported to Prometheus but never incremented. It is now counted once per relayed
-  `GameData` message at the relay funnel.
-- Fixed an orphaned reconnection replay buffer (found by the new `fuzz_reconnect_tokens` fuzz
-  target): a player re-registering a disconnect from a NEW room replaced its pending record and
-  left the old room's replay ring alive forever — capturing control events and replaying ghosts
-  for a room with nobody pending.
-- Fixed a send-task race (found by the close-code e2e suite) where a connection's write loop
-  ending in the same instant a close reason was requested could lose the reason — and with it
-  the semantic close code — because the unbiased `select!` took the loop-ended arm; terminal
-  paths now re-check the close listener non-blockingly.
-- Fixed [#131](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/131): the relay
-  silently dropped `GameData` under burst — each connection's outbound queue was a small bounded
-  channel (`batch_size * 4` = 40 messages) written with a fire-and-forget `try_send`, so a burst
-  that outpaced one recipient's drain rate discarded messages with only a metric to show for it.
-  The server no longer silently drops reliable delivery: the fast path is a
-  non-waiting try-enqueue, but a full reliable queue makes delivery wait (true backpressure) for up to
-  `websocket.slow_consumer_timeout_ms`, and only a recipient that stays full past that timeout is
-  disconnected as a slow consumer (metrics + warning log + best-effort `SLOW_CONSUMER` error
-  frame, then the close). Room senders are paced to their slowest healthy recipient; a dead
-  recipient costs reliable senders at most one timeout window before it is evicted. Protocol-v3
-  `latest` / `volatile` omissions are instead explicit in `DeliveryReport`. Covered end to end by
-  `tests/relay_backpressure_e2e.rs`; delivery semantics are documented in `docs/protocol.md`.
-- Undeliverable binary game data is no longer silently dropped by the send path: a payload that
-  cannot be converted for a recipient (e.g. an internal binary encoding relayed to a JSON-only
-  client) now surfaces an explicit `Error` frame with code `UNSUPPORTED_GAME_DATA_FORMAT` to that
-  recipient in place of each undeliverable payload. A v3 recipient first receives an exact
-  `DeliveryReport` gap; the aggregate drop metric still increments.
-- Hardened release and documentation validation: `release.yml` now skips binary
-  attachment with a clear diagnostic when no `release-binary-*` artifacts exist,
-  uses an existing `actions/download-artifact` tag, and the workflow hygiene job
-  can verify pinned GitHub Action tags exist upstream. Documentation version
-  scans now prune vendored `third_party/` Markdown while rejecting unsyncable
-  versionless `signal-fish-server` dependency examples.
-- Fixed [#122](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/122): the
-  published `ghcr.io/ambiguous-interactive/signal-fish-server` image was built only for
-  `linux/amd64`, so pulling it on ARM64 Linux (AWS Graviton, Ampere, Raspberry Pi, Apple Silicon
-  under Docker) failed with `no matching manifest for linux/arm64/v8`. `docker-publish.yml` now
-  builds a single multi-architecture manifest covering `linux/amd64`, `linux/arm64`, and
-  `linux/arm/v7`. The Rust binary is cross-compiled natively on the build runner (the heavy
-  compile never runs under emulation; only the trivial runtime-image setup does), and the
-  `Dockerfile` resolves the cross toolchain per target arch (build-host-agnostic via
-  `$BUILDARCH`).
 - Fixed a class of CI failure where a root version bump silently invalidated the committed
   `clients/native` lockfile: it kept pinning the previous `signal-fish-server` version, so the
   `--locked` Browser Interop and WebRTC Interop builds failed with a cryptic "lock file needs to be
@@ -1041,42 +1098,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rate-limit protocol-v3 unsupported-format advisory errors per sender and
-  recipient while preserving an exact `DeliveryReport` for every omitted
-  sequence. Mixed-encoding malformed payloads can no longer double each relay
-  into an unbounded report/error stream; later advisories include the number
-  suppressed since the prior notice.
-- **Consolidated the pre-release protocol into a single v3.** The
-  delivery-reliability features that were briefly developed behind a separate
-  `protocol_version: 4` (server-stamped `GameData.seq` + incarnation `epoch`, and
-  the opt-in `RelayStats` frame) now negotiate under **v3** — there is no v4. v3
-  is the single unshipped/mutable "current" version (WebRTC signaling AND
-  delivery reliability), additive over the frozen v2 floor.
-  `SERVER_MAX_PROTOCOL_VERSION` and the `protocol.max_protocol_version` default
-  are now **3**; a client that still advertises `4`/`5` is clamped to 3. v2
-  remains byte-frozen (the pre-v3 forms are unchanged). Net effect for consumers:
-  a client obtains the reliability surface by negotiating v3 rather than v4. The
-  `[Unreleased]` entries that referenced "v4" describe these same features as
-  they now ship — under v3.
-- The activity reaper (`ConnectionManager::collect_expired_clients`) and the heartbeat-update
-  throttle (`ConnectionManager::should_update_last_seen`) now read the Tokio runtime clock
-  (`tokio::time::Instant`) instead of `std::time::Instant`. Production behavior is unchanged —
-  outside a paused runtime `tokio::time::Instant` wraps the same monotonic std clock — but tests
-  can now drive these windows deterministically with `tokio::time::advance()` under
-  `#[tokio::test(start_paused = true)]` at zero wall-clock cost. The `heartbeat.rs` reaper test
-  that previously relied on a real 25 ms sleep is now paused-clock and instant.
-- Raised `security.max_connections_per_ip` default `10` → `24`. Ten silently refused the 11th
-  concurrent connection from one IP, so a 16-player session behind a single NAT (LAN party,
-  office, venue) could not connect. `24` covers 16 players plus spectators and reconnect churn.
-  (The per-room player count is bounded separately by that room's `max_players`, default `8`.)
-- SDK platform/version enforcement (`protocol.sdk_compatibility.enforce`) now defaults to
-  `false` (opt-in): with the old default the prepopulated platform list made a default-config
-  server reject every client that did not claim to be a known engine — including
-  `platform: None` and custom/Rust clients. Deployments shipping engine SDKs re-enable it
-  explicitly.
-- `protocol.max_protocol_version` now defaults to `4`.
-- The `PlayerReconnected` notification fan-out is concurrent (bounded by the slowest recipient)
-  instead of serial per recipient.
 - Upgraded the dependency tree to current releases. The only direct major bump is `tower-http`
   0.6 → 0.7 (the CORS/trace middleware the server mounts); `bytes` moved 1.11 → 1.12 and every
   other crate advanced to its latest semver-compatible version via a lockfile refresh. The root and
@@ -1174,6 +1195,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Architecture Decision Record (ADR) documentation scaffolding under `docs/adr/`.
 - Added ADR index integration in `docs/README.md` and `docs/architecture.md`.
 
+
+## [0.1.1] - 2026-02-23
+
+### Changed
+
+- Updated locked dependency patch releases and expanded CI, release, hook,
+  and repository-policy validation.
+
 ## [0.1.0] - 2026-02-15
 
 ### Added
@@ -1190,6 +1219,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional TLS/mTLS support via `rustls` (`tls` feature).
 - Optional legacy full-mesh mode (`legacy-fullmesh` feature).
 
-[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...v0.2.0
+
+[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1199,7 +1199,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Architecture Decision Record (ADR) documentation scaffolding under `docs/adr/`.
 - Added ADR index integration in `docs/README.md` and `docs/architecture.md`.
 
-
 ## [0.1.1] - 2026-02-23
 
 ### Changed
@@ -1222,7 +1221,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docker image support.
 - Optional TLS/mTLS support via `rustls` (`tls` feature).
 - Optional legacy full-mesh mode (`legacy-fullmesh` feature).
-
 
 [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Registered shutdown waiting also includes scheduling margin after its three
   bounded close writes, so a handler completing at the final write deadline is
   not mistaken for a leaked socket under sanitizer or production shutdown load.
+  Server transport probes are now idle-only: decoded non-Pong traffic is
+  published before awaited application processing, skips an unnecessary probe,
+  or cancels an outstanding one. Exact matching Pongs still record RTT, stale
+  Pongs still cannot satisfy a probe, and genuine silence still closes `4003`.
 
 ### Changed
 

--- a/docs/adr/0006-protocol-v3-delivery-reliability.md
+++ b/docs/adr/0006-protocol-v3-delivery-reliability.md
@@ -67,10 +67,11 @@ Planned shutdown uses a bounded drain: v3 clients may receive `GoingAway`, all
 remaining sockets close with `4000 server_shutdown`, new room creation stops,
 and no reconnect token is armed for the exiting in-memory instance.
 
-The socket layer sends RFC 6455 Ping probes independently of application
-queues. A missing matching Pong by the configured deadline closes with `4003
-activity_timeout`; successful replies refresh liveness and produce RTT metrics.
-This needs no protocol negotiation or browser/client release because compliant
+After an otherwise-idle interval, the socket layer sends an RFC 6455 Ping
+independently of application queues. Decoded inbound non-Pong traffic skips or cancels
+the probe as fresh liveness; otherwise a missing matching Pong closes with
+`4003 activity_timeout`, while successful replies produce RTT metrics. This
+needs no protocol negotiation or browser/client release because compliant
 WebSocket stacks answer protocol Ping automatically.
 
 ### Compatibility and future seam

--- a/docs/architecture/scaling.md
+++ b/docs/architecture/scaling.md
@@ -189,16 +189,18 @@ server has two independent fail-loud mechanisms:
 
 | Fault | What may still work | Default detection path | Authoritative result |
 | --- | --- | --- | --- |
-| client → server blackhole | The client can keep receiving room traffic and RFC 6455 Ping frames | The matching Pong cannot return; the next probe plus its deadline is roughly bounded by `server_ping_interval_secs + pong_timeout_secs` (10 + 5 seconds by default) | close `4003 activity_timeout`; `signal_fish_websocket_ping_timeouts_total` increments |
-| server → client blackhole, otherwise idle | The server can keep receiving application `Ping` and game traffic | The client never receives the next protocol Ping, so no matching Pong returns; the same probe bound applies | close `4003 activity_timeout` |
-| server → client blackhole under reliable relay pressure | Client writes can still reach the server while its outbound socket/data queue stops draining | Queue/socket fill plus `slow_consumer_timeout_ms` (5 seconds by default), or `max_sojourn_ms` (15 seconds by default); a socket probe can win first depending on probe phase | close `4002 slow_consumer` when delivery pressure wins, otherwise `4003 activity_timeout` |
+| client → server blackhole | The client can keep receiving room traffic and RFC 6455 Ping frames | A probe scheduled just before the last inbound activity may be skipped, so the worst-case fixed-tick bound is nearly `2 × server_ping_interval_secs + pong_timeout_secs` (25 seconds by default) | close `4003 activity_timeout`; `signal_fish_websocket_ping_timeouts_total` increments |
+| server → client blackhole, both directions otherwise idle | No inbound non-Pong frame proves liveness | The client never receives the next protocol Ping, so no matching Pong returns; the same worst-case fixed-tick bound applies | close `4003 activity_timeout` |
+| server → client blackhole while client → server traffic continues | Client writes can still reach the server, so idle-only probes are skipped or cancelled | Outbound queue/socket pressure, a socket write failure, or an application-level policy; upstream traffic alone cannot prove the reverse path | close `4002 slow_consumer` when delivery pressure wins; otherwise detection requires another policy |
 | symmetric blackhole | Neither direction carries new traffic | The next protocol probe cannot complete | close `4003 activity_timeout` |
 
 The close code describes the mechanism that won, not the physical direction of
-the fault. In particular, application Pings crossing client → server do not
-make a blocked server → client path healthy. Keep protocol Ping handling enabled
-in the WebSocket stack, treat `4002` and `4003` as terminal for that physical
-connection, and reconnect according to the client contract.
+the fault. Idle-only probes deliberately treat decoded inbound non-Pong traffic as
+liveness so application backpressure cannot hide an already-arrived Pong. This
+means continuous client → server traffic does not independently test the
+reverse path; outbound pressure/failure or an application policy owns that
+case. Keep protocol Ping handling enabled, treat `4002` and `4003` as terminal
+for that physical connection, and reconnect according to the client contract.
 
 The directional real-socket experiments use shortened probe/grace values and
 prove all three distinct cases: the unaffected direction carries traffic,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -338,9 +338,11 @@ Complete reference of all configuration options with environment variable overri
   affected by the 300s default. Keep this enabled in production — it reclaims
   zombie sockets that would otherwise hold file descriptors open indefinitely.
 - `server_ping_interval_secs` / `pong_timeout_secs` - The server sends an RFC
-  6455 Ping every 10 seconds by default and requires its matching Pong within 5
-  seconds. The probe is written directly by the socket layer, outside the
-  application data/control queues; a miss closes with `4003 activity_timeout`.
+  6455 Ping after an otherwise-idle 10-second interval by default and requires
+  its matching Pong within 5 seconds. Recent decoded inbound non-Pong activity skips the
+  probe; a non-Pong frame arriving after the write cancels it as fresh liveness.
+  The probe is written directly by the socket layer, outside the application
+  data/control queues; a silent miss closes with `4003 activity_timeout`.
   Set the interval to `0` to disable server probes. The Pong timeout must remain
   greater than `0`; both fields are capped at 3600 seconds.
 - `socket_send_buffer_bytes` - Requested TCP send buffer inherited by accepted

--- a/docs/features.md
+++ b/docs/features.md
@@ -715,17 +715,22 @@ probes the underlying WebSocket transport independently:
 
 ```
 
-The RFC 6455 Ping bypasses application queues; the bounded socket send buffer
-limits data already handed to TCP ahead of it. Compliant WebSocket stacks
-answer automatically; a missing matching Pong closes the socket with `4003
-activity_timeout`. Set `server_ping_interval_secs` to `0` to disable these
-server probes. Separately, the activity reaper disconnects clients that send no
-traffic for longer than `server.ping_timeout`.
+After an otherwise-idle interval, the RFC 6455 Ping bypasses application
+queues; the bounded socket send buffer limits data already handed to TCP ahead
+of it. Decoded inbound non-Pong traffic skips an unnecessary probe or cancels an
+outstanding one, and compliant WebSocket stacks answer actual probes
+automatically. A silent missing matching Pong closes the socket with `4003
+activity_timeout`. Set `server_ping_interval_secs` to `0` to disable probes.
+Separately, the activity reaper disconnects clients that send no traffic for
+longer than `server.ping_timeout`.
 
 Prometheus reports missed matching-Pong deadlines with
 `signal_fish_websocket_ping_timeouts_total`. Successful probe latency uses the
 `signal_fish_websocket_ping_rtt_*` family, including
 `signal_fish_websocket_ping_rtt_samples_total` and millisecond summary gauges.
+Activity-based decisions use
+`signal_fish_websocket_ping_probes_skipped_activity_total` and
+`signal_fish_websocket_ping_probes_cancelled_activity_total`.
 
 ## Idle Timeout
 

--- a/progress/session-054-release-preparation-and-heartbeat.md
+++ b/progress/session-054-release-preparation-and-heartbeat.md
@@ -3,7 +3,7 @@
 ## Scope
 
 Repair the two independent failure classes exposed by generated release PR
-#182, make both classes deterministic under local and CI validation, and carry
+PR #182, make both classes deterministic under local and CI validation, and carry
 the remediation through an exact-head green pull request and reviewer closure.
 
 ## Baseline evidence
@@ -139,4 +139,8 @@ Adversarial audit:
 - `pwsh ... scripts/check-hook-readiness.ps1`: passed with zero warnings.
 - Worktree pre-commit and pre-push PowerShell preflights: passed. The profiled
   pre-commit run took 1,288 ms and reported its non-fatal 1,000 ms budget warning.
+- The first published exact-head Markdownlint run exposed two reconstructed
+  changelog double blanks and a paragraph-leading `#182` parsed as a heading.
+  Those three formatting defects were reproduced from the job log, corrected,
+  and `bash scripts/check-markdown.sh` passed locally before republishing.
 - `git diff --check`: passed.

--- a/progress/session-054-release-preparation-and-heartbeat.md
+++ b/progress/session-054-release-preparation-and-heartbeat.md
@@ -69,3 +69,74 @@ Targeted evidence:
 - `cargo test --test doc_consistency_script_tests -- --nocapture`: 5 passed.
 - `cargo test --test doc_consistency_policy_tests -- --nocapture`: 10 passed.
 - `bash scripts/check-doc-consistency.sh --skip-changelog-gate`: passed.
+
+### Idle-only WebSocket probes
+
+Red evidence:
+
+- `inbound_activity_skips_probes_until_the_connection_becomes_idle` failed in
+  1.23 seconds because the old fixed Pong-only loop emitted an RFC Ping while
+  application Ping frames were arriving every 200 ms.
+- The historical H10 failure consistently reached roughly 22.43 seconds in its
+  first reliable backpressure cycle before the sender closed `4003`, proving
+  the receive-loop head-of-line window exceeded the 10s + 5s probe contract.
+
+Green implementation:
+
+- One O(1) Tokio watch state tracks inbound generation, serial handler activity,
+  and at most one nonce/evidence record. A decoded non-Pong frame publishes
+  activity before parsing or any await; active processing keeps probes skipped.
+- Writer-side generation recheck closes the command/write race. Exact matching
+  Pongs record RTT; first post-write non-Pong activity cancels; wrong/stale Pongs
+  do nothing; genuine silence still closes 4003. Disabled probes avoid receive-
+  side state mutations.
+- Added skipped/cancelled activity counters to JSON snapshots and Prometheus,
+  documented the idle-only tradeoff and nearly `2 × interval + timeout`
+  fixed-tick worst case, and replaced the LLM heartbeat sample that taught the
+  head-of-line bug.
+- Strengthened cancellation coverage beyond the original deadline and proved a
+  later idle probe still succeeds. The state-table tests cover writer-race skip,
+  active-handler skip, first-evidence wins, wrong nonce, inclusive deadline,
+  late evidence, cancellation, and silence.
+
+Real-world evidence:
+
+- Five complete serialized H10 repetitions passed. Each ran two ~22.4s reliable
+  backpressure cycles plus the 60s volatile phase, conserved every volatile
+  offer as delivered or exact-reported dropped, recorded zero ping timeouts,
+  and exercised activity-based skipping.
+- The fifth attempted repetition exposed a separate observation flake: an
+  already-congested Linux TCP path can reset after the server's slow-consumer
+  decision before tungstenite surfaces the semantic Close. The test now accepts
+  only the two exact reset representations and only after both the server-side
+  slow-consumer metric and healthy-watcher departure independently prove the
+  intended cause. The replacement full repetition exercised this path and
+  passed reconnect, delivery, and liveness assertions.
+- Focused WebSocket unit tests: 3 passed; `server_ping_e2e`: 16 passed;
+  Prometheus renderer tests: 5 passed; targeted all-feature Clippy: passed.
+
+Adversarial audit:
+
+- Confirmed bounded race-safe state and no timeout inflation or unbounded queue.
+- Its actionable findings (post-deadline cancellation survival, fixed-tick bound,
+  non-Pong wording, and disabled-mode overhead) were implemented and retested.
+
+## Full-project verification
+
+- `cargo fmt --all -- --check`: passed.
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`: passed.
+- `cargo test --locked --all-features`: the first compile attempt exhausted the
+  runner's per-process allocation while writing an incremental dependency graph;
+  the coverage-equivalent bounded rerun with `CARGO_BUILD_JOBS=2` and
+  `CARGO_INCREMENTAL=0` passed every executed unit, integration, policy, and
+  documentation test. Only explicitly ignored nightly/on-demand tests skipped.
+- `cargo deny --all-features check`: advisories, bans, licenses, and sources
+  passed; only the repository's acknowledged duplicate-version warnings remain.
+- `bash scripts/check-ci-config.sh`, `check-doc-consistency.sh --changed-files`,
+  `check-workflow-hygiene.sh`, `check-llm-file-sizes.sh`,
+  `check-llm-example-files.sh`, and `check-msrv-consistency.sh`: passed. Reported
+  warnings are pre-existing advisory items outside this change's scope.
+- `pwsh ... scripts/check-hook-readiness.ps1`: passed with zero warnings.
+- Worktree pre-commit and pre-push PowerShell preflights: passed. The profiled
+  pre-commit run took 1,288 ms and reported its non-fatal 1,000 ms budget warning.
+- `git diff --check`: passed.

--- a/progress/session-054-release-preparation-and-heartbeat.md
+++ b/progress/session-054-release-preparation-and-heartbeat.md
@@ -143,4 +143,9 @@ Adversarial audit:
   changelog double blanks and a paragraph-leading `#182` parsed as a heading.
   Those three formatting defects were reproduced from the job log, corrected,
   and `bash scripts/check-markdown.sh` passed locally before republishing.
+- The next macOS Nextest run exposed a Bash 3.2 portability difference: under
+  `set -u`, expanding a declared-but-empty array fails before the first release
+  is appended. The checker now cardinality-guards its only pre-population array
+  expansion and removes the unused parallel date array; the macOS CI lane is
+  the permanent regression oracle for the platform's system Bash.
 - `git diff --check`: passed.

--- a/progress/session-054-release-preparation-and-heartbeat.md
+++ b/progress/session-054-release-preparation-and-heartbeat.md
@@ -1,0 +1,71 @@
+# Session 054 — release preparation and heartbeat liveness
+
+## Scope
+
+Repair the two independent failure classes exposed by generated release PR
+#182, make both classes deterministic under local and CI validation, and carry
+the remediation through an exact-head green pull request and reviewer closure.
+
+## Baseline evidence
+
+PR #182 was generated from `main` for version 0.4.1 and changes only the six
+canonical release files. Its MSRV, Linux/macOS/Windows Nextest, coverage, and
+AddressSanitizer jobs all fail the same documentation-consistency test because
+the generated `[0.4.1]` comparison starts at `v0.4.0`, while the repository has
+no corresponding dated changelog section. The dedicated documentation job
+passes only because it checks out full history and tags; normal shallow
+checkouts do not. The checker therefore has topology-dependent behavior.
+
+The Real-World Scenario Profiles job fails independently in the H10 reliable
+asymmetric-bandwidth scenario. Under sustained application backpressure, the
+receive task awaits message delivery and cannot promptly read the peer's Pong;
+the separate heartbeat task then closes the otherwise-active connection with
+code 4003. The same failure is reproducible on `main`, so the generated release
+diff did not introduce it.
+
+## Approved invariants
+
+- Reconstruct missing 0.1.1, 0.3.0, and 0.4.0 changelog releases from immutable
+  tag snapshots and leave only post-v0.4.0 changes under Unreleased.
+- Make changelog comparison validation depend only on repository files, never
+  on whether tags happened to be fetched.
+- Make release preparation reject an invalid baseline before mutating files.
+- Probe only otherwise-idle WebSocket connections. Any valid inbound frame
+  proves liveness immediately; stale or mismatched Pongs never satisfy a probe.
+- Preserve bounded, sequential application processing and the existing timeout
+  defaults rather than masking the race with a larger timeout.
+- Add deterministic regression tests, observability, and durable LLM guidance.
+
+## Red/green log
+
+### Release history and preparation
+
+Red evidence:
+
+- A fixture whose `[0.2.0]` link skipped the missing `0.1.1` section passed when
+  a local `v0.1.1` tag existed and failed without it.
+- A fixture with Cargo version `1.2.3` and latest dated changelog release `1.1.0`
+  was mutated successfully instead of failing preflight.
+
+Green implementation:
+
+- Reconstructed `0.1.1` (2026-02-23), `0.3.0` (2026-06-20), and `0.4.0`
+  (2026-07-12) from annotated tag history. A one-time top-level Markdown bullet
+  inventory proved conservation of all 132 existing blocks: 12 remain
+  Unreleased, 43 belong to 0.4.0, and 77 belong to 0.3.0. The sole additional
+  0.1.1 retrospective note is supported by its three-commit release range.
+- The checker now validates exactly one first-position Unreleased section,
+  strict unique descending semver headings, real calendar dates, one contiguous
+  adjacent comparison chain, and a direct oldest-release link using files only.
+- Release preparation now rejects Cargo/changelog drift, a missing/lightweight/
+  non-ancestor baseline tag, an existing target tag/section, and lockfile drift
+  before editing the six output files. It validates both the baseline and result.
+- Data-driven checker cases, topology parity, byte-identical preflight failure
+  assertions, and an integrated prepare-then-real-checker fixture are green.
+
+Targeted evidence:
+
+- `cargo test --test release_prepare_tests -- --nocapture`: 7 passed.
+- `cargo test --test doc_consistency_script_tests -- --nocapture`: 5 passed.
+- `cargo test --test doc_consistency_policy_tests -- --nocapture`: 10 passed.
+- `bash scripts/check-doc-consistency.sh --skip-changelog-gate`: passed.

--- a/scripts/check-doc-consistency.sh
+++ b/scripts/check-doc-consistency.sh
@@ -279,8 +279,10 @@ validate_changelog() {
         action_error "CHANGELOG.md must reference Keep a Changelog"
     fi
 
-    if ! grep -q '^## \[Unreleased\]$' <<< "$changelog"; then
-        action_error "CHANGELOG.md must contain an exact '## [Unreleased]' heading"
+    local unreleased_count
+    unreleased_count=$(grep -c '^## \[Unreleased\]$' <<< "$changelog" || true)
+    if [ "$unreleased_count" -ne 1 ]; then
+        action_error "CHANGELOG.md must contain an exact '## [Unreleased]' heading exactly once (found: $unreleased_count)"
     fi
 
     if grep -q '^## Unreleased$' <<< "$changelog"; then
@@ -327,18 +329,96 @@ validate_changelog() {
         fi
     fi
 
-    # Collect released versions from headers.
-    local versions
-    versions=$(grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' <<< "$changelog" \
-        | sed -E 's/^## \[([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/' || true)
+    local first_bracketed_heading
+    first_bracketed_heading=$(grep -E '^## \[' <<< "$changelog" | head -n 1 || true)
+    if [ "$first_bracketed_heading" != '## [Unreleased]' ]; then
+        action_error "CHANGELOG.md [Unreleased] must be the first bracketed section"
+    fi
 
-    if [ -z "$versions" ]; then
+    is_real_changelog_date() {
+        local value="$1"
+        local year month day max_day
+        if [[ ! "$value" =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})$ ]]; then
+            return 1
+        fi
+        year=$((10#${BASH_REMATCH[1]}))
+        month=$((10#${BASH_REMATCH[2]}))
+        day=$((10#${BASH_REMATCH[3]}))
+        if ((year < 1 || month < 1 || month > 12 || day < 1)); then
+            return 1
+        fi
+        case "$month" in
+            2)
+                max_day=28
+                if ((year % 400 == 0 || (year % 4 == 0 && year % 100 != 0))); then
+                    max_day=29
+                fi
+                ;;
+            4|6|9|11) max_day=30 ;;
+            *) max_day=31 ;;
+        esac
+        ((day <= max_day))
+    }
+
+    semver_is_greater() {
+        local lhs="$1"
+        local rhs="$2"
+        local lhs_major lhs_minor lhs_patch rhs_major rhs_minor rhs_patch
+        IFS=. read -r lhs_major lhs_minor lhs_patch <<< "$lhs"
+        IFS=. read -r rhs_major rhs_minor rhs_patch <<< "$rhs"
+        if ((10#$lhs_major != 10#$rhs_major)); then
+            ((10#$lhs_major > 10#$rhs_major))
+        elif ((10#$lhs_minor != 10#$rhs_minor)); then
+            ((10#$lhs_minor > 10#$rhs_minor))
+        else
+            ((10#$lhs_patch > 10#$rhs_patch))
+        fi
+    }
+
+    # Parse every bracketed level-two heading, not just valid ones, so malformed
+    # releases cannot disappear from the comparison chain.
+    local -a versions=()
+    local -a release_dates=()
+    local heading version release_date seen_version
+    local release_heading_pattern='^## \[((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})$'
+    while IFS= read -r heading; do
+        [ -z "$heading" ] && continue
+        if [ "$heading" = '## [Unreleased]' ]; then
+            continue
+        fi
+        if [[ "$heading" =~ $release_heading_pattern ]]; then
+            version="${BASH_REMATCH[1]}"
+            release_date="${BASH_REMATCH[5]}"
+        else
+            action_error "CHANGELOG.md has malformed release heading: '$heading'"
+            continue
+        fi
+
+        if ! is_real_changelog_date "$release_date"; then
+            action_error "CHANGELOG.md release [$version] has invalid calendar date $release_date"
+        fi
+        for seen_version in "${versions[@]}"; do
+            if [ "$seen_version" = "$version" ]; then
+                action_error "CHANGELOG.md has duplicate dated release section for $version"
+            fi
+        done
+        versions+=("$version")
+        release_dates+=("$release_date")
+    done < <(grep -E '^## \[' <<< "$changelog" || true)
+
+    if [ "${#versions[@]}" -eq 0 ]; then
         action_warn "No dated release sections found in CHANGELOG.md"
         return
     fi
 
-    local latest_version
-    latest_version=$(printf '%s\n' "$versions" | sort -V | tail -n 1)
+    local index
+    for ((index = 1; index < ${#versions[@]}; index++)); do
+        if ! semver_is_greater "${versions[index - 1]}" "${versions[index]}"; then
+            action_error "CHANGELOG.md release sections must be in strictly descending semantic-version order (${versions[index - 1]} before ${versions[index]})"
+        fi
+    done
+
+    local latest_version="${versions[0]}"
 
     local unreleased_ref
     unreleased_ref=$(grep -E '^\[Unreleased\]:' <<< "$changelog" | sed -E 's/^\[Unreleased\]:[[:space:]]*(\S+).*$/\1/' || true)
@@ -350,37 +430,38 @@ validate_changelog() {
         fi
     fi
 
-    # Validate link references for every released version section.
-    local version
-    while IFS= read -r version; do
-        [ -z "$version" ] && continue
-
-        local release_ref
-        release_ref=$(grep -E "^\[$version\]:" <<< "$changelog" | sed -E "s/^\[$version\]:[[:space:]]*(\\S+).*$/\\1/" || true)
-        if [ -z "$release_ref" ]; then
+    # Validate a single, contiguous comparison chain using repository files
+    # alone. Checkout depth and fetched tags must never alter this result.
+    local release_ref release_ref_lines release_ref_count previous_version linked_previous
+    for ((index = 0; index < ${#versions[@]}; index++)); do
+        version="${versions[index]}"
+        release_ref_lines=$(grep -E "^\[$version\]:" <<< "$changelog" || true)
+        release_ref_count=$(awk 'NF { count++ } END { print count + 0 }' <<< "$release_ref_lines")
+        if [ "$release_ref_count" -ne 1 ]; then
+            action_error "CHANGELOG.md must define exactly one [$version]: link reference (found: $release_ref_count)"
             action_error "CHANGELOG.md must define a [$version]: link reference"
             continue
         fi
+        release_ref=$(sed -E "s/^\[$version\]:[[:space:]]*(\\S+).*$/\\1/" <<< "$release_ref_lines")
 
-        if [[ "$release_ref" =~ /releases/tag/v${version}([#?].*)?$ ]]; then
-            continue
-        fi
-
-        if [[ "$release_ref" =~ /compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.v${version}([#?].*)?$ ]]; then
-            local previous_version
-            previous_version="${BASH_REMATCH[1]}"
-            # A legitimate prior tag can predate changelog section backfills.
-            # Accept that immutable release identity, but still reject typos and
-            # nonexistent compare endpoints when neither evidence source exists.
-            if ! grep -Fxq "$previous_version" <<< "$versions" \
-                && ! git rev-parse --verify --quiet "refs/tags/v$previous_version" >/dev/null; then
-                action_error "[$version] compare link references unknown previous version v$previous_version (link: $release_ref)"
+        if [ "$index" -eq "$((${#versions[@]} - 1))" ]; then
+            if [[ ! "$release_ref" =~ /releases/tag/v${version}([#?].*)?$ ]]; then
+                action_error "CHANGELOG.md oldest release [$version] must link directly to /releases/tag/v$version (found: $release_ref)"
             fi
             continue
         fi
 
-        action_error "[$version] link must point to /releases/tag/v$version or /compare/vPREV...v$version (found: $release_ref)"
-    done < <(printf '%s\n' "$versions")
+        previous_version="${versions[index + 1]}"
+        if [[ "$release_ref" =~ /compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.v${version}([#?].*)?$ ]]; then
+            linked_previous="${BASH_REMATCH[1]}"
+            if [[ ! " ${versions[*]} " =~ " $linked_previous " ]]; then
+                action_error "[$version] compare link references unknown previous version v$linked_previous (link: $release_ref)"
+            fi
+        fi
+        if [[ ! "$release_ref" =~ /compare/v${previous_version}\.\.\.v${version}([#?].*)?$ ]]; then
+            action_error "[$version] link must compare adjacent releases v$previous_version...v$version (found: $release_ref)"
+        fi
+    done
 }
 
 validate_changelog

--- a/scripts/check-doc-consistency.sh
+++ b/scripts/check-doc-consistency.sh
@@ -378,7 +378,6 @@ validate_changelog() {
     # Parse every bracketed level-two heading, not just valid ones, so malformed
     # releases cannot disappear from the comparison chain.
     local -a versions=()
-    local -a release_dates=()
     local heading version release_date seen_version
     local release_heading_pattern='^## \[((0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*))\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})$'
     while IFS= read -r heading; do
@@ -397,13 +396,16 @@ validate_changelog() {
         if ! is_real_changelog_date "$release_date"; then
             action_error "CHANGELOG.md release [$version] has invalid calendar date $release_date"
         fi
-        for seen_version in "${versions[@]}"; do
-            if [ "$seen_version" = "$version" ]; then
-                action_error "CHANGELOG.md has duplicate dated release section for $version"
-            fi
-        done
+        # Bash 3.2 (the macOS system Bash) reports a declared-but-empty array as
+        # unbound under `set -u`. Do not expand the array before its first item.
+        if [ "${#versions[@]}" -gt 0 ]; then
+            for seen_version in "${versions[@]}"; do
+                if [ "$seen_version" = "$version" ]; then
+                    action_error "CHANGELOG.md has duplicate dated release section for $version"
+                fi
+            done
+        fi
         versions+=("$version")
-        release_dates+=("$release_date")
     done < <(grep -E '^## \[' <<< "$changelog" || true)
 
     if [ "${#versions[@]}" -eq 0 ]; then
@@ -454,7 +456,7 @@ validate_changelog() {
         previous_version="${versions[index + 1]}"
         if [[ "$release_ref" =~ /compare/v([0-9]+\.[0-9]+\.[0-9]+)\.\.\.v${version}([#?].*)?$ ]]; then
             linked_previous="${BASH_REMATCH[1]}"
-            if [[ ! " ${versions[*]} " =~ " $linked_previous " ]]; then
+            if [[ " ${versions[*]} " != *" $linked_previous "* ]]; then
                 action_error "[$version] compare link references unknown previous version v$linked_previous (link: $release_ref)"
             fi
         fi

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -165,6 +165,65 @@ if grep -Eq "^## \\[${NEXT_VERSION//./\\.}\\]([[:space:]]|$)" CHANGELOG.md; then
     exit 1
 fi
 
+LATEST_CHANGELOG_VERSION=$(grep -E '^## \[(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' CHANGELOG.md \
+    | head -n 1 \
+    | sed -E 's/^## \[([^]]+)\].*/\1/' || true)
+if [ -z "$LATEST_CHANGELOG_VERSION" ] || [ "$LATEST_CHANGELOG_VERSION" != "$CURRENT_VERSION" ]; then
+    echo "ERROR: Cargo.toml version $CURRENT_VERSION must equal the latest dated CHANGELOG.md release (found: ${LATEST_CHANGELOG_VERSION:-none})." >&2
+    exit 1
+fi
+
+CURRENT_TAG="refs/tags/v$CURRENT_VERSION"
+if ! git rev-parse --verify --quiet "$CURRENT_TAG" >/dev/null; then
+    echo "ERROR: Baseline tag v$CURRENT_VERSION is missing." >&2
+    exit 1
+fi
+if [ "$(git cat-file -t "$CURRENT_TAG")" != "tag" ]; then
+    echo "ERROR: Baseline tag v$CURRENT_VERSION must be annotated." >&2
+    exit 1
+fi
+CURRENT_TAG_COMMIT=$(git rev-parse "$CURRENT_TAG^{commit}")
+if ! git merge-base --is-ancestor "$CURRENT_TAG_COMMIT" HEAD; then
+    echo "ERROR: Baseline tag v$CURRENT_VERSION must resolve to an ancestor of HEAD." >&2
+    exit 1
+fi
+if git rev-parse --verify --quiet "refs/tags/v$NEXT_VERSION" >/dev/null; then
+    echo "ERROR: Target tag v$NEXT_VERSION already exists locally." >&2
+    exit 1
+fi
+
+# These two overrides are narrow test seams. Production and the workflow use
+# the real commands, while isolated fixture tests can validate transformations
+# without resolving the repository's dependency graph.
+PREPARE_RELEASE_CARGO_BIN=${PREPARE_RELEASE_CARGO_BIN:-cargo}
+PREPARE_RELEASE_DOC_CHECK=${PREPARE_RELEASE_DOC_CHECK:-scripts/check-doc-consistency.sh}
+
+# Validate the released baseline before touching any of the six output files.
+# The documentation checker is deliberately file-only: fetched tags and clone
+# depth cannot change whether the comparison chain is valid.
+for lockfile in Cargo.lock clients/native/Cargo.lock; do
+    lock_entry_state=$(awk -v current_version="$CURRENT_VERSION" '
+        BEGIN { target = 0; entries = 0; matching = 0 }
+        /^\[\[package\]\]$/ { target = 0 }
+        /^name = "signal-fish-server"$/ { target = 1 }
+        target == 1 && /^version = "/ {
+            entries++
+            if ($0 == "version = \"" current_version "\"") matching++
+            target = 0
+        }
+        END { print entries ":" matching }
+    ' "$lockfile")
+    if [ "$lock_entry_state" != "1:1" ]; then
+        echo "ERROR: Expected exactly one signal-fish-server package entry at version $CURRENT_VERSION in $lockfile." >&2
+        exit 1
+    fi
+done
+"$PREPARE_RELEASE_DOC_CHECK" --skip-changelog-gate
+for manifest in Cargo.toml clients/native/Cargo.toml; do
+    "$PREPARE_RELEASE_CARGO_BIN" metadata --locked --no-deps --format-version 1 \
+        --manifest-path "$manifest" >/dev/null
+done
+
 UNRELEASED_BODY=$(awk '
     /^## \[Unreleased\]$/ { in_unreleased = 1; next }
     in_unreleased && /^## \[/ { exit }
@@ -341,12 +400,6 @@ if [ "$(read_package_version)" != "$NEXT_VERSION" ]; then
     echo "ERROR: Cargo.toml version update did not persist." >&2
     exit 1
 fi
-
-# These two overrides are narrow test seams. Production and the workflow use
-# the real commands, while isolated fixture tests can validate transformations
-# without resolving the repository's dependency graph.
-PREPARE_RELEASE_CARGO_BIN=${PREPARE_RELEASE_CARGO_BIN:-cargo}
-PREPARE_RELEASE_DOC_CHECK=${PREPARE_RELEASE_DOC_CHECK:-scripts/check-doc-consistency.sh}
 
 for manifest in Cargo.toml clients/native/Cargo.toml; do
     "$PREPARE_RELEASE_CARGO_BIN" metadata --locked --no-deps --format-version 1 \

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -92,6 +92,12 @@ pub struct ServerMetrics {
     /// Server-initiated RFC 6455 WebSocket pings that did not receive their
     /// matching Pong before `websocket.pong_timeout_secs`.
     pub websocket_ping_timeouts: AtomicU64,
+    /// Scheduled liveness probes omitted because inbound traffic already
+    /// proved the connection active during the preceding interval.
+    pub websocket_ping_probes_skipped_activity: AtomicU64,
+    /// Outstanding liveness probes cancelled when a non-Pong inbound frame
+    /// proved the connection active after the Ping write began.
+    pub websocket_ping_probes_cancelled_activity: AtomicU64,
     /// Delivery attempts routed through the reliable server delivery and
     /// reservation paths: one per message per recipient, counted before the
     /// outcome is known. Together with
@@ -340,6 +346,8 @@ pub struct ConnectionMetrics {
     pub websocket_backpressure_events: u64,
     pub websocket_slow_consumer_disconnects: u64,
     pub websocket_ping_timeouts: u64,
+    pub websocket_ping_probes_skipped_activity: u64,
+    pub websocket_ping_probes_cancelled_activity: u64,
     pub websocket_ping_rtt: OperationLatencyMetrics,
     pub websocket_delivery_attempts: u64,
     pub websocket_deliveries_enqueued: u64,
@@ -547,6 +555,8 @@ impl ServerMetrics {
             websocket_backpressure_events: AtomicU64::new(0),
             websocket_slow_consumer_disconnects: AtomicU64::new(0),
             websocket_ping_timeouts: AtomicU64::new(0),
+            websocket_ping_probes_skipped_activity: AtomicU64::new(0),
+            websocket_ping_probes_cancelled_activity: AtomicU64::new(0),
             websocket_delivery_attempts: AtomicU64::new(0),
             websocket_deliveries_enqueued: AtomicU64::new(0),
             websocket_deliveries_channel_closed: AtomicU64::new(0),
@@ -691,6 +701,16 @@ impl ServerMetrics {
 
     pub fn increment_websocket_ping_timeouts(&self) {
         self.websocket_ping_timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_websocket_ping_probes_skipped_activity(&self) {
+        self.websocket_ping_probes_skipped_activity
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn increment_websocket_ping_probes_cancelled_activity(&self) {
+        self.websocket_ping_probes_cancelled_activity
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     pub async fn record_websocket_ping_rtt(&self, duration: Duration) {
@@ -1373,6 +1393,12 @@ impl ServerMetrics {
                     .websocket_slow_consumer_disconnects
                     .load(Ordering::Relaxed),
                 websocket_ping_timeouts: self.websocket_ping_timeouts.load(Ordering::Relaxed),
+                websocket_ping_probes_skipped_activity: self
+                    .websocket_ping_probes_skipped_activity
+                    .load(Ordering::Relaxed),
+                websocket_ping_probes_cancelled_activity: self
+                    .websocket_ping_probes_cancelled_activity
+                    .load(Ordering::Relaxed),
                 websocket_ping_rtt,
                 websocket_delivery_attempts: self
                     .websocket_delivery_attempts

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -15,10 +15,10 @@ use axum::extract::ws::{Message, WebSocket};
 use futures_util::{SinkExt, StreamExt};
 use rand::RngExt;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::sync::{mpsc, oneshot, watch, RwLock};
 use tokio::time::Instant;
 
 use super::batching::{send_batch, send_queued, MessageBatcher, QueueWriteError, WritePhase};
@@ -51,43 +51,181 @@ pub(super) const REGISTERED_SHUTDOWN_CLOSE_WRITE_STEPS: u32 =
 
 struct ServerPingCommand {
     nonce: u64,
-    write_timing: oneshot::Sender<PingWriteTiming>,
+    baseline_generation: u64,
+    write_outcome: oneshot::Sender<PingWriteOutcome>,
 }
 
+#[derive(Clone, Copy, Debug)]
 struct PingWriteTiming {
-    started_at: Instant,
     completed_at: Instant,
 }
 
-#[derive(Clone, Copy)]
-struct ObservedPong {
-    nonce: u64,
-    received_at: Instant,
+#[derive(Clone, Copy, Debug)]
+enum PingWriteOutcome {
+    Written(PingWriteTiming),
+    SkippedActivity { generation: u64 },
 }
 
-fn pong_rtt_for_probe(
-    observation: Option<ObservedPong>,
-    nonce: u64,
-    write_started_at: Instant,
-    deadline_at: Instant,
-) -> Option<Duration> {
-    let pong = observation?;
-    (pong.nonce == nonce && pong.received_at >= write_started_at && pong.received_at <= deadline_at)
-        .then(|| pong.received_at.duration_since(write_started_at))
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PingProbeEvidence {
+    MatchingPong { received_at: Instant },
+    InboundActivity { received_at: Instant },
 }
 
-fn try_record_active_pong(
-    observations: &mpsc::Sender<ObservedPong>,
-    active_nonce: &AtomicU64,
+#[derive(Clone, Copy, Debug)]
+struct ActivePingProbe {
+    nonce: u64,
+    started_at: Instant,
+    evidence: Option<PingProbeEvidence>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PingProbeState {
+    inbound_generation: u64,
+    inbound_processing: bool,
+    active: Option<ActivePingProbe>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PingProbeResolution {
+    MatchingPong(Duration),
+    InboundActivity { generation: u64 },
+    TimedOut,
+}
+
+fn begin_ping_probe(
+    state: &watch::Sender<PingProbeState>,
+    baseline_generation: u64,
+    nonce: u64,
+    started_at: Instant,
+) -> Result<(), u64> {
+    let mut result = Err(baseline_generation);
+    state.send_modify(|current| {
+        if current.inbound_generation == baseline_generation
+            && !current.inbound_processing
+            && current.active.is_none()
+        {
+            current.active = Some(ActivePingProbe {
+                nonce,
+                started_at,
+                evidence: None,
+            });
+            result = Ok(());
+        } else {
+            result = Err(current.inbound_generation);
+        }
+    });
+    result
+}
+
+fn record_inbound_probe_activity(state: &watch::Sender<PingProbeState>, received_at: Instant) {
+    state.send_modify(|current| {
+        current.inbound_generation = current.inbound_generation.wrapping_add(1);
+        current.inbound_processing = true;
+        if let Some(active) = current.active.as_mut() {
+            if active.evidence.is_none() && received_at >= active.started_at {
+                active.evidence = Some(PingProbeEvidence::InboundActivity { received_at });
+            }
+        }
+    });
+}
+
+struct InboundProbeActivityGuard {
+    state: watch::Sender<PingProbeState>,
+}
+
+impl InboundProbeActivityGuard {
+    fn begin(state: &watch::Sender<PingProbeState>, received_at: Instant) -> Self {
+        record_inbound_probe_activity(state, received_at);
+        Self {
+            state: state.clone(),
+        }
+    }
+}
+
+impl Drop for InboundProbeActivityGuard {
+    fn drop(&mut self) {
+        self.state.send_if_modified(|current| {
+            if current.inbound_processing {
+                current.inbound_processing = false;
+                true
+            } else {
+                false
+            }
+        });
+    }
+}
+
+fn try_record_matching_pong(
+    state: &watch::Sender<PingProbeState>,
     nonce: u64,
     received_at: Instant,
 ) -> bool {
-    let current_nonce = active_nonce.load(Ordering::Acquire);
-    current_nonce != 0
-        && current_nonce == nonce
-        && observations
-            .try_send(ObservedPong { nonce, received_at })
-            .is_ok()
+    let mut recorded = false;
+    state.send_if_modified(|current| {
+        let Some(active) = current.active.as_mut() else {
+            return false;
+        };
+        if active.nonce != nonce || active.evidence.is_some() || received_at < active.started_at {
+            return false;
+        }
+        active.evidence = Some(PingProbeEvidence::MatchingPong { received_at });
+        recorded = true;
+        true
+    });
+    recorded
+}
+
+fn clear_ping_probe(state: &watch::Sender<PingProbeState>, nonce: u64) {
+    state.send_if_modified(|current| {
+        if current.active.is_some_and(|active| active.nonce == nonce) {
+            current.active = None;
+            true
+        } else {
+            false
+        }
+    });
+}
+
+fn resolve_ping_probe(
+    state: &watch::Sender<PingProbeState>,
+    nonce: u64,
+    deadline_at: Instant,
+    deadline_reached: bool,
+) -> Option<PingProbeResolution> {
+    let mut resolution = None;
+    state.send_if_modified(|current| {
+        let Some(active) = current.active else {
+            return false;
+        };
+        if active.nonce != nonce {
+            return false;
+        }
+
+        resolution = match active.evidence {
+            Some(PingProbeEvidence::MatchingPong { received_at }) if received_at <= deadline_at => {
+                Some(PingProbeResolution::MatchingPong(
+                    received_at.duration_since(active.started_at),
+                ))
+            }
+            Some(PingProbeEvidence::InboundActivity { received_at })
+                if received_at <= deadline_at =>
+            {
+                Some(PingProbeResolution::InboundActivity {
+                    generation: current.inbound_generation,
+                })
+            }
+            _ if deadline_reached => Some(PingProbeResolution::TimedOut),
+            _ => None,
+        };
+        if resolution.is_some() {
+            current.active = None;
+            true
+        } else {
+            false
+        }
+    });
+    resolution
 }
 
 /// Enqueue a message on this connection's own outbound queue, honoring the
@@ -542,13 +680,14 @@ pub(super) async fn handle_socket(
     // application delivery lanes. At most one probe is outstanding, so one
     // slot is sufficient and cannot accumulate stale probes.
     let (ping_command_tx, mut ping_command_rx) = mpsc::channel::<ServerPingCommand>(1);
-    // The socket reader forwards only the first Pong matching the nonce that
-    // the writer has marked active. A bounded channel preserves that match
-    // without allowing unsolicited Pongs to grow memory or overwrite it.
-    let active_ping_nonce = Arc::new(AtomicU64::new(0));
-    let active_ping_nonce_for_send = Arc::clone(&active_ping_nonce);
-    let active_ping_nonce_for_receive = Arc::clone(&active_ping_nonce);
-    let (pong_observation_tx, pong_observation_rx) = mpsc::channel::<ObservedPong>(1);
+    // One coalescing O(1) state connects ticker, writer, and reader. It records
+    // inbound activity before application handling can block, and retains only
+    // the first evidence for the single active probe.
+    let (ping_probe_state_tx, ping_probe_state_rx) = watch::channel(PingProbeState::default());
+    let ping_probe_state_for_send = ping_probe_state_tx.clone();
+    let server_ping_interval_secs = server.config().websocket_config.server_ping_interval_secs;
+    let ping_probe_state_for_receive =
+        (server_ping_interval_secs > 0).then(|| ping_probe_state_tx.clone());
 
     // Keep a clone of tx for sending auth responses
     let tx_clone = tx.clone();
@@ -685,19 +824,19 @@ pub(super) async fn handle_socket(
         return;
     };
 
-    let server_ping_interval_secs = server.config().websocket_config.server_ping_interval_secs;
     if server_ping_interval_secs > 0 {
         let pong_timeout = Duration::from_secs(server.config().websocket_config.pong_timeout_secs);
         let ping_commands = ping_command_tx.clone();
         let ping_close_signal = close_signal.clone();
         let mut ping_task_close = ping_task_close;
-        let mut pong_observations = pong_observation_rx;
-        let active_ping_nonce_for_ping = Arc::clone(&active_ping_nonce);
+        let mut probe_states = ping_probe_state_rx;
+        let probe_state_updates = ping_probe_state_tx.clone();
         let server_for_ping = server.clone();
         let effective_player_id_for_ping = Arc::clone(&effective_player_id);
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(server_ping_interval_secs));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            let mut consumed_generation = probe_states.borrow().inbound_generation;
             // Start probing after one full configured interval.
             ticker.tick().await;
             loop {
@@ -709,28 +848,22 @@ pub(super) async fn handle_socket(
                     _ = ticker.tick() => {}
                 }
 
-                let nonce = random_ping_nonce();
-                // Discard unsolicited/stale Pongs before publishing this
-                // probe. The write task returns timestamps bracketing the send,
-                // so even an exact Pong observed before the write begins cannot
-                // satisfy the unpredictable probe while a fast reply received
-                // before the send future returns remains valid.
-                loop {
-                    match pong_observations.try_recv() {
-                        Ok(stale) => {
-                            tracing::debug!(
-                                stale_nonce = stale.nonce,
-                                "Discarding stale WebSocket Pong observation"
-                            );
-                        }
-                        Err(mpsc::error::TryRecvError::Empty) => break,
-                        Err(mpsc::error::TryRecvError::Disconnected) => return,
-                    }
+                let current_state = *probe_states.borrow_and_update();
+                let observed_generation = current_state.inbound_generation;
+                if current_state.inbound_processing || observed_generation != consumed_generation {
+                    consumed_generation = observed_generation;
+                    server_for_ping
+                        .metrics()
+                        .increment_websocket_ping_probes_skipped_activity();
+                    continue;
                 }
-                let (write_timing_tx, write_timing_rx) = oneshot::channel();
+
+                let nonce = random_ping_nonce();
+                let (write_outcome_tx, write_outcome_rx) = oneshot::channel();
                 let command = ServerPingCommand {
                     nonce,
-                    write_timing: write_timing_tx,
+                    baseline_generation: consumed_generation,
+                    write_outcome: write_outcome_tx,
                 };
                 tokio::select! {
                     reason = ping_task_close.closed() => {
@@ -743,93 +876,93 @@ pub(super) async fn handle_socket(
                         }
                     }
                 }
-                let write_timing = tokio::select! {
+                let write_outcome = tokio::select! {
                     reason = ping_task_close.closed() => {
                         tracing::debug!(?reason, "Connection closing during WebSocket Ping write");
                         break;
                     }
-                    result = write_timing_rx => {
-                        let Ok(write_timing) = result else {
+                    result = write_outcome_rx => {
+                        let Ok(write_outcome) = result else {
                             break;
                         };
-                        write_timing
+                        write_outcome
+                    }
+                };
+                let write_timing = match write_outcome {
+                    PingWriteOutcome::Written(timing) => timing,
+                    PingWriteOutcome::SkippedActivity { generation } => {
+                        consumed_generation = generation;
+                        probe_states.borrow_and_update();
+                        server_for_ping
+                            .metrics()
+                            .increment_websocket_ping_probes_skipped_activity();
+                        continue;
                     }
                 };
 
                 let deadline_at = write_timing.completed_at + pong_timeout;
                 let deadline = tokio::time::sleep_until(deadline_at);
                 tokio::pin!(deadline);
-                loop {
+                let resolution = loop {
+                    if let Some(resolution) =
+                        resolve_ping_probe(&probe_state_updates, nonce, deadline_at, false)
+                    {
+                        break resolution;
+                    }
                     tokio::select! {
                         reason = ping_task_close.closed() => {
                             tracing::debug!(?reason, "Connection closing while awaiting WebSocket Pong");
                             return;
                         }
-                        observation = pong_observations.recv() => {
-                            let Some(observation) = observation else {
+                        changed = probe_states.changed() => {
+                            if changed.is_err() {
                                 return;
-                            };
-                            if let Some(rtt) = pong_rtt_for_probe(
-                                Some(observation),
-                                nonce,
-                                write_timing.started_at,
-                                deadline_at,
-                            ) {
-                                server_for_ping
-                                    .metrics()
-                                    .record_websocket_ping_rtt(rtt)
-                                    .await;
-                                active_ping_nonce_for_ping.store(0, Ordering::Release);
-                                break;
                             }
                         }
                         () = &mut deadline => {
-                            // Receiving the observation and the timer can become
-                            // ready together. Give a Pong stamped on or before the
-                            // deadline one final observation before timing out.
-                            let observation = match pong_observations.try_recv() {
-                                Ok(observation) => Some(observation),
-                                Err(mpsc::error::TryRecvError::Empty) => None,
-                                Err(mpsc::error::TryRecvError::Disconnected) => {
-                                    active_ping_nonce_for_ping.store(0, Ordering::Release);
-                                    return;
-                                }
-                            };
-                            if let Some(rtt) = pong_rtt_for_probe(
-                                observation,
+                            break resolve_ping_probe(
+                                &probe_state_updates,
                                 nonce,
-                                write_timing.started_at,
                                 deadline_at,
-                            ) {
-                                server_for_ping
-                                    .metrics()
-                                    .record_websocket_ping_rtt(rtt)
-                                    .await;
-                                active_ping_nonce_for_ping.store(0, Ordering::Release);
-                                break;
-                            }
-                            active_ping_nonce_for_ping.store(0, Ordering::Release);
-                            if ping_close_signal.request_close(CloseReason::ActivityTimeout) {
-                                let current_player_id =
-                                    *effective_player_id_for_ping.read().await;
-                                tracing::info!(
-                                    %current_player_id,
-                                    timeout_secs = pong_timeout.as_secs(),
-                                    "WebSocket Pong timeout - closing connection"
-                                );
-                                server_for_ping
-                                    .metrics()
-                                    .increment_websocket_ping_timeouts();
-                            }
-                            return;
+                                true,
+                            )
+                            .unwrap_or(PingProbeResolution::TimedOut);
                         }
+                    }
+                };
+                match resolution {
+                    PingProbeResolution::MatchingPong(rtt) => {
+                        server_for_ping
+                            .metrics()
+                            .record_websocket_ping_rtt(rtt)
+                            .await;
+                    }
+                    PingProbeResolution::InboundActivity { generation } => {
+                        consumed_generation = generation;
+                        server_for_ping
+                            .metrics()
+                            .increment_websocket_ping_probes_cancelled_activity();
+                    }
+                    PingProbeResolution::TimedOut => {
+                        if ping_close_signal.request_close(CloseReason::ActivityTimeout) {
+                            let current_player_id = *effective_player_id_for_ping.read().await;
+                            tracing::info!(
+                                %current_player_id,
+                                timeout_secs = pong_timeout.as_secs(),
+                                "WebSocket Pong timeout - closing connection"
+                            );
+                            server_for_ping
+                                .metrics()
+                                .increment_websocket_ping_timeouts();
+                        }
+                        return;
                     }
                 }
             }
         });
     } else {
         drop(ping_task_close);
-        drop(pong_observation_rx);
+        drop(ping_probe_state_rx);
     }
 
     // Periodic per-connection RelayStats emission (protocol v3, opt-in via
@@ -960,9 +1093,19 @@ pub(super) async fn handle_socket(
                             let Some(command) = command else {
                                 break;
                             };
-                            let payload = command.nonce.to_be_bytes().to_vec().into();
                             let write_started_at = Instant::now();
-                            active_ping_nonce_for_send.store(command.nonce, Ordering::Release);
+                            if let Err(generation) = begin_ping_probe(
+                                &ping_probe_state_for_send,
+                                command.baseline_generation,
+                                command.nonce,
+                                write_started_at,
+                            ) {
+                                let _ = command.write_outcome.send(
+                                    PingWriteOutcome::SkippedActivity { generation }
+                                );
+                                continue;
+                            }
+                            let payload = command.nonce.to_be_bytes().to_vec().into();
                             match tokio::time::timeout(
                                 ping_write_timeout,
                                 sender.send(Message::Ping(payload)),
@@ -970,14 +1113,15 @@ pub(super) async fn handle_socket(
                             .await
                             {
                                 Ok(Ok(())) => {
-                                    let _ = command.write_timing.send(PingWriteTiming {
-                                        started_at: write_started_at,
-                                        completed_at: Instant::now(),
-                                    });
+                                    let _ = command.write_outcome.send(
+                                        PingWriteOutcome::Written(PingWriteTiming {
+                                            completed_at: Instant::now(),
+                                        })
+                                    );
                                     continue;
                                 }
                                 Ok(Err(err)) => {
-                                    active_ping_nonce_for_send.store(0, Ordering::Release);
+                                    clear_ping_probe(&ping_probe_state_for_send, command.nonce);
                                     tracing::debug!(
                                         error = %err,
                                         "Failed to write WebSocket Ping"
@@ -986,7 +1130,7 @@ pub(super) async fn handle_socket(
                                         .request_close(CloseReason::ActivityTimeout);
                                 }
                                 Err(_elapsed) => {
-                                    active_ping_nonce_for_send.store(0, Ordering::Release);
+                                    clear_ping_probe(&ping_probe_state_for_send, command.nonce);
                                     if send_task_close_signal
                                         .request_close(CloseReason::ActivityTimeout)
                                     {
@@ -1259,6 +1403,18 @@ pub(super) async fn handle_socket(
                     tracing::warn!(%active_player_id, "WebSocket error: {}", e);
                     break;
                 }
+            };
+            let received_at = Instant::now();
+            let _inbound_activity_guard = if !matches!(&msg, Message::Pong(_)) {
+                // Publish transport liveness before parsing or any awaited
+                // application work. Reliable delivery can backpressure the
+                // handler, but it must not hide an already-decoded frame from
+                // the idle-probe state machine.
+                ping_probe_state_for_receive
+                    .as_ref()
+                    .map(|state| InboundProbeActivityGuard::begin(state, received_at))
+            } else {
+                None
             };
 
             match msg {
@@ -1699,12 +1855,9 @@ pub(super) async fn handle_socket(
                 Message::Pong(payload) => {
                     if let Ok(bytes) = <[u8; 8]>::try_from(payload.as_ref()) {
                         let nonce = u64::from_be_bytes(bytes);
-                        try_record_active_pong(
-                            &pong_observation_tx,
-                            &active_ping_nonce_for_receive,
-                            nonce,
-                            Instant::now(),
-                        );
+                        if let Some(state) = &ping_probe_state_for_receive {
+                            try_record_matching_pong(state, nonce, received_at);
+                        }
                     }
                     // Publish the probe observation before a potentially slow
                     // activity refresh so deadline evaluation stays independent.
@@ -1790,124 +1943,74 @@ mod tests {
     }
 
     #[test]
-    fn pong_probe_accepts_matching_observation_after_write_starts() {
-        let write_started_at = Instant::now();
-        let write_completed_at = write_started_at + Duration::from_millis(2);
-        let deadline_at = write_completed_at + Duration::from_millis(5);
+    fn ping_probe_state_distinguishes_skip_pong_activity_and_timeout() {
+        let (state, _updates) = watch::channel(PingProbeState::default());
+        let started_at = Instant::now();
+        let deadline_at = started_at + Duration::from_millis(10);
 
+        let activity = InboundProbeActivityGuard::begin(&state, started_at);
+        assert_eq!(begin_ping_probe(&state, 0, 1, started_at), Err(1));
+        drop(activity);
+
+        assert_eq!(begin_ping_probe(&state, 1, 2, started_at), Ok(()));
+        assert!(!try_record_matching_pong(
+            &state,
+            99,
+            started_at + Duration::from_millis(1)
+        ));
+        assert!(try_record_matching_pong(
+            &state,
+            2,
+            started_at + Duration::from_millis(2)
+        ));
+        let activity =
+            InboundProbeActivityGuard::begin(&state, started_at + Duration::from_millis(3));
         assert_eq!(
-            pong_rtt_for_probe(
-                Some(ObservedPong {
-                    nonce: 1,
-                    received_at: write_started_at - Duration::from_millis(1),
-                }),
-                1,
-                write_started_at,
-                deadline_at,
-            ),
-            None,
+            resolve_ping_probe(&state, 2, deadline_at, false),
+            Some(PingProbeResolution::MatchingPong(Duration::from_millis(2))),
+            "the first valid probe evidence must win"
         );
+        drop(activity);
+
+        assert_eq!(begin_ping_probe(&state, 2, 3, started_at), Ok(()));
+        let activity =
+            InboundProbeActivityGuard::begin(&state, started_at + Duration::from_millis(4));
         assert_eq!(
-            pong_rtt_for_probe(
-                Some(ObservedPong {
-                    nonce: 1,
-                    received_at: write_started_at,
-                }),
-                1,
-                write_started_at,
-                deadline_at,
-            ),
-            Some(Duration::ZERO),
+            resolve_ping_probe(&state, 3, deadline_at, false),
+            Some(PingProbeResolution::InboundActivity { generation: 3 })
         );
+        drop(activity);
+
+        assert_eq!(begin_ping_probe(&state, 3, 4, started_at), Ok(()));
         assert_eq!(
-            pong_rtt_for_probe(
-                Some(ObservedPong {
-                    nonce: 1,
-                    received_at: write_started_at + Duration::from_millis(1),
-                }),
-                1,
-                write_started_at,
-                deadline_at,
-            ),
-            Some(Duration::from_millis(1)),
-        );
-        assert!(
-            write_started_at + Duration::from_millis(1) < write_completed_at,
-            "the regression case is a valid Pong observed before send completion",
-        );
-        assert_eq!(
-            pong_rtt_for_probe(
-                Some(ObservedPong {
-                    nonce: 2,
-                    received_at: write_started_at + Duration::from_millis(1),
-                }),
-                1,
-                write_started_at,
-                deadline_at,
-            ),
-            None,
-        );
-        assert_eq!(
-            pong_rtt_for_probe(
-                Some(ObservedPong {
-                    nonce: 1,
-                    received_at: deadline_at,
-                }),
-                1,
-                write_started_at,
-                deadline_at,
-            ),
-            Some(deadline_at.duration_since(write_started_at)),
-        );
-        assert_eq!(
-            pong_rtt_for_probe(
-                Some(ObservedPong {
-                    nonce: 1,
-                    received_at: deadline_at + Duration::from_nanos(1),
-                }),
-                1,
-                write_started_at,
-                deadline_at,
-            ),
-            None,
+            resolve_ping_probe(&state, 4, deadline_at, true),
+            Some(PingProbeResolution::TimedOut)
         );
     }
 
     #[test]
-    fn pong_probe_preserves_first_active_match() {
-        let active_nonce = AtomicU64::new(0);
-        let (observations, mut receiver) = mpsc::channel(1);
-        let first_received_at = Instant::now();
+    fn ping_probe_deadline_is_inclusive_and_late_evidence_cannot_satisfy_it() {
+        let (state, _updates) = watch::channel(PingProbeState::default());
+        let started_at = Instant::now();
+        let deadline_at = started_at + Duration::from_millis(5);
 
-        assert!(!try_record_active_pong(
-            &observations,
-            &active_nonce,
-            0,
-            first_received_at,
-        ));
-        active_nonce.store(7, Ordering::Release);
-        assert!(!try_record_active_pong(
-            &observations,
-            &active_nonce,
+        assert_eq!(begin_ping_probe(&state, 0, 7, started_at), Ok(()));
+        assert!(try_record_matching_pong(&state, 7, deadline_at));
+        assert_eq!(
+            resolve_ping_probe(&state, 7, deadline_at, true),
+            Some(PingProbeResolution::MatchingPong(Duration::from_millis(5)))
+        );
+
+        assert_eq!(begin_ping_probe(&state, 0, 8, started_at), Ok(()));
+        assert!(try_record_matching_pong(
+            &state,
             8,
-            first_received_at,
+            deadline_at + Duration::from_nanos(1)
         ));
-        assert!(try_record_active_pong(
-            &observations,
-            &active_nonce,
-            7,
-            first_received_at,
-        ));
-        assert!(!try_record_active_pong(
-            &observations,
-            &active_nonce,
-            7,
-            first_received_at + Duration::from_millis(1),
-        ));
-
-        let observation = receiver.try_recv().expect("first matching Pong retained");
-        assert_eq!(observation.nonce, 7);
-        assert_eq!(observation.received_at, first_received_at);
+        assert_eq!(
+            resolve_ping_probe(&state, 8, deadline_at, true),
+            Some(PingProbeResolution::TimedOut)
+        );
     }
 
     #[test]

--- a/src/websocket/prometheus.rs
+++ b/src/websocket/prometheus.rs
@@ -129,6 +129,20 @@ pub(crate) fn render_prometheus_metrics(snapshot: &MetricsSnapshot) -> String {
         "Server-initiated WebSocket pings that missed their matching Pong deadline",
         snapshot.connections.websocket_ping_timeouts,
     );
+    counter(
+        &mut buf,
+        "signal_fish_websocket_ping_probes_skipped_activity_total",
+        "Scheduled WebSocket liveness probes skipped because inbound activity already proved liveness",
+        snapshot.connections.websocket_ping_probes_skipped_activity,
+    );
+    counter(
+        &mut buf,
+        "signal_fish_websocket_ping_probes_cancelled_activity_total",
+        "Outstanding WebSocket liveness probes cancelled by non-Pong inbound activity",
+        snapshot
+            .connections
+            .websocket_ping_probes_cancelled_activity,
+    );
     emit_latency_metrics(
         &mut buf,
         "signal_fish_websocket_ping_rtt",
@@ -729,6 +743,14 @@ mod tests {
         assert!(
             rendered.contains("signal_fish_websocket_ping_timeouts_total 0"),
             "expected websocket ping timeout counter line"
+        );
+        assert!(
+            rendered.contains("signal_fish_websocket_ping_probes_skipped_activity_total 0"),
+            "expected activity-skipped websocket ping counter line"
+        );
+        assert!(
+            rendered.contains("signal_fish_websocket_ping_probes_cancelled_activity_total 0"),
+            "expected activity-cancelled websocket ping counter line"
         );
         assert!(
             rendered.contains("signal_fish_websocket_ping_rtt_samples_total 0"),

--- a/tests/asymmetric_bandwidth_flap_e2e.rs
+++ b/tests/asymmetric_bandwidth_flap_e2e.rs
@@ -4,9 +4,10 @@
 //! a healthy peer shares the room. The same physical link exercises both v3
 //! delivery contracts:
 //!
-//! - reliable traffic eventually exceeds the 15-second sojourn ceiling, closes
-//!   with `4002 slow_consumer`, and can reconnect twice with the token carried
-//!   on `RoomJoined` / `Reconnected` (the observable flap loop);
+//! - reliable traffic eventually exceeds the 15-second sojourn ceiling, makes
+//!   the server's `4002 slow_consumer` decision (the close frame is asserted
+//!   when the already-congested TCP path preserves it), and can reconnect twice
+//!   with the token carried on `RoomJoined` / `Reconnected`;
 //! - volatile traffic never parks or evicts the recipient, survives production
 //!   transport Pings, and sends causally prior exact `DeliveryReport` ranges
 //!   for every sequence gap the peer observes.
@@ -32,7 +33,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use test_helpers::{create_test_server_with_config, RunningTestServer};
-use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::{error::ProtocolError, Error as WebSocketError, Message};
 use websocket_test_helpers::chaos_proxy::{ChaosProxy, Direction};
 use websocket_test_helpers::room16::{self, PlayerHandle};
 use websocket_test_helpers::{assert_message_conservation, next_matching_server_message_within};
@@ -59,9 +60,13 @@ struct WatcherState {
 }
 
 struct CloseObservation {
-    code: u16,
-    reason: String,
+    termination: ReliableTermination,
     game_data: u64,
+}
+
+enum ReliableTermination {
+    SemanticClose { code: u16, reason: String },
+    ResetWithoutClosingHandshake,
 }
 
 #[derive(Default)]
@@ -199,13 +204,29 @@ fn spawn_close_observer(mut ws: WsStream, cycle: u64) -> tokio::task::JoinHandle
     tokio::spawn(async move {
         let mut game_data = 0;
         loop {
-            let frame = ws
-                .next()
-                .await
-                .unwrap_or_else(|| panic!("reliable cycle {cycle}: victim ended without Close"))
-                .unwrap_or_else(|error| {
+            let frame = match ws.next().await {
+                Some(Ok(frame)) => frame,
+                Some(Err(WebSocketError::Protocol(
+                    ProtocolError::ResetWithoutClosingHandshake,
+                ))) => {
+                    return CloseObservation {
+                        termination: ReliableTermination::ResetWithoutClosingHandshake,
+                        game_data,
+                    };
+                }
+                Some(Err(WebSocketError::Io(error)))
+                    if error.kind() == std::io::ErrorKind::ConnectionReset =>
+                {
+                    return CloseObservation {
+                        termination: ReliableTermination::ResetWithoutClosingHandshake,
+                        game_data,
+                    };
+                }
+                Some(Err(error)) => {
                     panic!("reliable cycle {cycle}: victim websocket error before Close: {error}")
-                });
+                }
+                None => panic!("reliable cycle {cycle}: victim ended without Close"),
+            };
             match frame {
                 Message::Text(text) => {
                     if matches!(
@@ -218,8 +239,10 @@ fn spawn_close_observer(mut ws: WsStream, cycle: u64) -> tokio::task::JoinHandle
                 }
                 Message::Close(Some(frame)) => {
                     return CloseObservation {
-                        code: frame.code.into(),
-                        reason: frame.reason.to_string(),
+                        termination: ReliableTermination::SemanticClose {
+                            code: frame.code.into(),
+                            reason: frame.reason.to_string(),
+                        },
                         game_data,
                     };
                 }
@@ -493,11 +516,27 @@ async fn asymmetric_bandwidth_preserves_lossy_delivery_and_control_progress() {
             .await
             .unwrap_or_else(|_| panic!("reliable cycle {cycle}: close frame stayed buried"))
             .expect("reliable close observer panicked");
-        assert_eq!(close.code, 4002, "reliable cycle {cycle}: wrong close code");
-        assert_eq!(
-            close.reason, "slow_consumer",
-            "reliable cycle {cycle}: wrong close reason"
-        );
+        match &close.termination {
+            ReliableTermination::SemanticClose { code, reason } => {
+                assert_eq!(*code, 4002, "reliable cycle {cycle}: wrong close code");
+                assert_eq!(
+                    reason, "slow_consumer",
+                    "reliable cycle {cycle}: wrong close reason"
+                );
+            }
+            ReliableTermination::ResetWithoutClosingHandshake => {
+                assert_eq!(
+                    metrics
+                        .websocket_slow_consumer_disconnects
+                        .load(Ordering::Relaxed),
+                    cycle,
+                    "reliable cycle {cycle}: transport reset lacked the independent server-side slow-consumer decision"
+                );
+                eprintln!(
+                    "H10 reliable cycle {cycle}: close frame lost after proven slow-consumer decision"
+                );
+            }
+        }
         assert!(
             close.game_data > 0,
             "reliable cycle {cycle}: constrained peer received no data; throttle was vacuous"
@@ -667,6 +706,18 @@ async fn asymmetric_bandwidth_preserves_lossy_delivery_and_control_progress() {
     let _watcher_ws = watcher_task.await.expect("watcher task panicked");
     sender_stop.send_replace(true);
     sender_reader.await.expect("sender reader task panicked");
+    assert_eq!(
+        metrics.websocket_ping_timeouts.load(Ordering::Relaxed),
+        0,
+        "active H10 connections must never fail an idle liveness probe"
+    );
+    assert!(
+        metrics
+            .websocket_ping_probes_skipped_activity
+            .load(Ordering::Relaxed)
+            > 0,
+        "H10 sustained inbound traffic never exercised activity-based probe skipping"
+    );
     assert_message_conservation(&metrics).await;
     running.shutdown().await;
 }

--- a/tests/doc_consistency_script_tests.rs
+++ b/tests/doc_consistency_script_tests.rs
@@ -194,7 +194,7 @@ fn run_checker_with_fixture_and_tags(
 }
 
 #[test]
-fn test_release_compare_accepts_existing_tag_without_dated_section() {
+fn test_release_compare_rejects_existing_tag_without_dated_section() {
     let changelog = "# Changelog\n\n\
         The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n\
         ## [Unreleased]\n\n### Changed\n- Pending.\n\n\
@@ -204,12 +204,28 @@ fn test_release_compare_accepts_existing_tag_without_dated_section() {
         [0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.1...v0.2.0\n\
         [0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0\n";
 
+    let (tagless_exit_code, tagless_output) =
+        run_checker_with_fixture(&[("CHANGELOG.md", changelog)], &[], &[]);
     let (exit_code, output) =
         run_checker_with_fixture_and_tags(&[("CHANGELOG.md", changelog)], &[], &[], &["v0.1.1"]);
     assert_eq!(
+        (
+            exit_code,
+            output.contains("compare link references unknown previous version")
+        ),
+        (
+            tagless_exit_code,
+            tagless_output.contains("compare link references unknown previous version")
+        ),
+        "Fetched tags changed changelog validity.\nTagless:\n{tagless_output}\nTagged:\n{output}"
+    );
+    assert_ne!(
         exit_code, 0,
-        "An existing immutable release tag is a valid compare endpoint even when its dated \
-         changelog section has not been backfilled.\nOutput:\n{output}"
+        "Fetched tags must not make an incomplete changelog valid.\nOutput:\n{output}"
+    );
+    assert!(
+        output.contains("compare link references unknown previous version"),
+        "The failure should identify the missing dated release section.\nOutput:\n{output}"
     );
 }
 
@@ -553,6 +569,61 @@ fn test_doc_consistency_script_data_driven_cases() {
             args: vec![],
             expected_exit: 1,
             must_contain: vec!["compare link references unknown previous version"],
+            must_not_contain: vec![],
+        },
+        ScriptCase {
+            name: "fails_when_release_sections_are_not_strictly_descending",
+            overrides: vec![(
+                "CHANGELOG.md",
+                "# Changelog\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n## [Unreleased]\n\n## [0.1.0] - 2026-02-15\n\n### Added\n- Initial.\n\n## [0.2.0] - 2026-02-24\n\n### Added\n- Later.\n\n[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.2.0...HEAD\n[0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...v0.2.0\n[0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0\n",
+            )],
+            args: vec![],
+            expected_exit: 1,
+            must_contain: vec!["strictly descending semantic-version order"],
+            must_not_contain: vec![],
+        },
+        ScriptCase {
+            name: "fails_when_release_section_is_duplicated",
+            overrides: vec![(
+                "CHANGELOG.md",
+                "# Changelog\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n## [Unreleased]\n\n## [0.1.0] - 2026-02-15\n\n### Added\n- Initial.\n\n## [0.1.0] - 2026-02-16\n\n### Fixed\n- Duplicate.\n\n[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...HEAD\n[0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0\n",
+            )],
+            args: vec![],
+            expected_exit: 1,
+            must_contain: vec!["duplicate dated release section for 0.1.0"],
+            must_not_contain: vec![],
+        },
+        ScriptCase {
+            name: "fails_when_release_date_is_not_a_real_calendar_date",
+            overrides: vec![(
+                "CHANGELOG.md",
+                "# Changelog\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n## [Unreleased]\n\n## [0.1.0] - 2026-02-30\n\n### Added\n- Initial.\n\n[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...HEAD\n[0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0\n",
+            )],
+            args: vec![],
+            expected_exit: 1,
+            must_contain: vec!["invalid calendar date 2026-02-30"],
+            must_not_contain: vec![],
+        },
+        ScriptCase {
+            name: "fails_when_release_compare_skips_adjacent_section",
+            overrides: vec![(
+                "CHANGELOG.md",
+                "# Changelog\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n## [Unreleased]\n\n## [0.3.0] - 2026-03-01\n\n### Added\n- Third.\n\n## [0.2.0] - 2026-02-24\n\n### Added\n- Second.\n\n## [0.1.0] - 2026-02-15\n\n### Added\n- Initial.\n\n[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.3.0...HEAD\n[0.3.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...v0.3.0\n[0.2.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...v0.2.0\n[0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v0.1.0\n",
+            )],
+            args: vec![],
+            expected_exit: 1,
+            must_contain: vec!["must compare adjacent releases v0.2.0...v0.3.0"],
+            must_not_contain: vec![],
+        },
+        ScriptCase {
+            name: "fails_when_oldest_release_uses_a_compare_link",
+            overrides: vec![(
+                "CHANGELOG.md",
+                "# Changelog\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n## [Unreleased]\n\n## [0.1.0] - 2026-02-15\n\n### Added\n- Initial.\n\n[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.1.0...HEAD\n[0.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.0.0...v0.1.0\n",
+            )],
+            args: vec![],
+            expected_exit: 1,
+            must_contain: vec!["oldest release [0.1.0] must link directly"],
             must_not_contain: vec![],
         },
         // ---------------------------------------------------------------

--- a/tests/release_prepare_tests.rs
+++ b/tests/release_prepare_tests.rs
@@ -1,6 +1,7 @@
 #![cfg(unix)]
 
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
@@ -17,7 +18,13 @@ impl Fixture {
     fn new(version: &str) -> Self {
         let temp = tempfile::tempdir().expect("create release fixture");
         let root = temp.path().to_path_buf();
-        for directory in [".llm", "clients/native", "docs", "fuzz", "scripts"] {
+        for directory in [
+            ".llm/code-samples/protocol",
+            "clients/native",
+            "docs/guides",
+            "fuzz",
+            "scripts",
+        ] {
             fs::create_dir_all(root.join(directory)).expect("create fixture directory");
         }
 
@@ -50,34 +57,76 @@ impl Fixture {
         );
         write(
             &root.join(".llm/context.md"),
-            &format!("# Context\n\n- **Version:** {version}\n"),
+            &format!(
+                "# Context\n\n- **Version:** {version}\n\n\
+                 [v2 client sample](code-samples/protocol/v2-client-messages.jsonl)\n\
+                 [v2 server sample](code-samples/protocol/v2-server-messages.jsonl)\n"
+            ),
         );
         write(
             &root.join("CHANGELOG.md"),
-            "# Changelog\n\n\
+            &format!("# Changelog\n\n\
              The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n\n\
              ## [Unreleased]\n\n\
              ### Added\n\n\
              - Ship the release preparation workflow.\n\n\
              ### Fixed\n\n\
              - Preserve categorized notes.\n\n\
-             ## [1.1.0] - 2026-07-01\n\n\
+             ## [{version}] - 2026-07-01\n\n\
              ### Added\n\n\
              - Previous release.\n\n\
-             [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v1.1.0...HEAD\n\
-             [1.1.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v1.1.0\n",
+             [Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v{version}...HEAD\n\
+             [{version}]: https://github.com/Ambiguous-Interactive/signal-fish-server/releases/tag/v{version}\n"),
         );
         write(
-            &root.join("scripts/check-doc-consistency.sh"),
-            "#!/usr/bin/env bash\nexit 0\n",
+            &root.join("README.md"),
+            "# README\n\n[v2 client sample](.llm/code-samples/protocol/v2-client-messages.jsonl)\n[v2 server sample](.llm/code-samples/protocol/v2-server-messages.jsonl)\n",
         );
+        write(
+            &root.join(".llm/code-samples/protocol/v2-client-messages.jsonl"),
+            "{\"type\":\"Authenticate\",\"data\":{}}\n",
+        );
+        write(
+            &root.join(".llm/code-samples/protocol/v2-server-messages.jsonl"),
+            "{\"type\":\"Authenticated\",\"data\":{\"app_name\":\"test\",\"rate_limits\":{}}}\n",
+        );
+        write(
+            &root.join("docs/guides/rust-client.md"),
+            "# Rust client\n\n```rust\npub enum GameDataEncoding {\n    Json,\n    MessagePack,\n}\n```\n",
+        );
+        let checker =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/check-doc-consistency.sh");
+        let checker_destination = root.join("scripts/check-doc-consistency.sh");
+        fs::copy(&checker, &checker_destination).expect("copy real document checker");
+        let mut permissions = fs::metadata(&checker_destination)
+            .expect("read checker metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&checker_destination, permissions)
+            .expect("make fixture checker executable");
 
+        for arguments in [
+            vec!["init", "--quiet"],
+            vec!["config", "user.name", "Release Fixture"],
+            vec!["config", "user.email", "release-fixture@example.invalid"],
+            vec!["add", "."],
+            vec!["commit", "--quiet", "-m", "released baseline"],
+        ] {
+            let status = Command::new("git")
+                .args(arguments)
+                .current_dir(&root)
+                .status()
+                .expect("initialize fixture release history");
+            assert!(status.success(), "fixture Git setup failed");
+        }
         let status = Command::new("git")
-            .args(["init", "--quiet"])
+            .args(["tag", "-a"])
+            .arg(format!("v{version}"))
+            .args(["-m", "released baseline"])
             .current_dir(&root)
             .status()
-            .expect("initialize fixture worktree");
-        assert!(status.success(), "git init failed for release fixture");
+            .expect("create fixture release tag");
+        assert!(status.success(), "fixture release tag setup failed");
 
         Self { _temp: temp, root }
     }
@@ -93,6 +142,17 @@ impl Fixture {
             .output()
             .expect("run prepare-release.sh")
     }
+
+    fn run_with_real_doc_checker(&self, arguments: &[&str]) -> Output {
+        let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/prepare-release.sh");
+        Command::new("bash")
+            .arg(script)
+            .args(arguments)
+            .current_dir(&self.root)
+            .env("PREPARE_RELEASE_CARGO_BIN", "true")
+            .output()
+            .expect("run prepare-release.sh with real document checker")
+    }
 }
 
 fn write(path: &Path, content: &str) {
@@ -102,6 +162,32 @@ fn write(path: &Path, content: &str) {
 fn read(path: impl AsRef<Path>) -> String {
     let path = path.as_ref();
     fs::read_to_string(path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+}
+
+const RELEASE_FILES: [&str; 6] = [
+    "Cargo.toml",
+    "Cargo.lock",
+    "clients/native/Cargo.lock",
+    "CHANGELOG.md",
+    "docs/library-usage.md",
+    ".llm/context.md",
+];
+
+fn release_file_snapshot(fixture: &Fixture) -> Vec<(&'static str, String)> {
+    RELEASE_FILES
+        .iter()
+        .map(|path| (*path, read(fixture.root.join(path))))
+        .collect()
+}
+
+fn assert_release_files_unchanged(fixture: &Fixture, before: &[(&str, String)]) {
+    for (path, expected) in before {
+        assert_eq!(
+            read(fixture.root.join(path)),
+            *expected,
+            "{path} changed despite a preflight failure"
+        );
+    }
 }
 
 #[test]
@@ -139,7 +225,11 @@ fn prepare_release_applies_every_semver_bump_and_synchronizes_release_files() {
         assert!(!docs.contains("1.2.3"));
         assert_eq!(
             read(fixture.root.join(".llm/context.md")),
-            format!("# Context\n\n- **Version:** {expected}\n")
+            format!(
+                "# Context\n\n- **Version:** {expected}\n\n\
+                 [v2 client sample](code-samples/protocol/v2-client-messages.jsonl)\n\
+                 [v2 server sample](code-samples/protocol/v2-server-messages.jsonl)\n"
+            )
         );
 
         let changelog = read(fixture.root.join("CHANGELOG.md"));
@@ -194,8 +284,8 @@ fn prepare_release_fails_closed_on_empty_notes_existing_version_or_lock_drift() 
 
     let duplicate = Fixture::new("1.2.3");
     let changelog = read(duplicate.root.join("CHANGELOG.md")).replace(
-        "## [1.1.0] - 2026-07-01",
-        "## [1.2.4] - 2026-07-10\n\n### Fixed\n\n- Already cut.\n\n## [1.1.0] - 2026-07-01",
+        "## [1.2.3] - 2026-07-01",
+        "## [1.2.4] - 2026-07-10\n\n### Fixed\n\n- Already cut.\n\n## [1.2.3] - 2026-07-01",
     );
     write(&duplicate.root.join("CHANGELOG.md"), &changelog);
     let output = duplicate.run(&["--bump", "patch", "--date", RELEASE_DATE]);
@@ -218,4 +308,110 @@ fn prepare_release_rejects_semver_arithmetic_overflow() {
     let output = fixture.run(&["--bump", "major", "--date", RELEASE_DATE]);
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("Cannot safely increment"));
+}
+
+#[test]
+fn prepare_release_rejects_cargo_version_without_matching_latest_release_before_mutation() {
+    let fixture = Fixture::new("1.2.3");
+    let changelog = read(fixture.root.join("CHANGELOG.md"))
+        .replace("[1.2.3]", "[1.1.0]")
+        .replace("v1.2.3", "v1.1.0");
+    write(&fixture.root.join("CHANGELOG.md"), &changelog);
+    let before = release_file_snapshot(&fixture);
+
+    let output = fixture.run(&["--bump", "patch", "--date", RELEASE_DATE]);
+
+    assert!(!output.status.success(), "invalid release baseline passed");
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("latest dated CHANGELOG.md release"),
+        "unexpected diagnostic:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_release_files_unchanged(&fixture, &before);
+}
+
+#[test]
+fn prepare_release_rejects_invalid_tag_baselines_before_mutation() {
+    for tag_kind in ["missing", "lightweight", "non-ancestor", "target-exists"] {
+        let fixture = Fixture::new("1.2.3");
+        if tag_kind != "target-exists" {
+            let status = Command::new("git")
+                .args(["tag", "--delete", "v1.2.3"])
+                .current_dir(&fixture.root)
+                .status()
+                .expect("delete fixture tag");
+            assert!(status.success());
+        }
+        match tag_kind {
+            "missing" => {}
+            "lightweight" => {
+                assert!(Command::new("git")
+                    .args(["tag", "v1.2.3"])
+                    .current_dir(&fixture.root)
+                    .status()
+                    .expect("create lightweight tag")
+                    .success());
+            }
+            "non-ancestor" => {
+                let tree = Command::new("git")
+                    .args(["rev-parse", "HEAD^{tree}"])
+                    .current_dir(&fixture.root)
+                    .output()
+                    .expect("resolve fixture tree");
+                assert!(tree.status.success());
+                let tree = String::from_utf8(tree.stdout).expect("tree hash is UTF-8");
+                let commit = Command::new("git")
+                    .args(["commit-tree", tree.trim(), "-m", "unrelated release"])
+                    .current_dir(&fixture.root)
+                    .output()
+                    .expect("create unrelated commit");
+                assert!(commit.status.success());
+                let commit = String::from_utf8(commit.stdout).expect("commit hash is UTF-8");
+                assert!(Command::new("git")
+                    .args(["tag", "-a", "v1.2.3", commit.trim(), "-m", "unrelated"])
+                    .current_dir(&fixture.root)
+                    .status()
+                    .expect("create unrelated annotated tag")
+                    .success());
+            }
+            "target-exists" => {
+                assert!(Command::new("git")
+                    .args(["tag", "-a", "v1.2.4", "-m", "already released"])
+                    .current_dir(&fixture.root)
+                    .status()
+                    .expect("create target tag")
+                    .success());
+            }
+            _ => unreachable!(),
+        }
+
+        let before = release_file_snapshot(&fixture);
+        let output = fixture.run(&["--bump", "patch", "--date", RELEASE_DATE]);
+        assert!(
+            !output.status.success(),
+            "{tag_kind} tag baseline unexpectedly passed"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let expected = match tag_kind {
+            "missing" => "is missing",
+            "lightweight" => "must be annotated",
+            "non-ancestor" => "ancestor of HEAD",
+            "target-exists" => "already exists locally",
+            _ => unreachable!(),
+        };
+        assert!(stderr.contains(expected), "unexpected diagnostic: {stderr}");
+        assert_release_files_unchanged(&fixture, &before);
+    }
+}
+
+#[test]
+fn prepared_release_passes_the_real_document_checker() {
+    let fixture = Fixture::new("1.2.3");
+    let output = fixture.run_with_real_doc_checker(&["--bump", "patch", "--date", RELEASE_DATE]);
+    assert!(
+        output.status.success(),
+        "integrated preparation failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 }

--- a/tests/server_ping_e2e.rs
+++ b/tests/server_ping_e2e.rs
@@ -225,6 +225,158 @@ async fn missing_pong_closes_with_activity_timeout() {
 }
 
 #[tokio::test]
+async fn inbound_activity_skips_probes_until_the_connection_becomes_idle() {
+    let (running, server) = start_server(1, 1).await;
+    let ws = connect(running.addr()).await;
+    let (mut sink, mut stream) = ws.split();
+    let mut traffic = tokio::time::interval(tokio::time::Duration::from_millis(200));
+    let active_until = tokio::time::Instant::now() + tokio::time::Duration::from_millis(2_500);
+
+    while tokio::time::Instant::now() < active_until {
+        tokio::select! {
+            _ = traffic.tick() => {
+                sink.send(Message::Text(
+                    serde_json::to_string(&ClientMessage::Ping)
+                        .expect("serialize application Ping")
+                        .into(),
+                ))
+                .await
+                .expect("send active application traffic");
+            }
+            frame = stream.next() => {
+                let frame = frame
+                    .expect("connection closed during active traffic")
+                    .expect("websocket read failed during active traffic");
+                assert!(
+                    !matches!(frame, Message::Ping(_)),
+                    "an active connection received an unnecessary liveness probe"
+                );
+            }
+        }
+    }
+
+    let payload = loop {
+        let frame = tokio::time::timeout(tokio::time::Duration::from_secs(3), stream.next())
+            .await
+            .expect("idle connection never received a liveness probe")
+            .expect("connection closed before idle liveness probe")
+            .expect("websocket read failed before idle liveness probe");
+        if let Message::Ping(payload) = frame {
+            break payload;
+        }
+    };
+    sink.send(Message::Pong(payload))
+        .await
+        .expect("answer idle liveness probe");
+    assert!(
+        server
+            .metrics()
+            .websocket_ping_probes_skipped_activity
+            .load(std::sync::atomic::Ordering::Relaxed)
+            >= 2,
+        "active inbound traffic did not skip scheduled probes"
+    );
+    assert_eq!(
+        server
+            .metrics()
+            .websocket_ping_timeouts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "active inbound traffic caused a false liveness timeout"
+    );
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn non_pong_activity_cancels_an_outstanding_probe() {
+    let (running, server) = start_server(1, 2).await;
+    let mut ws = connect(running.addr()).await;
+
+    // Do not read the server Ping: tungstenite would otherwise queue its
+    // automatic Pong. Wait until the first probe is outstanding, then prove a
+    // separate decoded application frame cancels it.
+    tokio::time::sleep(tokio::time::Duration::from_millis(1_200)).await;
+    ws.send(Message::Text(
+        serde_json::to_string(&ClientMessage::Ping)
+            .expect("serialize application Ping")
+            .into(),
+    ))
+    .await
+    .expect("send post-probe application activity");
+
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
+    loop {
+        if server
+            .metrics()
+            .websocket_ping_probes_cancelled_activity
+            .load(std::sync::atomic::Ordering::Relaxed)
+            == 1
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "post-probe activity never cancelled the liveness probe"
+        );
+        tokio::task::yield_now().await;
+    }
+    let survive_until = tokio::time::Instant::now() + tokio::time::Duration::from_millis(2_200);
+    let mut traffic = tokio::time::interval(tokio::time::Duration::from_millis(200));
+    let mut saw_application_pong = false;
+    while tokio::time::Instant::now() < survive_until {
+        tokio::select! {
+            _ = traffic.tick() => {
+                ws.send(Message::Text(
+                    serde_json::to_string(&ClientMessage::Ping)
+                        .expect("serialize follow-up application Ping")
+                        .into(),
+                ))
+                .await
+                .expect("connection died after probe cancellation");
+            }
+            frame = ws.next() => {
+                let frame = frame
+                    .expect("connection closed after probe cancellation")
+                    .expect("websocket read failed after probe cancellation");
+                if let Message::Text(text) = frame {
+                    let message: ServerMessage = serde_json::from_str(&text)
+                        .expect("decode post-cancellation application response");
+                    saw_application_pong |= matches!(message, ServerMessage::Pong);
+                }
+            }
+        }
+    }
+    assert!(
+        saw_application_pong,
+        "connection did not process application traffic beyond the old probe deadline"
+    );
+    assert_eq!(
+        server
+            .metrics()
+            .websocket_ping_timeouts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        0
+    );
+
+    let payload = loop {
+        let frame = tokio::time::timeout(tokio::time::Duration::from_secs(3), ws.next())
+            .await
+            .expect("idle connection never received a later probe")
+            .expect("connection closed before later probe")
+            .expect("websocket read failed before later probe");
+        if let Message::Ping(payload) = frame {
+            break payload;
+        }
+    };
+    ws.send(Message::Pong(payload))
+        .await
+        .expect("answer later idle probe");
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
 async fn zero_interval_disables_server_ping_frames() {
     let (running, _server) = start_server(0, 1).await;
     let mut ws = connect(running.addr()).await;


### PR DESCRIPTION
## Summary

This permanently addresses the two independent failure classes exposed by generated release PR #182:

- rebuild and enforce the missing changelog release chain without depending on fetched Git tags;
- make release preparation fail atomically before mutating any canonical release file;
- replace Pong-only fixed-interval heartbeats with bounded idle-only transport probes;
- add regression tests, metrics, operational docs, durable LLM guidance, and an evidence log.

## Root causes and fixes

### Release preparation

Normal shallow checkouts failed because the checker treated fetched tags as substitutes for missing dated changelog sections. The changelog now contains reconstructed 0.1.1, 0.3.0, and 0.4.0 releases, and the checker validates a unique descending file-backed section/link chain identically in tagged and tagless clones.

`prepare-release.sh` now preflights Cargo/changelog alignment, annotated ancestor baseline tags, target tag/section absence, lockfile alignment, and the real doc checker before editing the six release files. Fixture failures assert those files remain byte-identical. The checker also cardinality-guards empty-array expansion for Bash 3.2/macOS strict mode.

### WebSocket liveness

During reliable backpressure, serial application handling could block the receive loop long enough that a valid automatic Pong remained unread and the independent probe task closed an active connection with 4003. The new O(1) state publishes decoded non-Pong activity before any application await, skips unnecessary probes, rechecks activity at write time, and cancels an outstanding probe on post-write activity. Only an exact matching Pong records RTT; stale/wrong Pongs do not satisfy probes; genuine silence still closes 4003.

New Prometheus/JSON counters distinguish activity-skipped and activity-cancelled probes. The protocol, configuration, scaling, feature, ADR, changelog, and LLM guidance now document the invariant and its fixed-tick bound.

## Evidence

- Full `cargo test --locked --all-features`: all executed unit, integration, policy, and doc tests passed (nightly/on-demand ignores remained ignored).
- Full `cargo clippy --locked --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check`, `cargo deny --all-features check`, pinned Markdownlint, ShellCheck, repository policy scripts, doc consistency, MSRV consistency, hook readiness, real pre-commit, and real pre-push: passed.
- Release regressions: 7 prepare tests, 5 checker-script tests, and 10 policy tests passed.
- Heartbeat regressions: 3 focused state tests, 16 server-ping E2E tests, and 5 Prometheus renderer tests passed.
- H10 asymmetric-bandwidth experiment: five complete serialized repetitions passed; each covered two ~22.4s reliable backpressure/reconnect cycles plus a 60s volatile phase, exact delivery conservation, zero ping timeouts, and activity skips.
- An adversarial subagent audit found no unbounded state, timeout inflation, or unresolved race. Its four actionable coverage/documentation findings were implemented and retested.

The complete red/green data and exploratory record is in `progress/session-054-release-preparation-and-heartbeat.md`.

## Rollout

Merge this remediation first. Then close/replace broken generated release PR #182 and rerun Prepare Release from the repaired baseline, so the generated release PR exercises these permanent gates.

Exact review head: `505358e0804cd9b5c7d00bf79d1c8339001d69a6`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket connection teardown semantics and release automation gates used by CI; behavior is heavily regression-tested but affects production liveness timing and release cut safety.
> 
> **Overview**
> Addresses release PR #182 failures by making **changelog validation topology-independent** and stopping **false `4003` closes** when reliable delivery backpressure blocks the receive loop.
> 
> **Release history and preparation** reconstructs dated `0.1.1`, `0.3.0`, and `0.4.0` sections and moves misplaced notes out of `[Unreleased]`. `check-doc-consistency.sh` now enforces a single first `[Unreleased]`, strictly descending semver headings, real dates, and an adjacent compare chain using **files only** (no fetched tags). `prepare-release.sh` runs doc/lockfile/tag preflight **before** editing the six release files and rejects Cargo/changelog drift, bad baseline tags, and existing target tags. Bash 3.2 empty-array expansion is guarded for macOS CI.
> 
> **WebSocket liveness** replaces fixed-interval Pong-only probes with **idle-only** RFC 6455 Pings: decoded non-Pong frames bump activity **before** awaited application work; ticks skip probes when traffic was recent; the writer rechecks generation; post-write non-Pong activity cancels an outstanding probe; only exact matching Pongs count. New counters `websocket_ping_probes_skipped_activity` and `websocket_ping_probes_cancelled_activity` feed JSON/Prometheus. Docs, ADR-0006, scaling tables, and LLM guidance describe the ~`2 × interval + timeout` worst case and that continuous client→server traffic does not prove the reverse path.
> 
> **Tests**: expanded release/checker fixtures, `server_ping_e2e` idle/cancel cases, and H10 now tolerates TCP reset after a proven slow-consumer decision while asserting zero ping timeouts and activity-based skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 505358e0804cd9b5c7d00bf79d1c8339001d69a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->