### PR TITLE
Make release publication retry-safe

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -227,7 +227,8 @@ jobs:
             echo
             echo "## After merge"
             echo
-            echo "Run **Release - Publish Crate** from \`${DEFAULT_BRANCH}\` with \`release_version=${VERSION}\`."
+            echo "Run **Release - Publish Crate** from \`${DEFAULT_BRANCH}\`."
+            echo "The workflow derives version \`${VERSION}\` from the reviewed Cargo.toml; do not re-enter it."
             echo "That workflow creates or verifies annotated tag \`${TAG}\`, then publishes crates.io and GHCR."
             echo "It creates the GitHub Release and attaches the SBOM and platform archives."
           } > "$body_file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -651,17 +651,34 @@ jobs:
           - target: aarch64-pc-windows-msvc
             os: windows-latest
     steps:
-      - name: Checkout repository
+      # Keep workflow policy/tools separate from the immutable release source.
+      # A retry may intentionally build an older tag that predates these
+      # helpers, while the workflow itself must retain the reviewed tooling
+      # from the dispatch revision.
+      - name: Checkout publication tooling
+        uses: actions/checkout@v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          path: publication-tools
+          sparse-checkout: |
+            scripts/read-toml-string.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Checkout exact source
         uses: actions/checkout@v7.0.0
         with:
           ref: ${{ needs.resolve-release.outputs.source_revision }}
+          path: source
+          persist-credentials: false
 
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
+        working-directory: source
         run: |
           set -euo pipefail
-          CHANNEL=$(bash scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
+          CHANNEL=$(bash ../publication-tools/scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
           if [ -z "$CHANNEL" ]; then
             echo "ERROR: Could not extract channel from rust-toolchain.toml" >&2
             exit 1
@@ -691,11 +708,13 @@ jobs:
 
       - name: Build release binary
         shell: bash
+        working-directory: source
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Package binary and checksum
         id: package
         shell: bash
+        working-directory: source
         run: |
           set -euo pipefail
 
@@ -728,7 +747,7 @@ jobs:
             shasum -a 256 "$ARCHIVE" > "${ARCHIVE}.sha256"
           fi
 
-          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+          echo "archive=source/$ARCHIVE" >> "$GITHUB_OUTPUT"
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 # Publishes the crate to crates.io and creates a GitHub Release with changelog.
 #
 # Runs on:
-#   - Manual workflow dispatch (with version input)
+#   - Manual workflow dispatch from the default branch (version derived from Cargo.toml)
 #   - Tag pushes matching v* pattern
 #
 # Release gating:
@@ -27,24 +27,21 @@
 # Steps:
 #   1. Resolve one version/source identity and validate Cargo.toml + CHANGELOG
 #   2. Preflight: verify CI and doc-validation passed on that exact commit
-#   3. Create or validate the immutable annotated Git tag
-#   4. Call Docker Publish directly and verify version tags/platforms/OCI labels
-#   5. Dry-run and idempotently publish the crate from the tagged commit
-#   6. Generate SBOM (CycloneDX JSON) for supply-chain provenance
-#   7. Create/verify the GitHub Release and record the GHCR digest in its notes
-#   8. build-binaries: cross-compile standalone binaries for every supported
+#   3. Require crates.io credentials and dry-run the exact package
+#   4. Create or validate the immutable annotated Git tag
+#   5. Call Docker Publish directly and verify version tags/platforms/OCI labels
+#   6. Idempotently publish the crate from a clean tagged checkout
+#   7. Generate SBOM (CycloneDX JSON) for supply-chain provenance
+#   8. Create/verify the GitHub Release and record the GHCR digest in its notes
+#   9. build-binaries: cross-compile standalone binaries for every supported
 #      OS/arch (Linux/macOS/Windows x86_64+aarch64) in parallel with publish
-#   9. attach-binaries: download all binary artifacts and attach them (with
+#  10. attach-binaries: download all binary artifacts and attach them (with
 #      SHA-256 checksums) to the GitHub Release in a single upload
 
 name: Release - Publish Crate
 
 on:
   workflow_dispatch:
-    inputs:
-      release_version:
-        description: "Version to publish, e.g. 0.1.0 (must match Cargo.toml, no 'v' prefix)"
-        required: true
   push:
     tags:
       - "v*"
@@ -54,7 +51,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: release-${{ github.event_name == 'workflow_dispatch' && format('v{0}', github.event.inputs.release_version) || github.ref_name }}
+  group: release-publish
   cancel-in-progress: false
 
 env:
@@ -80,56 +77,11 @@ jobs:
       - name: Validate canonical release identity
         id: release
         shell: bash
-        run: |
-          set -euo pipefail
-
-          source_revision=$(git rev-parse "HEAD^{commit}")
-          cargo_version=$(bash scripts/read-toml-string.sh Cargo.toml version package || true)
-          if [ -z "$cargo_version" ]; then
-            echo "ERROR: Could not extract [package].version from Cargo.toml." >&2
-            exit 1
-          fi
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            version="${{ github.event.inputs.release_version }}"
-            tag="v${version}"
-          else
-            tag="${GITHUB_REF#refs/tags/}"
-            version="${tag#v}"
-          fi
-
-          if [ "$version" != "$cargo_version" ] || [ "$tag" != "v${cargo_version}" ]; then
-            echo "ERROR: Workflow version ($version), Git tag ($tag), and Cargo.toml ($cargo_version) disagree." >&2
-            exit 1
-          fi
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: Release version is not canonical semantic version text: $version" >&2
-            exit 1
-          fi
-          escaped_version=${version//./\\.}
-          if ! grep -Eq "^## \\[${escaped_version}\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
-            echo "ERROR: CHANGELOG.md has no ## [${version}] release section, with or without a date." >&2
-            exit 1
-          fi
-
-          if [ "${{ github.event_name }}" = "push" ]; then
-            git fetch --no-tags origin "refs/tags/${tag}:refs/tags/${tag}"
-            if [ "$(git cat-file -t "refs/tags/${tag}" 2>/dev/null || true)" != "tag" ]; then
-              echo "ERROR: Direct release tag $tag must be annotated, not lightweight." >&2
-              exit 1
-            fi
-            tag_revision=$(git rev-parse "refs/tags/${tag}^{commit}")
-            if [ "$tag_revision" != "$source_revision" ]; then
-              echo "ERROR: $tag resolves to $tag_revision, not release commit $source_revision." >&2
-              exit 1
-            fi
-          fi
-
-          {
-            echo "version=$version"
-            echo "tag=$tag"
-            echo "source_revision=$source_revision"
-          } >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_EVENT_REF: ${{ github.ref }}
+        run: bash scripts/resolve-release-source.sh
 
   preflight:
     name: Preflight
@@ -308,9 +260,84 @@ jobs:
 
           echo "All required CI checks passed. Proceeding with release."
 
+  publication-readiness:
+    name: Publication readiness
+    needs: [resolve-release, preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      crate_exists: ${{ steps.crate.outputs.exists }}
+    steps:
+      - name: Checkout publication tooling
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          path: publication-tools
+          sparse-checkout: |
+            scripts/check-clean-release-worktree.sh
+            scripts/check-crates-io-release.sh
+            scripts/read-toml-string.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Checkout exact release source
+        uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.resolve-release.outputs.source_revision }}
+          path: source
+
+      - name: Check for an idempotent crates.io retry
+        id: crate
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-release.outputs.version }}
+          RELEASE_SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
+        run: bash publication-tools/scripts/check-crates-io-release.sh
+
+      - name: Require crates.io token
+        if: steps.crate.outputs.exists != 'true'
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "ERROR: CRATES_IO_TOKEN is required before release artifacts are published." >&2
+            exit 1
+          fi
+
+      - name: Read Rust toolchain
+        id: readiness-toolchain
+        shell: bash
+        run: |
+          channel=$(bash publication-tools/scripts/read-toml-string.sh source/rust-toolchain.toml channel toolchain || true)
+          if [ -z "$channel" ]; then
+            echo "ERROR: Could not extract channel from rust-toolchain.toml." >&2
+            exit 1
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.readiness-toolchain.outputs.channel }}
+
+      - name: Validate publish package
+        run: cargo publish --locked --dry-run
+        working-directory: source
+
+      - name: Verify dry-run preserved a clean checkout
+        shell: bash
+        working-directory: source
+        run: bash ../publication-tools/scripts/check-clean-release-worktree.sh
+
   ensure-tag:
     name: Ensure immutable annotated tag
-    needs: [resolve-release, preflight]
+    needs: [resolve-release, publication-readiness]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -377,21 +404,34 @@ jobs:
       source_revision: ${{ needs.resolve-release.outputs.source_revision }}
 
   publish:
-    needs: [resolve-release, publish-container]
+    needs: [resolve-release, publication-readiness, publish-container]
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
+      - name: Checkout publication tooling
+        uses: actions/checkout@v7.0.0
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          path: publication-tools
+          sparse-checkout: |
+            scripts/check-clean-release-worktree.sh
+            scripts/read-toml-string.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-release.outputs.source_revision }}
+          path: source
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
         run: |
-          CHANNEL=$(bash scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
+          CHANNEL=$(bash publication-tools/scripts/read-toml-string.sh source/rust-toolchain.toml channel toolchain || true)
           if [ -z "$CHANNEL" ]; then
             echo "ERROR: Could not extract channel from rust-toolchain.toml"
             exit 1
@@ -433,71 +473,19 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: publish-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            source/target
+          key: publish-${{ runner.os }}-cargo-${{ hashFiles('source/**/Cargo.lock') }}
           restore-keys: |
             publish-${{ runner.os }}-cargo-
 
-      - name: Publish (dry-run)
-        run: cargo publish --locked --dry-run
-        env:
-          RUSTC_WRAPPER: ${{ steps.sccache-check.outputs.working == 'true' && 'sccache' || '' }}
-          SCCACHE_GHA_ENABLED: ${{ steps.sccache-check.outputs.working == 'true' && 'true' || 'false' }}
-          SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
-          SCCACHE_STARTUP_NOTIFY_TIMEOUT: "60"
-          SCCACHE_IDLE_TIMEOUT: "0"
-
-      - name: Check for an idempotent crates.io retry
-        id: crate
+      - name: Verify clean checkout before publication
         shell: bash
-        env:
-          VERSION: ${{ needs.resolve-release.outputs.version }}
-          SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
-        run: |
-          set -euo pipefail
-
-          api_url="https://crates.io/api/v1/crates/signal-fish-server/${VERSION}"
-          user_agent="signal-fish-server-release-workflow (https://github.com/${GITHUB_REPOSITORY})"
-          status=$(curl --user-agent "$user_agent" --retry 3 --retry-all-errors --silent --show-error \
-            --output crate-version.json --write-out '%{http_code}' "$api_url")
-          case "$status" in
-            404)
-              echo "exists=false" >> "$GITHUB_OUTPUT"
-              ;;
-            200)
-              checksum=$(jq -r '.version.checksum // empty' crate-version.json)
-              if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
-                echo "ERROR: crates.io returned no valid checksum for signal-fish-server ${VERSION}." >&2
-                exit 1
-              fi
-
-              crate_file="signal-fish-server-${VERSION}.crate"
-              curl --user-agent "$user_agent" --retry 3 --retry-all-errors --fail --silent --show-error \
-                --location --output "$crate_file" \
-                "https://crates.io/api/v1/crates/signal-fish-server/${VERSION}/download"
-              actual_checksum=$(sha256sum "$crate_file" | awk '{print $1}')
-              if [ "$actual_checksum" != "$checksum" ]; then
-                echo "ERROR: Downloaded crate checksum $actual_checksum does not match crates.io $checksum." >&2
-                exit 1
-              fi
-
-              vcs_info=$(tar -xOf "$crate_file" --wildcards '*/.cargo_vcs_info.json' 2>/dev/null || true)
-              published_revision=$(printf '%s' "$vcs_info" | jq -r '.git.sha1 // empty' 2>/dev/null || true)
-              if [ "$published_revision" != "$SOURCE_REVISION" ]; then
-                echo "ERROR: signal-fish-server ${VERSION} already exists on crates.io from revision '$published_revision', expected '$SOURCE_REVISION'." >&2
-                exit 1
-              fi
-              echo "Crate ${VERSION} already exists from ${SOURCE_REVISION}; retry is safe."
-              echo "exists=true" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "ERROR: crates.io version lookup failed closed with HTTP ${status}." >&2
-              exit 1
-              ;;
-          esac
+        working-directory: source
+        run: bash ../publication-tools/scripts/check-clean-release-worktree.sh
 
       - name: Publish to crates.io
-        if: steps.crate.outputs.exists != 'true'
+        if: needs.publication-readiness.outputs.crate_exists != 'true'
+        working-directory: source
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish --locked
@@ -510,10 +498,12 @@ jobs:
       - name: Generate SBOM (CycloneDX)
         id: sbom
         run: cargo sbom --output-format cyclone_dx_json_1_5 > sbom.cdx.json
+        working-directory: source
         continue-on-error: true
 
       - name: Extract changelog for release
         id: changelog
+        working-directory: source
         run: |
           VERSION="${{ needs.resolve-release.outputs.version }}"
           # Extract the section for this version from CHANGELOG.md
@@ -572,7 +562,7 @@ jobs:
           tag_name: ${{ needs.resolve-release.outputs.tag }}
           name: ${{ needs.resolve-release.outputs.tag }}
           target_commitish: ${{ needs.resolve-release.outputs.source_revision }}
-          body_path: release_notes.md
+          body_path: source/release_notes.md
           draft: false
           prerelease: false
         env:
@@ -583,7 +573,7 @@ jobs:
         uses: softprops/action-gh-release@v3.0.2
         with:
           tag_name: ${{ needs.resolve-release.outputs.tag }}
-          files: sbom.cdx.json
+          files: source/sbom.cdx.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.llm/skills/github-actions-release-publication-safety.md
+++ b/.llm/skills/github-actions-release-publication-safety.md
@@ -25,6 +25,11 @@ If the matching tag already exists during a retry:
 3. Detach at the tagged commit and revalidate Cargo and changelog metadata.
 4. Reuse that source revision without moving the tag.
 
+If resolution detaches the active worktree, preserve any workflow-revision
+parsers or policy helpers in runner-temporary storage before detaching. An
+absolute path inside the same checkout is insufficient because checkout
+replaces the file behind that path.
+
 This permits a workflow-only fix on `main` to finish a partially published older
 commit while preserving the immutable artifact identity.
 

--- a/.llm/skills/github-actions-release-publication-safety.md
+++ b/.llm/skills/github-actions-release-publication-safety.md
@@ -30,6 +30,13 @@ parsers or policy helpers in runner-temporary storage before detaching. An
 absolute path inside the same checkout is insufficient because checkout
 replaces the file behind that path.
 
+Apply that boundary to every downstream consumer, including binary build
+matrices: check out workflow-revision tooling and immutable release source into
+separate directories, run parsers from the tooling checkout against explicit
+source paths, and set build/package working directories to the source checkout.
+A retry is not safe if one matrix job silently falls back to helpers embedded in
+the historical tag.
+
 This permits a workflow-only fix on `main` to finish a partially published older
 commit while preserving the immutable artifact identity.
 
@@ -65,6 +72,8 @@ Cargo's own protection remains the final defense.
 - [ ] Manual dispatch derives Cargo version from the default branch.
 - [ ] Existing retry tags are annotated, immutable, dispatched-commit
   ancestors, and metadata-consistent.
+- [ ] Resolver, publication, container, and binary jobs keep dispatch-revision
+  tooling separate from immutable release source.
 - [ ] Registry collision checks run before irreversible publication.
 - [ ] Registry scratch files live under `$RUNNER_TEMP` and are cleaned.
 - [ ] A `git status --porcelain=v1 --untracked-files=all` gate immediately

--- a/.llm/skills/github-actions-release-publication-safety.md
+++ b/.llm/skills/github-actions-release-publication-safety.md
@@ -1,0 +1,75 @@
+# Skill: GitHub Actions Release Publication Safety
+
+<!--
+  trigger: cargo publish, release retry, dirty checkout, immutable tag,
+  crates.io probe, runner temp, release identity
+  | Retry-safe release identity and clean publication workspace patterns | Infrastructure
+-->
+
+**Trigger**: When publishing a crate, recovering a partial release, resolving
+an existing release tag, or inspecting registry state before publication.
+
+---
+
+## One Release Identity
+
+Manual release publication must run from the default branch and derive its
+version from the reviewed `Cargo.toml`. A second free-form workflow input is not
+confirmation; it is a competing identity that can be mistyped.
+
+If the matching tag already exists during a retry:
+
+1. Fetch the exact remote tag and require an annotated tag object.
+2. Require its commit to be reachable from the commit that was dispatched, not
+   merely from a later default-branch tip.
+3. Detach at the tagged commit and revalidate Cargo and changelog metadata.
+4. Reuse that source revision without moving the tag.
+
+This permits a workflow-only fix on `main` to finish a partially published older
+commit while preserving the immutable artifact identity.
+
+## Readiness Before Mutation
+
+Run the authoritative crates.io checksum and `.cargo_vcs_info.json` comparison
+before creating a tag or publishing GHCR state. Fail closed on API errors,
+malformed checksums, downloaded-byte mismatches, and source-revision conflicts.
+Require embedded Cargo VCS metadata to contain the exact revision and the
+boolean value `dirty: false`; missing, dirty, or wrong-type metadata is unsafe.
+
+Require `CRATES_IO_TOKEN` only when the version is absent. A matching
+already-published crate must remain recoverable without upload credentials.
+
+## Publication Workspace Boundary
+
+Registry lookups are readiness probes, not package source generation. Write
+response JSON, downloaded `.crate` archives, and similar data only to a
+`mktemp` directory under `$RUNNER_TEMP`, with an EXIT cleanup trap.
+
+Immediately before `cargo publish`, run:
+
+```bash
+dirty=$(git status --porcelain=v1 --untracked-files=all)
+```
+
+Fail with the complete dirty-path list when it is non-empty. `git diff` alone is
+insufficient because it misses untracked files. Never add `--allow-dirty`;
+Cargo's own protection remains the final defense.
+
+## Checklist
+
+- [ ] Manual dispatch derives Cargo version from the default branch.
+- [ ] Existing retry tags are annotated, immutable, dispatched-commit
+  ancestors, and metadata-consistent.
+- [ ] Registry collision checks run before irreversible publication.
+- [ ] Registry scratch files live under `$RUNNER_TEMP` and are cleaned.
+- [ ] A `git status --porcelain=v1 --untracked-files=all` gate immediately
+  precedes `cargo publish`.
+- [ ] `cargo publish` never uses `--allow-dirty`.
+- [ ] Tests execute production resolver, registry-probe, and clean-gate logic
+  against absent, matching, and conflicting fixtures.
+
+## Related Skills
+
+- [GitHub Actions Release Gating](./github-actions-release.md)
+- [CI Configuration Validation Tests](./github-actions-config-tests.md)
+- [Repository Source Hygiene Guards](./repo-source-hygiene-guards.md)

--- a/.llm/skills/github-actions-release.md
+++ b/.llm/skills/github-actions-release.md
@@ -294,6 +294,7 @@ redundant here and strictly worse, because `always()` also runs on cancellation
 ## Related Skills
 
 - [GitHub Actions Config Tests](./github-actions-config-tests.md) — Tests that validate release workflow correctness
+- [Release Publication Safety](./github-actions-release-publication-safety.md) — Retry identity and clean worktrees
 - [GitHub Actions Scheduled Workflows](./github-actions-scheduled-workflows.md) — Cron schedules, job guards
 - [GitHub Actions Workflow Config](./github-actions-workflow-config.md) — Path filters, permissions, concurrency
 - [CI CD Troubleshooting Categories](./ci-cd-troubleshooting-categories.md) — Diagnosing CI failures

--- a/.llm/skills/index.md
+++ b/.llm/skills/index.md
@@ -44,6 +44,7 @@
 - [Bash Scripts in CI/CD](./github-actions-bash-scripts.md)
 - [GitHub Actions Caching & Action Versioning](./github-actions-caching.md)
 - [CI Configuration Validation Tests](./github-actions-config-tests.md)
+- [GitHub Actions Release Publication Safety](./github-actions-release-publication-safety.md)
 - [GitHub Actions Release Gating](./github-actions-release.md)
 - [GitHub Actions Scheduled Workflows](./github-actions-scheduled-workflows.md)
 - [GitHub Actions Workflow Configuration](./github-actions-workflow-config.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make release publication retry-safe by deriving the manual version from the
+  reviewed default-branch source, reusing only matching immutable annotated
+  tags, validating crates.io state before tag and container mutation, keeping
+  registry probes outside the checkout, and enforcing a clean source tree
+  immediately before `cargo publish`.
+
 ## [0.4.1] - 2026-07-18
 
 ### Added

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,9 +33,12 @@ bash scripts/prepare-release.sh --bump patch
 ```
 
 Do not create or move the version tag by hand for the normal manual path. Run
-the **Release - Publish Crate** workflow with `release_version=X.Y.Z`. It creates
-an annotated `vX.Y.Z` tag before publication, or verifies that an existing tag
-is annotated and already points at the exact release commit.
+the **Release - Publish Crate** workflow from the default branch without a
+version input. It derives the reviewed version from `Cargo.toml`, eliminating a
+second operator-entered identity. If the matching tag already exists after a
+partial run, the workflow requires that it is annotated, reachable from the
+dispatched default-branch commit, and consistent with the tagged Cargo and
+changelog metadata; the retry then publishes that immutable source commit.
 
 The release workflow directly calls the reusable container workflow. It does
 not depend on a tag created with `GITHUB_TOKEN` starting a second workflow.
@@ -43,15 +46,22 @@ Publication proceeds in this order:
 
 1. validate the Cargo, changelog, source, and tag identity;
 2. verify required CI for the source commit;
-3. create or validate the immutable annotated tag;
-4. build and verify the versioned multi-architecture GHCR manifest;
-5. publish the crate idempotently;
-6. create or complete the GitHub Release and record the image digest;
-7. attach the SBOM and available platform binaries.
+3. query crates.io from an isolated temporary directory, reject conflicting
+   published bytes/source, require the token only for an absent version, and
+   dry-run the exact package from a clean checkout;
+4. create or validate the immutable annotated tag;
+5. build and verify the versioned multi-architecture GHCR manifest;
+6. verify the source checkout is still clean and publish the crate idempotently;
+7. create or complete the GitHub Release and record the image digest;
+8. attach the SBOM and available platform binaries.
 
 If a run stops after creating one artifact, rerun the same version. The retry
 accepts only artifacts that prove the same source revision. Existing version
 tags are never moved; missing aliases are repaired from the verified digest.
+Registry responses and downloaded `.crate` files remain under `RUNNER_TEMP`,
+and the final untracked-aware cleanliness gate prevents publication probes from
+silently changing the package contents. Never bypass that boundary with
+`cargo publish --allow-dirty`.
 
 ## Direct Tags and Historical Backfills
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -58,6 +58,9 @@ Publication proceeds in this order:
 If a run stops after creating one artifact, rerun the same version. The retry
 accepts only artifacts that prove the same source revision. Existing version
 tags are never moved; missing aliases are repaired from the verified digest.
+Resolver, container, publication, and binary jobs load policy helpers from the
+dispatched workflow revision in a checkout separate from the immutable tagged
+source, so a workflow-only recovery fix can safely complete an older release.
 Registry responses and downloaded `.crate` files remain under `RUNNER_TEMP`,
 and the final untracked-aware cleanliness gate prevents publication probes from
 silently changing the package contents. Never bypass that boundary with

--- a/progress/session-055-release-publish-recovery.md
+++ b/progress/session-055-release-publish-recovery.md
@@ -1,0 +1,82 @@
+# Session 055 — release publication recovery
+
+## Scope
+
+Repair the failed 0.4.1 publication, eliminate redundant operator-entered
+release identity, keep crates.io probes out of the source checkout, and carry
+the remediation through local policy validation, adversarial review, and a
+fully green pull request.
+
+## Baseline evidence
+
+- Release run `29627225895` failed closed because the dispatched version was
+  `0.10.1` while `Cargo.toml` contained `0.4.1`.
+- Release run `29627247402` resolved commit
+  `b41d678fb96821eef998dd2ff97d6439b64dafeb`, passed CI preflight, created the
+  annotated `v0.4.1` tag, published the verified GHCR image, and built all six
+  binary targets.
+- Its crates.io idempotency probe wrote `crate-version.json` into the checkout.
+  The following `cargo publish --locked` correctly rejected that untracked file
+  and exited 101 before uploading the crate.
+- crates.io therefore still exposes 0.4.0 as latest, and no GitHub Release for
+  v0.4.1 exists. The immutable tag and GHCR state are valid recovery inputs.
+
+## Approved invariants
+
+- Manual publication derives the version from the default branch; operators do
+  not retype it.
+- Existing release tags are immutable, annotated, merged into the default
+  branch, and reused as the exact source of an idempotent retry.
+- Network probes and downloaded registry artifacts live under `RUNNER_TEMP`,
+  never in the source checkout.
+- A clean Git worktree is an explicit publication precondition. The workflow
+  never bypasses Cargo with `--allow-dirty`.
+- `CRATES_IO_TOKEN` remains the authentication mechanism and is required before
+  mutation only when crates.io does not already contain the matching release.
+
+## Red/green log
+
+Green implementation:
+
+- Manual dispatch now derives strict semver from the reviewed default branch.
+  A production resolver reuses an existing tag only when it is annotated,
+  reachable from the dispatched commit and default branch, and has matching
+  Cargo/changelog metadata at its immutable source commit.
+- Publication readiness now validates crates.io checksum and embedded VCS
+  revision plus boolean `dirty: false` before any tag/container mutation. A
+  missing version requires the existing token; an already-published matching
+  retry does not.
+- Registry JSON and crate downloads use a trapped `RUNNER_TEMP` directory. Both
+  readiness and final publication run an untracked-aware clean-worktree helper,
+  and the final gate immediately precedes Cargo publication.
+- Data-driven Git and mocked-registry fixtures execute the production helpers
+  across absent/matching/lightweight/unmerged/mismatched tag states, direct tag
+  events, clean/tracked/untracked worktrees, absent/matching/conflicting crates,
+  and registry failure.
+- Adversarial review strengthened fixture isolation against inherited Git
+  signing, rejected dirty/missing/wrong-type Cargo VCS provenance, and made the
+  registry-probe test assert the entire source checkout remains clean.
+
+Targeted evidence:
+
+- `cargo test --locked --test release_publish_tests -- --nocapture`: 3 passed.
+- `cargo test --locked --test ci_config_tests`: 285 passed, 1 ignored after the
+  SBOM path assertion was aligned with the isolated `source/` checkout.
+- `actionlint`, `shellcheck`, workflow hygiene, LLM size/example policy,
+  markdown, documentation consistency, and `git diff --check`: passed.
+
+Full verification:
+
+- `cargo fmt --check`: passed.
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`: passed.
+- `cargo test --locked --all-features`: passed after rebuilding one stale local
+  incremental test artifact; the fresh 16-player binary passed 13/13 both in
+  isolation and in the complete rerun.
+- `cargo deny --all-features check` through `scripts/check-ci-config.sh`: passed
+  with the repository's existing duplicate-dependency warnings.
+- Hook readiness, pre-commit worktree policy (905 ms), and pre-push worktree
+  policy (539 ms): passed.
+- Explicit documentation policy suites: 15 passed. Explicit CI configuration
+  suite: 285 passed, 1 ignored.
+- Independent adversarial review: zero remaining issues after three findings
+  were fixed and covered by behavioral fixtures.

--- a/progress/session-055-release-publish-recovery.md
+++ b/progress/session-055-release-publish-recovery.md
@@ -59,7 +59,7 @@ Green implementation:
 
 Targeted evidence:
 
-- `cargo test --locked --test release_publish_tests -- --nocapture`: 3 passed.
+- `cargo test --locked --test release_publish_tests -- --nocapture`: 4 passed.
 - `cargo test --locked --test ci_config_tests`: 285 passed, 1 ignored after the
   SBOM path assertion was aligned with the isolated `source/` checkout.
 - `actionlint`, `shellcheck`, workflow hygiene, LLM size/example policy,
@@ -80,3 +80,15 @@ Full verification:
   suite: 285 passed, 1 ignored.
 - Independent adversarial review: zero remaining issues after three findings
   were fixed and covered by behavioral fixtures.
+
+## Pull request review
+
+- PR #185 opened at commit `a8c50ac` and all fast workflows passed.
+- Cursor Bugbot found that retry detachment replaced the default relative TOML
+  helper with the historical tag's copy. The resolver now snapshots the
+  dispatch-revision helper under runner-temporary storage before detaching, and
+  a production-path fixture proves recovery when the historical tag does not
+  contain that helper.
+- GitHub Copilot was explicitly requested and awaited, but the service reported
+  that the requesting account had reached its review quota. A retry remains
+  scheduled after the feedback fix and CI rerun.

--- a/progress/session-055-release-publish-recovery.md
+++ b/progress/session-055-release-publish-recovery.md
@@ -60,7 +60,7 @@ Green implementation:
 Targeted evidence:
 
 - `cargo test --locked --test release_publish_tests -- --nocapture`: 4 passed.
-- `cargo test --locked --test ci_config_tests`: 285 passed, 1 ignored after the
+- `cargo test --locked --test ci_config_tests`: 286 passed, 1 ignored after the
   SBOM path assertion was aligned with the isolated `source/` checkout.
 - `actionlint`, `shellcheck`, workflow hygiene, LLM size/example policy,
   markdown, documentation consistency, and `git diff --check`: passed.
@@ -77,7 +77,7 @@ Full verification:
 - Hook readiness, pre-commit worktree policy (905 ms), and pre-push worktree
   policy (539 ms): passed.
 - Explicit documentation policy suites: 15 passed. Explicit CI configuration
-  suite: 285 passed, 1 ignored.
+  suite: 286 passed, 1 ignored.
 - Independent adversarial review: zero remaining issues after three findings
   were fixed and covered by behavioral fixtures.
 
@@ -89,6 +89,11 @@ Full verification:
   dispatch-revision helper under runner-temporary storage before detaching, and
   a production-path fixture proves recovery when the historical tag does not
   contain that helper.
+- The new-head Bugbot pass then found the same boundary missing from the binary
+  matrix. Binary builds now use isolated dispatch-tooling and exact-source
+  checkouts, with a CI configuration test pinning the checkout order, parser
+  path, source working directory, and artifact path.
 - GitHub Copilot was explicitly requested and awaited, but the service reported
-  that the requesting account had reached its review quota. A retry remains
-  scheduled after the feedback fix and CI rerun.
+  that the requesting account had reached its review quota. The required retry
+  after the feedback fix was also requested and awaited, and returned the same
+  external quota result.

--- a/scripts/check-clean-release-worktree.sh
+++ b/scripts/check-clean-release-worktree.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Cargo publish requires a pristine source tree, including no untracked files.
+set -euo pipefail
+
+dirty=$(git status --porcelain=v1 --untracked-files=all)
+if [ -n "$dirty" ]; then
+    echo "ERROR: Refusing to publish a dirty release checkout:" >&2
+    printf '%s\n' "$dirty" >&2
+    echo "Release probes and generated files must use RUNNER_TEMP." >&2
+    exit 1
+fi

--- a/scripts/check-crates-io-release.sh
+++ b/scripts/check-crates-io-release.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Fail closed unless a crates.io version is absent or matches the exact source.
+set -euo pipefail
+
+VERSION=${RELEASE_VERSION:-}
+SOURCE_REVISION=${RELEASE_SOURCE_REVISION:-}
+OUTPUT_FILE=${RELEASE_OUTPUT_FILE:-${GITHUB_OUTPUT:-}}
+API_BASE=${CRATES_IO_API_BASE:-https://crates.io/api/v1}
+
+if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "ERROR: RELEASE_VERSION must be strict X.Y.Z semver: ${VERSION}" >&2
+    exit 2
+fi
+if [[ ! "$SOURCE_REVISION" =~ ^[0-9a-f]{40}$ ]] || [ -z "$OUTPUT_FILE" ]; then
+    echo "ERROR: RELEASE_SOURCE_REVISION and release output file are required." >&2
+    exit 2
+fi
+
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+scratch_dir=$(mktemp -d "${RUNNER_TEMP}/crates-io-retry.XXXXXX")
+cleanup() {
+    rm -rf -- "$scratch_dir"
+}
+trap cleanup EXIT
+
+api_url="${API_BASE}/crates/signal-fish-server/${VERSION}"
+user_agent="signal-fish-server-release-workflow (https://github.com/${GITHUB_REPOSITORY:-Ambiguous-Interactive/signal-fish-server})"
+response_file="${scratch_dir}/crate-version.json"
+status=$(curl --user-agent "$user_agent" --retry 3 --retry-all-errors --silent --show-error \
+    --output "$response_file" --write-out '%{http_code}' "$api_url")
+
+case "$status" in
+    404)
+        echo "exists=false" >> "$OUTPUT_FILE"
+        ;;
+    200)
+        checksum=$(jq -r '.version.checksum // empty' "$response_file")
+        if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "ERROR: crates.io returned no valid checksum for signal-fish-server ${VERSION}." >&2
+            exit 1
+        fi
+
+        crate_file="${scratch_dir}/signal-fish-server-${VERSION}.crate"
+        curl --user-agent "$user_agent" --retry 3 --retry-all-errors --fail --silent --show-error \
+            --location --output "$crate_file" \
+            "${API_BASE}/crates/signal-fish-server/${VERSION}/download"
+        actual_checksum=$(sha256sum "$crate_file" | awk '{print $1}')
+        if [ "$actual_checksum" != "$checksum" ]; then
+            echo "ERROR: Downloaded crate checksum ${actual_checksum} does not match crates.io ${checksum}." >&2
+            exit 1
+        fi
+
+        vcs_info=$(tar -xOf "$crate_file" --wildcards '*/.cargo_vcs_info.json' 2>/dev/null || true)
+        published_revision=$(printf '%s' "$vcs_info" | jq -r '.git.sha1 // empty' 2>/dev/null || true)
+        if [ "$published_revision" != "$SOURCE_REVISION" ]; then
+            echo "ERROR: signal-fish-server ${VERSION} already exists on crates.io from revision '${published_revision}', expected '${SOURCE_REVISION}'." >&2
+            exit 1
+        fi
+        published_dirty=$(printf '%s' "$vcs_info" | jq -r \
+            'if (.git | type) != "object" or (.git | has("dirty") | not) then "missing"
+             elif (.git.dirty | type) != "boolean" then "invalid-type"
+             else (.git.dirty | tostring) end' \
+            2>/dev/null || true)
+        if [ "$published_dirty" != "false" ]; then
+            echo "ERROR: signal-fish-server ${VERSION} has invalid cargo VCS cleanliness metadata '${published_dirty:-unreadable}'; expected dirty=false." >&2
+            exit 1
+        fi
+        echo "Crate ${VERSION} already exists from ${SOURCE_REVISION}; retry is safe."
+        echo "exists=true" >> "$OUTPUT_FILE"
+        ;;
+    *)
+        echo "ERROR: crates.io version lookup failed closed with HTTP ${status}." >&2
+        exit 1
+        ;;
+esac

--- a/scripts/resolve-release-source.sh
+++ b/scripts/resolve-release-source.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Resolve the one immutable version/tag/source identity used by release.yml.
+set -euo pipefail
+
+EVENT_NAME=${RELEASE_EVENT_NAME:-${GITHUB_EVENT_NAME:-}}
+DEFAULT_BRANCH=${RELEASE_DEFAULT_BRANCH:-}
+EVENT_REF=${RELEASE_EVENT_REF:-${GITHUB_REF:-}}
+OUTPUT_FILE=${RELEASE_OUTPUT_FILE:-${GITHUB_OUTPUT:-}}
+READ_TOML_SCRIPT=${READ_TOML_SCRIPT:-scripts/read-toml-string.sh}
+
+if [ -z "$EVENT_NAME" ] || [ -z "$DEFAULT_BRANCH" ] || [ -z "$EVENT_REF" ] || [ -z "$OUTPUT_FILE" ]; then
+    echo "ERROR: release event, default branch, ref, and output file are required." >&2
+    exit 2
+fi
+
+read_cargo_version() {
+    bash "$READ_TOML_SCRIPT" Cargo.toml version package 2>/dev/null || true
+}
+
+validate_annotated_tag() {
+    local candidate_tag=$1
+    if [ "$(git cat-file -t "refs/tags/${candidate_tag}" 2>/dev/null || true)" != "tag" ]; then
+        echo "ERROR: Existing release tag ${candidate_tag} is lightweight; releases require an annotated tag." >&2
+        exit 1
+    fi
+}
+
+if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+    if [ "$EVENT_REF" != "refs/heads/${DEFAULT_BRANCH}" ]; then
+        echo "ERROR: Release publication must be dispatched from ${DEFAULT_BRANCH}; got ${EVENT_REF}." >&2
+        exit 1
+    fi
+
+    dispatch_revision=$(git rev-parse "HEAD^{commit}")
+    version=$(read_cargo_version)
+    if [ -z "$version" ]; then
+        echo "ERROR: Could not extract [package].version from Cargo.toml." >&2
+        exit 1
+    fi
+    tag="v${version}"
+
+    set +e
+    tag_result=$(git ls-remote --exit-code --tags origin "refs/tags/${tag}" 2>&1)
+    tag_status=$?
+    set -e
+    if [ "$tag_status" -eq 0 ]; then
+        git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
+        validate_annotated_tag "$tag"
+        source_revision=$(git rev-parse "refs/tags/${tag}^{commit}")
+        if ! git merge-base --is-ancestor "$source_revision" "$dispatch_revision"; then
+            echo "ERROR: Existing release tag ${tag} was not reachable from dispatched commit ${dispatch_revision}." >&2
+            exit 1
+        fi
+        echo "Reusing existing annotated tag ${tag} at ${source_revision}."
+    elif [ "$tag_status" -eq 2 ]; then
+        source_revision=$dispatch_revision
+    else
+        echo "ERROR: Failed to check release tag ${tag}: ${tag_result}" >&2
+        exit "$tag_status"
+    fi
+elif [ "$EVENT_NAME" = "push" ]; then
+    case "$EVENT_REF" in
+        refs/tags/v*) ;;
+        *)
+            echo "ERROR: Release tag events must use refs/tags/v*: ${EVENT_REF}." >&2
+            exit 1
+            ;;
+    esac
+    tag=${EVENT_REF#refs/tags/}
+    version=${tag#v}
+    event_revision=$(git rev-parse "HEAD^{commit}")
+    git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}"
+    validate_annotated_tag "$tag"
+    source_revision=$(git rev-parse "refs/tags/${tag}^{commit}")
+    if [ "$source_revision" != "$event_revision" ]; then
+        echo "ERROR: ${tag} resolves to ${source_revision}, not release commit ${event_revision}." >&2
+        exit 1
+    fi
+else
+    echo "ERROR: Unsupported release event: ${EVENT_NAME}." >&2
+    exit 1
+fi
+
+if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "ERROR: Release version is not canonical semantic version text: ${version}" >&2
+    exit 1
+fi
+
+git fetch --no-tags origin \
+    "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+if ! git merge-base --is-ancestor "$source_revision" "origin/${DEFAULT_BRANCH}"; then
+    echo "ERROR: Release source ${source_revision} is not merged into ${DEFAULT_BRANCH}." >&2
+    exit 1
+fi
+
+git checkout --detach "$source_revision"
+cargo_version=$(read_cargo_version)
+if [ "$version" != "$cargo_version" ] || [ "$tag" != "v${cargo_version}" ]; then
+    echo "ERROR: Workflow version (${version}), Git tag (${tag}), and source Cargo.toml (${cargo_version}) disagree." >&2
+    exit 1
+fi
+escaped_version=${version//./\\.}
+if ! grep -Eq "^## \\[${escaped_version}\\]( - [0-9]{4}-[0-9]{2}-[0-9]{2})?$" CHANGELOG.md; then
+    echo "ERROR: CHANGELOG.md has no ## [${version}] release section, with or without a date." >&2
+    exit 1
+fi
+
+{
+    echo "version=$version"
+    echo "tag=$tag"
+    echo "source_revision=$source_revision"
+} >> "$OUTPUT_FILE"

--- a/scripts/resolve-release-source.sh
+++ b/scripts/resolve-release-source.sh
@@ -6,7 +6,24 @@ EVENT_NAME=${RELEASE_EVENT_NAME:-${GITHUB_EVENT_NAME:-}}
 DEFAULT_BRANCH=${RELEASE_DEFAULT_BRANCH:-}
 EVENT_REF=${RELEASE_EVENT_REF:-${GITHUB_REF:-}}
 OUTPUT_FILE=${RELEASE_OUTPUT_FILE:-${GITHUB_OUTPUT:-}}
-READ_TOML_SCRIPT=${READ_TOML_SCRIPT:-scripts/read-toml-string.sh}
+
+# Preserve the dispatch revision's parser before a retry detaches the worktree
+# to a historical tag. Tests may inject an already-isolated helper explicitly.
+resolver_scratch=
+cleanup() {
+    if [ -n "$resolver_scratch" ]; then
+        rm -rf -- "$resolver_scratch"
+    fi
+}
+trap cleanup EXIT
+if [ -n "${READ_TOML_SCRIPT:-}" ]; then
+    readonly READ_TOML_SCRIPT
+else
+    scratch_base=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+    resolver_scratch=$(mktemp -d "${scratch_base}/release-resolver.XXXXXX")
+    cp scripts/read-toml-string.sh "${resolver_scratch}/read-toml-string.sh"
+    readonly READ_TOML_SCRIPT="${resolver_scratch}/read-toml-string.sh"
+fi
 
 if [ -z "$EVENT_NAME" ] || [ -z "$DEFAULT_BRANCH" ] || [ -z "$EVENT_REF" ] || [ -z "$OUTPUT_FILE" ]; then
     echo "ERROR: release event, default branch, ref, and output file are required." >&2

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4120,6 +4120,8 @@ fn test_release_dispatch_derives_identity_and_reuses_only_safe_tags() {
         "source_revision=$(git rev-parse \"refs/tags/${tag}^{commit}\")",
         "git merge-base --is-ancestor \"$source_revision\" \"$dispatch_revision\"",
         "git merge-base --is-ancestor \"$source_revision\" \"origin/${DEFAULT_BRANCH}\"",
+        "resolver_scratch=$(mktemp -d \"${scratch_base}/release-resolver.XXXXXX\")",
+        "cp scripts/read-toml-string.sh \"${resolver_scratch}/read-toml-string.sh\"",
         "git checkout --detach \"$source_revision\"",
         "source Cargo.toml (${cargo_version}) disagree",
     ] {

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4307,6 +4307,47 @@ fn test_release_workflow_builds_all_platform_binaries() {
 }
 
 #[test]
+fn test_release_binary_builds_use_dispatch_tooling_with_exact_source() {
+    let root = repo_root();
+    let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let binaries = extract_workflow_job_block(&release, "build-binaries")
+        .expect("release.yml must define build-binaries");
+    let tooling_position = binaries
+        .find("- name: Checkout publication tooling")
+        .expect("build-binaries must check out dispatch-revision publication tooling");
+    let source_position = binaries
+        .find("- name: Checkout exact source")
+        .expect("build-binaries must check out the immutable release source");
+
+    assert!(
+        tooling_position < source_position,
+        "build-binaries must isolate current workflow tooling before historical source"
+    );
+    for required in [
+        "ref: ${{ github.sha }}",
+        "path: publication-tools",
+        "scripts/read-toml-string.sh",
+        "sparse-checkout-cone-mode: false",
+        "ref: ${{ needs.resolve-release.outputs.source_revision }}",
+        "path: source",
+        "working-directory: source",
+        "bash ../publication-tools/scripts/read-toml-string.sh rust-toolchain.toml",
+        "echo \"archive=source/$ARCHIVE\"",
+    ] {
+        assert!(
+            binaries.contains(required),
+            "build-binaries must contain `{required}` so workflow-only recovery fixes remain \
+             available while every artifact is built from the exact tagged source.\n\
+             Job block:\n{binaries}"
+        );
+    }
+    assert!(
+        !binaries.contains("bash scripts/read-toml-string.sh"),
+        "build-binaries must not execute a parser from the historical source checkout"
+    );
+}
+
+#[test]
 fn test_release_workflow_attaches_binaries_with_checksums() {
     // Prebuilt binaries are only trustworthy/usable if they are (a) uploaded to
     // the Release and (b) accompanied by checksums users can verify. Match on

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4032,6 +4032,15 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
          runs; workflow-created PRs made with GITHUB_TOKEN do not trigger new workflows."
     );
 
+    assert!(
+        prepare
+            .contains("The workflow derives version \\`${VERSION}\\` from the reviewed Cargo.toml")
+            && !prepare.contains("with \\`release_version=${VERSION}\\`"),
+        "The generated release PR must direct maintainers to dispatch from the default branch \
+         without retyping the reviewed version. Redundant release identity input caused the \
+         failed 0.10.1 dispatch for the 0.4.1 release.\nJob block:\n{prepare}"
+    );
+
     assert_eq!(
         prepare
             .matches(
@@ -4063,6 +4072,170 @@ fn test_prepare_release_workflow_creates_a_ci_triggering_semver_release_pr() {
             && install_toolchain < prepare_files,
         "The pinned Rust toolchain must be installed after checkout and before release \
          preparation invokes Cargo."
+    );
+}
+
+#[test]
+fn test_release_dispatch_derives_identity_and_reuses_only_safe_tags() {
+    let root = repo_root();
+    let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let on_block = extract_yaml_mapping_block(&release, "on", 0)
+        .expect("release.yml must define workflow triggers");
+    let resolve = extract_workflow_job_block(&release, "resolve-release")
+        .expect("release.yml must define resolve-release");
+    let resolver = read_live_file(&root.join("scripts/resolve-release-source.sh"));
+
+    assert!(
+        on_block.contains("workflow_dispatch:") && !on_block.contains("release_version:"),
+        "Manual release publication must derive the reviewed Cargo.toml version instead of \
+         asking an operator to retype it.\nTrigger block:\n{on_block}"
+    );
+    assert!(
+        release.contains("group: release-publish")
+            && !release.contains("github.event.inputs.release_version"),
+        "All release attempts must share one non-cancelling publication lock and must not derive \
+         concurrency identity from removed manual input."
+    );
+
+    for required in [
+        "RELEASE_EVENT_NAME: ${{ github.event_name }}",
+        "RELEASE_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
+        "RELEASE_EVENT_REF: ${{ github.ref }}",
+        "run: bash scripts/resolve-release-source.sh",
+    ] {
+        assert!(
+            resolve.contains(required),
+            "resolve-release must pass `{required}` to the tested release resolver.\n\
+             Job block:\n{resolve}"
+        );
+    }
+
+    for required in [
+        "Release publication must be dispatched from ${DEFAULT_BRANCH}",
+        "dispatch_revision=$(git rev-parse \"HEAD^{commit}\")",
+        "version=$(read_cargo_version)",
+        "tag=\"v${version}\"",
+        "git ls-remote --exit-code --tags origin \"refs/tags/${tag}\"",
+        "Existing release tag ${candidate_tag} is lightweight",
+        "source_revision=$(git rev-parse \"refs/tags/${tag}^{commit}\")",
+        "git merge-base --is-ancestor \"$source_revision\" \"$dispatch_revision\"",
+        "git merge-base --is-ancestor \"$source_revision\" \"origin/${DEFAULT_BRANCH}\"",
+        "git checkout --detach \"$source_revision\"",
+        "source Cargo.toml (${cargo_version}) disagree",
+    ] {
+        assert!(
+            resolver.contains(required),
+            "resolve-release must contain `{required}` so a manual retry can safely reuse an \
+             immutable annotated release tag while rejecting unmerged or mismatched sources.\n\
+             Resolver:\n{resolver}"
+        );
+    }
+}
+
+#[test]
+fn test_release_publication_keeps_probes_outside_the_checkout() {
+    let root = repo_root();
+    let release = read_live_file(&root.join(".github/workflows/release.yml"));
+    let readiness = extract_workflow_job_block(&release, "publication-readiness")
+        .expect("release.yml must define publication-readiness");
+    let ensure_tag = extract_workflow_job_block(&release, "ensure-tag")
+        .expect("release.yml must define ensure-tag");
+    let publish =
+        extract_workflow_job_block(&release, "publish").expect("release.yml must define publish");
+    let probe = extract_named_workflow_step(&readiness, "Check for an idempotent crates.io retry")
+        .expect("publication-readiness must define the crates.io retry probe");
+    let clean = extract_named_workflow_step(&publish, "Verify clean checkout before publication")
+        .expect("publish must define a clean-checkout publication gate");
+    let crate_check = read_live_file(&root.join("scripts/check-crates-io-release.sh"));
+    let clean_check = read_live_file(&root.join("scripts/check-clean-release-worktree.sh"));
+
+    for required in [
+        "needs: [resolve-release, preflight]",
+        "crate_exists: ${{ steps.crate.outputs.exists }}",
+        "Check for an idempotent crates.io retry",
+        "Require crates.io token",
+        "if: steps.crate.outputs.exists != 'true'",
+        "CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}",
+        "cargo publish --locked --dry-run",
+        "Verify dry-run preserved a clean checkout",
+    ] {
+        assert!(
+            readiness.contains(required),
+            "publication-readiness must contain `{required}` before any irreversible release \
+             mutation.\nJob block:\n{readiness}"
+        );
+    }
+    assert!(
+        ensure_tag.contains("needs: [resolve-release, publication-readiness]"),
+        "ensure-tag must run only after credentials and the exact package pass readiness.\n\
+         Job block:\n{ensure_tag}"
+    );
+
+    for required in [
+        "mktemp -d \"${RUNNER_TEMP}/crates-io-retry.XXXXXX\"",
+        "trap cleanup EXIT",
+        "response_file=\"${scratch_dir}/crate-version.json\"",
+        "crate_file=\"${scratch_dir}/signal-fish-server-${VERSION}.crate\"",
+        "--output \"$response_file\"",
+    ] {
+        assert!(
+            crate_check.contains(required),
+            "The crates.io retry probe must contain `{required}` so generated registry files \
+             cannot dirty the package checkout.\nScript:\n{crate_check}"
+        );
+    }
+    for forbidden in [
+        "--output crate-version.json",
+        "crate_file=\"signal-fish-server-${VERSION}.crate\"",
+    ] {
+        assert!(
+            !crate_check.contains(forbidden),
+            "The crates.io retry probe must not write checkout-relative scratch path \
+             `{forbidden}`.\nScript:\n{crate_check}"
+        );
+    }
+    assert!(
+        probe.contains("run: bash publication-tools/scripts/check-crates-io-release.sh"),
+        "Publication readiness must execute the tested crates.io probe helper.\nStep:\n{probe}"
+    );
+
+    for required in [
+        "git status --porcelain=v1 --untracked-files=all",
+        "Refusing to publish a dirty release checkout",
+        "Release probes and generated files must use RUNNER_TEMP",
+    ] {
+        assert!(
+            clean_check.contains(required),
+            "The clean-checkout gate must contain `{required}` with actionable diagnostics.\n\
+             Script:\n{clean_check}"
+        );
+    }
+    assert!(
+        clean.contains("run: bash ../publication-tools/scripts/check-clean-release-worktree.sh"),
+        "The final clean gate must execute the tested helper.\nStep:\n{clean}"
+    );
+    let clean_position = publish
+        .find("Verify clean checkout before publication")
+        .expect("clean gate position");
+    let publish_position = publish
+        .find("Publish to crates.io")
+        .expect("publish position");
+    assert!(
+        clean_position < publish_position,
+        "The checkout must be verified immediately before Cargo \
+         publication.\nJob block:\n{publish}"
+    );
+    let between = &publish[clean_position..publish_position];
+    assert_eq!(
+        between.matches("      - name:").count(),
+        1,
+        "No step may mutate the checkout between the clean gate and Cargo publication.\n\
+         Intervening block:\n{between}"
+    );
+    assert!(
+        !release.contains("--allow-dirty"),
+        "Release automation must never bypass Cargo's dirty-checkout protection with \
+         --allow-dirty."
     );
 }
 
@@ -4408,23 +4581,37 @@ fn test_release_identity_fails_closed_across_artifacts() {
     let release = read_live_file(&root.join(".github/workflows/release.yml"));
     let docker = read_live_file(&root.join(".github/workflows/docker-publish.yml"));
     let verifier = read_live_file(&root.join("scripts/verify-release-image.sh"));
+    let resolver = read_live_file(&root.join("scripts/resolve-release-source.sh"));
+    let crate_check = read_live_file(&root.join("scripts/check-crates-io-release.sh"));
 
     let required_by_file = [
         (
             "release.yml",
             &release,
             vec![
-                "Cargo.toml version package",
-                "escaped_version=${version//./\\\\.}",
-                "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
-                "git fetch --no-tags origin \"refs/tags/${tag}:refs/tags/${tag}\"",
+                "scripts/resolve-release-source.sh",
                 "git cat-file -t \"refs/tags/${TAG}\"",
                 "refusing to move it",
-                ".cargo_vcs_info.json",
-                "published_revision",
                 "target_commitish: ${{ needs.resolve-release.outputs.source_revision }}",
                 "Verify GitHub Release identity",
             ],
+        ),
+        (
+            "resolve-release-source.sh",
+            &resolver,
+            vec![
+                "Cargo.toml version package",
+                "escaped_version=${version//./\\\\.}",
+                "grep -Eq \"^## \\\\[${escaped_version}\\\\]",
+                "git fetch --force origin \"refs/tags/${tag}:refs/tags/${tag}\"",
+                "git merge-base --is-ancestor",
+                "git checkout --detach",
+            ],
+        ),
+        (
+            "check-crates-io-release.sh",
+            &crate_check,
+            vec![".cargo_vcs_info.json", "published_revision", "RUNNER_TEMP"],
         ),
         (
             "docker-publish.yml",
@@ -14851,6 +15038,8 @@ fn test_release_workflow_requires_preflight() {
         release_yml.display()
     );
 
+    let publication_readiness = extract_workflow_job_block(&content, "publication-readiness")
+        .expect("release.yml must define publication-readiness");
     let ensure_tag = extract_workflow_job_block(&content, "ensure-tag")
         .expect("release.yml must define ensure-tag");
     let publish_container = extract_workflow_job_block(&content, "publish-container")
@@ -14859,13 +15048,18 @@ fn test_release_workflow_requires_preflight() {
         extract_workflow_job_block(&content, "publish").expect("release.yml must define publish");
 
     // The irreversible publication chain must remain resolve -> preflight ->
-    // immutable tag -> verified container -> crate/GitHub Release.
+    // credential/package readiness -> immutable tag -> verified container ->
+    // crate/GitHub Release.
     assert!(
-        ensure_tag.contains("needs: [resolve-release, preflight]")
+        publication_readiness.contains("needs: [resolve-release, preflight]")
+            && ensure_tag.contains("needs: [resolve-release, publication-readiness]")
             && publish_container.contains("needs: [resolve-release, ensure-tag]")
-            && publish.contains("needs: [resolve-release, publish-container]"),
+            && publish
+                .contains("needs: [resolve-release, publication-readiness, publish-container]"),
         "release.yml publication jobs must preserve the fail-closed dependency chain \
-         resolve-release -> preflight -> ensure-tag -> publish-container -> publish.\n\
+         resolve-release -> preflight -> publication-readiness -> ensure-tag -> \
+         publish-container -> publish.\n\
+         publication-readiness:\n{publication_readiness}\n\
          ensure-tag:\n{ensure_tag}\n\
          publish-container:\n{publish_container}\n\
          publish:\n{publish}"
@@ -16520,9 +16714,9 @@ fn test_release_workflow_attaches_sbom_to_release() {
 
     // The attach step must reference sbom.cdx.json
     assert!(
-        content.contains("files: sbom.cdx.json"),
+        content.contains("files: source/sbom.cdx.json"),
         "release.yml must attach sbom.cdx.json to the GitHub release.\n\
-         Add 'files: sbom.cdx.json' to the 'Attach SBOM to release' step.\n\
+         Add 'files: source/sbom.cdx.json' to the 'Attach SBOM to release' step.\n\
          This allows release consumers to download the SBOM for audit purposes.\n\
          File: {}",
         release_yml.display()

--- a/tests/release_publish_tests.rs
+++ b/tests/release_publish_tests.rs
@@ -130,6 +130,19 @@ impl ReleaseFixture {
             .expect("run release resolver")
     }
 
+    fn resolve_with_production_reader(&self, event: &str, event_ref: &str) -> Output {
+        let _ = fs::remove_file(&self.output);
+        Command::new("bash")
+            .arg(&self.resolver)
+            .current_dir(&self.root)
+            .env("RELEASE_EVENT_NAME", event)
+            .env("RELEASE_DEFAULT_BRANCH", "main")
+            .env("RELEASE_EVENT_REF", event_ref)
+            .env("RELEASE_OUTPUT_FILE", &self.output)
+            .output()
+            .expect("run release resolver with production reader lookup")
+    }
+
     fn resolved_value(&self, key: &str) -> String {
         fs::read_to_string(&self.output)
             .expect("read release outputs")
@@ -286,6 +299,33 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
             );
         }
     }
+}
+
+#[test]
+fn release_source_resolver_preserves_dispatch_revision_tooling_across_detach() {
+    let fixture = ReleaseFixture::new("1.2.3");
+    let release = fixture.head();
+    fixture.tag(true, &release);
+
+    let dispatch_reader = fixture.root.join("scripts/read-toml-string.sh");
+    fs::create_dir_all(dispatch_reader.parent().expect("reader parent"))
+        .expect("create dispatch scripts directory");
+    fs::copy(&fixture.reader, &dispatch_reader).expect("install dispatch revision reader");
+    git(&fixture.root, &["add", "scripts/read-toml-string.sh"]);
+    git(
+        &fixture.root,
+        &["commit", "-m", "add fixed release tooling"],
+    );
+    git(&fixture.root, &["push", "origin", "main"]);
+
+    let output = fixture.resolve_with_production_reader("workflow_dispatch", "refs/heads/main");
+    assert!(
+        output.status.success(),
+        "resolver must keep using dispatch-revision tooling after detaching to a tag that lacks it:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fixture.resolved_value("source_revision"), release);
 }
 
 #[test]

--- a/tests/release_publish_tests.rs
+++ b/tests/release_publish_tests.rs
@@ -1,0 +1,586 @@
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use common::{repo_root, unique_temp_dir, write_file};
+
+fn run(dir: &Path, program: &str, args: &[&str]) -> Output {
+    Command::new(program)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {program} {args:?}: {error}"))
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = run(dir, "git", args);
+    assert!(
+        output.status.success(),
+        "git {args:?} failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .expect("git output must be UTF-8")
+        .trim()
+        .to_owned()
+}
+
+fn write_release_metadata(root: &Path, version: &str) {
+    write_file(
+        &root.join("Cargo.toml"),
+        &format!("[package]\nname = \"fixture\"\nversion = \"{version}\"\n"),
+    );
+    write_file(
+        &root.join("CHANGELOG.md"),
+        &format!("# Changelog\n\n## [Unreleased]\n\n## [{version}] - 2026-07-18\n"),
+    );
+}
+
+struct ReleaseFixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    output: PathBuf,
+    resolver: PathBuf,
+    reader: PathBuf,
+}
+
+impl ReleaseFixture {
+    fn new(version: &str) -> Self {
+        let temp = unique_temp_dir("release-source-resolver");
+        let root = temp.path().join("work");
+        let remote = temp.path().join("origin.git");
+        fs::create_dir_all(&root).expect("create fixture worktree");
+        assert!(run(temp.path(), "git", &["init", "--bare", "origin.git"])
+            .status
+            .success());
+        git(&root, &["init", "-b", "main"]);
+        git(&root, &["config", "user.name", "Release Fixture"]);
+        git(
+            &root,
+            &["config", "user.email", "release-fixture@example.com"],
+        );
+        // Never inherit workstation signing policy: these fixtures run without
+        // an interactive agent and must not block waiting for a PIN or prompt.
+        git(&root, &["config", "commit.gpgsign", "false"]);
+        git(&root, &["config", "tag.gpgsign", "false"]);
+        write_release_metadata(&root, version);
+        git(&root, &["add", "."]);
+        git(&root, &["commit", "-m", "release source"]);
+        git(
+            &root,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("remote path"),
+            ],
+        );
+        git(&root, &["push", "-u", "origin", "main"]);
+
+        let project = repo_root();
+        let output = temp.path().join("release-output");
+        Self {
+            output,
+            resolver: project.join("scripts/resolve-release-source.sh"),
+            reader: project.join("scripts/read-toml-string.sh"),
+            _temp: temp,
+            root,
+        }
+    }
+
+    fn head(&self) -> String {
+        git(&self.root, &["rev-parse", "HEAD^{commit}"])
+    }
+
+    fn commit(&self, message: &str) -> String {
+        write_file(&self.root.join("workflow-marker"), message);
+        git(&self.root, &["add", "workflow-marker"]);
+        git(&self.root, &["commit", "-m", message]);
+        git(&self.root, &["push", "origin", "main"]);
+        self.head()
+    }
+
+    fn tag(&self, annotated: bool, target: &str) {
+        let mut args = vec!["tag"];
+        if annotated {
+            args.extend(["-a", "v1.2.3", target, "-m", "release"]);
+        } else {
+            args.extend(["v1.2.3", target]);
+        }
+        git(&self.root, &args);
+        git(&self.root, &["push", "origin", "refs/tags/v1.2.3"]);
+    }
+
+    fn resolve(&self, event: &str, event_ref: &str) -> Output {
+        let _ = fs::remove_file(&self.output);
+        Command::new("bash")
+            .arg(&self.resolver)
+            .current_dir(&self.root)
+            .env("RELEASE_EVENT_NAME", event)
+            .env("RELEASE_DEFAULT_BRANCH", "main")
+            .env("RELEASE_EVENT_REF", event_ref)
+            .env("RELEASE_OUTPUT_FILE", &self.output)
+            .env("READ_TOML_SCRIPT", &self.reader)
+            .output()
+            .expect("run release resolver")
+    }
+
+    fn resolved_value(&self, key: &str) -> String {
+        fs::read_to_string(&self.output)
+            .expect("read release outputs")
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}=")))
+            .unwrap_or_else(|| panic!("missing {key} output"))
+            .to_owned()
+    }
+}
+
+#[test]
+fn release_source_resolver_covers_retry_and_rejection_states() {
+    struct Case {
+        name: &'static str,
+        arrange: fn(&ReleaseFixture) -> String,
+        event: &'static str,
+        event_ref: &'static str,
+        succeeds: bool,
+        diagnostic: &'static str,
+    }
+
+    fn no_tag(fixture: &ReleaseFixture) -> String {
+        fixture.head()
+    }
+    fn matching_ancestor(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.tag(true, &release);
+        fixture.commit("workflow-only fix");
+        release
+    }
+    fn lightweight(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.tag(false, &release);
+        release
+    }
+    fn non_ancestor(fixture: &ReleaseFixture) -> String {
+        let tree = git(&fixture.root, &["rev-parse", "HEAD^{tree}"]);
+        let commit = git(
+            &fixture.root,
+            &["commit-tree", &tree, "-m", "unrelated release"],
+        );
+        fixture.tag(true, &commit);
+        commit
+    }
+    fn metadata_mismatch(fixture: &ReleaseFixture) -> String {
+        write_release_metadata(&fixture.root, "1.2.2");
+        git(&fixture.root, &["add", "Cargo.toml", "CHANGELOG.md"]);
+        git(&fixture.root, &["commit", "-m", "mismatched source"]);
+        let mismatched = fixture.head();
+        fixture.tag(true, &mismatched);
+        write_release_metadata(&fixture.root, "1.2.3");
+        git(&fixture.root, &["add", "Cargo.toml", "CHANGELOG.md"]);
+        git(&fixture.root, &["commit", "-m", "restore reviewed version"]);
+        git(&fixture.root, &["push", "origin", "main"]);
+        mismatched
+    }
+    fn direct_match(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.tag(true, &release);
+        release
+    }
+    fn direct_event_mismatch(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.tag(true, &release);
+        fixture.commit("later main commit")
+    }
+
+    let cases = [
+        Case {
+            name: "manual without tag uses dispatched head",
+            arrange: no_tag,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: true,
+            diagnostic: "",
+        },
+        Case {
+            name: "manual retry reuses matching annotated ancestor",
+            arrange: matching_ancestor,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: true,
+            diagnostic: "",
+        },
+        Case {
+            name: "lightweight tag is rejected",
+            arrange: lightweight,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "lightweight",
+        },
+        Case {
+            name: "unrelated tag is rejected",
+            arrange: non_ancestor,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "not reachable",
+        },
+        Case {
+            name: "tagged metadata mismatch is rejected",
+            arrange: metadata_mismatch,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "source Cargo.toml",
+        },
+        Case {
+            name: "direct matching annotated tag passes",
+            arrange: direct_match,
+            event: "push",
+            event_ref: "refs/tags/v1.2.3",
+            succeeds: true,
+            diagnostic: "",
+        },
+        Case {
+            name: "direct tag event commit mismatch is rejected",
+            arrange: direct_event_mismatch,
+            event: "push",
+            event_ref: "refs/tags/v1.2.3",
+            succeeds: false,
+            diagnostic: "not release commit",
+        },
+    ];
+
+    for case in cases {
+        let fixture = ReleaseFixture::new("1.2.3");
+        let expected_source = (case.arrange)(&fixture);
+        let output = fixture.resolve(case.event, case.event_ref);
+        assert_eq!(
+            output.status.success(),
+            case.succeeds,
+            "{}:\nstdout:\n{}\nstderr:\n{}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if case.succeeds {
+            assert_eq!(fixture.resolved_value("version"), "1.2.3", "{}", case.name);
+            assert_eq!(
+                fixture.resolved_value("source_revision"),
+                expected_source,
+                "{}",
+                case.name
+            );
+        } else {
+            assert!(
+                String::from_utf8_lossy(&output.stderr).contains(case.diagnostic),
+                "{} missing diagnostic `{}`:\n{}",
+                case.name,
+                case.diagnostic,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}
+
+#[test]
+fn clean_release_worktree_gate_detects_tracked_and_untracked_changes() {
+    let cases = [
+        ("clean", None, true, ""),
+        (
+            "tracked",
+            Some(("tracked.txt", "changed")),
+            false,
+            "tracked.txt",
+        ),
+        (
+            "untracked",
+            Some(("crate-version.json", "{}")),
+            false,
+            "crate-version.json",
+        ),
+    ];
+    let script = repo_root().join("scripts/check-clean-release-worktree.sh");
+
+    for (name, mutation, succeeds, diagnostic) in cases {
+        let root = unique_temp_dir(&format!("clean-release-{name}"));
+        let root_path = root.path();
+        git(root_path, &["init", "-b", "main"]);
+        git(root_path, &["config", "user.name", "Release Fixture"]);
+        git(
+            root_path,
+            &["config", "user.email", "release-fixture@example.com"],
+        );
+        git(root_path, &["config", "commit.gpgsign", "false"]);
+        git(root_path, &["config", "tag.gpgsign", "false"]);
+        write_file(&root_path.join("tracked.txt"), "original");
+        git(root_path, &["add", "tracked.txt"]);
+        git(root_path, &["commit", "-m", "baseline"]);
+        if let Some((path, content)) = mutation {
+            write_file(&root_path.join(path), content);
+        }
+
+        let output = run(root_path, "bash", &[script.to_str().expect("script path")]);
+        assert_eq!(output.status.success(), succeeds, "{name}");
+        if !succeeds {
+            assert!(
+                String::from_utf8_lossy(&output.stderr).contains(diagnostic),
+                "{name} missing path diagnostic: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+}
+
+#[test]
+fn crates_io_probe_is_idempotent_and_never_dirties_the_checkout() {
+    struct Case {
+        name: &'static str,
+        status: &'static str,
+        response_checksum: &'static str,
+        published_revision: &'static str,
+        published_dirty: &'static str,
+        succeeds: bool,
+        expected_output: &'static str,
+        diagnostic: &'static str,
+    }
+
+    let expected_revision = "0123456789abcdef0123456789abcdef01234567";
+    let cases = [
+        Case {
+            name: "absent version",
+            status: "404",
+            response_checksum: "actual",
+            published_revision: expected_revision,
+            published_dirty: "false",
+            succeeds: true,
+            expected_output: "exists=false",
+            diagnostic: "",
+        },
+        Case {
+            name: "matching published version",
+            status: "200",
+            response_checksum: "actual",
+            published_revision: expected_revision,
+            published_dirty: "false",
+            succeeds: true,
+            expected_output: "exists=true",
+            diagnostic: "",
+        },
+        Case {
+            name: "checksum mismatch",
+            status: "200",
+            response_checksum: "zeros",
+            published_revision: expected_revision,
+            published_dirty: "false",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "does not match crates.io",
+        },
+        Case {
+            name: "source revision mismatch",
+            status: "200",
+            response_checksum: "actual",
+            published_revision: "89abcdef0123456789abcdef0123456789abcdef",
+            published_dirty: "false",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "already exists on crates.io from revision",
+        },
+        Case {
+            name: "dirty published source",
+            status: "200",
+            response_checksum: "actual",
+            published_revision: expected_revision,
+            published_dirty: "true",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "expected dirty=false",
+        },
+        Case {
+            name: "missing source cleanliness metadata",
+            status: "200",
+            response_checksum: "actual",
+            published_revision: expected_revision,
+            published_dirty: "missing",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "expected dirty=false",
+        },
+        Case {
+            name: "wrong type source cleanliness metadata",
+            status: "200",
+            response_checksum: "actual",
+            published_revision: expected_revision,
+            published_dirty: "string",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "invalid-type",
+        },
+        Case {
+            name: "registry outage",
+            status: "503",
+            response_checksum: "actual",
+            published_revision: expected_revision,
+            published_dirty: "false",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "failed closed with HTTP 503",
+        },
+    ];
+
+    for case in cases {
+        let root = unique_temp_dir(&format!("crates-probe-{}", case.name.replace(' ', "-")));
+        let root_path = root.path();
+        let bin = root_path.join("bin");
+        let package = root_path.join("package/signal-fish-server-1.2.3");
+        let runner_temp = root_path.join("runner-temp");
+        let checkout = root_path.join("checkout");
+        fs::create_dir_all(&bin).expect("create mock bin");
+        fs::create_dir_all(&package).expect("create package fixture");
+        fs::create_dir_all(&runner_temp).expect("create runner temp");
+        fs::create_dir_all(&checkout).expect("create clean checkout");
+        git(&checkout, &["init", "-b", "main"]);
+        git(&checkout, &["config", "user.name", "Release Fixture"]);
+        git(
+            &checkout,
+            &["config", "user.email", "release-fixture@example.com"],
+        );
+        git(&checkout, &["config", "commit.gpgsign", "false"]);
+        write_file(&checkout.join("tracked.txt"), "baseline");
+        git(&checkout, &["add", "tracked.txt"]);
+        git(&checkout, &["commit", "-m", "baseline"]);
+        let dirty_metadata = match case.published_dirty {
+            "false" | "true" => format!(",\"dirty\":{}", case.published_dirty),
+            "missing" => String::new(),
+            "string" => ",\"dirty\":\"false\"".to_owned(),
+            value => panic!("unknown dirty metadata fixture {value}"),
+        };
+        write_file(
+            &package.join(".cargo_vcs_info.json"),
+            &format!(
+                "{{\"git\":{{\"sha1\":\"{}\"{dirty_metadata}}}}}",
+                case.published_revision
+            ),
+        );
+        let crate_file = root_path.join("signal-fish-server-1.2.3.crate");
+        assert!(run(
+            root_path,
+            "tar",
+            &[
+                "-czf",
+                crate_file.to_str().expect("crate path"),
+                "-C",
+                root_path.join("package").to_str().expect("package path"),
+                "signal-fish-server-1.2.3",
+            ],
+        )
+        .status
+        .success());
+        let actual_checksum = git_style_sha256(&crate_file);
+        let response_checksum = match case.response_checksum {
+            "actual" => actual_checksum,
+            "zeros" => "0".repeat(64),
+            _ => unreachable!(),
+        };
+        let response = root_path.join("response.json");
+        write_file(
+            &response,
+            &format!("{{\"version\":{{\"checksum\":\"{response_checksum}\"}}}}"),
+        );
+        let curl = bin.join("curl");
+        write_file(
+            &curl,
+            "#!/usr/bin/env bash\nset -euo pipefail\noutput=\"\"\nurl=\"\"\nwhile (($#)); do\n  case \"$1\" in\n    --output) output=$2; shift 2 ;;\n    http*) url=$1; shift ;;\n    *) shift ;;\n  esac\ndone\nif [[ \"$url\" == */download ]]; then\n  cp \"$MOCK_CRATE\" \"$output\"\nelse\n  cp \"$MOCK_RESPONSE\" \"$output\"\n  printf '%s' \"$MOCK_STATUS\"\nfi\n",
+        );
+        let mut permissions = fs::metadata(&curl).expect("curl metadata").permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(0o755);
+        }
+        fs::set_permissions(&curl, permissions).expect("make mock curl executable");
+
+        let output_file = root_path.join("outputs");
+        let path = format!(
+            "{}:{}",
+            bin.display(),
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let output = Command::new("bash")
+            .arg(repo_root().join("scripts/check-crates-io-release.sh"))
+            .current_dir(&checkout)
+            .env("PATH", path)
+            .env("MOCK_CRATE", &crate_file)
+            .env("MOCK_RESPONSE", &response)
+            .env("MOCK_STATUS", case.status)
+            .env("RUNNER_TEMP", &runner_temp)
+            .env("RELEASE_VERSION", "1.2.3")
+            .env("RELEASE_SOURCE_REVISION", expected_revision)
+            .env("RELEASE_OUTPUT_FILE", &output_file)
+            .output()
+            .expect("run crates.io probe");
+        assert_eq!(
+            output.status.success(),
+            case.succeeds,
+            "{}:\nstdout:\n{}\nstderr:\n{}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if case.succeeds {
+            assert_eq!(
+                fs::read_to_string(&output_file)
+                    .expect("probe output")
+                    .trim(),
+                case.expected_output,
+                "{}",
+                case.name
+            );
+        } else {
+            assert!(
+                String::from_utf8_lossy(&output.stderr).contains(case.diagnostic),
+                "{} missing diagnostic `{}`: {}",
+                case.name,
+                case.diagnostic,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        assert_eq!(
+            fs::read_dir(&runner_temp)
+                .expect("read runner temp")
+                .count(),
+            0,
+            "{} left registry scratch files behind",
+            case.name
+        );
+        assert_eq!(
+            git(
+                &checkout,
+                &["status", "--porcelain=v1", "--untracked-files=all"]
+            ),
+            "",
+            "{} dirtied the release checkout",
+            case.name
+        );
+    }
+}
+
+fn git_style_sha256(path: &Path) -> String {
+    let output = Command::new("sha256sum")
+        .arg(path)
+        .output()
+        .expect("run sha256sum");
+    assert!(output.status.success());
+    String::from_utf8(output.stdout)
+        .expect("sha256sum output")
+        .split_whitespace()
+        .next()
+        .expect("checksum")
+        .to_owned()
+}


### PR DESCRIPTION
## Summary

- derive manual release identity from the reviewed default-branch `Cargo.toml`
- safely reuse only immutable annotated ancestor tags for partial-release recovery
- move crates.io probes to isolated runner temp storage and enforce a clean exact-source checkout immediately before publication
- validate token/package readiness before tag or container mutation while retaining `CRATES_IO_TOKEN`
- add production-helper behavioral fixtures, workflow policy tests, release docs, changelog guidance, and durable LLM release-safety concepts

## Root cause

The 0.4.1 retry wrote `crate-version.json` into the package checkout. The following `cargo publish --locked` correctly rejected the dirty worktree. A separate manual dispatch also demonstrated that a free-form version input could disagree with the reviewed package version.

## Recovery behavior

After merge, dispatching **Release - Publish Crate** from `main` derives 0.4.1, reuses annotated `v0.4.1` at `b41d678fb96821eef998dd2ff97d6439b64dafeb`, runs the fixed tooling from the dispatch revision against that exact source, verifies/reuses existing GHCR state, and publishes from a clean checkout.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `scripts/check-ci-config.sh` / `cargo deny --all-features check`
- actionlint and shellcheck for changed workflows/helpers
- documentation, workflow hygiene, LLM file/example, hook readiness, pre-commit, and pre-push policy suites
- independent adversarial review: zero remaining findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core release and crates.io publication ordering, identity resolution, and registry probes—mistakes could block releases or publish from the wrong revision; mitigated by fail-closed scripts and extensive CI tests.
> 
> **Overview**
> Hardens **Release - Publish Crate** so partial failures (e.g. registry probes dirtying the checkout or a mistyped manual version) can be retried without corrupting artifacts.
> 
> **Release identity:** Manual dispatch no longer takes `release_version`; it must run from the default branch and reads semver from reviewed `Cargo.toml`. `scripts/resolve-release-source.sh` centralizes validation and can **reuse** an existing annotated `v*` tag only when it is an ancestor of the dispatch commit, merged into default branch, and matches Cargo/changelog at the tagged commit.
> 
> **Readiness before mutation:** A new **`publication-readiness`** job runs **before** tag/container steps: isolated crates.io probe (`check-crates-io-release.sh` under `RUNNER_TEMP`), token required only when the crate is absent, `cargo publish --dry-run`, and a clean-worktree gate (`check-clean-release-worktree.sh`). Tag creation and GHCR publish wait on this job.
> 
> **Tooling vs source:** Publication, publish, and binary matrix jobs check out **dispatch-revision** helpers (`publication-tools` / `github.sha`) separately from the **immutable** release tree (`source/`), so workflow fixes on `main` can finish an older tagged release.
> 
> **Docs & tests:** Prepare-release PR text, `docs/releasing.md`, changelog, LLM release-safety skill, `release_publish_tests.rs`, and expanded `ci_config_tests.rs` lock in the new pipeline order and behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c3640ee9bac58116be51d71c1a73c47ade88f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->