### PR TITLE
Verify the fixed Signal Fish Godot client release

### DIFF
--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -1,4 +1,4 @@
-# Exact-release issue-242 reproduction in two genuine Godot no-thread WASM
+# Exact-release issue-242 acceptance in two genuine Godot no-thread WASM
 # exports. Godot downloads are cached only under their official SHA-512 values;
 # Chromium is installed fresh from the repository's exact npm lockfile.
 
@@ -134,7 +134,7 @@ jobs:
             --target wasm32-unknown-emscripten \
             --release \
             -- -D warnings
-      - name: Characterize released graph plus expected-busted control
+      - name: Verify released graph plus expected-busted control
         env:
           INSTALL_PLAYWRIGHT_DEPS: "1"
         run: bash scripts/run-fortress-wasm-interop.sh
@@ -161,4 +161,4 @@ jobs:
         with:
           manifest-path: clients/fortress-wasm/Cargo.toml
           arguments: --all-features
-          rust-version: 1.89.0
+          rust-version: 1.94.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Advance the Fortress/Godot no-thread WASM acceptance gate to the exact
+  crates.io releases `signal-fish-client` 0.9.0 and
+  `signal-fish-client-godot` 0.9.0. The primary two-browser cell now requires
+  every P13 health invariant to pass, while the one-admission-per-callback
+  negative control must remain explicitly `BUSTED`.
+
 ## [0.5.0] - 2026-07-18
 
 ### Fixed

--- a/clients/README.md
+++ b/clients/README.md
@@ -51,4 +51,4 @@ against the real server binary.
 | Fortress compatibility cell | Runtime | Result |
 |---|---|---|
 | Native | Two Rust processes over loopback WebSockets | CI-enforced healthy |
-| WASM | Godot 4.5 no-thread export in two independent headless-Chromium processes | Released 0.9.0 client/adapter must pass every healthy gate; Chromium only |
+| WASM | Godot 4.5 no-thread export in two independent headless-Chromium processes | CI-enforced healthy with released 0.9.0 client/adapter; Chromium only |

--- a/clients/README.md
+++ b/clients/README.md
@@ -6,8 +6,8 @@ documented protocol end to end against the real server and serve as executable d
 Each client is a **standalone package OUTSIDE the root `signal-fish-server` package** — its own `Cargo.lock`, its
 own `deny.toml`, its own CI job — so the server crate's MSRV build, lockfile, and coverage gates are untouched,
 and the root `Cargo.toml` excludes the whole `clients/` tree from `cargo package`, so the published server crate
-ships none of it. (The root panic/timeout policy scans do walk the client sources, and the root MSRV-consistency
-check pins the native client's `rust-version` to the server's — those root disciplines apply identically.)
+ships none of it. (The root panic/timeout policy scans do walk the client sources. The native fixtures track the
+server MSRV; the Godot/WASM fixture declares the higher floor required by its exact released adapter.)
 See [ADR-0004](../docs/adr/0004-native-reference-client.md) for the full rationale and PLAN.md P7 for the roadmap
 context.
 
@@ -18,7 +18,7 @@ context.
 | Native | [`native/`](native/README.md) | Rust + [webrtc-rs](https://github.com/webrtc-rs/webrtc) 0.17 (real DTLS/SCTP data channels) | ✅ In-repo, CI-enforced (`.github/workflows/webrtc-interop.yml`) |
 | Browser | [`browser/`](browser/README.md) | TypeScript + real headless-Chromium `RTCPeerConnection` (playwright-core) | ✅ In-repo, CI-enforced (`.github/workflows/browser-interop.yml`) |
 | Fortress | [`fortress/`](fortress/README.md) | Rust + `fortress-rollback` 0.10.0 + released Signal Fish Rust client 0.8.0 | ✅ In-repo issue-242 regression, CI-enforced (`.github/workflows/fortress-interop.yml`) |
-| Fortress WASM | [`fortress-wasm/`](fortress-wasm/README.md) | Godot 4.5 no-thread WASM + Fortress 0.10.0 + released Rust client 0.8.0 | ⚠️ CI-enforced expected-`BUSTED` Chromium characterization (`.github/workflows/fortress-wasm-interop.yml`) |
+| Fortress WASM | [`fortress-wasm/`](fortress-wasm/README.md) | Godot 4.5 no-thread WASM + Fortress 0.10.0 + released client/adapter 0.9.0 | CI-enforced healthy Chromium acceptance plus expected-`BUSTED` negative control (`.github/workflows/fortress-wasm-interop.yml`) |
 
 Both clients speak the same JSONL stdout event contract and exit codes (the
 [native README](native/README.md) is canonical), so one Rust interop harness asserts over native and browser
@@ -51,4 +51,4 @@ against the real server binary.
 | Fortress compatibility cell | Runtime | Result |
 |---|---|---|
 | Native | Two Rust processes over loopback WebSockets | CI-enforced healthy |
-| WASM | Godot 4.5 no-thread export in two independent headless-Chromium processes | `BUSTED`: released 0.8.0 completes about one send/callback; P13 remains open; Chromium only |
+| WASM | Godot 4.5 no-thread export in two independent headless-Chromium processes | Released 0.9.0 client/adapter must pass every healthy gate; Chromium only |

--- a/clients/fortress-wasm/Cargo.lock
+++ b/clients/fortress-wasm/Cargo.lock
@@ -674,11 +674,10 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-client"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99859e8e40cc1cdf242c46986d347ee77c4a7aa0bf81f23f7fcce469512e590"
+checksum = "d4a0c8576d40f08c65d9fcac178922d2bd285925b5c532efd12be0dc8d5f7d93"
 dependencies = [
- "godot",
  "rmp",
  "rmp-serde",
  "serde",
@@ -691,6 +690,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-fish-client-godot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55d64089536052fa79b97ad4d4f1679a8a8df6534fe7a8e7b1085e0d41bfab"
+dependencies = [
+ "godot",
+ "signal-fish-client",
+ "tracing",
+]
+
+[[package]]
 name = "signal-fish-fortress-wasm-interop"
 version = "0.1.0"
 dependencies = [
@@ -699,6 +709,7 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-fish-client",
+ "signal-fish-client-godot",
  "uuid",
  "web-time",
 ]

--- a/clients/fortress-wasm/Cargo.toml
+++ b/clients/fortress-wasm/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]
 description = "Godot no-thread WASM Fortress interoperability fixture for Signal Fish Server"
 repository = "https://github.com/Ambiguous-Interactive/signal-fish-server"
-rust-version = "1.89.0"
+rust-version = "1.94.0"
 publish = false
 
 [lib]
@@ -17,7 +17,8 @@ fortress-rollback = "=0.10.0"
 godot = { version = "=0.4.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-signal-fish-client = { version = "=0.8.0", default-features = false, features = ["transport-godot"] }
+signal-fish-client = { version = "=0.9.0", default-features = false, features = ["polling-client"] }
+signal-fish-client-godot = "=0.9.0"
 uuid = { version = "1.23", features = ["serde", "v4", "js"] }
 web-time = "=1.1.0"
 

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -1,8 +1,9 @@
 # Fortress + Signal Fish Godot/WASM interoperability fixture
 
 This standalone fixture is the browser half of the issue-242 regression. It
-compiles the registry releases `fortress-rollback` 0.10.0 and
-`signal-fish-client` 0.8.0 into a Godot 4.5 GDExtension for
+compiles the registry releases `fortress-rollback` 0.10.0,
+`signal-fish-client` 0.9.0, and `signal-fish-client-godot` 0.9.0 into a Godot
+4.5 GDExtension for
 `wasm32-unknown-emscripten`, exports with the official no-thread web template,
 and drives two independent Chromium processes through the server built from the
 current checkout.
@@ -23,17 +24,12 @@ bash scripts/run-fortress-wasm-interop.sh
 ```
 
 The runner requires Emscripten 3.1.74, Godot 4.5 stable with its official web
-templates, and Rust `nightly-2026-03-01` plus `rust-src`. The exact released
-graph produces a reproducible `BUSTED` result. The complete exact-head reports
-reached confirmed frame 607, but client completions remained near one per
-callback and missed the healthy throughput gates despite multi-send adapter
-admission. Observed callback cadence also varies with runner load, and one peer
-recorded a wait recommendation; those failures are accepted only alongside the
-per-peer completion bottleneck. The characterization gate requires both peers
-to reach at least 600 confirmed frames, preserve every conservation and
-correctness gate, and avoid unrelated failures before the expected `BUSTED`
-result can pass CI. An unexpectedly healthy release is surfaced rather than
-silently classified as busted. P13 therefore remains open.
+templates, and Rust `nightly-2026-03-01` plus `rust-src`. The adapter's declared
+Rust floor is 1.94.0, intentionally higher than the standalone server crate's
+MSRV. The primary cell requires both peers to satisfy every healthy throughput,
+progress, queue-age, conservation, rollback, checksum, cadence, and runtime
+identity gate. Any missing report or invariant violation fails closed as
+`BUSTED`; only the complete two-peer result prints `HEALTHY`.
 
 The runner then executes a one-admission-per-callback negative control and
 requires the same healthy validator to classify that run as the expected

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -31,6 +31,10 @@ progress, queue-age, conservation, rollback, checksum, cadence, and runtime
 identity gate. Any missing report or invariant violation fails closed as
 `BUSTED`; only the complete two-peer result prints `HEALTHY`.
 
+Exact-head CI with the released 0.9.0 graph passed the complete primary cell:
+both reports satisfied every health and identity invariant and printed
+`HEALTHY`. The following capped control printed its expected `BUSTED` verdict.
+
 The runner then executes a one-admission-per-callback negative control and
 requires the same healthy validator to classify that run as the expected
 `BUSTED` result. The negative control runs the same minimum 600 active callbacks

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -168,6 +168,7 @@ try {
     ["creator", creatorReport, healthViolations("creator", creatorReport)],
     ["joiner", joinerReport, healthViolations("joiner", joinerReport)],
   ];
+  const healthyViolations = peerHealth.flatMap(([, , violations]) => violations);
   if (mode === "released") {
     for (const [name, report, violations] of peerHealth) {
       assert(

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -263,6 +263,8 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
     args: [
       "--disable-background-timer-throttling",
       "--disable-backgrounding-occluded-windows",
+      "--disable-frame-rate-limit",
+      "--disable-gpu-vsync",
       "--disable-renderer-backgrounding",
       "--disable-features=CalculateNativeWinOcclusion",
       "--enable-webgl",

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -20,7 +20,8 @@ const reportKeys = [
   "schema_version", "status", "origin", "runtime_error", "role", "run_mode",
   "instance_nonce", "expected_remote_nonce", "player_id", "remote_player_id", "room_code",
   "browser_process_id", "browser_artifact", "build_sha", "signal_fish_client_version",
-  "fortress_rollback_version", "godot_rust_version", "godot_runtime", "target", "target_os", "godot_threads",
+  "signal_fish_client_godot_version", "fortress_rollback_version", "godot_rust_version",
+  "godot_runtime", "target", "target_os", "godot_threads",
   "worker_count", "callback_count", "poll_count", "active_callback_count", "callback_intervals",
   "acceptance_thresholds", "max_admissions_per_callback", "current_frame", "confirmed_frame",
   "game_frame", "game_checksum", "frames_advanced", "rollback_count", "max_rollback_depth",
@@ -127,7 +128,7 @@ try {
   });
   const room = await waitForGlobal(creator.page, "__FORTRESS_ROOM_READY", 15_000);
   assertExactKeys(room, ["schema_version", "role", "instance_nonce", "room_code"], "room-ready");
-  assert(room.schema_version === 1, "room-ready schema mismatch");
+  assert(room.schema_version === 2, "room-ready schema mismatch");
   assert(room.role === "creator", "room-ready role mismatch");
   assert(room.instance_nonce === creatorNonce, "room-ready nonce mismatch");
   assert(typeof room.room_code === "string" && room.room_code.length > 0, "empty room code");
@@ -167,41 +168,23 @@ try {
     ["creator", creatorReport, healthViolations("creator", creatorReport)],
     ["joiner", joinerReport, healthViolations("joiner", joinerReport)],
   ];
-  const healthyViolations = peerHealth.flatMap(([, , violations]) => violations);
   if (mode === "released") {
     for (const [name, report, violations] of peerHealth) {
       assert(
-        report.confirmed_frame >= 600,
-        `${name}: released graph did not complete the full 600-confirmed-frame characterization`,
-      );
-      assert(
         report.max_admissions_per_callback > 1,
-        `${name}: released characterization never attempted multi-send admission`,
+        `${name}: released graph never attempted multi-send admission`,
       );
       assert(
         report.callback_intervals.mean_us >= 8_000,
-        `${name}: released characterization observed a synthetic/too-fast callback mean`,
-      );
-      assert(violations.length > 0, `${name}: released graph unexpectedly satisfied every P13 healthy gate`);
-      assert(
-        report.client_game_data_sent_during_run <= report.active_callback_count * 2,
-        `${name}: released graph did not reproduce the per-callback completion bottleneck`,
+        `${name}: released graph observed a synthetic/too-fast callback mean`,
       );
       assert(
-        report.client_game_data_sent_during_run * 1_000 < report.running_elapsed_ms * 120,
-        `${name}: released graph did not reproduce the completed-rate bottleneck`,
-      );
-      assert(
-        violations.every((violation) =>
-          /non-nominal callback mean|oldest queue age|stall_count|wait_recommendations|active wall time|completed rate|sends per callback/.test(
-            violation,
-          ),
-        ),
-        `${name}: released graph developed an unrelated healthy-gate failure:\n${violations.join("\n")}`,
+        violations.length === 0,
+        `${name}: released graph failed P13 healthy gates:\n${violations.join("\n")}`,
       );
     }
     process.stdout.write(
-      `BUSTED fortress-wasm expected released-client characterization (${healthyViolations.length} healthy-gate violations)\n`,
+      "HEALTHY fortress-wasm released-client interoperability\n",
     );
   } else {
     for (const [name, report, violations] of peerHealth) {
@@ -318,7 +301,7 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
     },
     {
       config: {
-        schema_version: 1,
+        schema_version: 2,
         server_url: `ws://127.0.0.1:${serverPort}/v2/ws`,
         role,
         room_code: roomCode,
@@ -369,13 +352,14 @@ function validateIdentityAndRuntime(creatorReport, joinerReport, creatorBrowser,
     ["joiner", joinerReport, joinerBrowser],
   ]) {
     assertExactKeys(report, reportKeys, `${name} report`);
-    assert(report.schema_version === 1 && report.status === "complete", `${name}: incomplete schema`);
+    assert(report.schema_version === 2 && report.status === "complete", `${name}: incomplete schema`);
     assert(report.origin === "rust-gdextension", `${name}: report did not originate in Rust`);
     assert(report.runtime_error === null, `${name}: ${report.runtime_error}`);
     assert(report.role === name, `${name}: role mismatch`);
     assert(report.room_code === roomCode, `${name}: room mismatch`);
     assert(report.build_sha === buildSha, `${name}: current-checkout identity mismatch`);
-    assert(report.signal_fish_client_version === "0.8.0", `${name}: client version drift`);
+    assert(report.signal_fish_client_version === "0.9.0", `${name}: client version drift`);
+    assert(report.signal_fish_client_godot_version === "0.9.0", `${name}: Godot adapter version drift`);
     assert(report.fortress_rollback_version === "0.10.0", `${name}: Fortress version drift`);
     assert(report.godot_rust_version === "0.4.5", `${name}: godot-rust version drift`);
     assertExactKeys(

--- a/clients/fortress-wasm/project/main.gd
+++ b/clients/fortress-wasm/project/main.gd
@@ -10,6 +10,11 @@ var result_published := false
 
 
 func _ready() -> void:
+	# The fixture has no visual oracle. Avoid spending the shared runner's two
+	# browser CPU slices on blank-frame rendering, while retaining Godot's real
+	# main loop and a production-like 60 Hz engine cap for `_process` callbacks.
+	RenderingServer.set_render_loop_enabled(false)
+	Engine.max_fps = 60
 	var config_json := JavaScriptBridge.eval(
 		"JSON.stringify(globalThis.%s ?? null)" % CONFIG_KEY,
 		true,

--- a/clients/fortress-wasm/project/main.gd
+++ b/clients/fortress-wasm/project/main.gd
@@ -62,7 +62,7 @@ func _publish_bridge_error(message: String) -> void:
 		return
 	result_published = true
 	var result := {
-		"schema_version": 1,
+		"schema_version": 2,
 		"status": "complete",
 		"runtime_error": message,
 		"origin": "gdscript-bootstrap-error",

--- a/clients/fortress-wasm/src/lib.rs
+++ b/clients/fortress-wasm/src/lib.rs
@@ -11,9 +11,9 @@ use relay::{InboundRelayFrame, RelaySocket};
 use serde::{Deserialize, Serialize};
 use signal_fish_client::protocol::GameDataEncoding;
 use signal_fish_client::{
-    GodotWebSocketTransport, JoinRoomParams, SignalFishConfig, SignalFishError, SignalFishEvent,
-    SignalFishPollingClient,
+    JoinRoomParams, SignalFishConfig, SignalFishError, SignalFishEvent, SignalFishPollingClient,
 };
+use signal_fish_client_godot::GodotWebSocketTransport;
 use uuid::Uuid;
 use web_time::{Duration, Instant};
 use workload::{
@@ -22,11 +22,12 @@ use workload::{
     MIN_COMPLETED_MESSAGES_PER_SECOND, NOMINAL_FPS, TARGET_CONFIRMED_FRAMES,
 };
 
-const REPORT_SCHEMA_VERSION: u32 = 1;
+const REPORT_SCHEMA_VERSION: u32 = 2;
 const MIN_ACTIVE_CALLBACKS: u64 = 600;
 const NEGATIVE_ACTIVE_CALLBACK_BUDGET: u64 = MIN_ACTIVE_CALLBACKS;
 const RUNTIME_DEADLINE: Duration = Duration::from_secs(90);
-const SIGNAL_FISH_CLIENT_VERSION: &str = "0.8.0";
+const SIGNAL_FISH_CLIENT_VERSION: &str = "0.9.0";
+const SIGNAL_FISH_CLIENT_GODOT_VERSION: &str = "0.9.0";
 const FORTRESS_ROLLBACK_VERSION: &str = "0.10.0";
 const GODOT_RUST_VERSION: &str = "0.4.5";
 const WASM_TARGET: &str = "wasm32-unknown-emscripten";
@@ -123,6 +124,7 @@ struct Report {
     browser_artifact: String,
     build_sha: String,
     signal_fish_client_version: &'static str,
+    signal_fish_client_godot_version: &'static str,
     fortress_rollback_version: &'static str,
     godot_rust_version: &'static str,
     godot_runtime: GodotRuntimeIdentity,
@@ -633,6 +635,7 @@ impl Runtime {
             browser_artifact: self.config.browser_artifact.clone(),
             build_sha: self.config.build_sha.clone(),
             signal_fish_client_version: SIGNAL_FISH_CLIENT_VERSION,
+            signal_fish_client_godot_version: SIGNAL_FISH_CLIENT_GODOT_VERSION,
             fortress_rollback_version: FORTRESS_ROLLBACK_VERSION,
             godot_rust_version: GODOT_RUST_VERSION,
             godot_runtime: self.config.godot_runtime.clone(),

--- a/progress/session-056-p13-released-client-acceptance.md
+++ b/progress/session-056-p13-released-client-acceptance.md
@@ -36,3 +36,13 @@ Focused local verification passed:
 
 The authoritative completion evidence is the dedicated real Godot 4.5
 no-thread Emscripten/two-Chromium workflow on the exact PR head.
+
+The first hosted 0.9.0 run disproved the old completion-bottleneck prediction:
+both peers transferred more than two sends per callback, drained six-frame
+peaks with about 42 ms maximum queue age, and preserved every exact ledger.
+However, two blank Godot render loops received only about 24 callbacks/second
+on the shared runner, so wall-clock throughput missed the unchanged 120/s gate
+and downstream Fortress waits appeared. The follow-up keeps the real Godot
+main loop and 60 Hz engine cap but disables unused blank-frame rendering and
+Chromium's headless frame/vsync cap. This removes fixture rendering overhead
+without relaxing any acceptance threshold or introducing a synthetic clock.

--- a/progress/session-056-p13-released-client-acceptance.md
+++ b/progress/session-056-p13-released-client-acceptance.md
@@ -27,7 +27,7 @@ run remains an expected-`BUSTED` negative control.
 Focused local verification passed:
 
 - exact locked feature-tree inspection shows core 0.9.0, adapter 0.9.0,
-  godot-rust 0.4.5, and Fortress 0.10.0 from the standalone graph;
+  `godot-rust` 0.4.5, and Fortress 0.10.0 from the standalone graph;
 - all 286 applicable `ci_config_tests` passed (one expensive matrix ignored);
 - all six MSRV consistency script tests and the live repository check passed;
 - targeted Clippy passed with warnings denied;

--- a/progress/session-056-p13-released-client-acceptance.md
+++ b/progress/session-056-p13-released-client-acceptance.md
@@ -46,3 +46,17 @@ and downstream Fortress waits appeared. The follow-up keeps the real Godot
 main loop and 60 Hz engine cap but disables unused blank-frame rendering and
 Chromium's headless frame/vsync cap. This removes fixture rendering overhead
 without relaxing any acceptance threshold or introducing a synthetic clock.
+
+## Hosted result
+
+Fortress WASM workflow run `29659394663` passed on exact head `652900b`. The
+primary two-process Godot 4.5 no-thread Chromium cell printed `HEALTHY`, proving
+that both complete reports passed every existing 60 Hz cadence, 120 completed
+messages/s, confirmation, rollback, checksum, queue, conservation, loss, and
+runtime-identity invariant. The capped run then printed the expected `BUSTED`
+verdict with 22 healthy-gate violations, preserving a non-vacuous negative
+control. P13 is complete for the explicitly scoped Chromium platform cell.
+
+Cursor Bugbot found no issues on the exact head after its earlier undefined
+negative-control diagnostic finding was fixed. Copilot responded that the
+requesting user's review quota was exhausted, and no review threads remain.

--- a/progress/session-056-p13-released-client-acceptance.md
+++ b/progress/session-056-p13-released-client-acceptance.md
@@ -1,0 +1,38 @@
+# Session 056 — P13 released-client acceptance
+
+## Trigger
+
+The fixed Signal Fish client is now available on crates.io as 0.9.0 together
+with the new lockstep `signal-fish-client-godot` 0.9.0 adapter. P13 had remained
+intentionally pinned to client 0.8.0 and accepted only the known completion
+bottleneck while waiting for these releases.
+
+## Change
+
+The standalone Godot/WASM fixture now exact-pins both 0.9.0 registry crates.
+The core dependency enables only `polling-client`; the companion crate owns
+`GodotWebSocketTransport`, matching the released breaking package boundary.
+Runtime reports and structural policy tests attest both versions. Because the
+adapter requires Rust 1.94, the fixture declares that honest standalone floor
+and continues to build under its separately pinned nightly toolchain without
+raising the server crate's MSRV.
+
+The primary two-Chromium classifier no longer accepts the historical
+completion bottleneck. Both peers must pass every existing P13 health and
+identity invariant and print `HEALTHY`. The bounded one-admission-per-callback
+run remains an expected-`BUSTED` negative control.
+
+## Verification
+
+Focused local verification passed:
+
+- exact locked feature-tree inspection shows core 0.9.0, adapter 0.9.0,
+  godot-rust 0.4.5, and Fortress 0.10.0 from the standalone graph;
+- all 286 applicable `ci_config_tests` passed (one expensive matrix ignored);
+- all six MSRV consistency script tests and the live repository check passed;
+- targeted Clippy passed with warnings denied;
+- root and fixture formatting, JavaScript and shell syntax, Cargo metadata,
+  documentation consistency, internal links, and Markdown policy passed.
+
+The authoritative completion evidence is the dedicated real Godot 4.5
+no-thread Emscripten/two-Chromium workflow on the exact PR head.

--- a/scripts/check-msrv-consistency.sh
+++ b/scripts/check-msrv-consistency.sh
@@ -2,8 +2,9 @@
 # Signal Fish Server - MSRV Consistency Checker
 # https://github.com/Ambiguous-Interactive/signal-fish-server
 #
-# Validates that all configuration files use the same Rust version
-# as defined in Cargo.toml (the single source of truth for MSRV).
+# Validates that server configuration files use the Rust version defined in
+# Cargo.toml. The Godot/WASM fixture has a separate floor imposed by its exact
+# released adapter dependency.
 #
 # This script is run:
 # - By CI (`.github/workflows/ci.yml` msrv job)
@@ -47,6 +48,7 @@ if [ ! -f Cargo.toml ]; then
 fi
 
 MSRV=$(bash scripts/read-toml-string.sh Cargo.toml rust-version package || true)
+FORTRESS_WASM_MSRV_REQUIRED="1.94.0"
 
 if [ -z "$MSRV" ]; then
     echo -e "${RED}ERROR: Could not extract rust-version from Cargo.toml${NC}"
@@ -147,9 +149,12 @@ else
 fi
 
 # Check 6: clients/fortress-wasm/Cargo.toml (Godot/WASM interoperability fixture)
+# signal-fish-client-godot 0.9.0 requires Rust 1.94. Keep this standalone
+# fixture honest about that higher dependency-imposed floor; it builds with the
+# separately pinned nightly toolchain in fortress-wasm-interop.yml.
 if [ -f clients/fortress-wasm/Cargo.toml ]; then
     FORTRESS_WASM_MSRV=$(bash scripts/read-toml-string.sh clients/fortress-wasm/Cargo.toml rust-version package || true)
-    check_file "clients/fortress-wasm/Cargo.toml" "$MSRV" "$FORTRESS_WASM_MSRV" "rust-version"
+    check_file "clients/fortress-wasm/Cargo.toml" "$FORTRESS_WASM_MSRV_REQUIRED" "$FORTRESS_WASM_MSRV" "rust-version"
 else
     check_missing "clients/fortress-wasm/Cargo.toml"
     FAILED=$((FAILED + 1))
@@ -203,7 +208,7 @@ if [ "$FAILED" -ne 0 ]; then
     echo "   rust-version = \"$MSRV\""
     echo ""
     echo "6. Update clients/fortress-wasm/Cargo.toml:"
-    echo "   rust-version = \"$MSRV\""
+    echo "   rust-version = \"$FORTRESS_WASM_MSRV_REQUIRED\""
     echo ""
     echo "7. Update .devcontainer/Dockerfile (optional):"
     echo "   # Project MSRV: $MSRV"
@@ -214,6 +219,7 @@ if [ "$FAILED" -ne 0 ]; then
 else
     echo -e "${GREEN}SUCCESS${NC}: All $CHECKS MSRV consistency checks passed ✓"
     echo ""
-    echo "All configuration files are consistent with MSRV: $MSRV"
+    echo "All server configuration files are consistent with MSRV: $MSRV"
+    echo "Godot/WASM fixture is consistent with adapter MSRV: $FORTRESS_WASM_MSRV_REQUIRED"
     exit 0
 fi

--- a/scripts/run-fortress-wasm-interop.sh
+++ b/scripts/run-fortress-wasm-interop.sh
@@ -52,7 +52,8 @@ mkdir -p "${GODOT_BIN_DIR}" "${EXPORT_DIR}" "${ARTIFACT_DIR}"
 
 feature_tree="${ARTIFACT_DIR}/cargo-feature-tree.txt"
 cargo +"${NIGHTLY}" tree --manifest-path "${MANIFEST_PATH}" --locked -e features >"${feature_tree}"
-grep -F 'signal-fish-client v0.8.0' "${feature_tree}" >/dev/null
+grep -F 'signal-fish-client v0.9.0' "${feature_tree}" >/dev/null
+grep -F 'signal-fish-client-godot v0.9.0' "${feature_tree}" >/dev/null
 grep -F 'fortress-rollback v0.10.0' "${feature_tree}" >/dev/null
 grep -F 'godot v0.4.5' "${feature_tree}" >/dev/null
 if grep -Eq 'transport-websocket-emscripten|sync-send' "${feature_tree}"; then
@@ -96,4 +97,4 @@ timeout --foreground 180s node "${FIXTURE_ROOT}/harness.mjs" \
 timeout --foreground 180s node "${FIXTURE_ROOT}/harness.mjs" \
     negative "${EXPORT_DIR}" "${SERVER_BIN}" "${ARTIFACT_DIR}" "${BUILD_SHA}"
 
-printf 'BUSTED (expected): released Signal Fish client 0.8.0 does not satisfy the Godot no-thread WASM healthy gates\n'
+printf 'HEALTHY: released Signal Fish client 0.9.0 satisfies the Godot no-thread WASM healthy gates\n'

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -22016,6 +22016,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "relay_sent_sequence_hash === joinerReport.relay_received_sequence_hash",
         "joinerReport.relay_sent_first_sequence === creatorReport.relay_received_first_sequence",
         "joinerReport.relay_sent_last_sequence === creatorReport.relay_received_last_sequence",
+        "const healthyViolations = peerHealth.flatMap",
         "BUSTED fortress-wasm expected negative control",
         "HEALTHY fortress-wasm released-client interoperability",
     ] {

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -21900,7 +21900,6 @@ fn test_fortress_interop_gate_is_pinned_and_runs_current_server() {
 #[test]
 fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     let root = repo_root();
-    let root_manifest = read_file(&root.join("Cargo.toml"));
     let manifest = read_file(&root.join("clients/fortress-wasm/Cargo.toml"));
     let lockfile = read_file(&root.join("clients/fortress-wasm/Cargo.lock"));
     let source = read_file(&root.join("clients/fortress-wasm/src/lib.rs"));
@@ -21912,7 +21911,8 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
 
     for dependency in [
         "fortress-rollback = \"=0.10.0\"",
-        "signal-fish-client = { version = \"=0.8.0\", default-features = false, features = [\"transport-godot\"] }",
+        "signal-fish-client = { version = \"=0.9.0\", default-features = false, features = [\"polling-client\"] }",
+        "signal-fish-client-godot = \"=0.9.0\"",
         "godot = { version = \"=0.4.5\", features = [\"api-custom\", \"experimental-wasm\", \"experimental-wasm-nothreads\", \"lazy-function-tables\"] }",
     ] {
         assert!(
@@ -21922,12 +21922,12 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     }
     assert_eq!(
         extract_toml_version(&manifest, "rust-version"),
-        extract_toml_version(&root_manifest, "rust-version"),
-        "the Godot/WASM fixture must track the server MSRV"
+        Some("1.94.0".to_owned())
     );
     for locked in [
         "name = \"fortress-rollback\"\nversion = \"0.10.0\"",
-        "name = \"signal-fish-client\"\nversion = \"0.8.0\"",
+        "name = \"signal-fish-client\"\nversion = \"0.9.0\"",
+        "name = \"signal-fish-client-godot\"\nversion = \"0.9.0\"",
         "name = \"godot\"\nversion = \"0.4.5\"",
     ] {
         let start = lockfile
@@ -21968,6 +21968,10 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "enqueue_joiner_ack",
         "relay_sent_sequence_hash",
         "relay_received_sequence_hash",
+        "use signal_fish_client_godot::GodotWebSocketTransport;",
+        "const SIGNAL_FISH_CLIENT_GODOT_VERSION: &str = \"0.9.0\";",
+        "signal_fish_client_godot_version: SIGNAL_FISH_CLIENT_GODOT_VERSION",
+        "const REPORT_SCHEMA_VERSION: u32 = 2;",
     ] {
         assert!(
             source.contains(required),
@@ -21998,6 +22002,8 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "sharedArrayBufferType === \"undefined\"",
         "workerConstructions === 0",
         "report.callback_count === report.poll_count",
+        "report.schema_version === 2",
+        "report.signal_fish_client_godot_version === \"0.9.0\"",
         "report.godot_runtime.string === \"4.5-stable (official)\"",
         "assertExactKeys(report, reportKeys",
         "report.relay_send_retries <= 8",
@@ -22011,7 +22017,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "joinerReport.relay_sent_first_sequence === creatorReport.relay_received_first_sequence",
         "joinerReport.relay_sent_last_sequence === creatorReport.relay_received_last_sequence",
         "BUSTED fortress-wasm expected negative control",
-        "BUSTED fortress-wasm expected released-client characterization",
+        "HEALTHY fortress-wasm released-client interoperability",
     ] {
         assert!(
             harness.contains(required),
@@ -22032,23 +22038,20 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     let released_classification = &harness[released_start..negative_start];
     let negative_classification = &harness[negative_start..negative_end];
     for required in [
-        "report.confirmed_frame >= 600",
         "report.max_admissions_per_callback > 1",
         "report.callback_intervals.mean_us >= 8_000",
-        "report.client_game_data_sent_during_run <= report.active_callback_count * 2",
-        "report.client_game_data_sent_during_run * 1_000 < report.running_elapsed_ms * 120",
-        "/non-nominal callback mean|oldest queue age|stall_count|wait_recommendations|active wall time|completed rate|sends per callback/.test(",
-        "released graph developed an unrelated healthy-gate failure",
+        "violations.length === 0",
+        "released graph failed P13 healthy gates",
     ] {
         assert!(
             released_classification.contains(required),
             "P13 released classifier is missing `{required}`"
         );
     }
-    assert_eq!(
-        released_classification.matches("violations.every").count(),
-        1,
-        "P13 released classifier must reject every unrelated healthy-gate violation"
+    assert!(
+        !released_classification.contains("violations.every")
+            && !released_classification.contains("completion bottleneck"),
+        "P13 released classifier must require health instead of accepting the old bottleneck"
     );
     for required in [
         "report.active_callback_count >= 600",
@@ -22123,6 +22126,9 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "negative \"${EXPORT_DIR}\"",
         "timeout --foreground 180s",
         "timeout --foreground",
+        "signal-fish-client v0.9.0",
+        "signal-fish-client-godot v0.9.0",
+        "HEALTHY: released Signal Fish client 0.9.0",
     ] {
         assert!(
             runner.contains(required),
@@ -22166,6 +22172,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "GODOT_TEMPLATES_SHA512:",
         "sha512sum --check",
         "cargo +\"$RUST_NIGHTLY\" clippy",
+        "rust-version: 1.94.0",
         "actions/upload-artifact@v7.0.1",
         "if: failure()",
     ] {

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -21984,6 +21984,8 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     );
     for required in [
         "Engine.get_version_info()",
+        "RenderingServer.set_render_loop_enabled(false)",
+        "Engine.max_fps = 60",
         "config[\"schema_version\"] = int(",
         "config[\"browser_process_id\"] = int(",
         "config[\"godot_runtime\"]",
@@ -21997,6 +21999,8 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
 
     for required in [
         "chromium.launchServer",
+        "\"--disable-frame-rate-limit\"",
+        "\"--disable-gpu-vsync\"",
         "creatorReport.browser_process_id !== joinerReport.browser_process_id",
         "crossOriginIsolated === false",
         "sharedArrayBufferType === \"undefined\"",

--- a/tests/msrv_consistency_script_tests.rs
+++ b/tests/msrv_consistency_script_tests.rs
@@ -7,6 +7,8 @@ use std::fs;
 
 const MATCHING_CLIENT_MANIFEST: &str = "[package]\nrust-version = \"1.88.0\"\n";
 const MISMATCHED_CLIENT_MANIFEST: &str = "[package]\nrust-version = \"1.87.0\"\n";
+const MATCHING_WASM_MANIFEST: &str = "[package]\nrust-version = \"1.94.0\"\n";
+const MISMATCHED_WASM_MANIFEST: &str = "[package]\nrust-version = \"1.93.0\"\n";
 const CLIENT_MANIFESTS: [&str; 3] = [
     "clients/native/Cargo.toml",
     "clients/fortress/Cargo.toml",
@@ -86,9 +88,8 @@ channel="1.88.0"
     ];
 
     for (name, cargo_toml, toolchain_toml, clippy_toml) in cases {
-        // All standalone Rust client manifests reuse the same `[package]`
-        // rust-version shape as the root manifest, so each whitespace variant
-        // exercises their parsers too.
+        // The native fixtures reuse the server floor. The Godot/WASM fixture
+        // independently pins the higher floor imposed by its released adapter.
         let (exit_code, output) = run_msrv_script_with_files(&[
             ("Cargo.toml", cargo_toml),
             ("rust-toolchain.toml", toolchain_toml),
@@ -96,7 +97,7 @@ channel="1.88.0"
             ("Dockerfile", "FROM rust:1.88-bookworm\n"),
             ("clients/native/Cargo.toml", cargo_toml),
             ("clients/fortress/Cargo.toml", cargo_toml),
-            ("clients/fortress-wasm/Cargo.toml", cargo_toml),
+            ("clients/fortress-wasm/Cargo.toml", MATCHING_WASM_MANIFEST),
         ]);
 
         assert_eq!(
@@ -104,7 +105,8 @@ channel="1.88.0"
             "case {name} should accept valid TOML whitespace variants.\nOutput:\n{output}"
         );
         assert!(
-            output.contains("All configuration files are consistent with MSRV: 1.88.0"),
+            output.contains("All server configuration files are consistent with MSRV: 1.88.0")
+                && output.contains("Godot/WASM fixture is consistent with adapter MSRV: 1.94.0"),
             "case {name} should parse the MSRV consistently.\nOutput:\n{output}"
         );
     }
@@ -122,7 +124,7 @@ fn test_msrv_script_reports_mismatch_after_tolerant_parsing() {
         ("Dockerfile", "FROM rust:1.88-bookworm\n"),
         ("clients/native/Cargo.toml", MATCHING_CLIENT_MANIFEST),
         ("clients/fortress/Cargo.toml", MATCHING_CLIENT_MANIFEST),
-        ("clients/fortress-wasm/Cargo.toml", MATCHING_CLIENT_MANIFEST),
+        ("clients/fortress-wasm/Cargo.toml", MATCHING_WASM_MANIFEST),
     ]);
 
     assert_eq!(
@@ -145,10 +147,11 @@ fn test_msrv_script_reports_each_client_manifest_mismatch() {
             ("Dockerfile", "FROM rust:1.88-bookworm\n"),
         ];
         files.extend(CLIENT_MANIFESTS.map(|path| {
-            let contents = if path == mismatched_path {
-                MISMATCHED_CLIENT_MANIFEST
-            } else {
-                MATCHING_CLIENT_MANIFEST
+            let contents = match (path, path == mismatched_path) {
+                ("clients/fortress-wasm/Cargo.toml", true) => MISMATCHED_WASM_MANIFEST,
+                ("clients/fortress-wasm/Cargo.toml", false) => MATCHING_WASM_MANIFEST,
+                (_, true) => MISMATCHED_CLIENT_MANIFEST,
+                (_, false) => MATCHING_CLIENT_MANIFEST,
             };
             (path, contents)
         }));
@@ -180,7 +183,14 @@ fn test_msrv_script_fails_when_each_client_manifest_is_missing() {
             CLIENT_MANIFESTS
                 .into_iter()
                 .filter(|path| *path != missing_path)
-                .map(|path| (path, MATCHING_CLIENT_MANIFEST)),
+                .map(|path| {
+                    let manifest = if path == "clients/fortress-wasm/Cargo.toml" {
+                        MATCHING_WASM_MANIFEST
+                    } else {
+                        MATCHING_CLIENT_MANIFEST
+                    };
+                    (path, manifest)
+                }),
         );
 
         let (exit_code, output) = run_msrv_script_with_files(&files);
@@ -226,7 +236,7 @@ fn test_msrv_script_parses_dockerfile_from_line_variants() {
             ("Dockerfile", dockerfile),
             ("clients/native/Cargo.toml", MATCHING_CLIENT_MANIFEST),
             ("clients/fortress/Cargo.toml", MATCHING_CLIENT_MANIFEST),
-            ("clients/fortress-wasm/Cargo.toml", MATCHING_CLIENT_MANIFEST),
+            ("clients/fortress-wasm/Cargo.toml", MATCHING_WASM_MANIFEST),
         ]);
 
         assert_eq!(


### PR DESCRIPTION
## What changed

- exact-pin `signal-fish-client` 0.9.0 and the new lockstep `signal-fish-client-godot` 0.9.0 adapter in the real Fortress/Godot no-thread WASM fixture
- flip the primary two-Chromium P13 classifier from the historical expected-`BUSTED` characterization to strict `HEALTHY`, while retaining the expected-`BUSTED` one-admission negative control
- attest both released crate versions at runtime, bump the report/config schema to v2, and preserve exact crates.io lockfile/source checks
- declare and enforce the adapter-imposed Rust 1.94 fixture floor without raising the server crate's 1.89 MSRV
- update acceptance docs, changelog, and session progress

## Why

Client 0.8.0 reproduced the issue-242 Godot browser completion bottleneck. The ownership-transfer fix is now published in client 0.9.0, and the breaking Godot transport boundary moved into the companion adapter crate. P13 can therefore test the official fixed release instead of accepting the old failure.

## Local verification

- 286 applicable `ci_config_tests` passed (one expensive nested matrix ignored)
- all 6 MSRV consistency tests plus the live repository check passed
- targeted Clippy passed with warnings denied
- root/fixture formatting, JavaScript and shell syntax, locked Cargo metadata/feature tree, docs consistency, internal links, and Markdown policy passed

The dedicated Fortress WASM workflow is the authoritative real Godot 4.5 no-thread Emscripten/two-Chromium acceptance proof.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to the standalone Fortress WASM fixture, CI gates, and MSRV policy—not server runtime—but they redefine a critical interoperability acceptance path and depend on new published crates.
> 
> **Overview**
> **P13 Godot/WASM acceptance** moves from the historical expected-`BUSTED` characterization on client **0.8.0** to strict **HEALTHY** on exact-pinned **`signal-fish-client` 0.9.0** and **`signal-fish-client-godot` 0.9.0**. The core crate uses `polling-client` only; **`GodotWebSocketTransport`** comes from the new adapter crate. Reports and harness config bump to **schema v2**, including **`signal_fish_client_godot_version`**.
> 
> The primary two-Chromium cell in **`harness.mjs`** now requires **zero** P13 health violations (throughput, conservation, cadence, etc.) instead of asserting the old per-callback completion bottleneck. The **one-admission-per-callback** negative control still must print **`BUSTED`**.
> 
> **Fixture/runtime tuning** (no relaxed thresholds): **`main.gd`** disables blank-frame rendering and caps **`Engine.max_fps` at 60**; Chromium launches with **`--disable-frame-rate-limit`** and **`--disable-gpu-vsync`** so CI can hit the unchanged 120 msg/s gate.
> 
> **Tooling/docs:** Fortress WASM **`rust-version` is 1.94.0** (adapter floor); **`check-msrv-consistency.sh`** and tests treat it separately from the server MSRV. Workflow wording and **`cargo-deny`** use **1.94.0**; changelog and client READMEs describe healthy 0.9.0 acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3a380606d71b19c71b0deacfe2c8ede983dbcd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->