### PR TITLE
Prove reconnect retry during teardown

### DIFF
--- a/.llm/context-architecture-and-files.md
+++ b/.llm/context-architecture-and-files.md
@@ -40,10 +40,11 @@ stdout event contract and exit codes (the native README is canonical).
 `clients/fortress/` is the native Fortress rollback interoperability fixture;
 `clients/fortress-wasm/` reuses its deterministic workload and relay ledger in
 a Godot 4.5, single-threaded Emscripten build exercised by two isolated browser
-processes via `scripts/run-fortress-wasm-interop.sh`. The exact released WASM
-graph is an expected-`BUSTED` characterization: its adapter admits multiple
-messages per callback, but client completions remain near one per callback.
-P13 stays open until that released-client bottleneck is removed.
+processes via `scripts/run-fortress-wasm-interop.sh`. The exact released 0.9.0
+client + Godot adapter graph is required to pass every health gate in two
+Chromium processes; the same harness retains an expected-`BUSTED`
+one-admission-per-callback negative control. P13 is complete for the explicitly
+scoped Chromium cell.
 
 ## Architectural Invariants
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Complete the H6 reconnect-race falsification matrix with a deterministic,
+  test-only teardown gate. The gate proves a reconnect rejected as
+  `PlayerAlreadyConnected` after its record is armed does not consume the token,
+  and that the same token succeeds as soon as the old connection is removed.
 - Advance the Fortress/Godot no-thread WASM acceptance gate to the exact
   crates.io releases `signal-fish-client` 0.9.0 and
   `signal-fish-client-godot` 0.9.0. The primary two-browser cell now requires

--- a/progress/session-057-p10c-h6-reconnect-teardown.md
+++ b/progress/session-057-p10c-h6-reconnect-teardown.md
@@ -1,0 +1,40 @@
+# Session 057 — P10.C H6 reconnect-during-teardown
+
+## Trigger
+
+H6 registered three reconnection race facets, but Session 017 covered only the
+window boundary and duplicate-claim cases. The remaining prediction was that a
+reconnect arriving after teardown arms its pending record but before the old
+connection disappears receives `PlayerAlreadyConnected` without consuming the
+token, and succeeds when the client retries after teardown.
+
+## Change
+
+The server's unit-test build now exposes a two-event teardown gate at that exact
+boundary. It pauses the real unregister transaction after
+`register_disconnection_for_reconnect` completes and before room/connection
+removal begins; release builds contain neither the gate nor its branch.
+
+The new handler-level test drives the complete state transition:
+
+- a v3-style token is pre-issued before disconnect;
+- unregister arms the same token and stops at the explicit gate;
+- the target remains registered while the pending record is present;
+- a fresh connection receives exact `PlayerAlreadyConnected`;
+- manager validation proves the token remains valid after rejection;
+- releasing the gate completes the real teardown; and
+- the same fresh connection then redeems that token and receives `Reconnected`
+  with the original player and room identities, proving it was not consumed.
+
+There are no sleeps, polling races, retry loops used for synchronization, or
+assertions about which task a scheduler happens to run first.
+
+## Verification
+
+Focused verification passed:
+
+- `cargo fmt --all`
+- `cargo test --locked --lib reconnect_during_teardown_preserves_token_for_retry -- --nocapture`
+
+The broader cheap local checks, exact-head CI evidence, and automated reviewer
+results will be recorded before the session is closed.

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,8 @@ use std::net::SocketAddr;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex as StdMutex;
 use thiserror::Error;
 use tokio::sync::{mpsc, watch, Notify, RwLock};
 use tokio::time::Duration;
@@ -115,6 +117,8 @@ pub struct EnhancedGameServer {
     pending_durable_player_detaches: Arc<DashMap<(RoomId, PlayerId), ()>>,
     #[cfg(test)]
     fail_retain_room_publication_snapshot: AtomicBool,
+    #[cfg(test)]
+    reconnect_teardown_test_gate: StdMutex<Option<Arc<ReconnectTeardownTestGate>>>,
     /// Spectator lifecycle manager
     spectator_service: SpectatorService,
     /// Transport-level security options (TLS, token binding, etc.)
@@ -131,6 +135,28 @@ pub struct EnhancedGameServer {
     /// until both socket halves have completed their bounded close path.
     active_socket_tasks: AtomicUsize,
     active_socket_tasks_notify: Notify,
+}
+
+/// Test-only synchronization point for the narrow interval after a reconnect
+/// record is armed but before the old connection is removed. Production has no
+/// hook or branch at this boundary; `cfg(test)` keeps the deterministic H6 race
+/// harness out of release builds.
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct ReconnectTeardownTestGate {
+    armed: Notify,
+    release: Notify,
+}
+
+#[cfg(test)]
+impl ReconnectTeardownTestGate {
+    pub(crate) async fn wait_until_armed(&self) {
+        self.armed.notified().await;
+    }
+
+    pub(crate) fn release(&self) {
+        self.release.notify_one();
+    }
 }
 
 #[derive(Debug, Error)]
@@ -339,6 +365,8 @@ impl EnhancedGameServer {
             pending_durable_player_detaches: Arc::new(DashMap::new()),
             #[cfg(test)]
             fail_retain_room_publication_snapshot: AtomicBool::new(false),
+            #[cfg(test)]
+            reconnect_teardown_test_gate: StdMutex::new(None),
             spectator_service,
             transport_security,
             dashboard_metrics_cache: dashboard_metrics_cache.clone(),
@@ -704,6 +732,11 @@ impl EnhancedGameServer {
             self.discard_pre_issued_reconnection_token(player_id).await;
         }
 
+        #[cfg(test)]
+        if registered_reconnect {
+            self.pause_after_reconnect_registration_for_test().await;
+        }
+
         if self.is_draining() {
             self.connection_manager
                 .request_close_for(player_id, CloseReason::Shutdown);
@@ -801,6 +834,29 @@ impl EnhancedGameServer {
     pub(crate) fn fail_retain_room_publication_snapshot_for_test(&self, fail: bool) {
         self.fail_retain_room_publication_snapshot
             .store(fail, std::sync::atomic::Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_reconnect_teardown_test_gate(&self) -> Arc<ReconnectTeardownTestGate> {
+        let gate = Arc::new(ReconnectTeardownTestGate::default());
+        *self
+            .reconnect_teardown_test_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(Arc::clone(&gate));
+        gate
+    }
+
+    #[cfg(test)]
+    async fn pause_after_reconnect_registration_for_test(&self) {
+        let gate = self
+            .reconnect_teardown_test_gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(gate) = gate {
+            gate.armed.notify_one();
+            gate.release.notified().await;
+        }
     }
 
     pub(crate) fn should_retain_room_publication_snapshot(&self) -> bool {

--- a/src/server/room_service_tests.rs
+++ b/src/server/room_service_tests.rs
@@ -155,6 +155,7 @@ async fn create_test_server_with_message_coordinator_and_lock(
         active_session_plans: Arc::new(DashMap::new()),
         pending_durable_player_detaches: Arc::new(DashMap::new()),
         fail_retain_room_publication_snapshot: AtomicBool::new(false),
+        reconnect_teardown_test_gate: StdMutex::new(None),
         spectator_service,
         transport_security: TransportSecurityConfig::default(),
         dashboard_metrics_cache,

--- a/src/server/signaling_tests.rs
+++ b/src/server/signaling_tests.rs
@@ -2610,6 +2610,100 @@ async fn reconnect_room_full_failure_releases_claim_for_retry() {
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
+async fn reconnect_during_teardown_preserves_token_for_retry() {
+    let server = create_test_server().await;
+    let (existing, _existing_rx) = register_client(&server).await;
+    let (reconnecting, _old_rx) = register_client(&server).await;
+    let (current, mut current_rx) = register_client(&server).await;
+
+    let room_id = create_db_room(&server, existing).await;
+    server
+        .database
+        .add_player_to_room(&room_id, player_info(reconnecting, "reconnecting"))
+        .await
+        .expect("add reconnecting player");
+    for player_id in [existing, reconnecting] {
+        server
+            .connection_manager
+            .assign_client_to_room(&player_id, room_id)
+            .await;
+    }
+
+    // Production v3 joins pre-issue the token that disconnect later arms. Seed
+    // that same state directly so the test knows the exact wire token before
+    // opening the deterministic teardown gate.
+    let manager = server.reconnection_manager().expect("reconnection enabled");
+    let token = manager.pre_issue_token(reconnecting, room_id).await;
+    let gate = server.install_reconnect_teardown_test_gate();
+    let teardown = {
+        let server = Arc::clone(&server);
+        tokio::spawn(async move {
+            server.disconnect_client(&reconnecting).await;
+        })
+    };
+
+    timeout(Duration::from_secs(5), gate.wait_until_armed())
+        .await
+        .expect("disconnect must arm the reconnect record before the deterministic gate");
+    assert!(
+        manager.has_pending_reconnection(&reconnecting).await,
+        "the gated teardown must have armed a pending reconnect record"
+    );
+    assert!(
+        server.connection_manager.has_client(&reconnecting),
+        "the old connection must still be registered at the teardown boundary"
+    );
+
+    let first_attempt = server
+        .handle_reconnect(&current, &reconnecting, &room_id, &token)
+        .await;
+    assert!(
+        !first_attempt,
+        "reconnect during teardown must reject while the old connection is registered"
+    );
+    match recv(&mut current_rx).await.as_ref() {
+        ServerMessage::ReconnectionFailed { error_code, .. } => {
+            assert_eq!(*error_code, ErrorCode::PlayerAlreadyConnected);
+        }
+        other => panic!("expected PlayerAlreadyConnected during teardown, got {other:?}"),
+    }
+    manager
+        .validate_reconnection(&reconnecting, &room_id, &token)
+        .await
+        .expect("PlayerAlreadyConnected must leave the reconnect token valid");
+
+    gate.release();
+    timeout(Duration::from_secs(5), teardown)
+        .await
+        .expect("released teardown must complete")
+        .expect("teardown task must not panic");
+    assert!(
+        !server.connection_manager.has_client(&reconnecting),
+        "released teardown must remove the old connection"
+    );
+    assert!(
+        manager.has_pending_reconnection(&reconnecting).await,
+        "completed teardown must leave the unconsumed record pending"
+    );
+
+    let second_attempt = server
+        .handle_reconnect(&current, &reconnecting, &room_id, &token)
+        .await;
+    assert!(
+        second_attempt,
+        "the same token must succeed after teardown completes"
+    );
+    match recv(&mut current_rx).await.as_ref() {
+        ServerMessage::Reconnected(payload) => {
+            assert_eq!(payload.player_id, reconnecting);
+            assert_eq!(payload.room_id, room_id);
+        }
+        other => panic!("expected Reconnected after teardown retry, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn reconnect_reassign_failure_rolls_back_membership_and_releases_claim() {
     let server = create_test_server().await;
     let (existing, _existing_rx) = register_client(&server).await;

--- a/tests/reconnect_window_races_e2e.rs
+++ b/tests/reconnect_window_races_e2e.rs
@@ -1,9 +1,10 @@
 //! P10.C **H6** — reconnect window / claim edge races (falsification experiment).
 //!
-//! Falsifies two DETERMINISTIC edges of the reconnection state machine through
-//! the real WebSocket stack. The third edge listed for H6 (reconnect-during-
-//! teardown) is an inherently timing-narrow race and is deliberately NOT
-//! attempted here — see "Deferred" below.
+//! Falsifies two deterministic edges of the reconnection state machine through
+//! the real WebSocket stack. H6's third edge (reconnect-during-teardown) is
+//! covered at the handler/unregister boundary by the deterministic test-only
+//! gate in
+//! `server::signaling_tests::reconnect_during_teardown_preserves_token_for_retry`.
 //!
 //! # Pre-registered prediction (PLAN.md, P10.C H6)
 //!
@@ -12,7 +13,7 @@
 //! > reconnect-during-teardown requires client retry (`PlayerAlreadyConnected`;
 //! > token NOT consumed) → F3 SDK rule.
 //!
-//! Prediction for the two facets below: **both PASS.**
+//! Prediction for all three facets: **PASS.**
 //!
 //! # Facet 1 — window boundary, independent of the cleanup tick
 //!
@@ -65,19 +66,19 @@
 //! widening the window to 3600s, after which the very same post-sleep call
 //! returns `Reconnected` instead of `ReconnectionFailed` (reverted).
 //!
-//! # Deferred (NOT implemented here)
+//! # Facet 3 — reconnect during teardown
 //!
-//! NOTE: the reconnect-during-teardown race — a `Reconnect` arriving while
-//! `has_client(player)` is still true mid-teardown, yielding
-//! `PlayerAlreadyConnected` with the token NOT consumed (the early guard at
-//! `src/server/reconnection_service.rs:247-260`) — is an inherently
-//! timing-narrow RACE that cannot be made deterministic without flakiness. It
-//! is deferred to nightly / a future harness knob per the PLAN, and drives the
-//! F3 SDK "retry on PlayerAlreadyConnected" rule.
+//! A `cfg(test)` gate pauses the real unregister transaction after it arms the
+//! pending record and before it removes the old connection. A replacement then
+//! receives `PlayerAlreadyConnected`; direct manager validation proves the
+//! token remains valid. Releasing the gate completes teardown, and the same
+//! replacement's successful use of that token for `Reconnected` proves it was
+//! not consumed. The gate replaces the former timing-narrow race with explicit
+//! events and no sleeps.
 //!
 //! # Result
 //!
-//! CONFIRMED — both facets pass; prediction upheld. (Observed detail: the
+//! CONFIRMED — all three facets pass; prediction upheld. (Observed detail: the
 //! post-window rejection surfaces as `ReconnectionTokenInvalid`, because the
 //! token's own embedded expiry — armed to `disconnect + window` — is checked a
 //! hair before the dedicated `WindowExpired` gate.)


### PR DESCRIPTION
## Summary

- add a one-shot `cfg(test)` gate at the exact boundary after teardown arms a reconnect record and before it removes the old connection
- prove a concurrent reconnect receives `PlayerAlreadyConnected`, leaves the token valid, and successfully redeems that same token after teardown
- close H6's final registered race facet and correct stale P13 architecture context

## Why

P10.C H6 had deterministic coverage for window boundaries and duplicate claims, but reconnect-during-teardown remained deferred because the natural race was too timing-narrow for a zero-flake test. Explicit event synchronization makes that state reproducible without sleeps or scheduler assumptions.

## Validation

- `cargo clippy --locked --lib --all-features -- -D warnings`
- `cargo test --locked --lib reconnect_during_teardown_preserves_token_for_retry -- --nocapture`
- `cargo test --locked --test reconnect_window_races_e2e`
- `bash scripts/check-doc-consistency.sh`
- `bash scripts/check-markdown.sh`
- `bash scripts/check-internal-links.sh`
- independent adversarial review: zero remaining issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization (`#[cfg(test)]`) on the unregister path; production behavior is unchanged aside from documentation updates.
> 
> **Overview**
> **Closes the last H6 reconnect-race facet** with deterministic coverage instead of timing-dependent e2e tests.
> 
> A **`cfg(test)` `ReconnectTeardownTestGate`** pauses `unregister_client` immediately after `register_disconnection_for_reconnect` and before room/connection removal. Release builds have no gate or branch. Tests install the gate via `install_reconnect_teardown_test_gate()` and release it when ready.
> 
> **`reconnect_during_teardown_preserves_token_for_retry`** drives the full story: pending reconnect is armed while the old socket is still registered → `handle_reconnect` gets **`PlayerAlreadyConnected`** → **`validate_reconnection` still accepts the token** → after gate release, the **same token** yields **`Reconnected`** with original player/room ids. No sleeps or scheduler assumptions.
> 
> Docs/changelog mark H6’s three-facet matrix **CONFIRMED**; the reconnect-window e2e defers facet 3 to this unit test. Architecture notes also state P13 passes on released 0.9.0 Fortress/Godot WASM in the scoped Chromium cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdd5857b492ecff05383ec9ad85ae423ee49ed4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->