### PR TITLE
Close ARM64 release tracking

### DIFF
--- a/progress/session-057-p10c-h6-reconnect-teardown.md
+++ b/progress/session-057-p10c-h6-reconnect-teardown.md
@@ -35,6 +35,12 @@ Focused verification passed:
 
 - `cargo fmt --all`
 - `cargo test --locked --lib reconnect_during_teardown_preserves_token_for_retry -- --nocapture`
+- `cargo clippy --locked --lib --all-features -- -D warnings`
+- `cargo test --locked --test reconnect_window_races_e2e`
+- documentation consistency, Markdown, and internal-link checks
 
-The broader cheap local checks, exact-head CI evidence, and automated reviewer
-results will be recorded before the session is closed.
+PR #188 passed every applicable exact-head workflow at
+`bdd5857b492ecff05383ec9ad85ae423ee49ed4e` (Dependabot records skipped as
+expected). Cursor Bugbot found no issues on that exact head, Copilot was
+explicitly requested but quota-blocked, and no review threads remained. The PR
+merged as `9d945fb1922ec1c1ae53328699085b22d3912db1`.

--- a/progress/session-058-p11-arm64-release-closure.md
+++ b/progress/session-058-p11-arm64-release-closure.md
@@ -1,0 +1,45 @@
+# Session 058 — P11 ARM64 release closure
+
+## Trigger
+
+Issue #122 still reported that `latest` could not be pulled on Linux ARM64 even
+though PR #123 had added the multi-architecture build and the release policy had
+since grown exact platform drift guards. The tracking state needed to be tested
+against the registry rather than inferred from workflow configuration.
+
+## Evidence
+
+Fresh Buildx inspection proved that both published indexes contain the promised
+runtime platform set:
+
+- `latest` resolves to
+  `sha256:31d8adb477ffe2aea65b6edcd0cefae671cf16bf48e6e52122ea9c464a3a1c7c`;
+- `0.5.0` resolves to
+  `sha256:af1f3b965f8ec7e7f7678112bd260485d092669d1bba49f7dc0d4eb0849487c8`;
+- each index contains `linux/amd64`, `linux/arm64`, and `linux/arm/v7`; and
+- the canonical verifier passed for `v0.5.0`, `0.5.0`, and `0.5`, proving one
+  shared release digest plus revision
+  `16ac09b042436b6dbc5cca0b68c462eb2a8ab33f` and version `0.5.0` labels on
+  every runtime manifest.
+
+The in-repo policy surface independently pins the same contract:
+
+- `.github/workflows/docker-publish.yml` publishes all three platforms;
+- `Dockerfile` maps every published platform to an explicit Rust target and
+  linker; and
+- `tests/ci_config_tests.rs` requires ARM64, validates the workflow platform
+  list, and checks the cross-compilation map.
+
+## Outcome
+
+Issue #122 received the current registry evidence and was closed as completed.
+`PLAN.md` now records the current-release audit under P11. No production or
+workflow change was needed, and no changelog entry was added because the
+user-visible fix is already recorded in the existing #122 changelog entry.
+
+## Verification
+
+- `docker buildx imagetools inspect` for `latest` and `0.5.0`
+- `bash scripts/verify-release-image.sh` for `v0.5.0`, `0.5.0`, and `0.5`
+- focused multi-architecture and Dockerfile policy tests
+- documentation consistency, Markdown, internal-link, and LLM file-size checks


### PR DESCRIPTION
## Summary

- verify the published `latest` and `0.5.0` GHCR indexes contain Linux AMD64, ARM64, and ARMv7
- run the canonical release-image verifier across `v0.5.0`, `0.5.0`, and `0.5`
- close the stale ARM64 image issue #122 with current registry evidence
- complete the exact-head CI/reviewer record for Session 057 and add the required Session 058 progress log

## Why

Issue #122 remained open after PR #123 implemented multi-architecture publication. Workflow configuration alone was insufficient proof, so this session re-audited the live registry and confirmed the fix remains present in both the rolling and current release images.

## Impact

No runtime, workflow, or release artifact changed. This PR aligns repository tracking with the already-published, regression-guarded state. The existing changelog entry for #122 remains the user-facing release note.

## Validation

- `docker buildx imagetools inspect` for `latest` and `0.5.0`
- `bash scripts/verify-release-image.sh ghcr.io/ambiguous-interactive/signal-fish-server 16ac09b042436b6dbc5cca0b68c462eb2a8ab33f 0.5.0 v0.5.0 0.5.0 0.5`
- 8 focused Docker policy tests plus the exact issue-#122 ARM64 guard
- documentation consistency, Markdown, internal links, LLM file sizes, diff checks, and repository hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Progress and verification documentation only; no application, CI workflow, or image publication changes.
> 
> **Overview**
> **No runtime, workflow, or release artifacts change**—this PR brings repository tracking in line with what is already published on GHCR.
> 
> **Session 058 (`progress/session-058-p11-arm64-release-closure.md`)** documents a live registry audit for stale ARM64 issue **#122**: `docker buildx imagetools inspect` on `latest` and `0.5.0`, the canonical `verify-release-image.sh` run across `v0.5.0` / `0.5.0` / `0.5`, and cross-checks against existing in-repo policy (Docker publish workflow, `Dockerfile` platform map, `tests/ci_config_tests.rs`). Outcome recorded: issue closed with evidence, **P11** audit noted in `PLAN.md` (per session text), no new changelog entry.
> 
> **Session 057 progress log** is extended with the full verification matrix (clippy, `reconnect_window_races_e2e`, doc checks) and the exact-head CI/reviewer closure for merged PR **#188**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd9d017a461c03badcb7b0a2564664f295be19f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->