### PR TITLE
Add scheduled Firefox WASM interop

### DIFF
--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -1,6 +1,6 @@
 # Exact-release issue-242 acceptance in two genuine Godot no-thread WASM
 # exports. Godot downloads are cached only under their official SHA-512 values;
-# Chromium is installed fresh from the repository's exact npm lockfile.
+# The selected browser is installed fresh from the repository's exact npm lockfile.
 
 name: Fortress WASM Interop
 
@@ -34,6 +34,8 @@ on:
       - "scripts/run-fortress-wasm-interop.sh"
       - ".github/workflows/fortress-wasm-interop.yml"
   workflow_dispatch:
+  schedule:
+    - cron: "37 5 * * 2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -56,9 +58,15 @@ env:
 
 jobs:
   browser-interop:
-    name: Godot no-thread Chromium E2E
+    name: Godot no-thread ${{ matrix.browser }} E2E
     runs-on: ubuntu-latest
     timeout-minutes: 50
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '["firefox"]' || '["chromium"]') }}
+    env:
+      FORTRESS_WASM_BROWSER: ${{ matrix.browser }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.0
@@ -142,7 +150,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7.0.1
         with:
-          name: fortress-wasm-failure-${{ github.run_id }}
+          name: fortress-wasm-${{ matrix.browser }}-failure-${{ github.run_id }}
           path: |
             clients/fortress-wasm/artifacts/
             clients/fortress-wasm/project/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Extend the exact-release Fortress/Godot no-thread WASM interoperability gate
+  with a weekly Firefox cell. Pull requests retain the deterministic Chromium
+  gate, while the scheduled run applies the same healthy released-client and
+  expected-busted negative-control oracles to a separately attested Firefox
+  process pair.
 - Complete the H6 reconnect-race falsification matrix with a deterministic,
   test-only teardown gate. The gate proves a reconnect rejected as
   `PlayerAlreadyConnected` after its record is armed does not consume the token,

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -5,8 +5,10 @@ compiles the registry releases `fortress-rollback` 0.10.0,
 `signal-fish-client` 0.9.0, and `signal-fish-client-godot` 0.9.0 into a Godot
 4.5 GDExtension for
 `wasm32-unknown-emscripten`, exports with the official no-thread web template,
-and drives two independent Chromium processes through the server built from the
-current checkout.
+and drives two independent browser processes through the server built from the
+current checkout. Chromium is the required pull-request gate. A weekly Firefox
+cell runs the same released-client and negative-control oracles to detect
+browser-specific drift without lengthening every pull request.
 
 The Rust `FortressWasmPeer::process` callback owns the full game/network loop.
 Each callback calls `SignalFishPollingClient::poll` exactly once, advances the
@@ -47,3 +49,9 @@ substitute for them; neither can the expected frame-progress and checksum-sample
 shortfalls after the fixed 600-callback budget. Browser logs, errors,
 diagnostics, and any available partial report are retained before peer shutdown
 on failures.
+
+Set `FORTRESS_WASM_BROWSER=firefox` to reproduce the scheduled Firefox cell;
+the default is `chromium`. Both browsers come from the exact `playwright-core`
+version in `clients/browser/package-lock.json` and are installed afresh rather
+than restored from a browser cache. A manual workflow dispatch also selects
+Firefox, allowing exact-head verification before merge.

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -62,8 +62,13 @@ mkdirSync(artifactDirectory, { recursive: true });
 const requireFromBrowser = createRequire(
   join(fixtureDirectory, "..", "browser", "package.json"),
 );
-const { chromium } = requireFromBrowser("playwright-core");
-const browserExecutable = chromium.executablePath();
+const browserName = process.env.FORTRESS_WASM_BROWSER ?? "chromium";
+if (!new Set(["chromium", "firefox"]).has(browserName)) {
+  throw new Error(`unsupported browser: ${browserName}`);
+}
+const playwright = requireFromBrowser("playwright-core");
+const browserType = playwright[browserName];
+const browserExecutable = browserType.executablePath();
 const browserStat = statSync(browserExecutable);
 const browserArtifact = `${browserExecutable}:${browserStat.size}`;
 const browserArtifactSha256 = createHash("sha256")
@@ -257,10 +262,12 @@ try {
 async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, pageUrl }) {
   const logs = [];
   const errors = [];
-  const server = await chromium.launchServer({
+  const launchOptions = {
     headless: true,
     executablePath: browserExecutable,
-    args: [
+  };
+  if (browserName === "chromium") {
+    launchOptions.args = [
       "--disable-background-timer-throttling",
       "--disable-backgrounding-occluded-windows",
       "--disable-frame-rate-limit",
@@ -269,8 +276,9 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
       "--disable-features=CalculateNativeWinOcclusion",
       "--enable-webgl",
       "--ignore-gpu-blocklist",
-    ],
-  });
+    ];
+  }
+  const server = await browserType.launchServer(launchOptions);
   const pid = server.process()?.pid;
   const peer = {
     role,
@@ -283,8 +291,8 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
     errors,
   };
   try {
-    assert(Number.isInteger(pid) && pid > 0, `${role}: missing independent Chromium PID`);
-    peer.browser = await chromium.connect(server.wsEndpoint());
+    assert(Number.isInteger(pid) && pid > 0, `${role}: missing independent ${browserName} PID`);
+    peer.browser = await browserType.connect(server.wsEndpoint());
     peer.context = await peer.browser.newContext();
     await peer.context.addInitScript(
     ({ config }) => {
@@ -346,7 +354,7 @@ async function browserAttestation(peer) {
         : 0,
     resultIdentity: globalThis.__FORTRESS_RESULT?.instance_nonce,
   }));
-  return { ...values, browserPid: peer.pid, browserArtifact, browserArtifactSha256 };
+  return { ...values, browserName, browserPid: peer.pid, browserArtifact, browserArtifactSha256 };
 }
 
 function validateIdentityAndRuntime(creatorReport, joinerReport, creatorBrowser, joinerBrowser, roomCode) {
@@ -391,6 +399,7 @@ function validateIdentityAndRuntime(creatorReport, joinerReport, creatorBrowser,
     );
     assert(JSON.stringify(report.acceptance_thresholds) === JSON.stringify(expectedThresholds), `${name}: shared acceptance thresholds drifted`);
     assert(report.browser_process_id === browser.browserPid, `${name}: browser PID binding mismatch`);
+    assert(browser.browserName === browserName, `${name}: browser name binding mismatch`);
     assert(report.instance_nonce === browser.resultIdentity, `${name}: page/report identity mismatch`);
     assert(report.browser_artifact === `${browserArtifact}:${browserArtifactSha256}`, `${name}: browser artifact mismatch`);
     assert(browser.crossOriginIsolated === false, `${name}: page unexpectedly cross-origin isolated`);
@@ -401,7 +410,7 @@ function validateIdentityAndRuntime(creatorReport, joinerReport, creatorBrowser,
   assert(joinerReport.run_mode === creatorReport.run_mode, "peer run-mode mismatch");
   assert(creatorReport.instance_nonce !== joinerReport.instance_nonce, "duplicate instance nonces");
   assert(creatorReport.player_id !== joinerReport.player_id, "duplicate Signal Fish player ids");
-  assert(creatorReport.browser_process_id !== joinerReport.browser_process_id, "peers share Chromium process");
+  assert(creatorReport.browser_process_id !== joinerReport.browser_process_id, "peers share browser process");
   assert(creatorReport.expected_remote_nonce === joinerReport.instance_nonce, "creator expected-remote nonce mismatch");
   assert(joinerReport.expected_remote_nonce === creatorReport.instance_nonce, "joiner expected-remote nonce mismatch");
   assert(creatorReport.remote_player_id === joinerReport.player_id, "creator remote player mismatch");

--- a/progress/session-059-p13-firefox-wasm-interop.md
+++ b/progress/session-059-p13-firefox-wasm-interop.md
@@ -1,0 +1,36 @@
+# Session 059 — P13 scheduled Firefox WASM interoperability
+
+## Trigger
+
+P13 deliberately limited its release-client acceptance claim to Chromium and
+deferred a Firefox cell until the primary Godot/no-thread reproduction was
+deterministic. Session 056 made the exact released 0.9.0 graph healthy under
+that primary gate, so the deferred cross-browser check is now actionable.
+
+## Change
+
+- The existing fail-closed harness selects `chromium` by default or `firefox`
+  through `FORTRESS_WASM_BROWSER`; both paths retain separate browser processes,
+  executable hashing, PID/report binding, no-worker attestation, exact relay
+  ledgers, and the same health classifier.
+- Pull requests and pushes continue to run Chromium, preserving the established
+  acceptance signal and runtime. Weekly schedules and manual dispatches run
+  Firefox with the same released-client and one-admission negative-control
+  cells, allowing exact-head verification before merge.
+- The runner installs only the selected browser from the exact locked
+  `playwright-core` version. Browser binaries remain uncached so a mutable local
+  installation cannot satisfy CI.
+- Structural policy coverage pins the schedule, event-to-browser mapping,
+  selector, and exact selected-browser installation path.
+
+## Verification
+
+- Red-green focused `ci_config_tests` coverage for the scheduled selector and
+  browser-agnostic harness path, followed by the full suite: 286 passed, one
+  ignored.
+- `node --check`, `bash -n`, ShellCheck, Actionlint, and workflow hygiene.
+- Documentation consistency, Markdown lint, Cargo deny, and the documentation
+  policy/script suites (five passed).
+- Exact-head Chromium and manually dispatched Firefox workflow evidence is
+  recorded after publication; the heavy Godot/WASM gate is intentionally left
+  to CI under the goal's local-testing constraint.

--- a/scripts/run-fortress-wasm-interop.sh
+++ b/scripts/run-fortress-wasm-interop.sh
@@ -86,10 +86,19 @@ BUILD_SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
 readonly BUILD_SHA
 
 npm --prefix "${REPO_ROOT}/clients/browser" ci
+browser_name="${FORTRESS_WASM_BROWSER:-chromium}"
+readonly browser_name
+case "${browser_name}" in
+    chromium | firefox) ;;
+    *)
+        printf 'BUSTED: unsupported Fortress WASM browser: %s\n' "${browser_name}" >&2
+        exit 1
+        ;;
+esac
 if [[ "${INSTALL_PLAYWRIGHT_DEPS:-0}" == "1" ]]; then
-    node "${REPO_ROOT}/clients/browser/node_modules/playwright-core/cli.js" install --with-deps chromium
+    node "${REPO_ROOT}/clients/browser/node_modules/playwright-core/cli.js" install --with-deps "${browser_name}"
 else
-    node "${REPO_ROOT}/clients/browser/node_modules/playwright-core/cli.js" install chromium
+    node "${REPO_ROOT}/clients/browser/node_modules/playwright-core/cli.js" install "${browser_name}"
 fi
 
 timeout --foreground 180s node "${FIXTURE_ROOT}/harness.mjs" \

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -21998,7 +21998,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     }
 
     for required in [
-        "chromium.launchServer",
+        "browserType.launchServer",
         "\"--disable-frame-rate-limit\"",
         "\"--disable-gpu-vsync\"",
         "creatorReport.browser_process_id !== joinerReport.browser_process_id",
@@ -22180,6 +22180,9 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "rust-version: 1.94.0",
         "actions/upload-artifact@v7.0.1",
         "if: failure()",
+        "schedule:",
+        "browser: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '[\"firefox\"]' || '[\"chromium\"]') }}",
+        "FORTRESS_WASM_BROWSER: ${{ matrix.browser }}",
     ] {
         assert!(
             workflow.contains(required),
@@ -22188,8 +22191,31 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     }
     assert!(
         !workflow.contains("node_modules\n") && !workflow.contains("playwright-browsers"),
-        "P13 must not cache mutable/unverified Chromium installations"
+        "P13 must not cache mutable/unverified browser installations"
     );
+    for required in [
+        "process.env.FORTRESS_WASM_BROWSER ?? \"chromium\"",
+        "new Set([\"chromium\", \"firefox\"])",
+        "browserType.launchServer",
+        "browserType.connect",
+        "browser.browserName === browserName",
+        "\"peers share browser process\"",
+    ] {
+        assert!(
+            harness.contains(required),
+            "P13 harness must retain selectable Chromium/Firefox execution: `{required}`"
+        );
+    }
+    for required in [
+        "browser_name=\"${FORTRESS_WASM_BROWSER:-chromium}\"",
+        "install --with-deps \"${browser_name}\"",
+        "install \"${browser_name}\"",
+    ] {
+        assert!(
+            runner.contains(required),
+            "P13 runner must install the selected exact Playwright browser: `{required}`"
+        );
+    }
 }
 
 fn extract_ci_dep_detect_step(ci_content: &str) -> String {


### PR DESCRIPTION
## Summary

- keep Chromium as the deterministic push and pull-request gate
- run the exact released-client and negative-control Godot/WASM oracles in Firefox on weekly schedules and manual dispatches
- bind browser name, executable hash, and process identity into the harness attestation
- pin the event mapping and selected-browser installation path with CI policy coverage

## Why

P13 intentionally deferred Firefox until the primary Chromium reproduction became deterministic. The released 0.9.0 graph is now healthy under that primary gate, so the deferred cross-browser cell can run without weakening or replacing the established acceptance signal.

## Validation

Local cheap gates:

- `cargo test --locked --test ci_config_tests` (286 passed, 1 ignored)
- documentation policy/script suites (5 passed)
- focused red-green P13 policy test
- JavaScript and Bash syntax checks, ShellCheck, Actionlint
- workflow hygiene, documentation consistency, Markdown lint, Cargo deny
- pre-commit and pre-push policy hooks

Exact-head GitHub evidence at `1403cb4`:

- all 12 applicable workflows passed; the two Dependabot automation runs were intentionally skipped
- Fortress WASM Interop run `29663770171` passed the real Chromium released-client and expected-busted control
- Advanced Safety run `29663770224` and CI run `29663770218` passed
- Cursor Bugbot found no issues; Copilot responded that the requesting user had exhausted review quota
- zero review threads remain

Firefox is selected only by scheduled and manually dispatched events, so its first full runtime evidence is intentionally separate from the Chromium-only pull-request event.