### PR TITLE
Refresh dependency hygiene without duplicating WebSocket stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Native reference clients can now coordinate bounded rebuilds of an
+  incomplete WebRTC pair before the P2P deadline, allowing homogeneous clients
+  to recover when packet loss leaves ICE connected but the SCTP data-channel
+  handshake stalled.
+
 - Refresh the compatible runtime, TLS, parser, and test-tool dependency set
   while keeping Axum and the WebSocket test client on one aligned Tungstenite
   version. Remove the redundant production declaration of the test-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Refresh the compatible runtime, TLS, parser, and test-tool dependency set
+  while keeping Axum and the WebSocket test client on one aligned Tungstenite
+  version. Remove the redundant production declaration of the test-only
+  `tokio-tungstenite` client. Restore the local full supply-chain audit on
+  current cargo-deny by passing its global feature option before the `check`
+  subcommand.
 - Extend the exact-release Fortress/Godot no-thread WASM interoperability gate
   with a weekly Firefox cell. Pull requests retain the deterministic Chromium
   gate, while the scheduled run applies the same healthy released-client and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2132,7 +2132,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2251,9 +2251,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2263,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2442,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2551,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "saphyr"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5bcc48916766e53689486df76c80ccf62a38f20d20b816056ff6ab84197cbd"
+checksum = "8acd6cfc4803660d26a3fb5bd8f5e47bc0eea5229f4d32f7cb4ee21a733e6961"
 dependencies = [
  "hashlink",
  "ordered-float",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "saphyr-parser"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbeae0f40b92f2afe16422744aabb145187167184cc18bf4d01da5acdc665f09"
+checksum = "ebfd783fcf1b3f6bafd557be0e1427ec54f826f513c3cdd749f9844484df2a13"
 dependencies = [
  "arraydeque",
  "thiserror",
@@ -2915,9 +2915,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3068,9 +3068,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
 dependencies = [
  "bytes",
  "libc",
@@ -3349,9 +3349,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
 dependencies = [
  "glob",
  "serde",
@@ -3480,9 +3480,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -3725,16 +3725,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3752,31 +3743,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3786,22 +3760,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3810,22 +3772,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3834,22 +3784,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3858,22 +3796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ tokio = { version = "1.52", features = [
 # Web framework
 axum = { version = "0.8", features = ["ws"] }
 tower-http = { version = "0.7", features = ["cors", "trace"] }
-tokio-tungstenite = "0.29"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -143,7 +142,7 @@ trybuild = "1.0"
 # actually parsing them, rather than approximating a parser with fragile quote/
 # indent heuristics. `default-features = false` drops the encoding_rs dependency
 # (UTF-8 input only), which is all the test fixtures and on-disk workflows need.
-saphyr = { version = "0.0.9", default-features = false }
+saphyr = { version = "0.0.11", default-features = false }
 
 [[bin]]
 name = "signal-fish-server"

--- a/clients/native/Cargo.lock
+++ b/clients/native/Cargo.lock
@@ -887,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2176,7 +2176,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2479,7 +2479,6 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -2663,7 +2662,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -62,6 +62,7 @@ Exactly one of `--create-room` / `--join-code` is required; everything else has 
 | `--disable-mdns` | off | Test harness only: expose raw host candidates instead of mDNS names so unicast packet-loss experiments do not fault their discovery control plane. Normal candidate privacy is unchanged when omitted |
 | `--drop-ice-from <N>` | — | Matrix-harness fault injection: drop inbound `IceCandidate` signals from the planned peer named `cNN`, while preserving offer/answer signaling, every other P2P edge, and the relay floor. The flag fails loudly if the ordinal does not resolve to exactly one planned peer |
 | `--p2p-timeout-secs <S>` | `15` | Window for WebRTC pair establishment before the overall transport status resolves |
+| `--p2p-retry-count <N>` | `0` | Bounded coordinated rebuilds for a planned pair whose data channels do not open. Both endpoints must support the reference client's `PairRetry` signal extension; homogeneous recovery tests opt in, while general interoperability stays matchbox-only |
 | `--run-for-secs <S>` | `30` | Soft cap: exit 1 if the flag-driven success criteria are still unmet |
 | `--max-runtime-secs <S>` | `60` | Hard watchdog: abort with exit 4 no matter what (the no-hang guarantee) |
 | `--success-release-file <PATH>` | — | Test harness only: after success criteria hold, emit `success_criteria_met` and stay connected until PATH exists; the normal bounded exit behavior is unchanged when omitted |
@@ -121,7 +122,7 @@ process continues to its normal bounded exit.
 | `game_starting` | `is_authority` | Lobby finalized (this client's own authority flag); never re-broadcast to late joiners |
 | `session_plan` | `topology`, `transport`, `host`, `peers[{player_id, initiate}]`, `ice_servers_count`, `fallback` | The full authoritative per-recipient v3 directive; Relay/Relay carries no peers |
 | `new_peer` | `peer_id`, `you_initiate` | Compatible incremental pairing directive (the universal server uses full plans) |
-| `signal_sent` | `to`, `kind` | Outbound `Signal` relayed (`kind` ∈ `offer`/`answer`/`ice_candidate`/`other`) |
+| `signal_sent` | `to`, `kind` | Outbound `Signal` relayed (`kind` ∈ `offer`/`answer`/`ice_candidate`/`pair_retry`/`other`) |
 | `signal_received` | `from`, `kind` | Inbound `Signal` arrived (emitted even when `--cripple-ice` then drops it) |
 | `ice_candidate_dropped` | `from` | Native-only `--drop-ice-from` discarded this peer's inbound candidate after `signal_received` made the signaling hop observable. The older shared `--cripple-ice` contract remains unchanged and does not emit this event |
 | `pc_state` | `peer`, `state` | RTCPeerConnection state transition (informational) |
@@ -173,6 +174,12 @@ string (interop with minimal clients).
 
 ## Transport-status semantics
 
+- Before status resolution, an incomplete pair is rebuilt at most
+  `--p2p-retry-count` times. A `PairRetry` marker crosses the same ordered
+  signaling relay before the fresh Offer, so both endpoints discard the old
+  generation while retaining the server-authored glare role. The default is
+  zero because this coordination extension is only safe when both endpoints
+  implement it; matchbox/browser interoperability must not assume that.
 - The overall WebRTC status resolves when every currently expected pair is connected or at
   `--p2p-timeout-secs`. `connected: true` iff **at least one** pair is connected; a zero-pair resolution also
   emits `fallback_engaged`.

--- a/clients/native/src/cli.rs
+++ b/clients/native/src/cli.rs
@@ -114,6 +114,13 @@ pub struct Cli {
     #[arg(long, default_value_t = 15)]
     pub p2p_timeout_secs: u64,
 
+    /// Maximum coordinated rebuilds for a planned pair whose data channels do
+    /// not open. Retries use the server's opaque Signal relay and preserve the
+    /// plan's glare role. Fault-injection tests that require a permanently
+    /// missing pair set this to 0.
+    #[arg(long, default_value_t = 0)]
+    pub p2p_retry_count: u8,
+
     /// Soft cap: exit nonzero if the flag-driven success criteria are still
     /// unmet after this many seconds.
     #[arg(long, default_value_t = 30)]
@@ -286,6 +293,7 @@ mod tests {
         assert_eq!(cli.runtime, RuntimeFlavor::Multi);
         assert_eq!(cli.runtime.as_str(), "multi");
         assert_eq!(cli.tick_stall_ms, 0, "fault injection is off by default");
+        assert_eq!(cli.p2p_retry_count, 0, "pair retry is opt-in");
         assert_eq!(cli.drop_ice_from, None);
         assert!(!cli.disable_mdns);
         assert_eq!(cli.success_release_file, None);

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -103,6 +103,15 @@ fn retryable_missing_peers(
         .collect()
 }
 
+fn note_current_pair_connected(
+    connected: &mut BTreeSet<PlayerId>,
+    reported: &mut BTreeSet<PlayerId>,
+    peer: PlayerId,
+) -> bool {
+    connected.insert(peer);
+    reported.insert(peer)
+}
+
 /// Keepalive cadence. `docs/guides/building-a-client.md` makes a periodic
 /// `Ping` mandatory for every client (the server evicts idle connections);
 /// this driver models that contract so anyone using it as a template
@@ -215,6 +224,7 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         pair_roles: BTreeMap::new(),
         pair_retry_attempts: BTreeMap::new(),
         connected_pairs: BTreeSet::new(),
+        pair_connected_reported: BTreeSet::new(),
         ice_gathering_complete: BTreeSet::new(),
         last_ice_servers: Vec::new(),
         transport_status: None,
@@ -627,9 +637,14 @@ struct Orchestrator<'a> {
     pair_roles: BTreeMap<PlayerId, bool>,
     /// Latest coordinated retry attempt applied per peer.
     pair_retry_attempts: BTreeMap<PlayerId, u8>,
-    /// Peers whose pair fully connected (both channels open) at some point.
-    /// Drives the `--exchange` obligations and the Appendix G resolution.
+    /// Peers whose current generation has both channels open. Drives the
+    /// `--exchange` obligations and Appendix G resolution.
     connected_pairs: BTreeSet<PlayerId>,
+    /// Peers whose logical `p2p_pair_connected` event was emitted for the
+    /// current room obligation. A coordinated rebuild clears current
+    /// connectivity but retains this set so the fresh generation is not
+    /// misreported as a second logical pair.
+    pair_connected_reported: BTreeSet<PlayerId>,
     /// Peers whose current connection generation emitted the terminal local
     /// ICE gathering callback. Harness-held success uses this as the exact
     /// outbound signal-ledger boundary.
@@ -1393,6 +1408,7 @@ impl Orchestrator<'_> {
                 });
                 if is_terminal_peer_connection_state(&state) {
                     self.connected_pairs.remove(&peer);
+                    self.pair_connected_reported.remove(&peer);
                     self.ice_gathering_complete.remove(&peer);
                     self.sent_labels.remove(&peer);
                     self.received_labels.remove(&peer);
@@ -1518,6 +1534,7 @@ impl Orchestrator<'_> {
             FatalError::protocol(format!("pair retry from unplanned peer {peer}"))
         })?;
         self.pair_retry_attempts.insert(peer, attempt);
+        self.connected_pairs.remove(&peer);
         self.ice_gathering_complete.remove(&peer);
         self.sent_labels.remove(&peer);
         self.received_labels.remove(&peer);
@@ -1564,6 +1581,7 @@ impl Orchestrator<'_> {
         self.pair_roles.remove(&peer);
         self.pair_retry_attempts.remove(&peer);
         self.connected_pairs.remove(&peer);
+        self.pair_connected_reported.remove(&peer);
         self.ice_gathering_complete.remove(&peer);
         self.peer_status_from.remove(&peer);
         self.sent_labels.remove(&peer);
@@ -1670,8 +1688,11 @@ impl Orchestrator<'_> {
     /// Both channels toward `peer` are open: emit the pair event, run the
     /// optional exchange, and check the all-pairs resolution condition.
     async fn on_pair_connected(&mut self, peer: PlayerId) -> Result<(), FatalError> {
-        let first_connection = self.connected_pairs.insert(peer);
-        if first_connection {
+        if note_current_pair_connected(
+            &mut self.connected_pairs,
+            &mut self.pair_connected_reported,
+            peer,
+        ) {
             emit(&Event::P2pPairConnected { peer });
         }
         if self.cli.exchange && self.exchange_released {
@@ -1997,9 +2018,9 @@ mod tests {
         authoritative_peer_delta, changed_transport_status, clear_departed_membership_plan,
         connection_targets_for_plan, consume_join_accountability_preface, harness_aware_base_wake,
         is_terminal_peer_connection_state, needs_ice_gathering_marker, negotiated_version_from,
-        next_handshake_message, p2p_retry_delay, require_finalized_membership_plan,
-        requires_authoritative_finalization_plan, resolve_drop_ice_from,
-        restore_reconnected_member, retryable_missing_peers,
+        next_handshake_message, note_current_pair_connected, p2p_retry_delay,
+        require_finalized_membership_plan, requires_authoritative_finalization_plan,
+        resolve_drop_ice_from, restore_reconnected_member, retryable_missing_peers,
         should_buffer_signal_for_unpaired_peer, should_defer_success_at_run_deadline,
         should_resolve_connected_pair, validate_json_negotiated_server_message,
         EXIT_PROTOCOL_ERROR,
@@ -2216,6 +2237,34 @@ mod tests {
             vec![retryable]
         );
         assert!(retryable_missing_peers(&expected, &connected_pairs, &attempts, 0).is_empty());
+    }
+
+    #[test]
+    fn retry_reconnects_current_pair_without_duplicate_logical_event() {
+        let peer = PlayerId::from_u128(2);
+        let mut connected = BTreeSet::new();
+        let mut reported = BTreeSet::new();
+        assert!(note_current_pair_connected(
+            &mut connected,
+            &mut reported,
+            peer
+        ));
+
+        connected.remove(&peer);
+        assert!(!note_current_pair_connected(
+            &mut connected,
+            &mut reported,
+            peer
+        ));
+        assert!(connected.contains(&peer));
+
+        connected.remove(&peer);
+        reported.remove(&peer);
+        assert!(note_current_pair_connected(
+            &mut connected,
+            &mut reported,
+            peer
+        ));
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -137,13 +137,11 @@ fn arm_pair_window(
     if !generation.arms_p2p_window() {
         return;
     }
-    let original_deadline = *deadline.get_or_insert(now + timeout);
-    if retry_count > 0 && retry_at.is_none() {
-        let candidate = now + p2p_retry_delay(timeout.as_secs());
-        if candidate < original_deadline {
-            *retry_at = Some(candidate);
-        }
-    }
+    let fresh_deadline = now + timeout;
+    *deadline = Some(fresh_deadline);
+    *retry_at = (retry_count > 0)
+        .then(|| now + p2p_retry_delay(timeout.as_secs()))
+        .filter(|candidate| *candidate < fresh_deadline);
 }
 
 /// Keepalive cadence. `docs/guides/building-a-client.md` makes a periodic
@@ -2338,7 +2336,7 @@ mod tests {
     }
 
     #[test]
-    fn retry_generation_preserves_the_original_p2p_window() {
+    fn retry_preserves_the_p2p_window_while_initial_pairing_refreshes_it() {
         assert!(PairGeneration::Initial.arms_p2p_window());
         assert!(!PairGeneration::Retry.arms_p2p_window());
 
@@ -2357,6 +2355,17 @@ mod tests {
         );
         assert_eq!(deadline, Some(original_deadline));
         assert_eq!(retry_at, Some(original_retry));
+
+        arm_pair_window(
+            &mut deadline,
+            &mut retry_at,
+            PairGeneration::Initial,
+            1,
+            Duration::from_secs(30),
+            started + Duration::from_secs(20),
+        );
+        assert_eq!(deadline, Some(started + Duration::from_secs(50)));
+        assert_eq!(retry_at, Some(started + Duration::from_secs(35)));
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -22,8 +22,11 @@
 //!    compatible servers), trickling ICE through `Signal`. The overall WebRTC
 //!    transport status resolves (Appendix G) when all expected pairs are
 //!    connected (a departure that removes the last unconnected expected pair
-//!    counts), or at `--p2p-timeout-secs` — `connected: true` iff at least
-//!    one pair is connected at that moment; a zero-pair resolution also emits
+//!    counts), or at `--p2p-timeout-secs`. Before that deadline, an incomplete
+//!    pair can get configured, bounded coordinated rebuilds so an
+//!    ICE-connected but stalled SCTP association cannot wedge forever. At
+//!    resolution, `connected: true`
+//!    iff at least one pair is connected at that moment; a zero-pair resolution also emits
 //!    `fallback_engaged`. Membership churn reports later real state changes;
 //!    unchanged states remain suppressed.
 //! 6. **Relay floor** — `GameData` keeps flowing over the WebSocket before,
@@ -78,6 +81,27 @@ const RELAY_SEND_SETTLE: Duration = Duration::from_millis(250);
 const EXIT_LINGER: Duration = Duration::from_millis(250);
 /// Poll cadence for an optional harness-controlled success release file.
 const SUCCESS_RELEASE_POLL: Duration = Duration::from_millis(100);
+
+/// Retry early enough to leave the original P2P window useful, while allowing
+/// ordinary ICE/DTLS/SCTP setup to settle first. The 15-second ceiling is also
+/// deliberately puts long-window retries beyond the nightly netem harness's
+/// 10-second loss window.
+fn p2p_retry_delay(p2p_timeout_secs: u64) -> Duration {
+    Duration::from_secs((p2p_timeout_secs / 2).clamp(1, 15))
+}
+
+fn retryable_missing_peers(
+    expected: &BTreeSet<PlayerId>,
+    connected: &BTreeSet<PlayerId>,
+    attempts: &BTreeMap<PlayerId, u8>,
+    retry_count: u8,
+) -> Vec<PlayerId> {
+    expected
+        .difference(connected)
+        .copied()
+        .filter(|peer| attempts.get(peer).copied().unwrap_or(0) < retry_count)
+        .collect()
+}
 
 /// Keepalive cadence. `docs/guides/building-a-client.md` makes a periodic
 /// `Ping` mandatory for every client (the server evicts idle connections);
@@ -188,11 +212,14 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         pending_membership_plans: BTreeMap::new(),
         webrtc_plan_seen: false,
         expected_peers: BTreeSet::new(),
+        pair_roles: BTreeMap::new(),
+        pair_retry_attempts: BTreeMap::new(),
         connected_pairs: BTreeSet::new(),
         ice_gathering_complete: BTreeSet::new(),
         last_ice_servers: Vec::new(),
         transport_status: None,
         p2p_deadline: None,
+        p2p_retry_at: None,
         // Late joiners arm the relay probe on entry (see RELAY_SEND_SETTLE):
         // the GameStarting trigger pre-dates the join and never re-fires.
         relay_send_at: (cli.relay_payload.is_some() && lobby_state == LobbyState::Finalized)
@@ -595,6 +622,11 @@ struct Orchestrator<'a> {
     webrtc_plan_seen: bool,
     /// Peers the authoritative plan names (plus compatible `NewPeer` deltas).
     expected_peers: BTreeSet<PlayerId>,
+    /// Server-authored glare role for each planned peer; retained so a
+    /// coordinated retry reproduces the same initiator/responder assignment.
+    pair_roles: BTreeMap<PlayerId, bool>,
+    /// Latest coordinated retry attempt applied per peer.
+    pair_retry_attempts: BTreeMap<PlayerId, u8>,
     /// Peers whose pair fully connected (both channels open) at some point.
     /// Drives the `--exchange` obligations and the Appendix G resolution.
     connected_pairs: BTreeSet<PlayerId>,
@@ -608,6 +640,8 @@ struct Orchestrator<'a> {
     transport_status: Option<bool>,
     /// When the P2P establishment window expires (set at first pairing).
     p2p_deadline: Option<Instant>,
+    /// When to rebuild any still-incomplete planned pair.
+    p2p_retry_at: Option<Instant>,
     /// When to send the `--relay-payload` GameData (trigger + settle; the
     /// trigger is GameStarting, or room entry for a Finalized-room late join).
     relay_send_at: Option<Instant>,
@@ -764,6 +798,9 @@ impl Orchestrator<'_> {
         if let Some(at) = self.p2p_deadline {
             wake = wake.min(at);
         }
+        if let Some(at) = self.p2p_retry_at {
+            wake = wake.min(at);
+        }
         if let Some(at) = self.linger_until {
             wake = wake.min(at);
         }
@@ -816,6 +853,10 @@ impl Orchestrator<'_> {
 
         if !self.relay_sent && self.relay_send_at.is_some_and(|at| now >= at) {
             self.send_relay_payload().await?;
+        }
+
+        if self.p2p_retry_at.is_some_and(|at| now >= at) {
+            self.retry_incomplete_pairs(now).await?;
         }
 
         if self.p2p_deadline.is_some_and(|at| now >= at) {
@@ -1136,6 +1177,9 @@ impl Orchestrator<'_> {
                     self.remove_pair_obligation(peer).await;
                 }
                 for peer in &plan.peers {
+                    if plan.transport == Transport::WebRtc && peer.player_id != self.my_id {
+                        self.pair_roles.insert(peer.player_id, peer.initiate);
+                    }
                     if plan.transport == Transport::WebRtc && added.remove(&peer.player_id) {
                         self.establish_pair(peer.player_id, peer.initiate).await?;
                     }
@@ -1159,6 +1203,7 @@ impl Orchestrator<'_> {
                     you_initiate,
                 });
                 // Same pairing path as a plan peer (late join, Appendix E).
+                self.pair_roles.insert(peer_id, you_initiate);
                 self.establish_pair(peer_id, you_initiate).await?;
             }
             ServerMessage::Signal { from, signal } => {
@@ -1390,6 +1435,23 @@ impl Orchestrator<'_> {
     /// Pair with `peer` per the server's directive: create the connection,
     /// offer when told to, then drain any defensively buffered signals.
     async fn establish_pair(&mut self, peer: PlayerId, initiate: bool) -> Result<(), FatalError> {
+        self.establish_pair_link(peer, initiate).await?;
+        if let Some(buffered) = self.pending_signals.remove(&peer) {
+            for signal in buffered {
+                self.apply_signal(peer, signal).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Create one link generation without recursively draining signals. Retry
+    /// handling calls this after clearing the old generation; normal pairing
+    /// uses [`Self::establish_pair`] to add the defensive signal drain.
+    async fn establish_pair_link(
+        &mut self,
+        peer: PlayerId,
+        initiate: bool,
+    ) -> Result<(), FatalError> {
         if peer == self.my_id {
             tracing::warn!(%peer, "server asked us to pair with ourselves; ignoring");
             return Ok(());
@@ -1409,7 +1471,12 @@ impl Orchestrator<'_> {
         if (newly_expected || needs_connection) && !self.connected_pairs.contains(&peer) {
             self.p2p_deadline =
                 Some(Instant::now() + Duration::from_secs(self.cli.p2p_timeout_secs));
+            if self.cli.p2p_retry_count > 0 && self.p2p_retry_at.is_none() {
+                self.p2p_retry_at =
+                    Some(Instant::now() + p2p_retry_delay(self.cli.p2p_timeout_secs));
+            }
         }
+        self.pair_roles.entry(peer).or_insert(initiate);
         let ice_servers = self.last_ice_servers.clone();
         match self.engine.pair_with(peer, initiate, &ice_servers).await {
             Ok(Some(offer_sdp)) => {
@@ -1425,16 +1492,77 @@ impl Orchestrator<'_> {
                 });
             }
         }
-        if let Some(buffered) = self.pending_signals.remove(&peer) {
-            for signal in buffered {
-                self.apply_signal(peer, signal).await?;
-            }
+        Ok(())
+    }
+
+    /// Ask the peer to rebuild the same planned link, then rebuild locally.
+    /// The marker is sent first; the server preserves per-sender FIFO, so a
+    /// responder processes it and installs its fresh peer connection before
+    /// the initiator's new Offer arrives.
+    async fn request_pair_retry(&mut self, peer: PlayerId, attempt: u8) -> Result<(), FatalError> {
+        self.send_signal(peer, SignalKind::PairRetry, json!({ "PairRetry": attempt }))
+            .await?;
+        self.rebuild_pair(peer, attempt).await
+    }
+
+    /// Apply a local or remote retry exactly once per attempt number.
+    async fn rebuild_pair(&mut self, peer: PlayerId, attempt: u8) -> Result<(), FatalError> {
+        if self
+            .pair_retry_attempts
+            .get(&peer)
+            .is_some_and(|current| *current >= attempt)
+        {
+            return Ok(());
         }
+        let initiate = *self.pair_roles.get(&peer).ok_or_else(|| {
+            FatalError::protocol(format!("pair retry from unplanned peer {peer}"))
+        })?;
+        self.pair_retry_attempts.insert(peer, attempt);
+        self.ice_gathering_complete.remove(&peer);
+        self.sent_labels.remove(&peer);
+        self.received_labels.remove(&peer);
+        self.pending_signals.remove(&peer);
+        self.engine.remove_peer(peer).await.map_err(|error| {
+            FatalError::connection(format!(
+                "close incomplete peer connection {peer}: {error:#}"
+            ))
+        })?;
+        self.establish_pair_link(peer, initiate).await
+    }
+
+    async fn retry_incomplete_pairs(&mut self, now: Instant) -> Result<(), FatalError> {
+        self.p2p_retry_at = None;
+        let retryable = retryable_missing_peers(
+            &self.expected_peers,
+            &self.connected_pairs,
+            &self.pair_retry_attempts,
+            self.cli.p2p_retry_count,
+        );
+        for peer in retryable {
+            let attempt = self
+                .pair_retry_attempts
+                .get(&peer)
+                .copied()
+                .unwrap_or(0)
+                .saturating_add(1);
+            self.request_pair_retry(peer, attempt).await?;
+        }
+        let another_retry_possible = !retryable_missing_peers(
+            &self.expected_peers,
+            &self.connected_pairs,
+            &self.pair_retry_attempts,
+            self.cli.p2p_retry_count,
+        )
+        .is_empty();
+        self.p2p_retry_at =
+            another_retry_possible.then(|| now + p2p_retry_delay(self.cli.p2p_timeout_secs));
         Ok(())
     }
 
     async fn remove_pair_obligation(&mut self, peer: PlayerId) {
         self.expected_peers.remove(&peer);
+        self.pair_roles.remove(&peer);
+        self.pair_retry_attempts.remove(&peer);
         self.connected_pairs.remove(&peer);
         self.ice_gathering_complete.remove(&peer);
         self.peer_status_from.remove(&peer);
@@ -1455,6 +1583,9 @@ impl Orchestrator<'_> {
     ) -> Result<(), FatalError> {
         let kind = SignalKind::classify(&signal);
         emit(&Event::SignalReceived { from, kind });
+        if kind == SignalKind::PairRetry {
+            return self.apply_signal(from, signal).await;
+        }
         if !self.engine.is_paired(from) {
             if should_buffer_signal_for_unpaired_peer(&self.expected_peers, from) {
                 self.pending_signals
@@ -1510,6 +1641,20 @@ impl Orchestrator<'_> {
                     }
                 }
             }
+            SignalKind::PairRetry => match signal.get("PairRetry").and_then(|value| value.as_u64())
+            {
+                Some(attempt) if attempt > 0 && attempt <= u64::from(self.cli.p2p_retry_count) => {
+                    self.rebuild_pair(from, attempt as u8)
+                        .await
+                        .map_err(|error| anyhow::anyhow!(error.message))
+                }
+                Some(attempt) => Err(anyhow::anyhow!(
+                    "PairRetry attempt {attempt} is outside the configured retry budget"
+                )),
+                None => Err(anyhow::anyhow!(
+                    "PairRetry payload is not a positive integer"
+                )),
+            },
             SignalKind::Other => Err(anyhow::anyhow!(
                 "signal does not match the matchbox PeerSignal convention"
             )),
@@ -1525,8 +1670,10 @@ impl Orchestrator<'_> {
     /// Both channels toward `peer` are open: emit the pair event, run the
     /// optional exchange, and check the all-pairs resolution condition.
     async fn on_pair_connected(&mut self, peer: PlayerId) -> Result<(), FatalError> {
-        self.connected_pairs.insert(peer);
-        emit(&Event::P2pPairConnected { peer });
+        let first_connection = self.connected_pairs.insert(peer);
+        if first_connection {
+            emit(&Event::P2pPairConnected { peer });
+        }
         if self.cli.exchange && self.exchange_released {
             self.send_exchange(peer).await?;
         }
@@ -1534,6 +1681,9 @@ impl Orchestrator<'_> {
         // one late pair is enough to change the overall any-pair state.
         if should_resolve_connected_pair(self.transport_status, self.all_expected_pairs_connected())
         {
+            if self.all_expected_pairs_connected() {
+                self.p2p_retry_at = None;
+            }
             self.resolve_transport_status().await?;
         }
         Ok(())
@@ -1832,6 +1982,8 @@ fn harness_aware_base_wake(
 mod tests {
     use std::collections::{BTreeMap, BTreeSet};
 
+    use tokio::time::Duration;
+
     use serde_json::json;
     use signal_fish_server::protocol::{
         DeliveryCountersByClass, DeliveryReportPayload, GameDataEncoding, LobbyState, PlayerId,
@@ -1845,11 +1997,12 @@ mod tests {
         authoritative_peer_delta, changed_transport_status, clear_departed_membership_plan,
         connection_targets_for_plan, consume_join_accountability_preface, harness_aware_base_wake,
         is_terminal_peer_connection_state, needs_ice_gathering_marker, negotiated_version_from,
-        next_handshake_message, require_finalized_membership_plan,
+        next_handshake_message, p2p_retry_delay, require_finalized_membership_plan,
         requires_authoritative_finalization_plan, resolve_drop_ice_from,
-        restore_reconnected_member, should_buffer_signal_for_unpaired_peer,
-        should_defer_success_at_run_deadline, should_resolve_connected_pair,
-        validate_json_negotiated_server_message, EXIT_PROTOCOL_ERROR,
+        restore_reconnected_member, retryable_missing_peers,
+        should_buffer_signal_for_unpaired_peer, should_defer_success_at_run_deadline,
+        should_resolve_connected_pair, validate_json_negotiated_server_message,
+        EXIT_PROTOCOL_ERROR,
     };
     use tokio_tungstenite::tungstenite::{Bytes, Message};
     use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
@@ -2041,6 +2194,28 @@ mod tests {
             &BTreeSet::from([peer]),
             peer
         ));
+    }
+
+    #[test]
+    fn pair_retry_delay_is_early_and_bounded() {
+        assert_eq!(p2p_retry_delay(1), Duration::from_secs(1));
+        assert_eq!(p2p_retry_delay(15), Duration::from_secs(7));
+        assert_eq!(p2p_retry_delay(180), Duration::from_secs(15));
+    }
+
+    #[test]
+    fn pair_retry_targets_only_missing_peers_with_budget() {
+        let connected = PlayerId::from_u128(2);
+        let exhausted = PlayerId::from_u128(3);
+        let retryable = PlayerId::from_u128(4);
+        let expected = BTreeSet::from([connected, exhausted, retryable]);
+        let connected_pairs = BTreeSet::from([connected]);
+        let attempts = BTreeMap::from([(exhausted, 1)]);
+        assert_eq!(
+            retryable_missing_peers(&expected, &connected_pairs, &attempts, 1),
+            vec![retryable]
+        );
+        assert!(retryable_missing_peers(&expected, &connected_pairs, &attempts, 0).is_empty());
     }
 
     #[test]

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -106,10 +106,44 @@ fn retryable_missing_peers(
 fn note_current_pair_connected(
     connected: &mut BTreeSet<PlayerId>,
     reported: &mut BTreeSet<PlayerId>,
+    retrying: &mut BTreeSet<PlayerId>,
     peer: PlayerId,
 ) -> bool {
     connected.insert(peer);
+    retrying.remove(&peer);
     reported.insert(peer)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PairGeneration {
+    Initial,
+    Retry,
+}
+
+impl PairGeneration {
+    fn arms_p2p_window(self) -> bool {
+        self == Self::Initial
+    }
+}
+
+fn arm_pair_window(
+    deadline: &mut Option<Instant>,
+    retry_at: &mut Option<Instant>,
+    generation: PairGeneration,
+    retry_count: u8,
+    timeout: Duration,
+    now: Instant,
+) {
+    if !generation.arms_p2p_window() {
+        return;
+    }
+    let original_deadline = *deadline.get_or_insert(now + timeout);
+    if retry_count > 0 && retry_at.is_none() {
+        let candidate = now + p2p_retry_delay(timeout.as_secs());
+        if candidate < original_deadline {
+            *retry_at = Some(candidate);
+        }
+    }
 }
 
 /// Keepalive cadence. `docs/guides/building-a-client.md` makes a periodic
@@ -225,6 +259,7 @@ async fn run_inner(cli: &Cli) -> Result<i32, FatalError> {
         pair_retry_attempts: BTreeMap::new(),
         connected_pairs: BTreeSet::new(),
         pair_connected_reported: BTreeSet::new(),
+        retrying_pairs: BTreeSet::new(),
         ice_gathering_complete: BTreeSet::new(),
         last_ice_servers: Vec::new(),
         transport_status: None,
@@ -645,6 +680,11 @@ struct Orchestrator<'a> {
     /// connectivity but retains this set so the fresh generation is not
     /// misreported as a second logical pair.
     pair_connected_reported: BTreeSet<PlayerId>,
+    /// Peers whose previous generation was discarded for a coordinated retry
+    /// and whose replacement is not connected yet. This blocks success during
+    /// the reconnect gap without turning partial-connectivity fallback into an
+    /// all-pairs requirement after the original P2P window expires.
+    retrying_pairs: BTreeSet<PlayerId>,
     /// Peers whose current connection generation emitted the terminal local
     /// ICE gathering callback. Harness-held success uses this as the exact
     /// outbound signal-ledger boundary.
@@ -878,6 +918,8 @@ impl Orchestrator<'_> {
             // The current P2P window expired: report any real state change.
             self.resolve_transport_status().await?;
             self.p2p_deadline = None;
+            self.p2p_retry_at = None;
+            self.retrying_pairs.clear();
         }
 
         self.process_exchange_gate(now).await?;
@@ -1451,7 +1493,8 @@ impl Orchestrator<'_> {
     /// Pair with `peer` per the server's directive: create the connection,
     /// offer when told to, then drain any defensively buffered signals.
     async fn establish_pair(&mut self, peer: PlayerId, initiate: bool) -> Result<(), FatalError> {
-        self.establish_pair_link(peer, initiate).await?;
+        self.establish_pair_link(peer, initiate, PairGeneration::Initial)
+            .await?;
         if let Some(buffered) = self.pending_signals.remove(&peer) {
             for signal in buffered {
                 self.apply_signal(peer, signal).await?;
@@ -1467,6 +1510,7 @@ impl Orchestrator<'_> {
         &mut self,
         peer: PlayerId,
         initiate: bool,
+        generation: PairGeneration,
     ) -> Result<(), FatalError> {
         if peer == self.my_id {
             tracing::warn!(%peer, "server asked us to pair with ourselves; ignoring");
@@ -1484,13 +1528,18 @@ impl Orchestrator<'_> {
         if needs_connection {
             self.ice_gathering_complete.remove(&peer);
         }
-        if (newly_expected || needs_connection) && !self.connected_pairs.contains(&peer) {
-            self.p2p_deadline =
-                Some(Instant::now() + Duration::from_secs(self.cli.p2p_timeout_secs));
-            if self.cli.p2p_retry_count > 0 && self.p2p_retry_at.is_none() {
-                self.p2p_retry_at =
-                    Some(Instant::now() + p2p_retry_delay(self.cli.p2p_timeout_secs));
-            }
+        if generation.arms_p2p_window()
+            && (newly_expected || needs_connection)
+            && !self.connected_pairs.contains(&peer)
+        {
+            arm_pair_window(
+                &mut self.p2p_deadline,
+                &mut self.p2p_retry_at,
+                generation,
+                self.cli.p2p_retry_count,
+                Duration::from_secs(self.cli.p2p_timeout_secs),
+                Instant::now(),
+            );
         }
         self.pair_roles.entry(peer).or_insert(initiate);
         let ice_servers = self.last_ice_servers.clone();
@@ -1530,10 +1579,15 @@ impl Orchestrator<'_> {
         {
             return Ok(());
         }
+        if self.p2p_deadline.is_none() {
+            tracing::debug!(%peer, attempt, "ignoring pair retry after the original P2P window");
+            return Ok(());
+        }
         let initiate = *self.pair_roles.get(&peer).ok_or_else(|| {
             FatalError::protocol(format!("pair retry from unplanned peer {peer}"))
         })?;
         self.pair_retry_attempts.insert(peer, attempt);
+        self.retrying_pairs.insert(peer);
         self.connected_pairs.remove(&peer);
         self.ice_gathering_complete.remove(&peer);
         self.sent_labels.remove(&peer);
@@ -1544,7 +1598,11 @@ impl Orchestrator<'_> {
                 "close incomplete peer connection {peer}: {error:#}"
             ))
         })?;
-        self.establish_pair_link(peer, initiate).await
+        if self.webrtc_plan_seen && self.transport_status.is_some() {
+            self.resolve_transport_status().await?;
+        }
+        self.establish_pair_link(peer, initiate, PairGeneration::Retry)
+            .await
     }
 
     async fn retry_incomplete_pairs(&mut self, now: Instant) -> Result<(), FatalError> {
@@ -1582,6 +1640,7 @@ impl Orchestrator<'_> {
         self.pair_retry_attempts.remove(&peer);
         self.connected_pairs.remove(&peer);
         self.pair_connected_reported.remove(&peer);
+        self.retrying_pairs.remove(&peer);
         self.ice_gathering_complete.remove(&peer);
         self.peer_status_from.remove(&peer);
         self.sent_labels.remove(&peer);
@@ -1691,6 +1750,7 @@ impl Orchestrator<'_> {
         if note_current_pair_connected(
             &mut self.connected_pairs,
             &mut self.pair_connected_reported,
+            &mut self.retrying_pairs,
             peer,
         ) {
             emit(&Event::P2pPairConnected { peer });
@@ -1851,6 +1911,9 @@ impl Orchestrator<'_> {
             ));
         }
         if self.webrtc_session_expected() {
+            for peer in &self.retrying_pairs {
+                unmet.push(format!("pair retry in progress for {peer}"));
+            }
             if self.transport_status.is_none() {
                 unmet.push("transport status not resolved".to_string());
             }
@@ -2015,14 +2078,15 @@ mod tests {
     use crate::wire;
 
     use super::{
-        authoritative_peer_delta, changed_transport_status, clear_departed_membership_plan,
-        connection_targets_for_plan, consume_join_accountability_preface, harness_aware_base_wake,
+        arm_pair_window, authoritative_peer_delta, changed_transport_status,
+        clear_departed_membership_plan, connection_targets_for_plan,
+        consume_join_accountability_preface, harness_aware_base_wake,
         is_terminal_peer_connection_state, needs_ice_gathering_marker, negotiated_version_from,
         next_handshake_message, note_current_pair_connected, p2p_retry_delay,
         require_finalized_membership_plan, requires_authoritative_finalization_plan,
         resolve_drop_ice_from, restore_reconnected_member, retryable_missing_peers,
         should_buffer_signal_for_unpaired_peer, should_defer_success_at_run_deadline,
-        should_resolve_connected_pair, validate_json_negotiated_server_message,
+        should_resolve_connected_pair, validate_json_negotiated_server_message, PairGeneration,
         EXIT_PROTOCOL_ERROR,
     };
     use tokio_tungstenite::tungstenite::{Bytes, Message};
@@ -2244,27 +2308,55 @@ mod tests {
         let peer = PlayerId::from_u128(2);
         let mut connected = BTreeSet::new();
         let mut reported = BTreeSet::new();
+        let mut retrying = BTreeSet::new();
         assert!(note_current_pair_connected(
             &mut connected,
             &mut reported,
+            &mut retrying,
             peer
         ));
 
         connected.remove(&peer);
+        retrying.insert(peer);
         assert!(!note_current_pair_connected(
             &mut connected,
             &mut reported,
+            &mut retrying,
             peer
         ));
         assert!(connected.contains(&peer));
+        assert!(retrying.is_empty());
 
         connected.remove(&peer);
         reported.remove(&peer);
         assert!(note_current_pair_connected(
             &mut connected,
             &mut reported,
+            &mut retrying,
             peer
         ));
+    }
+
+    #[test]
+    fn retry_generation_preserves_the_original_p2p_window() {
+        assert!(PairGeneration::Initial.arms_p2p_window());
+        assert!(!PairGeneration::Retry.arms_p2p_window());
+
+        let started = tokio::time::Instant::now();
+        let original_deadline = started + Duration::from_secs(30);
+        let original_retry = started + Duration::from_secs(15);
+        let mut deadline = Some(original_deadline);
+        let mut retry_at = Some(original_retry);
+        arm_pair_window(
+            &mut deadline,
+            &mut retry_at,
+            PairGeneration::Retry,
+            1,
+            Duration::from_secs(30),
+            started + Duration::from_secs(10),
+        );
+        assert_eq!(deadline, Some(original_deadline));
+        assert_eq!(retry_at, Some(original_retry));
     }
 
     #[test]

--- a/clients/native/src/events.rs
+++ b/clients/native/src/events.rs
@@ -129,6 +129,8 @@ pub enum SignalKind {
     Offer,
     Answer,
     IceCandidate,
+    /// Reference-client coordination for rebuilding an incomplete pair.
+    PairRetry,
     /// Anything not matching the matchbox `PeerSignal` convention.
     Other,
 }
@@ -146,6 +148,7 @@ impl SignalKind {
             Some("Offer") => Self::Offer,
             Some("Answer") => Self::Answer,
             Some("IceCandidate") => Self::IceCandidate,
+            Some("PairRetry") => Self::PairRetry,
             _ => Self::Other,
         }
     }
@@ -347,6 +350,10 @@ mod tests {
         assert_eq!(
             SignalKind::classify(&json!({"IceCandidate": "x"})),
             SignalKind::IceCandidate
+        );
+        assert_eq!(
+            SignalKind::classify(&json!({"PairRetry": 1})),
+            SignalKind::PairRetry
         );
         assert_eq!(SignalKind::classify(&json!("Offer")), SignalKind::Other);
         assert_eq!(

--- a/clients/native/tests/browser_interop_e2e.rs
+++ b/clients/native/tests/browser_interop_e2e.rs
@@ -756,7 +756,7 @@ async fn mesh_n3_browser_crippled_ice_fallback() {
     // deadline — the healthy native pair with one connected pair (>= 1 rule
     // => true), the crippled browser with zero (=> false + fallback). 6 s
     // comfortably covers the healthy pair's loopback establishment.
-    const HEALTHY_ARGS: &[&str] = &["--p2p-timeout-secs", "6"];
+    const HEALTHY_ARGS: &[&str] = &["--p2p-timeout-secs", "6", "--p2p-retry-count", "0"];
     const CRIPPLED_ARGS: &[&str] = &["--p2p-timeout-secs", "6", "--cripple-ice"];
     let run = run_three_clients(
         "mesh",

--- a/clients/native/tests/interop_e2e.rs
+++ b/clients/native/tests/interop_e2e.rs
@@ -706,8 +706,14 @@ async fn mesh_n3_partial_ice_cripple_relay_fallback() {
     // one connected pair (>= 1 rule => true), the crippled member with zero
     // (=> false + fallback). 6 s comfortably covers the healthy pair's
     // loopback establishment.
-    const HEALTHY_ARGS: &[&str] = &["--p2p-timeout-secs", "6"];
-    const CRIPPLED_ARGS: &[&str] = &["--p2p-timeout-secs", "6", "--cripple-ice"];
+    const HEALTHY_ARGS: &[&str] = &["--p2p-timeout-secs", "6", "--p2p-retry-count", "0"];
+    const CRIPPLED_ARGS: &[&str] = &[
+        "--p2p-timeout-secs",
+        "6",
+        "--p2p-retry-count",
+        "0",
+        "--cripple-ice",
+    ];
     let run = run_three_clients(
         "mesh",
         "interop-fallback3",

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -42,4 +42,13 @@ the direct test client.
 - ShellCheck, Bash syntax, CI config, documentation consistency, and workflow
   hygiene
 
+## CI follow-up
+
+The first exact-head WebRTC Interop run failed at its fast lockfile precheck,
+before compilation: removing the root package's normal `tokio-tungstenite`
+dependency changed the path package metadata recorded in
+`clients/native/Cargo.lock`. Regenerating that fixture lock removed the stale
+edge. A repository-wide `cargo metadata --locked --no-deps` sweep then passed
+for the root, native, Fortress native, Fortress WASM, and fuzz manifests.
+
 Exact-head CI and reviewer evidence remain pending publication.

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -94,9 +94,11 @@ state; scenarios without coordinated retry retain their exact one-report rule.
 
 A delayed Bugbot result on that head identified two further generation edges.
 The channel oracle now permits one additional open/exchange generation only
-for each observed retry marker on that exact peer while retaining the required
-final generation and exact event schema. Separately, a genuinely new initial
-pairing refreshes its full establishment/retry window; only
+for a peer with an observed retry marker while retaining the required final
+generation and exact event schema. Sent and received copies of the same
+attempt collapse to that one-peer fact, matching the client's attempt-number
+deduplication and the matrix's one-retry budget. Separately, a genuinely new
+initial pairing refreshes its full establishment/retry window; only
 `PairGeneration::Retry` preserves the existing deadline. The timer regression
 covers both policies so preventing retry extension cannot shorten a later
 `NewPeer` or authoritative-plan addition.

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -51,4 +51,17 @@ dependency changed the path package metadata recorded in
 edge. A repository-wide `cargo metadata --locked --no-deps` sweep then passed
 for the root, native, Fortress native, Fortress WASM, and fuzz manifests.
 
-Exact-head CI and reviewer evidence remain pending publication.
+The implementation head `93971e637a63db1e63ec0afac98593cbe078a7c1`
+then passed all 12 applicable pull-request workflows; the only non-success was
+the intentional Dependabot auto-merge skip. Verification Nightly's first
+attempt exposed a stochastic 1%-loss WebRTC N=8 mesh miss: 27 of 28 peer links
+formed, one SCTP INIT/ACK exchange did not recover, and the test failed loudly
+at its 360-second deadline. The isolated job retry passed without a source
+change, alongside green clean/loss matrices, WebRTC/Browser/Fortress interop,
+cross-platform nextest and lint, coverage, MSRV, Miri, AddressSanitizer, audit,
+SBOM, and documentation checks.
+
+Cursor Bugbot found no new issues on the exact implementation head. Copilot
+was explicitly requested after each push but reported that the requester quota
+was exhausted. No inline review threads were opened. PR:
+<https://github.com/Ambiguous-Interactive/signal-fish-server/pull/191>.

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -52,16 +52,32 @@ edge. A repository-wide `cargo metadata --locked --no-deps` sweep then passed
 for the root, native, Fortress native, Fortress WASM, and fuzz manifests.
 
 The implementation head `93971e637a63db1e63ec0afac98593cbe078a7c1`
-then passed all 12 applicable pull-request workflows; the only non-success was
-the intentional Dependabot auto-merge skip. Verification Nightly's first
-attempt exposed a stochastic 1%-loss WebRTC N=8 mesh miss: 27 of 28 peer links
-formed, one SCTP INIT/ACK exchange did not recover, and the test failed loudly
-at its 360-second deadline. The isolated job retry passed without a source
-change, alongside green clean/loss matrices, WebRTC/Browser/Fortress interop,
-cross-platform nextest and lint, coverage, MSRV, Miri, AddressSanitizer, audit,
-SBOM, and documentation checks.
+then passed all 12 applicable pull-request workflows after an isolated retry;
+the only non-success was the intentional Dependabot auto-merge skip. The first
+Verification Nightly attempt had exposed a 1%-loss WebRTC N=8 mesh miss: 27 of
+28 peer links formed, one SCTP INIT/ACK exchange did not recover, and the test
+failed loudly at its 360-second deadline.
 
-Cursor Bugbot found no new issues on the exact implementation head. Copilot
-was explicitly requested after each push but reported that the requester quota
-was exhausted. No inline review threads were opened. PR:
+The documentation-only head reproduced that same failure with a different
+client. That recurrence proved the earlier retry was not sufficient evidence:
+ICE remains `connected` when webrtc-rs exhausts the SCTP INIT/ACK handshake, so
+the reference client receives no terminal peer-connection state and never
+rebuilds the wedged link. The follow-up closes that class with one bounded,
+coordinated pair rebuild before the P2P deadline. A `PairRetry` marker crosses
+the server's ordered opaque signaling relay before the fresh Offer; both sides
+discard the old engine generation and retain the server-authored glare role.
+Retry attempts are generation-deduplicated and budgeted, connected peers do
+not emit duplicate logical pair events, and deliberate crippled/pair-partition
+negative controls explicitly disable retries. The extension is opt-in because
+non-reference peers do not negotiate `PairRetry`; the homogeneous netem matrix
+enables one attempt without changing general matchbox/browser interop.
+
+Local follow-up verification passed 57 native-client unit tests, native
+Clippy with warnings denied, both root/native formatting checks, and the root
+WebRTC matrix compile. The healthy native N=3 mesh scenario and the intentional
+crippled-ICE relay-fallback negative control both pass as real multi-process
+runs. The matrix's signal oracle still requires every sent signal to arrive
+exactly once and every Offer to have exactly one Answer, including retry
+generations. Cursor Bugbot found no issues on the pre-fix heads; Copilot was
+explicitly requested after each push but reported quota exhaustion. PR:
 <https://github.com/Ambiguous-Interactive/signal-fish-server/pull/191>.

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -72,7 +72,15 @@ negative controls explicitly disable retries. The extension is opt-in because
 non-reference peers do not negotiate `PairRetry`; the homogeneous netem matrix
 enables one attempt without changing general matchbox/browser interop.
 
-Local follow-up verification passed 57 native-client unit tests, native
+Cursor Bugbot then caught an asymmetric-open bookkeeping gap in the first
+retry implementation: the receiver could close a live generation while the
+logical `connected_pairs` set still counted it. Current connectivity and the
+one-per-obligation public pair event are now separate. A rebuild clears current
+connectivity and exchange state; the fresh generation restores it without a
+duplicate `p2p_pair_connected` event. Genuine terminal/removal paths clear
+both sets, and a focused state-transition regression covers all three edges.
+
+Local follow-up verification passed 58 native-client unit tests, native
 Clippy with warnings denied, both root/native formatting checks, and the root
 WebRTC matrix compile. The healthy native N=3 mesh scenario and the intentional
 crippled-ICE relay-fallback negative control both pass as real multi-process

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -1,0 +1,45 @@
+# Session 060 — P14 dependency hygiene
+
+## Trigger
+
+Dependabot PR #179 was the repository's only live maintenance work, but its
+base was ten commits behind `main` and its `tokio-tungstenite` 0.29→0.30 bump
+would create two WebSocket stacks. Axum 0.8.9 still resolves
+`tokio-tungstenite` and `tungstenite` 0.29, while 0.30 would be used only by
+the direct test client.
+
+## Change
+
+- Refreshed Tokio 1.52.3→1.52.4, UUID 1.23.4→1.24.0, Clap 4.6.1→4.6.2,
+  Rustls 0.23.41→0.23.42, Regex 1.13.0→1.13.1, Syn 2.0.118→2.0.119,
+  Trybuild 1.0.117→1.0.118, and Saphyr 0.0.9→0.0.11.
+- Removed `tokio-tungstenite` from normal dependencies because production code
+  uses Axum's WebSocket surface; the direct raw client is test-only and remains
+  a dev dependency.
+- Deliberately retained `tokio-tungstenite` 0.29 so the server and tests share
+  one Tungstenite implementation. The 0.30 upgrade remains deferred until the
+  server framework can move in lockstep.
+- The refreshed resolver also removed the otherwise-unused `windows-sys` 0.60
+  family; Quinn's compatible Windows target now shares the existing 0.52
+  family instead of retaining a third Windows bindings generation.
+- The required full local supply-chain audit exposed a same-class tooling bug:
+  `check-advisories.sh` placed cargo-deny's global `--all-features` option after
+  the `check` subcommand, which cargo-deny 0.20.2 rejects. The invocation is now
+  ordered correctly and the CI policy suite rejects the invalid form.
+
+## Verification
+
+- `cargo check --locked --all-features`
+- targeted Clippy for `ci_config_tests` with warnings denied
+- data-driven Saphyr validator behavior plus every live workflow parsed
+- exact server-Ping/Pong WebSocket regression
+- cargo metadata MSRV audit: all eight refreshed crates declare Rust 1.85 or
+  lower against the project's Rust 1.89 floor
+- `cargo tree`: one `tokio-tungstenite`/`tungstenite` version, with the root's
+  direct dependency classified `dev`
+- `scripts/check-advisories.sh --full`: no RustSec advisories; bans, licenses,
+  and sources all pass
+- ShellCheck, Bash syntax, CI config, documentation consistency, and workflow
+  hygiene
+
+Exact-head CI and reviewer evidence remain pending publication.

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -92,6 +92,15 @@ and the initial-versus-retry deadline policy. The netem oracle accepts only
 deduplicated real transport transitions and still requires the final expected
 state; scenarios without coordinated retry retain their exact one-report rule.
 
+A delayed Bugbot result on that head identified two further generation edges.
+The channel oracle now permits one additional open/exchange generation only
+for each observed retry marker on that exact peer while retaining the required
+final generation and exact event schema. Separately, a genuinely new initial
+pairing refreshes its full establishment/retry window; only
+`PairGeneration::Retry` preserves the existing deadline. The timer regression
+covers both policies so preventing retry extension cannot shorten a later
+`NewPeer` or authoritative-plan addition.
+
 The otherwise-green exact head then exposed the two equivalent Windows
 surfaces of a connection-reset race in the directional-partition oracle. The
 test already allowed raw `Io(ConnectionReset)` after observing the

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -92,6 +92,15 @@ and the initial-versus-retry deadline policy. The netem oracle accepts only
 deduplicated real transport transitions and still requires the final expected
 state; scenarios without coordinated retry retain their exact one-report rule.
 
+The otherwise-green exact head then exposed the two equivalent Windows
+surfaces of a connection-reset race in the directional-partition oracle. The
+test already allowed raw `Io(ConnectionReset)` after observing the
+authoritative server cause metric, but Tungstenite can wrap that same reset as
+`Protocol(ResetWithoutClosingHandshake)` before surfacing the forwarded close
+frame. The shared classifier now recognizes both forms, rejects unrelated I/O
+errors, and has a focused data-driven regression; the semantic server-cause
+and healed-room proofs remain mandatory.
+
 Local follow-up verification passed 59 native-client unit tests, native
 Clippy with warnings denied, both root/native formatting checks, and the root
 WebRTC matrix compile. The healthy native N=3 mesh scenario and the intentional

--- a/progress/session-060-p14-dependency-hygiene.md
+++ b/progress/session-060-p14-dependency-hygiene.md
@@ -80,7 +80,19 @@ connectivity and exchange state; the fresh generation restores it without a
 duplicate `p2p_pair_connected` event. Genuine terminal/removal paths clear
 both sets, and a focused state-transition regression covers all three edges.
 
-Local follow-up verification passed 58 native-client unit tests, native
+The next exact-head Bugbot pass found the remaining two edges of that same
+rebuild transition: a live-to-retrying pair could leave the aggregate status
+stale and disappear from exchange obligations long enough to satisfy the exit
+criteria, while creating the replacement generation restarted the P2P timeout.
+The retry gap is now explicit state that blocks success until the replacement
+connects or the original window expires. Rebuilding immediately re-resolves a
+previously reported aggregate status, and retry generations cannot arm or
+extend either P2P timer. Focused regressions pin both the reconnect transition
+and the initial-versus-retry deadline policy. The netem oracle accepts only
+deduplicated real transport transitions and still requires the final expected
+state; scenarios without coordinated retry retain their exact one-report rule.
+
+Local follow-up verification passed 59 native-client unit tests, native
 Clippy with warnings denied, both root/native formatting checks, and the root
 WebRTC matrix compile. The healthy native N=3 mesh scenario and the intentional
 crippled-ICE relay-fallback negative control both pass as real multi-process

--- a/scripts/check-advisories.sh
+++ b/scripts/check-advisories.sh
@@ -107,7 +107,7 @@ fi
 if [ "$FULL_MODE" = true ]; then
     echo ""
     echo -e "${BLUE}[INFO]${NC} Running full cargo-deny checks (licenses, bans, sources)..."
-    if cargo deny check --all-features; then
+    if cargo deny --all-features check; then
         echo -e "${GREEN}[OK]${NC} All cargo-deny checks passed."
     else
         echo -e "${RED}[FAIL]${NC} cargo-deny checks failed."

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -21205,6 +21205,18 @@ fn test_check_advisories_script_exists() {
     );
 
     assert!(
+        content.contains("cargo deny --all-features check"),
+        "scripts/check-advisories.sh --full must pass --all-features before the \
+         cargo-deny subcommand."
+    );
+
+    assert!(
+        !content.contains("cargo deny check --all-features"),
+        "scripts/check-advisories.sh must not pass the cargo-deny global \
+         --all-features option after the check subcommand."
+    );
+
+    assert!(
         content.contains("set -euo pipefail") || content.contains("set -eu"),
         "scripts/check-advisories.sh must use strict error handling (set -euo pipefail)."
     );

--- a/tests/partition_scenarios_e2e.rs
+++ b/tests/partition_scenarios_e2e.rs
@@ -233,6 +233,22 @@ async fn complete_while_servicing_healthy<T>(
     }
 }
 
+#[cfg(any(windows, test))]
+fn is_windows_reset_after_authoritative_cause(
+    error: &tokio_tungstenite::tungstenite::Error,
+) -> bool {
+    matches!(
+        error,
+        tokio_tungstenite::tungstenite::Error::Io(error)
+            if error.kind() == std::io::ErrorKind::ConnectionReset
+    ) || matches!(
+        error,
+        tokio_tungstenite::tungstenite::Error::Protocol(
+            tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake
+        )
+    )
+}
+
 async fn observe_until_close(ws: &mut WsStream) -> CloseObservation {
     let deadline = tokio::time::Instant::now() + EVENT_DEADLINE;
     let mut observation = CloseObservation::default();
@@ -244,15 +260,15 @@ async fn observe_until_close(ws: &mut WsStream) -> CloseObservation {
         let frame = match next {
             Ok(frame) => frame,
             #[cfg(windows)]
-            Err(tokio_tungstenite::tungstenite::Error::Io(error))
-                if error.kind() == std::io::ErrorKind::ConnectionReset =>
-            {
+            Err(error) if is_windows_reset_after_authoritative_cause(&error) => {
                 // ChaosProxy deliberately tears down both pumps when either
                 // half observes EOF. Windows may surface WSAECONNRESET before
-                // tungstenite exposes the already-forwarded close frame (the
-                // same platform behavior covered by server_ping_e2e). Every
-                // caller has already observed the authoritative server cause
-                // metric before resuming the paused direction.
+                // tungstenite exposes the already-forwarded close frame,
+                // either as a raw I/O reset or its protocol-level
+                // ResetWithoutClosingHandshake wrapper (the same platform
+                // behavior covered by server_ping_e2e). Every caller has
+                // already observed the authoritative server cause metric
+                // before resuming the paused direction.
                 observation.transport_reset_after_cause = true;
                 return observation;
             }
@@ -268,6 +284,23 @@ async fn observe_until_close(ws: &mut WsStream) -> CloseObservation {
             _ => {}
         }
     }
+}
+
+#[test]
+fn windows_partition_reset_classifier_covers_both_tungstenite_surfaces() {
+    let io_reset = tokio_tungstenite::tungstenite::Error::Io(std::io::Error::from(
+        std::io::ErrorKind::ConnectionReset,
+    ));
+    let protocol_reset = tokio_tungstenite::tungstenite::Error::Protocol(
+        tokio_tungstenite::tungstenite::error::ProtocolError::ResetWithoutClosingHandshake,
+    );
+    let unrelated = tokio_tungstenite::tungstenite::Error::Io(std::io::Error::from(
+        std::io::ErrorKind::TimedOut,
+    ));
+
+    assert!(is_windows_reset_after_authoritative_cause(&io_reset));
+    assert!(is_windows_reset_after_authoritative_cause(&protocol_reset));
+    assert!(!is_windows_reset_after_authoritative_cause(&unrelated));
 }
 
 async fn assert_room_healed(

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -530,7 +530,7 @@ fn assert_exact_channel_ledger(
     events: &[Value],
     event: &str,
     expected_peers: &BTreeSet<&str>,
-    retry_markers_by_peer: &BTreeMap<&str, usize>,
+    retried_peers: &BTreeSet<&str>,
     player_id: &str,
     who: &str,
 ) {
@@ -582,9 +582,10 @@ fn assert_exact_channel_ledger(
     for peer in expected_peers {
         for label in CHANNEL_LABELS {
             let count = counts.get(&(*peer, label)).copied().unwrap_or_default();
-            let max_generations = retry_markers_by_peer.get(peer).copied().unwrap_or_default() + 1;
+            let retried = retried_peers.contains(peer);
+            let max_generations = usize::from(retried) + 1;
             assert!(
-                channel_generation_count_is_valid(count, max_generations - 1),
+                channel_generation_count_is_valid(count, retried),
                 "{who}: expected 1..={max_generations} {event} generations for ({peer}, {label}); got {count}; ledger={counts:?}"
             );
         }
@@ -596,18 +597,18 @@ fn assert_exact_channel_ledger(
     );
 }
 
-fn channel_generation_count_is_valid(count: usize, retry_markers: usize) -> bool {
-    (1..=retry_markers + 1).contains(&count)
+fn channel_generation_count_is_valid(count: usize, retried: bool) -> bool {
+    (1..=usize::from(retried) + 1).contains(&count)
 }
 
 #[test]
 fn channel_generation_ledger_expands_only_for_observed_retry_markers() {
-    assert!(channel_generation_count_is_valid(1, 0));
-    assert!(!channel_generation_count_is_valid(0, 0));
-    assert!(!channel_generation_count_is_valid(2, 0));
-    assert!(channel_generation_count_is_valid(1, 1));
-    assert!(channel_generation_count_is_valid(2, 1));
-    assert!(!channel_generation_count_is_valid(3, 1));
+    assert!(channel_generation_count_is_valid(1, false));
+    assert!(!channel_generation_count_is_valid(0, false));
+    assert!(!channel_generation_count_is_valid(2, false));
+    assert!(channel_generation_count_is_valid(1, true));
+    assert!(channel_generation_count_is_valid(2, true));
+    assert!(!channel_generation_count_is_valid(3, true));
 }
 
 fn assert_exact_signal_ledger(
@@ -898,12 +899,12 @@ fn assert_client_barrier(
         scenario.topology.label()
     );
 
-    let mut retry_markers_by_peer = BTreeMap::<&str, usize>::new();
+    let mut retried_peers = BTreeSet::<&str>::new();
     for (event, peer_field) in [("signal_sent", "to"), ("signal_received", "from")] {
         for signal in events_named(window, event) {
             if string_field(signal, "kind", who) == "pair_retry" {
                 let peer = string_field(signal, peer_field, who);
-                *retry_markers_by_peer.entry(peer).or_default() += 1;
+                retried_peers.insert(peer);
             }
         }
     }
@@ -919,7 +920,7 @@ fn assert_client_barrier(
         window,
         "channel_open",
         &expected_connections,
-        &retry_markers_by_peer,
+        &retried_peers,
         player_id,
         who,
     );
@@ -927,7 +928,7 @@ fn assert_client_barrier(
         window,
         "channel_message_sent",
         &expected_connections,
-        &retry_markers_by_peer,
+        &retried_peers,
         player_id,
         who,
     );
@@ -935,7 +936,7 @@ fn assert_client_barrier(
         window,
         "channel_message",
         &expected_connections,
-        &retry_markers_by_peer,
+        &retried_peers,
         player_id,
         who,
     );

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -530,6 +530,7 @@ fn assert_exact_channel_ledger(
     events: &[Value],
     event: &str,
     expected_peers: &BTreeSet<&str>,
+    retry_markers_by_peer: &BTreeMap<&str, usize>,
     player_id: &str,
     who: &str,
 ) {
@@ -580,10 +581,11 @@ fn assert_exact_channel_ledger(
     }
     for peer in expected_peers {
         for label in CHANNEL_LABELS {
-            assert_eq!(
-                counts.get(&(*peer, label)),
-                Some(&1),
-                "{who}: expected exactly one {event} for ({peer}, {label}); ledger={counts:?}"
+            let count = counts.get(&(*peer, label)).copied().unwrap_or_default();
+            let max_generations = retry_markers_by_peer.get(peer).copied().unwrap_or_default() + 1;
+            assert!(
+                channel_generation_count_is_valid(count, max_generations - 1),
+                "{who}: expected 1..={max_generations} {event} generations for ({peer}, {label}); got {count}; ledger={counts:?}"
             );
         }
     }
@@ -592,6 +594,20 @@ fn assert_exact_channel_ledger(
         expected_peers.len() * CHANNEL_LABELS.len(),
         "{who}: {event} contains stray ledger entries: {counts:?}"
     );
+}
+
+fn channel_generation_count_is_valid(count: usize, retry_markers: usize) -> bool {
+    (1..=retry_markers + 1).contains(&count)
+}
+
+#[test]
+fn channel_generation_ledger_expands_only_for_observed_retry_markers() {
+    assert!(channel_generation_count_is_valid(1, 0));
+    assert!(!channel_generation_count_is_valid(0, 0));
+    assert!(!channel_generation_count_is_valid(2, 0));
+    assert!(channel_generation_count_is_valid(1, 1));
+    assert!(channel_generation_count_is_valid(2, 1));
+    assert!(!channel_generation_count_is_valid(3, 1));
 }
 
 fn assert_exact_signal_ledger(
@@ -882,6 +898,16 @@ fn assert_client_barrier(
         scenario.topology.label()
     );
 
+    let mut retry_markers_by_peer = BTreeMap::<&str, usize>::new();
+    for (event, peer_field) in [("signal_sent", "to"), ("signal_received", "from")] {
+        for signal in events_named(window, event) {
+            if string_field(signal, "kind", who) == "pair_retry" {
+                let peer = string_field(signal, peer_field, who);
+                *retry_markers_by_peer.entry(peer).or_default() += 1;
+            }
+        }
+    }
+
     assert_exact_peer_events(
         window,
         "p2p_pair_connected",
@@ -893,6 +919,7 @@ fn assert_client_barrier(
         window,
         "channel_open",
         &expected_connections,
+        &retry_markers_by_peer,
         player_id,
         who,
     );
@@ -900,6 +927,7 @@ fn assert_client_barrier(
         window,
         "channel_message_sent",
         &expected_connections,
+        &retry_markers_by_peer,
         player_id,
         who,
     );
@@ -907,6 +935,7 @@ fn assert_client_barrier(
         window,
         "channel_message",
         &expected_connections,
+        &retry_markers_by_peer,
         player_id,
         who,
     );

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -911,14 +911,36 @@ fn assert_client_barrier(
         who,
     );
 
-    let status = single_event(window, "transport_status_sent", who);
-    assert_eq!(string_field(status, "transport", who), "webrtc");
+    let statuses = events_named(window, "transport_status_sent");
+    assert!(!statuses.is_empty(), "{who}: no own transport status");
+    let own_states: Vec<bool> = statuses
+        .iter()
+        .map(|status| {
+            assert_eq!(string_field(status, "transport", who), "webrtc");
+            status
+                .get("connected")
+                .and_then(Value::as_bool)
+                .unwrap_or_else(|| panic!("{who}: own transport status lacks connected: {status}"))
+        })
+        .collect();
     assert_eq!(
-        status.get("connected").and_then(Value::as_bool),
-        Some(expected_connected),
-        "{who}: own transport status"
+        own_states.last(),
+        Some(&expected_connected),
+        "{who}: final own transport status"
     );
-    let mut peer_status_counts = BTreeMap::<&str, usize>::new();
+    assert!(
+        own_states.windows(2).all(|states| states[0] != states[1]),
+        "{who}: duplicate own transport status: {own_states:?}"
+    );
+    if !scenario.uses_netem() {
+        assert_eq!(
+            own_states.len(),
+            1,
+            "{who}: status transitions require the retry-enabled netem scenario"
+        );
+    }
+
+    let mut peer_statuses = BTreeMap::<&str, Vec<bool>>::new();
     for peer_status in events_named(window, "peer_transport_status") {
         assert_eq!(
             string_field(peer_status, "transport", who),
@@ -927,22 +949,38 @@ fn assert_client_barrier(
         );
         let peer = string_field(peer_status, "peer", who);
         assert!(room_peers.contains(peer), "{who}: stray peer status {peer}");
-        *peer_status_counts.entry(peer).or_default() += 1;
-        let expected_peer_connected =
-            !expected_connected_peers(peer, all_ids, host_id, scenario.topology, fault).is_empty();
-        assert_eq!(
-            peer_status.get("connected").and_then(Value::as_bool),
-            Some(expected_peer_connected),
-            "{who}: peer transport status for {peer}"
-        );
+        let connected = peer_status
+            .get("connected")
+            .and_then(Value::as_bool)
+            .unwrap_or_else(|| {
+                panic!("{who}: peer transport status lacks connected: {peer_status}")
+            });
+        peer_statuses.entry(peer).or_default().push(connected);
     }
     assert_eq!(
-        peer_status_counts.keys().copied().collect::<BTreeSet<_>>(),
+        peer_statuses.keys().copied().collect::<BTreeSet<_>>(),
         room_peers,
         "{who}: exact peer transport-status set"
     );
-    for (peer, count) in peer_status_counts {
-        assert_eq!(count, 1, "{who}: duplicate transport status from {peer}");
+    for (peer, states) in peer_statuses {
+        let expected_peer_connected =
+            !expected_connected_peers(peer, all_ids, host_id, scenario.topology, fault).is_empty();
+        assert_eq!(
+            states.last(),
+            Some(&expected_peer_connected),
+            "{who}: final peer transport status for {peer}"
+        );
+        assert!(
+            states.windows(2).all(|states| states[0] != states[1]),
+            "{who}: duplicate transport status from {peer}: {states:?}"
+        );
+        if !scenario.uses_netem() {
+            assert_eq!(
+                states.len(),
+                1,
+                "{who}: peer status transitions require the retry-enabled netem scenario"
+            );
+        }
     }
 
     single_event(window, "game_data_sent", who);

--- a/tests/webrtc_mesh_budget_e2e.rs
+++ b/tests/webrtc_mesh_budget_e2e.rs
@@ -249,6 +249,10 @@ fn client_args(
     }
     if scenario.uses_netem() {
         args.push("--disable-mdns".to_string());
+        args.extend(["--p2p-retry-count".to_string(), "1".to_string()]);
+    }
+    if scenario.crippled_ordinal().is_some() || scenario.partition_pair().is_some() {
+        args.extend(["--p2p-retry-count".to_string(), "0".to_string()]);
     }
     if let Some((left, right)) = scenario.partition_pair() {
         let target = if ordinal == left {
@@ -655,18 +659,29 @@ fn assert_exact_signal_ledger(
                         .copied()
                         .unwrap_or_default()
             };
+            let offers = kind_count("offer");
+            let answers = kind_count("answer");
+            let retries = kind_count("pair_retry");
             assert_eq!(
-                kind_count("offer"),
-                1,
-                "{} edge {left}<->{right}: exact offer ledger",
+                answers,
+                offers,
+                "{} edge {left}<->{right}: every offer has one answer",
                 topology.label()
             );
-            assert_eq!(
-                kind_count("answer"),
-                1,
-                "{} edge {left}<->{right}: exact answer ledger",
-                topology.label()
-            );
+            if retries == 0 {
+                assert_eq!(
+                    offers,
+                    1,
+                    "{} edge {left}<->{right}: exact initial offer ledger",
+                    topology.label()
+                );
+            } else {
+                assert!(
+                    (2..=retries + 1).contains(&offers),
+                    "{} edge {left}<->{right}: {retries} retry markers produced {offers} offer generations",
+                    topology.label()
+                );
+            }
             assert!(
                 kind_count("ice_candidate") > 0,
                 "{} edge {left}<->{right}: at least one trickle-ICE candidate",


### PR DESCRIPTION
## Summary

- refresh Tokio, UUID, Clap, Rustls, Regex, Syn, Trybuild, and Saphyr
- keep Axum and the direct test client aligned on one `tokio-tungstenite`/`tungstenite` 0.29 stack instead of accepting a duplicate 0.30 stack
- remove the redundant normal declaration of the test-only raw WebSocket client
- fix `check-advisories.sh --full` for cargo-deny 0.20 by placing the global `--all-features` option before `check`, with regression coverage
- recover homogeneous reference-client pairs when loss leaves ICE connected but stalls SCTP, using an opt-in bounded `PairRetry` rebuild that preserves the server-authored glare role

## Why

Dependabot #179 is ten commits behind `main` and its 0.29→0.30 WebSocket-client bump would preserve Axum's 0.29 stack while adding 0.30 only for tests. This takes the compatible update set while keeping the graph coherent. The required local audit then exposed the cargo-deny argument-order bug, which prevented the full policy check from running. Exact-head nightly runs also reproduced the same N=8 SCTP INIT/ACK stall twice with different peers; because ICE remained connected, no terminal callback rebuilt the wedged link. The follow-up coordinates one fresh generation in the homogeneous loss matrix while leaving general matchbox/browser interoperability unchanged by default.

## Validation

- `cargo check --locked --all-features`
- targeted Clippy for `ci_config_tests` with warnings denied
- focused workflow YAML parser and WebSocket Ping/Pong regressions
- cargo metadata MSRV audit (all refreshed crates ≤ Rust 1.85; project floor Rust 1.89)
- one resolved `tokio-tungstenite`/`tungstenite` version verified with `cargo tree`
- `scripts/check-advisories.sh --full` (advisories, bans, licenses, sources pass)
- 59 native unit tests and native Clippy with warnings denied
- real healthy N=3 mesh and intentional crippled-ICE fallback controls
- root WebRTC matrix compile with exact retry-generation signal ledgers
- ShellCheck, Bash syntax, CI config, doc consistency, workflow hygiene, and fast git hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real WebRTC establishment, signaling, and nightly mesh oracles; default retry count is 0 so general interop is unchanged, but netem and transport-status assertions are more complex.
> 
> **Overview**
> Refreshes the runtime/TLS/parser/test-tool dependency set while keeping **one** aligned `tokio-tungstenite`/`tungstenite` stack (production no longer declares the test-only client; Axum stays on 0.29). **cargo-deny** full audit is fixed by passing `--all-features` before `check`, with CI regression coverage.
> 
> The native reference client gains an **opt-in** `--p2p-retry-count` and a **`PairRetry`** signal extension: before the P2P deadline, both sides can discard a wedged generation (ICE up, SCTP/data channels stalled), rebuild while keeping the server glare role, and avoid duplicate `p2p_pair_connected` / stale transport status during the gap. Homogeneous netem matrix runs enable one retry; crippled/partition negatives and general browser interop explicitly keep retries at **0**.
> 
> WebRTC mesh budget oracles and partition tests are tightened for retry generations, deduplicated transport transitions, and Windows reset classification; interop scenarios that must stay permanently broken disable retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410ba10ab5d548770e649b09f5c6a33b809cc2c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->