### PR TITLE
Restore the red Firefox WASM cell, repair the load suite (#207), enforce no-unsafe (#205), and incorporate both dependency PRs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Run actionlint
         id: actionlint
         uses: devops-actions/actionlint@v0.1.12

--- a/.github/workflows/browser-interop.yml
+++ b/.github/workflows/browser-interop.yml
@@ -70,7 +70,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -234,8 +234,8 @@ jobs:
 
       # Without a symbolizer every sanitizer frame prints as a raw
       # `binary+0xADDRESS` offset. That is what made the 2026-07-27
-      # LeakSanitizer report on PR #202 undiagnosable: 22 indirect leaks, not
-      # one nameable frame, even after downloading the run artifacts. rustup's
+      # LeakSanitizer report on PR #202 undiagnosable (issue #209): 22 indirect
+      # leaks, not one nameable frame, even after downloading artifacts. rustup's
       # llvm-tools component does NOT ship llvm-symbolizer, so this searches the
       # runner's system LLVM instead. Best-effort by design: a missing
       # symbolizer degrades reports rather than failing an otherwise-green lane.

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -232,6 +232,41 @@ jobs:
           workspaces: ". -> target/asan"
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
+      # Without a symbolizer every sanitizer frame prints as a raw
+      # `binary+0xADDRESS` offset. That is what made the 2026-07-27
+      # LeakSanitizer report on PR #202 undiagnosable: 22 indirect leaks, not
+      # one nameable frame, even after downloading the run artifacts. rustup's
+      # llvm-tools component does NOT ship llvm-symbolizer, so this searches the
+      # runner's system LLVM instead. Best-effort by design: a missing
+      # symbolizer degrades reports rather than failing an otherwise-green lane.
+      - name: Locate llvm-symbolizer for sanitizer reports
+        shell: bash
+        run: |
+          set -uo pipefail
+          symbolizer=""
+          for candidate in llvm-symbolizer llvm-symbolizer-20 llvm-symbolizer-19 \
+                           llvm-symbolizer-18 llvm-symbolizer-17; do
+            if resolved="$(command -v "$candidate" 2>/dev/null)"; then
+              symbolizer="$resolved"
+              break
+            fi
+          done
+          if [ -z "$symbolizer" ]; then
+            for candidate in /usr/lib/llvm-*/bin/llvm-symbolizer; do
+              if [ -x "$candidate" ]; then
+                symbolizer="$candidate"
+                break
+              fi
+            done
+          fi
+          if [ -n "$symbolizer" ]; then
+            echo "ASAN_SYMBOLIZER_PATH=$symbolizer" >> "$GITHUB_ENV"
+            echo "sanitizer reports will be symbolized by $symbolizer"
+          else
+            echo "WARNING: no llvm-symbolizer found; sanitizer frames will be raw"
+            echo "addresses. Install LLVM on the runner to make reports actionable."
+          fi
+
       - name: Run tests with AddressSanitizer
         run: |
           set -euo pipefail
@@ -255,6 +290,7 @@ jobs:
           echo "sha: ${{ github.sha }}"
           echo "runner: ${RUNNER_OS:-unknown}/${RUNNER_ARCH:-unknown}"
           echo "ASAN_OPTIONS: ${ASAN_OPTIONS:-<unset>}"
+          echo "ASAN_SYMBOLIZER_PATH: ${ASAN_SYMBOLIZER_PATH:-<unset — frames below are raw addresses>}"
           echo "CARGO_TARGET_DIR: ${CARGO_TARGET_DIR:-<default>}"
           if [ ! -f asan-output.txt ]; then
             echo "asan-output.txt is missing"

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -117,7 +117,7 @@ jobs:
       CARGO_TARGET_DIR: target/miri
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Install Rust nightly toolchain with Miri
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -216,7 +216,7 @@ jobs:
       CARGO_TARGET_DIR: target/asan
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -116,7 +116,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -193,7 +193,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -226,14 +226,14 @@ jobs:
       - name: Install cargo-nextest (attempt 1)
         id: install_nextest
         continue-on-error: true
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       - name: Install cargo-nextest (retry on transient runner failure)
         # Only runs when attempt 1 failed (e.g., the Windows bash-startup flake).
         # No continue-on-error here, so a second failure correctly fails the job.
         if: steps.install_nextest.outcome == 'failure'
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
 
@@ -259,7 +259,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -361,7 +361,7 @@ jobs:
     # Runs on push/PR and daily via schedule (see workflow triggers).
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Extract MSRV for cargo-deny toolchain
         id: deny-msrv
         run: |
@@ -390,7 +390,7 @@ jobs:
     # Runs on push/PR and daily via schedule (see workflow triggers).
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -410,7 +410,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-audit
       - name: Run cargo-audit
@@ -428,7 +428,7 @@ jobs:
     # across all configuration files (rust-toolchain.toml, clippy.toml, Dockerfile, etc.)
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Extract MSRV from Cargo.toml
         id: msrv
         run: |
@@ -482,7 +482,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Set up Docker Buildx
         # Buildx unlocks the GitHub Actions layer cache below. Mirrors the proven
         # pattern in docker-publish.yml (same pinned action versions), turning a
@@ -538,7 +538,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -560,7 +560,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-llvm-cov
 
@@ -600,7 +600,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -632,7 +632,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -652,7 +652,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-sbom
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-sbom
 

--- a/.github/workflows/doc-validation.yml
+++ b/.github/workflows/doc-validation.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5 # Short timeout - this is a fast validation step
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - name: Install shellcheck
         run: |
           sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Generous timeout for building documentation with all features
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15 # Generous timeout for running all doc tests with features
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20 # Longer timeout - validates multiple languages (Rust, JSON, YAML, TOML, Bash)
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -631,7 +631,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10 # Moderate timeout for checking all external and internal links
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       # Use lychee for comprehensive link checking (external + internal + anchors)
       - name: Check all links with lychee
         uses: lycheeverse/lychee-action@v2.9.0
@@ -684,7 +684,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10 # Moderate timeout for future implementation of code reference validation
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - name: Check inline code references
         run: |
           echo "Inline code reference validation - placeholder for future implementation"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,7 +72,7 @@ jobs:
       is_backfill: ${{ steps.identity.outputs.is_backfill }}
     steps:
       - name: Checkout publication tooling
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
@@ -85,7 +85,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout exact source
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_ref || inputs.release_tag || github.ref }}
@@ -208,7 +208,7 @@ jobs:
       digest: ${{ steps.verify.outputs.digest || steps.rolling-digest.outputs.digest }}
     steps:
       - name: Checkout publication tooling
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
@@ -221,7 +221,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout exact source
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ needs.resolve.outputs.source_revision }}
           path: source
@@ -233,7 +233,7 @@ jobs:
         uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Setup Python
         uses: actions/setup-python@v7.0.0
         with:

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Install Java runtime
         uses: actions/setup-java@v5.6.0
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@v7.0.0

--- a/.github/workflows/fortress-interop.yml
+++ b/.github/workflows/fortress-interop.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Extract fixture MSRV
         id: deny-msrv
         run: |

--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -69,7 +69,7 @@ jobs:
       FORTRESS_WASM_BROWSER: ${{ matrix.browser }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Install pinned Rust nightly
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -163,7 +163,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Run cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2.1.1
         with:

--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -160,6 +160,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Same cleanup every other apt site in this repo performs: those
+          # mirrors periodically break `apt-get update` on GitHub runners, which
+          # would fail this step and take the Firefox cell red again.
+          sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
             libgl1 libglx-mesa0 libgl1-mesa-dri libegl1 libegl-mesa0 \

--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -142,14 +142,19 @@ jobs:
             --target wasm32-unknown-emscripten \
             --release \
             -- -D warnings
-      # `playwright install --with-deps firefox` installs NO GL stack: unlike the
-      # Chromium (libgbm1) and WebKit (libgl1/libegl1) dependency lists,
-      # Playwright's Firefox list contains no Mesa driver at all. The Godot web
-      # export needs WebGL2, and `webgl.force-enabled` only bypasses the
-      # blocklist — with no driver for the loader to resolve, the export still
-      # aborts at boot reporting WebGL2 as missing. Install the software
-      # rasterizer explicitly so this cell does not depend on whatever GL
-      # packages a runner image happens to carry.
+      # The Godot web export needs WebGL2, and Firefox — unlike Chromium, which
+      # carries SwiftShader — has no software fallback of its own: it needs a
+      # real Mesa GL stack AND an X display to resolve it through, even headless.
+      #
+      # The operative fix is the display (see the xvfb-run wrapper in
+      # scripts/run-fortress-wasm-interop.sh). This install is defensive: on the
+      # current ubuntu-24.04 image libgl1, libglx-mesa0, libgl1-mesa-dri, xvfb,
+      # and xauth are all already present and only the libegl1/libegl-mesa0
+      # loader packages are new. Pinning the whole set keeps the cell from
+      # depending on whatever a future runner image happens to ship, since
+      # `playwright install --with-deps firefox` contributes no GL packages of
+      # its own (its Chromium list carries libgbm1 and its WebKit list carries
+      # libgl1/libegl1, but the Firefox list has none).
       - name: Install Mesa software GL and Xvfb for headless Firefox
         if: matrix.browser == 'firefox'
         shell: bash

--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -142,6 +142,22 @@ jobs:
             --target wasm32-unknown-emscripten \
             --release \
             -- -D warnings
+      # `playwright install --with-deps firefox` installs NO GL stack: unlike the
+      # Chromium (libgbm1) and WebKit (libgl1/libegl1) dependency lists,
+      # Playwright's Firefox list contains no Mesa driver at all. The Godot web
+      # export needs WebGL2, and `webgl.force-enabled` only bypasses the
+      # blocklist — with no driver for the loader to resolve, the export still
+      # aborts at boot reporting WebGL2 as missing. Install the software
+      # rasterizer explicitly so this cell does not depend on whatever GL
+      # packages a runner image happens to carry.
+      - name: Install Mesa software GL for headless Firefox
+        if: matrix.browser == 'firefox'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            libgl1 libglx-mesa0 libgl1-mesa-dri libegl1 libegl-mesa0
       - name: Verify released graph plus expected-busted control
         env:
           INSTALL_PLAYWRIGHT_DEPS: "1"

--- a/.github/workflows/fortress-wasm-interop.yml
+++ b/.github/workflows/fortress-wasm-interop.yml
@@ -150,14 +150,15 @@ jobs:
       # aborts at boot reporting WebGL2 as missing. Install the software
       # rasterizer explicitly so this cell does not depend on whatever GL
       # packages a runner image happens to carry.
-      - name: Install Mesa software GL for headless Firefox
+      - name: Install Mesa software GL and Xvfb for headless Firefox
         if: matrix.browser == 'firefox'
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install --no-install-recommends -y \
-            libgl1 libglx-mesa0 libgl1-mesa-dri libegl1 libegl-mesa0
+            libgl1 libglx-mesa0 libgl1-mesa-dri libegl1 libegl-mesa0 \
+            xvfb xauth
       - name: Verify released graph plus expected-busted control
         env:
           INSTALL_PLAYWRIGHT_DEPS: "1"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -48,7 +48,7 @@ jobs:
         target: [decode_protocol, validate_inputs]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       # Nightly Toolchain Strategy:
       #   cargo-fuzz/libFuzzer requires NIGHTLY Rust: the sanitizer instrumentation
@@ -82,7 +82,7 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-fuzz
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Link Checker
         uses: lycheeverse/lychee-action@v2.9.0
         with:

--- a/.github/workflows/llm-file-sizes.yml
+++ b/.github/workflows/llm-file-sizes.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Run LLM file size checks
         run: bash scripts/check-llm-file-sizes.sh
 

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Install pinned markdownlint-cli2
         run: npm ci --no-audit --no-fund
       - name: Run markdown checks

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Read Rust toolchain
         id: toolchain
@@ -108,12 +108,12 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-mutants
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
 
@@ -162,7 +162,7 @@ jobs:
         shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Read Rust toolchain
         id: toolchain
@@ -194,14 +194,14 @@ jobs:
           save-if: false
 
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-mutants
 
       - name: Install cargo-nextest
         # The mutation oracle uses nextest process isolation plus the dedicated
         # profile's per-test termination for progress-removing mutants.
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,7 +75,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Checkout default branch
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       source_revision: ${{ steps.release.outputs.source_revision }}
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -271,7 +271,7 @@ jobs:
       crate_exists: ${{ steps.crate.outputs.exists }}
     steps:
       - name: Checkout publication tooling
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.sha }}
@@ -284,7 +284,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout exact release source
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-release.outputs.source_revision }}
@@ -344,7 +344,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-release.outputs.source_revision }}
@@ -410,7 +410,7 @@ jobs:
 
     steps:
       - name: Checkout publication tooling
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.sha }}
@@ -422,7 +422,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-release.outputs.source_revision }}
@@ -491,7 +491,7 @@ jobs:
         run: cargo publish --locked
 
       - name: Install cargo-sbom
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-sbom
 
@@ -656,7 +656,7 @@ jobs:
       # helpers, while the workflow itself must retain the reviewed tooling
       # from the dispatch revision.
       - name: Checkout publication tooling
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.sha }}
           path: publication-tools
@@ -666,7 +666,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout exact source
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ needs.resolve-release.outputs.source_revision }}
           path: source
@@ -804,7 +804,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.binary-artifacts.outputs.count != '0'
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
 
       - name: Download all binary artifacts
         if: steps.binary-artifacts.outputs.count != '0'

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -55,6 +55,6 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Check spelling with typos
         uses: crate-ci/typos@v1.48.0

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -12,10 +12,11 @@
 #   - concurrency-stress: tests/delivery_concurrency_stress.rs — the
 #     loom-substitute lane racing deliver_or_disconnect against receiver
 #     drops and explicit closes across thousands of scheduler samples.
-#   - load-smoke: the in-process latency-distribution smoke test from
-#     tests/load_tests.rs (the room-creation-throughput and
-#     sustained-connections candidates are excluded as known-broken — see the
-#     load-smoke job comment). NOTE these are throughput/latency smoke checks
+#   - load-smoke: the in-process latency-distribution, room-creation-throughput,
+#     and sustained-connections smoke tests from tests/load_tests.rs. The latter
+#     two were previously excluded as known-broken; issue #207 traced that to
+#     invalid room-code lengths across the whole suite — see the load-smoke job
+#     comment. NOTE these are throughput/latency smoke checks
 #     only — their clients are mpsc channels that cannot observe delivery
 #     (see the module docs in tests/load_tests.rs); the delivery contract is
 #     verified by the soak/backpressure suites above.

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -216,18 +216,18 @@ jobs:
         uses: taiki-e/install-action@v2.83.4
         with:
           tool: cargo-nextest
-      # Only the latency-distribution smoke test is activated by name. The
-      # other two candidates (test_load_room_creation_throughput,
-      # test_load_sustained_concurrent_connections) currently fail
-      # deterministically under the shared test-server defaults — they
-      # request 250-500 rooms in one game against max_rooms_per_game=100 and
-      # trip the room-creation rate limits, so their ">=95% success" asserts
-      # can never hold — and are excluded until they are repaired rather than
-      # shipped as a permanently red lane. The remaining #[ignore]d load
-      # tests (stress to failure, memory projection, connection-rate) are
-      # exploratory and stay manual. These tests cannot observe delivery —
-      # see the load_tests.rs module docs — so this job reports numbers and
-      # fails only on genuine test failure.
+      # All three room-based smoke cells are activated by name. The two
+      # throughput cells were previously excluded as "known-broken": every cell
+      # in load_tests.rs built a room code of the wrong length (the server
+      # requires exactly 6 characters), so no player ever entered a room. That
+      # zeroed the throughput cells' success rate and silently made the latency
+      # cell measure broadcasts into empty rooms. Issue #207 repaired the codes,
+      # raised the room ceiling for the 250-500 room cells, and added assertions
+      # that players actually joined, so all three now measure real work. The
+      # remaining #[ignore]d load tests (stress to failure, memory projection,
+      # connection-rate) are exploratory and stay manual. These tests cannot
+      # observe delivery — see the load_tests.rs module docs — so this job
+      # reports numbers and fails only on genuine test failure.
       - name: Run load smoke tests
         shell: bash
         run: |
@@ -235,6 +235,8 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test load_tests --run-ignored all --success-output final -- \
             test_load_message_latency_distribution \
+            test_load_room_creation_throughput \
+            test_load_sustained_concurrent_connections \
             2>&1 | tee load-output.txt
       - name: Report load numbers to job summary
         if: always()

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -97,7 +97,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -117,7 +117,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       - name: Run relay delivery soak
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -165,7 +165,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       - name: Run delivery concurrency stress
@@ -193,7 +193,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -213,7 +213,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       # All three room-based smoke cells are activated by name. The two
@@ -262,7 +262,7 @@ jobs:
     timeout-minutes: 150
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -285,7 +285,7 @@ jobs:
             .
             clients/native
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       - name: Build the native reference client
@@ -380,7 +380,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -436,7 +436,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -456,7 +456,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       # --run-ignored all: the PR-lane profiles (already covered by the ci.yml
@@ -525,7 +525,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -545,7 +545,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.83.4
+        uses: taiki-e/install-action@v2.85.2
         with:
           tool: cargo-nextest
       - name: Run split-brain failure catalog
@@ -562,7 +562,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash

--- a/.github/workflows/webrtc-interop.yml
+++ b/.github/workflows/webrtc-interop.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
         shell: bash
@@ -117,7 +117,7 @@ jobs:
     # own deny.toml (clients/native/deny.toml).
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Extract client MSRV for cargo-deny toolchain
         id: deny-msrv
         run: |

--- a/.github/workflows/workflow-hygiene.yml
+++ b/.github/workflows/workflow-hygiene.yml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Run workflow hygiene checks
         env:
           SIGNAL_FISH_CHECK_ACTION_REF_TAGS: "1"

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
       - name: Set up Python
         uses: actions/setup-python@v7.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,17 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Restore the weekly Firefox cell of the Fortress/Godot no-thread WASM
   interoperability gate, which had failed on every run since it was added. Two
-  independent causes: Firefox's blocklist refuses a WebGL context without an
-  accelerated adapter (fixed with `webgl.force-enabled`), and Playwright's
-  Firefox dependency list installs no GL driver at all — unlike its Chromium and
-  WebKit lists — so there was nothing for the loader to resolve even once the
-  blocklist was bypassed, and headless Firefox still needs an X display to
-  resolve that driver at all. The workflow now installs Mesa's software
-  rasterizer plus Xvfb, the runner script gives the Firefox harness a virtual
-  display, and the harness pins `LIBGL_ALWAYS_SOFTWARE`. Both browsers are
-  probed for a WebGL2 context before the export loads, so the failure is
-  reported with the browser's own reason, and a bounded wait for a page global
-  now reports the page's captured errors instead of a bare timeout.
+  causes: Firefox's blocklist refuses a WebGL context without an accelerated
+  adapter (`webgl.force-enabled`), and — unlike Chromium, which carries
+  SwiftShader — Firefox has no software fallback of its own, so even headless it
+  needs an X display to resolve a Mesa GL driver. The runner script now runs the
+  Firefox harness under `xvfb-run`; the workflow additionally pins the Mesa/EGL
+  packages as defensive hardening. Both browsers are probed for a WebGL2 context
+  before the export loads, so the failure is reported with the browser's own
+  reason, and a bounded wait for a page global now reports the page's captured
+  errors instead of a bare timeout.
 
 ## [0.5.1] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,14 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix a pre-existing nightly flake in which the chaos proxy's bandwidth fault
-  ran slower than its nominal rate. Pacing slept a fixed interval per chunk, so
-  the pump's own read/write/scheduling latency was added to every period and the
-  achieved rate drifted below nominal under load. A throttled recipient in the
-  mixed-encoding experiment was then evicted as a slow consumer — the outcome
-  that experiment exists to disprove. Chunks are now released against a virtual
-  clock with catch-up credit capped at one period, so a late iteration is
-  absorbed rather than compounding and a long stall cannot burst.
+- Make the chaos proxy's bandwidth fault rate-accurate. Pacing slept a fixed
+  interval per chunk, so the pump's own read/write/scheduling latency was added
+  to every period and the achieved rate drifted below nominal under load — a
+  "32 KiB/s" link delivered measurably less on a busy machine. Chunks are now
+  released against a virtual clock with catch-up credit capped at one period, so
+  a late iteration is absorbed rather than compounding and a long stall cannot
+  burst. This does not resolve the pre-existing H14 slow-consumer flake tracked
+  in issue #212; that experiment's assertion now reports its counters, elapsed
+  time, and the server's own message instead of a bare code mismatch.
 - Repair the load-test suite, which was measuring nothing. Every cell built a
   room code of the wrong length (10, 8, or 7 characters against the server's
   required 6), and `handle_join_room` reports a rejected join only by leaving

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,12 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entered a room. All three run in the nightly load lane (issue #207).
 
 - Restore the weekly Firefox cell of the Fortress/Godot no-thread WASM
-  interoperability gate. Headless Firefox has no GPU-backed WebGL, so its
-  blocklist refused a software context and the Godot web export aborted at boot
-  reporting WebGL2 as missing; the harness now forces the software context for
-  Firefox exactly as it already did for Chromium. A bounded wait for a page
-  global also reports the page's captured errors instead of a bare timeout, so
-  a boot failure is legible from the workflow log without downloading artifacts.
+  interoperability gate, which had failed on every run since it was added. Two
+  independent causes: Firefox's blocklist refuses a WebGL context without an
+  accelerated adapter (fixed with `webgl.force-enabled`), and Playwright's
+  Firefox dependency list installs no GL driver at all — unlike its Chromium and
+  WebKit lists — so there was nothing for the loader to resolve even once the
+  blocklist was bypassed. The workflow now installs Mesa's software rasterizer
+  for that cell and the harness pins `LIBGL_ALWAYS_SOFTWARE`. Both browsers are
+  probed for a WebGL2 context before the export loads, so the failure is
+  reported with the browser's own reason, and a bounded wait for a page global
+  now reports the page's captured errors instead of a bare timeout.
 
 ## [0.5.1] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore the weekly Firefox cell of the Fortress/Godot no-thread WASM
+  interoperability gate. Headless Firefox has no GPU-backed WebGL, so its
+  blocklist refused a software context and the Godot web export aborted at boot
+  reporting WebGL2 as missing; the harness now forces the software context for
+  Firefox exactly as it already did for Chromium. A bounded wait for a page
+  global also reports the page's captured errors instead of a bare timeout, so
+  a boot failure is legible from the workflow log without downloading artifacts.
+
 ## [0.5.1] - 2026-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accelerated adapter (fixed with `webgl.force-enabled`), and Playwright's
   Firefox dependency list installs no GL driver at all — unlike its Chromium and
   WebKit lists — so there was nothing for the loader to resolve even once the
-  blocklist was bypassed. The workflow now installs Mesa's software rasterizer
-  for that cell and the harness pins `LIBGL_ALWAYS_SOFTWARE`. Both browsers are
+  blocklist was bypassed, and headless Firefox still needs an X display to
+  resolve that driver at all. The workflow now installs Mesa's software
+  rasterizer plus Xvfb, the runner script gives the Firefox harness a virtual
+  display, and the harness pins `LIBGL_ALWAYS_SOFTWARE`. Both browsers are
   probed for a WebGL2 context before the export loads, so the failure is
   reported with the browser's own reason, and a bounded wait for a page global
   now reports the page's captured errors instead of a bare timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Require every workflow `apt-get update` to first drop the Azure CLI and
+  Microsoft prod source lists, enforced by a sweep test over all workflows.
+  Those mirrors periodically break `apt-get update` on GitHub runners; five call
+  sites already did this by convention and a sixth did not.
 - Symbolize AddressSanitizer/LeakSanitizer reports by locating the runner's
   `llvm-symbolizer` (rustup's `llvm-tools` component does not ship one). The
   lookup is best-effort and the diagnostic step now states whether

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Symbolize AddressSanitizer/LeakSanitizer reports by locating the runner's
+  `llvm-symbolizer` (rustup's `llvm-tools` component does not ship one). The
+  lookup is best-effort and the diagnostic step now states whether
+  symbolization was active, so an unsymbolized report is self-describing rather
+  than an undiagnosable stack of raw addresses.
+- Bump the pinned GitHub Actions group (`actions/checkout` 7.0.1,
+  `taiki-e/install-action` 2.85.2, and `actions/upload-artifact`), carrying
+  Dependabot #202 forward.
 - Refresh the compatible dependency set (Tokio 1.53.1, serde 1.0.229, futures
   0.3.33, clap 4.6.4, hdrhistogram 7.6.0 and others). The `tokio-tungstenite`
   0.30, `serial_test` 4.0, `base64` 0.23, and `syn` 3.0 declarations proposed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enforce the no-unsafe property that the server and its reference clients
+  already held by habit: every package manifest now declares an explicit
+  `unsafe_code` lint policy (`forbid`, or `deny` for the Godot fixture that
+  needs one `unsafe impl ExtensionLibrary` marker), and a git-discovery policy
+  test fails when a package omits it (issue #205).
+
+### Changed
+
+- Refresh the compatible dependency set (Tokio 1.53.1, serde 1.0.229, futures
+  0.3.33, clap 4.6.4, hdrhistogram 7.6.0 and others). The `tokio-tungstenite`
+  0.30, `serial_test` 4.0, `base64` 0.23, and `syn` 3.0 declarations proposed
+  alongside them are deliberately not taken: the first duplicates the
+  Tungstenite stack Axum still pins to 0.29, the second requires rustc 1.93.1
+  against a 1.89.0 MSRV, the third adds a second `base64` used by nothing but
+  this crate, and the fourth removes `syn::Arm::guard` without deduplicating
+  anything. The locked graph keeps exactly one WebSocket and one base64
+  implementation.
+
 ### Fixed
+
+- Repair the load-test suite, which was measuring nothing. Every cell built a
+  room code of the wrong length (10, 8, or 7 characters against the server's
+  required 6), and `handle_join_room` reports a rejected join only by leaving
+  the player roomless. The two throughput cells therefore recorded 0% success
+  and had been excluded from CI as "known-broken" against an incorrect
+  diagnosis, while the nightly latency cell passed while broadcasting into
+  empty rooms. Codes now come from one checked helper, the room ceiling is
+  sized for the cells that need it, and the cells assert that players actually
+  entered a room. All three run in the nightly load lane (issue #207).
 
 - Restore the weekly Firefox cell of the Fortress/Godot no-thread WASM
   interoperability gate. Headless Firefox has no GPU-backed WebGL, so its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix a pre-existing nightly flake in which the chaos proxy's bandwidth fault
+  ran slower than its nominal rate. Pacing slept a fixed interval per chunk, so
+  the pump's own read/write/scheduling latency was added to every period and the
+  achieved rate drifted below nominal under load. A throttled recipient in the
+  mixed-encoding experiment was then evicted as a slow consumer — the outcome
+  that experiment exists to disprove. Chunks are now released against a virtual
+  clock with catch-up credit capped at one period, so a late iteration is
+  absorbed rather than compounding and a long stall cannot burst.
 - Repair the load-test suite, which was measuring nothing. Every cell built a
   room code of the wrong length (10, 8, or 7 characters against the server's
   required 6), and `handle_join_room` reports a rejected join only by leaving

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ dependencies = [
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -134,15 +134,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -155,13 +155,13 @@ checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -178,9 +178,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -188,14 +188,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -205,7 +206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -224,7 +225,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -306,12 +307,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -333,9 +328,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -382,7 +377,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -399,9 +394,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytesize"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
 
 [[package]]
 name = "cast"
@@ -411,9 +406,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -429,15 +424,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -498,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -520,14 +515,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -678,18 +673,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -706,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -800,7 +795,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -834,13 +829,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -858,14 +853,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email_address"
@@ -878,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -893,7 +888,7 @@ checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -949,14 +944,14 @@ checksum = "c0637949cd816934f3b7aab44ff98e7ec1fb903c379e07dcb9eac943ec33499e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -997,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
@@ -1013,9 +1008,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1028,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1038,15 +1033,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1055,38 +1050,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1129,11 +1124,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1143,9 +1136,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1159,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1221,11 +1216,11 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.5.4"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+checksum = "f49d1053f4708f0af3cf9fc5bffc7e68a914a3c45becb231c80068c9c3f78bea"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -1250,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1260,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1270,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1295,18 +1290,18 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1345,7 +1340,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1571,7 +1566,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1590,24 +1585,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1622,9 +1617,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1649,9 +1644,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -1719,21 +1714,15 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1747,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1773,17 +1762,16 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1811,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1845,11 +1833,10 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -1953,6 +1940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,9 +1975,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
@@ -2027,9 +2020,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2044,7 +2037,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2070,7 +2063,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2081,9 +2074,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2101,15 +2094,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2123,23 +2117,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2158,18 +2152,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2210,6 +2204,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -2280,9 +2283,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 dependencies = [
  "bytecheck",
 ]
@@ -2293,7 +2296,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "http",
@@ -2375,7 +2378,7 @@ checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2414,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2442,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -2469,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2518,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -2617,9 +2620,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2637,29 +2640,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2722,14 +2725,14 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2783,7 +2786,7 @@ dependencies = [
  "axum",
  "axum-server",
  "axum-test",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "clap",
@@ -2818,7 +2821,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "subtle",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2844,15 +2847,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version",
  "simdutf8",
@@ -2881,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2925,6 +2928,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,14 +2955,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "target-triple"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
@@ -2974,38 +2988,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "num-conv",
@@ -3023,9 +3037,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3053,9 +3067,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3068,9 +3082,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.4"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317fafbbe3f02fc663dad00ea6186197de963cd4190e86a26d8d0fae095539af"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3084,13 +3098,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3105,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3139,22 +3153,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3176,18 +3191,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3286,7 +3301,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3373,8 +3388,8 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
- "sha1 0.10.6",
+ "rand 0.9.5",
+ "sha1 0.10.7",
  "thiserror",
 ]
 
@@ -3392,9 +3407,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+checksum = "c90e86058a30d42a1a928dfb4b49bb33c98c3a2b4909492e6b0881cd94798ec2"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -3405,13 +3420,13 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+checksum = "f153acc4e99a5f2a5aefa09fb078be54e26271b2813f6041200b224c098d8328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3547,9 +3562,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3560,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3570,9 +3585,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3580,31 +3595,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3622,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3681,7 +3696,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3692,7 +3707,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3803,9 +3818,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -3844,28 +3859,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3885,7 +3900,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3925,11 +3940,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ tls = ["axum-server", "rustls", "rustls-pki-types"]
 # hooks; a caller must explicitly attach a recorder to a connection.
 trace-validation = []
 
+# The signaling server carries no `unsafe` block and must not acquire one by
+# accident. `forbid` (not `deny`) is deliberate: it cannot be re-enabled by a
+# local `#[allow(unsafe_code)]`, so adding unsafe here requires editing this
+# manifest and defending the change in review.
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 # Async runtime. `sync` (mpsc/watch delivery channels) and `time` (backpressure
 # timeouts) are load-bearing for the no-silent-drop delivery path — keep them

--- a/clients/fortress-wasm/Cargo.toml
+++ b/clients/fortress-wasm/Cargo.toml
@@ -26,10 +26,13 @@ web-time = "=1.1.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(published_docs)"] }
-# `deny` rather than the `forbid` used by the server and the other two client
+# `deny` rather than the `forbid` used by the server and the other client
 # packages: godot-rust requires exactly one `unsafe impl ExtensionLibrary`
-# marker, which carries a local `#[allow]` at its single site in src/lib.rs.
-# Any second unsafe site is a compile error.
+# marker. It lives in the `extension_registration` module in src/lib.rs, which
+# carries the only `#[allow(unsafe_code)]` in the crate (the allow must sit on
+# the module, not the item — `#[gdextension]` re-emits the impl without
+# item-level attributes). Any unsafe site outside that module is a compile
+# error.
 unsafe_code = "deny"
 
 [lints.clippy]

--- a/clients/fortress-wasm/Cargo.toml
+++ b/clients/fortress-wasm/Cargo.toml
@@ -26,6 +26,11 @@ web-time = "=1.1.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(published_docs)"] }
+# `deny` rather than the `forbid` used by the server and the other two client
+# packages: godot-rust requires exactly one `unsafe impl ExtensionLibrary`
+# marker, which carries a local `#[allow]` at its single site in src/lib.rs.
+# Any second unsafe site is a compile error.
+unsafe_code = "deny"
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -61,21 +61,25 @@ Chromium reaches its own software rasterizer (SwiftShader) through
 `--enable-webgl --ignore-gpu-blocklist`. Firefox has no such fallback: it asks
 the platform for a GL device and, finding none, reports
 `Exhausted GL driver options (FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS)`. It
-needs all three of:
+needs two things:
 
 1. `webgl.force-enabled`, to bypass the blocklist that refuses WebGL without an
    accelerated adapter;
-2. a software GL driver — Playwright's Firefox dependency list installs no GL
-   packages at all, unlike its Chromium and WebKit lists, so the workflow
-   installs Mesa's rasterizer (`libgl1-mesa-dri` and friends);
-3. an **X display**, which headless Firefox still uses to resolve that driver.
-   `scripts/run-fortress-wasm-interop.sh` runs the Firefox harness under
+2. an **X display**, which headless Firefox still uses to resolve a Mesa GL
+   driver. `scripts/run-fortress-wasm-interop.sh` runs the Firefox harness under
    `xvfb-run`.
 
-Missing any one of them leaves the export aborting at boot with WebGL2 reported
-as missing. This is what made the cell environment-dependent — a workstation
-with `DISPLAY` set passes while a CI runner without one fails; reproduce the CI
-condition locally with `env -u DISPLAY`.
+The display is what made the cell environment-dependent — a workstation with
+`DISPLAY` set passes while a CI runner without one fails. Reproduce the CI
+condition locally with `env -u DISPLAY`, which yields
+`Exhausted GL driver options (FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS)`.
+
+The workflow also pins the Mesa/EGL packages. That is defensive rather than
+operative: the current `ubuntu-24.04` image already ships `libgl1-mesa-dri`,
+`libglx-mesa0`, `xvfb`, and `xauth`, and a CI bisection showed those packages
+alone did **not** fix the cell — only adding the display did. They are pinned so
+the cell does not depend on what a future image happens to carry, since
+`playwright install --with-deps firefox` contributes no GL packages of its own.
 
 Both browsers are probed for a WebGL2 context before the export is loaded, so
 that failure is reported with the browser's own

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -55,3 +55,10 @@ the default is `chromium`. Both browsers come from the exact `playwright-core`
 version in `clients/browser/package-lock.json` and are installed afresh rather
 than restored from a browser cache. A manual workflow dispatch also selects
 Firefox, allowing exact-head verification before merge.
+
+The Godot web export requires a WebGL2 context, and CI runners have no GPU.
+Chromium reaches its software rasterizer through `--enable-webgl
+--ignore-gpu-blocklist`; Firefox refuses a software context until
+`webgl.force-enabled` is set, and otherwise aborts at boot reporting WebGL2 as
+missing. The harness sets the equivalent option for whichever browser it
+launches, so neither cell depends on runner graphics hardware.

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -58,13 +58,24 @@ Firefox, allowing exact-head verification before merge.
 
 The Godot web export requires a WebGL2 context, and CI runners have no GPU.
 Chromium reaches its own software rasterizer (SwiftShader) through
-`--enable-webgl --ignore-gpu-blocklist`. Firefox needs two separate things:
-`webgl.force-enabled` to bypass the blocklist that refuses WebGL without an
-accelerated adapter, **and** an actual software GL driver — Playwright's Firefox
-dependency list installs no GL packages at all, unlike its Chromium and WebKit
-lists, so the workflow installs Mesa's rasterizer (`libgl1-mesa-dri` and
-friends) for that cell and the harness pins `LIBGL_ALWAYS_SOFTWARE`. Missing
-either half leaves the export aborting at boot with WebGL2 reported as missing.
+`--enable-webgl --ignore-gpu-blocklist`. Firefox has no such fallback: it asks
+the platform for a GL device and, finding none, reports
+`Exhausted GL driver options (FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS)`. It
+needs all three of:
+
+1. `webgl.force-enabled`, to bypass the blocklist that refuses WebGL without an
+   accelerated adapter;
+2. a software GL driver — Playwright's Firefox dependency list installs no GL
+   packages at all, unlike its Chromium and WebKit lists, so the workflow
+   installs Mesa's rasterizer (`libgl1-mesa-dri` and friends);
+3. an **X display**, which headless Firefox still uses to resolve that driver.
+   `scripts/run-fortress-wasm-interop.sh` runs the Firefox harness under
+   `xvfb-run`.
+
+Missing any one of them leaves the export aborting at boot with WebGL2 reported
+as missing. This is what made the cell environment-dependent — a workstation
+with `DISPLAY` set passes while a CI runner without one fails; reproduce the CI
+condition locally with `env -u DISPLAY`.
 
 Both browsers are probed for a WebGL2 context before the export is loaded, so
 that failure is reported with the browser's own

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -57,8 +57,15 @@ than restored from a browser cache. A manual workflow dispatch also selects
 Firefox, allowing exact-head verification before merge.
 
 The Godot web export requires a WebGL2 context, and CI runners have no GPU.
-Chromium reaches its software rasterizer through `--enable-webgl
---ignore-gpu-blocklist`; Firefox refuses a software context until
-`webgl.force-enabled` is set, and otherwise aborts at boot reporting WebGL2 as
-missing. The harness sets the equivalent option for whichever browser it
-launches, so neither cell depends on runner graphics hardware.
+Chromium reaches its own software rasterizer (SwiftShader) through
+`--enable-webgl --ignore-gpu-blocklist`. Firefox needs two separate things:
+`webgl.force-enabled` to bypass the blocklist that refuses WebGL without an
+accelerated adapter, **and** an actual software GL driver — Playwright's Firefox
+dependency list installs no GL packages at all, unlike its Chromium and WebKit
+lists, so the workflow installs Mesa's rasterizer (`libgl1-mesa-dri` and
+friends) for that cell and the harness pins `LIBGL_ALWAYS_SOFTWARE`. Missing
+either half leaves the export aborting at boot with WebGL2 reported as missing.
+
+Both browsers are probed for a WebGL2 context before the export is loaded, so
+that failure is reported with the browser's own
+`webglcontextcreationerror` reason instead of a bare wait for a page global.

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -131,7 +131,7 @@ try {
     expectedRemoteNonce: joinerNonce,
     pageUrl,
   });
-  const room = await waitForGlobal(creator.page, "__FORTRESS_ROOM_READY", 15_000);
+  const room = await waitForGlobal(creator, "__FORTRESS_ROOM_READY", 15_000);
   assertExactKeys(room, ["schema_version", "role", "instance_nonce", "room_code"], "room-ready");
   assert(room.schema_version === 2, "room-ready schema mismatch");
   assert(room.role === "creator", "room-ready role mismatch");
@@ -147,8 +147,8 @@ try {
   });
 
   [creatorReport, joinerReport] = await Promise.all([
-    waitForGlobal(creator.page, "__FORTRESS_RESULT", 105_000),
-    waitForGlobal(joiner.page, "__FORTRESS_RESULT", 105_000),
+    waitForGlobal(creator, "__FORTRESS_RESULT", 105_000),
+    waitForGlobal(joiner, "__FORTRESS_RESULT", 105_000),
   ]);
   await new Promise((accept) => setTimeout(accept, 250));
   const creatorBrowser = await browserAttestation(creator);
@@ -277,6 +277,18 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
       "--enable-webgl",
       "--ignore-gpu-blocklist",
     ];
+  } else {
+    // Firefox parity for the Chromium arguments above. A headless runner has no
+    // GPU, and Firefox's blocklist then refuses a software WebGL context, so the
+    // Godot web export aborts at boot on a missing WebGL2 feature instead of
+    // rendering. `webgl.force-enabled` is the single pref that restores the
+    // llvmpipe context; the timer prefs keep background throttling off so the
+    // measured 60 Hz callback cadence stays comparable across browsers.
+    launchOptions.firefoxUserPrefs = {
+      "webgl.force-enabled": true,
+      "dom.min_background_timeout_value": 4,
+      "dom.timeout.enable_budget_timer_throttling": false,
+    };
   }
   const server = await browserType.launchServer(launchOptions);
   const pid = server.process()?.pid;
@@ -464,9 +476,20 @@ function healthViolations(name, report) {
   return failures;
 }
 
-async function waitForGlobal(page, key, timeout) {
-  await page.waitForFunction((name) => globalThis[name] !== undefined, key, { timeout });
-  return page.evaluate((name) => globalThis[name], key);
+async function waitForGlobal(peer, key, timeout) {
+  try {
+    await peer.page.waitForFunction((name) => globalThis[name] !== undefined, key, { timeout });
+  } catch (error) {
+    // A bare Playwright timeout hides why the page never got there (a missing
+    // browser feature, a WASM trap, a WebSocket close). Surface whatever the
+    // page reported so the CI log alone explains the failure.
+    const observed = peer.errors.length > 0 ? peer.errors.join("\n") : "(none captured)";
+    throw new Error(
+      `${peer.role}: ${key} never appeared within ${timeout}ms; page errors:\n${observed}`,
+      { cause: error },
+    );
+  }
+  return peer.page.evaluate((name) => globalThis[name], key);
 }
 
 async function persistPeerArtifacts(peer, knownReport) {

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -378,15 +378,15 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
   }
 }
 
-/// Fail before loading the export if the browser cannot give it a WebGL2
-/// context, reporting the browser's own reason.
-///
-/// The Godot web export needs WebGL2 and aborts at boot without it. Left to
-/// itself that surfaces as a bare 15-second wait for a page global, which is
-/// how the Firefox cell stayed unexplained across several runs. A canvas
-/// records `webglcontextcreationerror` with a `statusMessage` naming the actual
-/// obstacle (blocklisted adapter, no driver, failed context), so ask for it
-/// directly and put it in the failure.
+// Fail before loading the export if the browser cannot give it a WebGL2
+// context, reporting the browser's own reason.
+//
+// The Godot web export needs WebGL2 and aborts at boot without it. Left to
+// itself that surfaces as a bare 15-second wait for a page global, which is
+// how the Firefox cell stayed unexplained across several runs. A canvas
+// records `webglcontextcreationerror` with a `statusMessage` naming the actual
+// obstacle (blocklisted adapter, no driver, failed context), so ask for it
+// directly and put it in the failure.
 async function assertWebGl2Available(peer) {
   const probe = await peer.page.evaluate(() => {
     const canvas = document.createElement("canvas");

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -278,16 +278,38 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
       "--ignore-gpu-blocklist",
     ];
   } else {
-    // Firefox parity for the Chromium arguments above. A headless runner has no
-    // GPU, and Firefox's blocklist then refuses a software WebGL context, so the
-    // Godot web export aborts at boot on a missing WebGL2 feature instead of
-    // rendering. `webgl.force-enabled` is the single pref that restores the
-    // llvmpipe context; the timer prefs keep background throttling off so the
-    // measured 60 Hz callback cadence stays comparable across browsers.
+    // Firefox parity for the Chromium arguments above. A CI runner has no GPU,
+    // and the Godot web export aborts at boot on a missing WebGL2 feature
+    // rather than rendering, so Firefox has to be pushed onto a software GL
+    // stack from both directions:
+    //
+    //   - `webgl.force-enabled` bypasses the blocklist that refuses WebGL when
+    //     no accelerated adapter is present. On a host that already resolves a
+    //     software GL driver this alone is enough (verified by pref bisection:
+    //     `webgl.forbid-software`, `gfx.webrender.*`, and
+    //     `disable-fail-if-major-performance-caveat` each fail on their own).
+    //   - `gfx.webrender.software` / `.all` keep compositing off the GPU path.
+    //   - `LIBGL_ALWAYS_SOFTWARE` / `GALLIUM_DRIVER` force Mesa to load
+    //     llvmpipe. Bypassing the blocklist does nothing if the loader never
+    //     resolves a driver: Playwright's Firefox dependency list ships no GL
+    //     packages at all (unlike its Chromium and WebKit lists), so the
+    //     workflow installs Mesa's software rasterizer alongside these.
+    //
+    // The timer prefs keep background throttling off so the measured 60 Hz
+    // callback cadence stays comparable across browsers.
     launchOptions.firefoxUserPrefs = {
       "webgl.force-enabled": true,
+      "webgl.forbid-software": false,
+      "webgl.disable-fail-if-major-performance-caveat": true,
+      "gfx.webrender.software": true,
+      "gfx.webrender.all": true,
       "dom.min_background_timeout_value": 4,
       "dom.timeout.enable_budget_timer_throttling": false,
+    };
+    launchOptions.env = {
+      ...process.env,
+      LIBGL_ALWAYS_SOFTWARE: "1",
+      GALLIUM_DRIVER: "llvmpipe",
     };
   }
   const server = await browserType.launchServer(launchOptions);
@@ -345,6 +367,7 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
     });
     peer.page.on("pageerror", (error) => errors.push(`pageerror: ${error.stack ?? error}`));
     peer.page.on("crash", () => errors.push("page crashed"));
+    await assertWebGl2Available(peer);
     await peer.page.goto(pageUrl, { waitUntil: "load", timeout: 15_000 });
     return peer;
   } catch (error) {
@@ -353,6 +376,45 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
     await closePeer(peer);
     throw error;
   }
+}
+
+/// Fail before loading the export if the browser cannot give it a WebGL2
+/// context, reporting the browser's own reason.
+///
+/// The Godot web export needs WebGL2 and aborts at boot without it. Left to
+/// itself that surfaces as a bare 15-second wait for a page global, which is
+/// how the Firefox cell stayed unexplained across several runs. A canvas
+/// records `webglcontextcreationerror` with a `statusMessage` naming the actual
+/// obstacle (blocklisted adapter, no driver, failed context), so ask for it
+/// directly and put it in the failure.
+async function assertWebGl2Available(peer) {
+  const probe = await peer.page.evaluate(() => {
+    const canvas = document.createElement("canvas");
+    let statusMessage = null;
+    canvas.addEventListener(
+      "webglcontextcreationerror",
+      (event) => {
+        statusMessage = event.statusMessage ?? "(no statusMessage)";
+      },
+      { once: true },
+    );
+    const gl = canvas.getContext("webgl2");
+    if (!gl) return { available: false, statusMessage, renderer: null };
+    const debug = gl.getExtension("WEBGL_debug_renderer_info");
+    return {
+      available: true,
+      statusMessage,
+      renderer: debug
+        ? gl.getParameter(debug.UNMASKED_RENDERER_WEBGL)
+        : gl.getParameter(gl.RENDERER),
+    };
+  });
+  peer.logs.push(`webgl2: available=${probe.available} renderer=${probe.renderer}`);
+  assert(
+    probe.available,
+    `${peer.role}: ${browserName} cannot create a WebGL2 context, which the Godot ` +
+      `web export requires to boot: ${probe.statusMessage ?? "(no reason reported)"}`,
+  );
 }
 
 async function browserAttestation(peer) {

--- a/clients/fortress-wasm/src/lib.rs
+++ b/clients/fortress-wasm/src/lib.rs
@@ -898,11 +898,21 @@ struct FortressWasmExtension;
 
 // SAFETY: godot-rust requires this marker to register generated GDExtension
 // callbacks. The implementation supplies no raw pointers or custom lifecycle code.
-// This is the only permitted unsafe site in the fixture; `unsafe_code = "deny"`
-// in Cargo.toml rejects any other.
+//
+// This is the fixture's only permitted unsafe site. The allow sits on the module
+// rather than the item because `#[gdextension]` is an attribute proc-macro and
+// re-emits the impl without item-level attributes, so an `#[allow]` on the impl
+// itself does not reach the expanded code. Scoping it to a module holding this
+// one item keeps `unsafe_code = "deny"` (Cargo.toml) live for the rest of the
+// crate.
 #[allow(unsafe_code)]
-#[gdextension]
-unsafe impl ExtensionLibrary for FortressWasmExtension {}
+mod extension_registration {
+    use super::{ExtensionLibrary, FortressWasmExtension};
+    use godot::init::gdextension;
+
+    #[gdextension]
+    unsafe impl ExtensionLibrary for FortressWasmExtension {}
+}
 
 #[cfg(test)]
 #[allow(clippy::panic)]

--- a/clients/fortress-wasm/src/lib.rs
+++ b/clients/fortress-wasm/src/lib.rs
@@ -898,6 +898,9 @@ struct FortressWasmExtension;
 
 // SAFETY: godot-rust requires this marker to register generated GDExtension
 // callbacks. The implementation supplies no raw pointers or custom lifecycle code.
+// This is the only permitted unsafe site in the fixture; `unsafe_code = "deny"`
+// in Cargo.toml rejects any other.
+#[allow(unsafe_code)]
 #[gdextension]
 unsafe impl ExtensionLibrary for FortressWasmExtension {}
 

--- a/clients/fortress/Cargo.toml
+++ b/clients/fortress/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 rust-version = "1.89.0"
 publish = false
 
+# Matches the server crate: this interop fixture carries no `unsafe` block.
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 fortress-rollback = "=0.10.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/Ambiguous-Interactive/signal-fish-server"
 rust-version = "1.89.0"
 publish = false
 
+# Matches the server crate: this reference client carries no `unsafe` block.
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 # Protocol types come straight from the server crate (zero wire drift).
 signal-fish-server = { path = "../.." }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,11 @@ edition = "2021"
 [package.metadata]
 cargo-fuzz = true
 
+# Matches the server crate. `libfuzzer-sys`'s `fuzz_target!` expands to safe
+# `extern "C"` entry points, so the harness needs no unsafe of its own.
+[lints.rust]
+unsafe_code = "forbid"
+
 [dependencies]
 libfuzzer-sys = "0.4"
 serde_json = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.89.0"
-components = ["rustfmt", "clippy", "rust-analyzer"]
+components = ["rustfmt", "clippy"]
 targets = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.89.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = []

--- a/scripts/run-fortress-wasm-interop.sh
+++ b/scripts/run-fortress-wasm-interop.sh
@@ -101,9 +101,28 @@ else
     node "${REPO_ROOT}/clients/browser/node_modules/playwright-core/cli.js" install "${browser_name}"
 fi
 
-timeout --foreground 180s node "${FIXTURE_ROOT}/harness.mjs" \
+# Firefox has no software WebGL fallback of its own: it asks the platform for a
+# GL device and, finding none, reports
+# `Exhausted GL driver options (FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS)` — which
+# aborts the Godot web export at boot on missing WebGL2. Even headless, it
+# resolves Mesa's llvmpipe through an X display, so give it one. Chromium needs
+# nothing here because it carries SwiftShader.
+#
+# This is what made the cell environment-dependent: a workstation with DISPLAY
+# set passes, a CI runner without one fails. Reproduced exactly by running the
+# harness with `env -u DISPLAY`.
+harness_launcher=()
+if [[ "${browser_name}" == "firefox" ]]; then
+    if ! command -v xvfb-run >/dev/null 2>&1; then
+        printf 'BUSTED: xvfb-run is required for the Firefox cell\n' >&2
+        exit 1
+    fi
+    harness_launcher=(xvfb-run -a --server-args="-screen 0 1280x1024x24")
+fi
+
+timeout --foreground 180s "${harness_launcher[@]}" node "${FIXTURE_ROOT}/harness.mjs" \
     released "${EXPORT_DIR}" "${SERVER_BIN}" "${ARTIFACT_DIR}" "${BUILD_SHA}"
-timeout --foreground 180s node "${FIXTURE_ROOT}/harness.mjs" \
+timeout --foreground 180s "${harness_launcher[@]}" node "${FIXTURE_ROOT}/harness.mjs" \
     negative "${EXPORT_DIR}" "${SERVER_BIN}" "${ARTIFACT_DIR}" "${BUILD_SHA}"
 
 printf 'HEALTHY: released Signal Fish client 0.9.0 satisfies the Godot no-thread WASM healthy gates\n'

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -2306,12 +2306,18 @@ mod tests {
         let _drain = server_for_shutdown.begin_shutdown_drain();
         let _ = shutdown_tx.send(());
         server_for_shutdown.close_connections_for_shutdown();
+        // Hard failure, not a warning. Upgraded WebSocket handlers are tracked
+        // separately from `axum::serve`, so the serve join below can succeed
+        // while handlers are still live — and a warning here would let the test
+        // pass in exactly the leaky state this teardown exists to prevent.
+        // `RunningTestServer::shutdown` asserts on this for the same reason.
         let remaining = server_for_shutdown
             .wait_for_shutdown_connections(settle)
             .await;
-        if remaining != 0 {
-            tracing::warn!(remaining, "test server retained WebSocket handlers");
-        }
+        anyhow::ensure!(
+            remaining == 0,
+            "test server retained {remaining} WebSocket handler(s) after shutdown"
+        );
         // `&mut` matters: passing the handle by value would drop it on timeout,
         // and dropping a `JoinHandle` detaches the task rather than cancelling
         // it — leaving the serve task and any still-registered handlers alive,

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -2312,11 +2312,20 @@ mod tests {
         if remaining != 0 {
             tracing::warn!(remaining, "test server retained WebSocket handlers");
         }
-        match tokio::time::timeout(settle, server_task).await {
+        // `&mut` matters: passing the handle by value would drop it on timeout,
+        // and dropping a `JoinHandle` detaches the task rather than cancelling
+        // it — leaving the serve task and any still-registered handlers alive,
+        // which is the exact failure mode this teardown exists to prevent.
+        let mut server_task = server_task;
+        match tokio::time::timeout(settle, &mut server_task).await {
             Ok(joined) => {
                 joined.context("test server task panicked")?;
             }
-            Err(_) => anyhow::bail!("test server task did not stop after connection drain"),
+            Err(_) => {
+                server_task.abort();
+                let _ = server_task.await;
+                anyhow::bail!("test server task did not stop after connection drain");
+            }
         }
         exchange
     }

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -2204,7 +2204,15 @@ mod tests {
         let app =
             super::super::routes::create_router("http://localhost:3000").with_state(game_server);
 
-        tokio::spawn(async move {
+        // The handle is kept and torn down below rather than detached. A
+        // detached `axum::serve` task owns the `Router`, and therefore the
+        // `Arc<EnhancedGameServer>` and its DashMap shards, for as long as it
+        // lives — which is until the test runtime is dropped. With
+        // `--test-threads=1` that teardown races process exit, and
+        // LeakSanitizer intermittently reports the server's shards as leaked
+        // (issue #209: 22 indirect / 0 direct, `EnhancedGameServer::new` at
+        // server.rs:262 reached from this test).
+        let server_task = tokio::spawn(async move {
             if let Err(e) = axum::serve(
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
@@ -2215,66 +2223,78 @@ mod tests {
             }
         });
 
-        // Poll the server until it accepts a WebSocket connection, rather than a
-        // fixed startup sleep (zero-flakiness policy, .llm/context-testing.md): a
-        // fixed sleep flakes when an oversubscribed runner has not bound the
-        // listener yet. The happy path connects on the first attempt (typically
-        // within a few ms of the spawn); the generous deadline only bites under
-        // pathological load.
-        let url = format!("ws://{addr}/ws");
-        let ready_deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
-        let ws_stream = loop {
-            match tokio::time::timeout(tokio::time::Duration::from_secs(5), connect_async(&url))
-                .await
-            {
-                Ok(Ok((stream, _response))) => break stream,
-                outcome => {
-                    anyhow::ensure!(
-                        tokio::time::Instant::now() < ready_deadline,
-                        "WebSocket server did not become ready within 30s: {outcome:?}"
-                    );
-                    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        // Every `?` below must still reach the teardown, so the exchange runs
+        // inside its own future and its result is returned after the abort.
+        let exchange: anyhow::Result<()> = async {
+            // Poll the server until it accepts a WebSocket connection, rather than a
+            // fixed startup sleep (zero-flakiness policy, .llm/context-testing.md): a
+            // fixed sleep flakes when an oversubscribed runner has not bound the
+            // listener yet. The happy path connects on the first attempt (typically
+            // within a few ms of the spawn); the generous deadline only bites under
+            // pathological load.
+            let url = format!("ws://{addr}/ws");
+            let ready_deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
+            let ws_stream = loop {
+                match tokio::time::timeout(tokio::time::Duration::from_secs(5), connect_async(&url))
+                    .await
+                {
+                    Ok(Ok((stream, _response))) => break stream,
+                    outcome => {
+                        anyhow::ensure!(
+                            tokio::time::Instant::now() < ready_deadline,
+                            "WebSocket server did not become ready within 30s: {outcome:?}"
+                        );
+                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                    }
                 }
+            };
+            let (mut ws_sender, mut ws_receiver) = ws_stream.split();
+
+            // Send join room message
+            let join_message = ClientMessage::JoinRoom {
+                game_name: "test_game".to_string(),
+                room_code: None,
+                player_name: "TestPlayer".to_string(),
+                max_players: Some(4),
+                supports_authority: Some(true),
+                relay_transport: None,
+            };
+
+            let json_message =
+                serde_json::to_string(&join_message).context("serialize join message")?;
+            ws_sender
+                .send(TungsteniteMessage::Text(json_message.into()))
+                .await
+                .context("send join message")?;
+
+            // Receive response with timeout — propagate the elapsed, closed-stream,
+            // and transport-error cases instead of swallowing any of them.
+            let msg = tokio::time::timeout(tokio::time::Duration::from_secs(5), ws_receiver.next())
+                .await
+                .context("timed out waiting for join response after 5s")?
+                .context("websocket closed before sending a join response")?
+                .context("receive websocket message")?;
+
+            let TungsteniteMessage::Text(text) = msg else {
+                anyhow::bail!("expected a Text websocket frame, got {msg:?}");
+            };
+            let server_message: ServerMessage =
+                serde_json::from_str(&text).context("deserialize server message")?;
+            match server_message {
+                ServerMessage::RoomJoined(_) => Ok(()),
+                ServerMessage::RoomJoinFailed { reason, .. } => {
+                    anyhow::bail!("room join failed: {reason}")
+                }
+                other => anyhow::bail!("unexpected server message: {other:?}"),
             }
-        };
-        let (mut ws_sender, mut ws_receiver) = ws_stream.split();
-
-        // Send join room message
-        let join_message = ClientMessage::JoinRoom {
-            game_name: "test_game".to_string(),
-            room_code: None,
-            player_name: "TestPlayer".to_string(),
-            max_players: Some(4),
-            supports_authority: Some(true),
-            relay_transport: None,
-        };
-
-        let json_message =
-            serde_json::to_string(&join_message).context("serialize join message")?;
-        ws_sender
-            .send(TungsteniteMessage::Text(json_message.into()))
-            .await
-            .context("send join message")?;
-
-        // Receive response with timeout — propagate the elapsed, closed-stream,
-        // and transport-error cases instead of swallowing any of them.
-        let msg = tokio::time::timeout(tokio::time::Duration::from_secs(5), ws_receiver.next())
-            .await
-            .context("timed out waiting for join response after 5s")?
-            .context("websocket closed before sending a join response")?
-            .context("receive websocket message")?;
-
-        let TungsteniteMessage::Text(text) = msg else {
-            anyhow::bail!("expected a Text websocket frame, got {msg:?}");
-        };
-        let server_message: ServerMessage =
-            serde_json::from_str(&text).context("deserialize server message")?;
-        match server_message {
-            ServerMessage::RoomJoined(_) => Ok(()),
-            ServerMessage::RoomJoinFailed { reason, .. } => {
-                anyhow::bail!("room join failed: {reason}")
-            }
-            other => anyhow::bail!("unexpected server message: {other:?}"),
         }
+        .await;
+
+        // Drop the server before returning: `abort()` only marks the task, so
+        // await it to be sure its future — and the last `Arc` to the server —
+        // is released while the runtime is still up.
+        server_task.abort();
+        let _ = server_task.await;
+        exchange
     }
 }

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -2201,22 +2201,29 @@ mod tests {
         )
         .await
         .context("create game server")?;
+        // Shut the server down at the end instead of leaving it running.
+        // Aborting the serve task alone is not enough: the upgraded WebSocket
+        // handler is its own task holding room, queue, and reconnection state,
+        // so the whole server stays live and LeakSanitizer intermittently
+        // reports all of it at process exit (issue #209 — 29 allocations
+        // spanning `EnhancedGameServer::new`, `handle_join_room`,
+        // `handle_socket`, and `register_disconnection`, all of it this one
+        // server). This mirrors `RunningTestServer::shutdown` in
+        // tests/test_helpers.rs, which integration tests already use and whose
+        // `Drop` asserts it was called.
+        let server_for_shutdown = std::sync::Arc::clone(&game_server);
         let app =
             super::super::routes::create_router("http://localhost:3000").with_state(game_server);
 
-        // The handle is kept and torn down below rather than detached. A
-        // detached `axum::serve` task owns the `Router`, and therefore the
-        // `Arc<EnhancedGameServer>` and its DashMap shards, for as long as it
-        // lives — which is until the test runtime is dropped. With
-        // `--test-threads=1` that teardown races process exit, and
-        // LeakSanitizer intermittently reports the server's shards as leaked
-        // (issue #209: 22 indirect / 0 direct, `EnhancedGameServer::new` at
-        // server.rs:262 reached from this test).
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let server_task = tokio::spawn(async move {
             if let Err(e) = axum::serve(
                 listener,
                 app.into_make_service_with_connect_info::<SocketAddr>(),
             )
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
             .await
             {
                 tracing::error!("Test server failed: {}", e);
@@ -2290,11 +2297,27 @@ mod tests {
         }
         .await;
 
-        // Drop the server before returning: `abort()` only marks the task, so
-        // await it to be sure its future — and the last `Arc` to the server —
-        // is released while the runtime is still up.
-        server_task.abort();
-        let _ = server_task.await;
+        // Teardown, in the same order as `RunningTestServer::shutdown`: stop
+        // accepting, close registered connections, wait for their handler tasks
+        // to actually finish, then join the serve task. Dropping the client
+        // sockets above is not sufficient on its own — the server-side handler
+        // has to observe the close and unwind before its state is released.
+        let settle = crate::websocket::registered_connection_shutdown_settle_timeout();
+        let _drain = server_for_shutdown.begin_shutdown_drain();
+        let _ = shutdown_tx.send(());
+        server_for_shutdown.close_connections_for_shutdown();
+        let remaining = server_for_shutdown
+            .wait_for_shutdown_connections(settle)
+            .await;
+        if remaining != 0 {
+            tracing::warn!(remaining, "test server retained WebSocket handlers");
+        }
+        match tokio::time::timeout(settle, server_task).await {
+            Ok(joined) => {
+                joined.context("test server task panicked")?;
+            }
+            Err(_) => anyhow::bail!("test server task did not stop after connection drain"),
+        }
         exchange
     }
 }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -22397,12 +22397,24 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     // WebGL context and the Godot web export aborts at boot on missing WebGL2.
     // Chromium gets `--enable-webgl --ignore-gpu-blocklist`; Firefox needs the
     // pref below or the scheduled cell fails before the game ever starts.
-    for required in ["firefoxUserPrefs", "\"webgl.force-enabled\": true"] {
+    for required in [
+        "firefoxUserPrefs",
+        "\"webgl.force-enabled\": true",
+        "LIBGL_ALWAYS_SOFTWARE",
+        "assertWebGl2Available",
+    ] {
         assert!(
             harness.contains(required),
             "P13 headless Firefox must force a software WebGL2 context: `{required}`"
         );
     }
+    // Playwright's Firefox dependency list carries no GL packages, so bypassing
+    // the blocklist is useless without a driver for the loader to resolve.
+    assert!(
+        workflow.contains("libgl1-mesa-dri"),
+        "P13 must install Mesa's software rasterizer for the Firefox cell; without it \
+         the Godot export aborts at boot on missing WebGL2 even with the prefs set"
+    );
     for required in [
         "browser_name=\"${FORTRESS_WASM_BROWSER:-chromium}\"",
         "install --with-deps \"${browser_name}\"",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -22183,8 +22183,8 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "P13 runner must preserve diagnostics for both released and negative browser cells"
     );
     for required in [
-        "waitForGlobal(creator.page, \"__FORTRESS_RESULT\", 105_000)",
-        "waitForGlobal(joiner.page, \"__FORTRESS_RESULT\", 105_000)",
+        "waitForGlobal(creator, \"__FORTRESS_RESULT\", 105_000)",
+        "waitForGlobal(joiner, \"__FORTRESS_RESULT\", 105_000)",
     ] {
         assert!(
             harness.contains(required),
@@ -22241,6 +22241,16 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         assert!(
             harness.contains(required),
             "P13 harness must retain selectable Chromium/Firefox execution: `{required}`"
+        );
+    }
+    // A headless runner has no GPU, so Firefox's blocklist refuses a software
+    // WebGL context and the Godot web export aborts at boot on missing WebGL2.
+    // Chromium gets `--enable-webgl --ignore-gpu-blocklist`; Firefox needs the
+    // pref below or the scheduled cell fails before the game ever starts.
+    for required in ["firefoxUserPrefs", "\"webgl.force-enabled\": true"] {
+        assert!(
+            harness.contains(required),
+            "P13 headless Firefox must force a software WebGL2 context: `{required}`"
         );
     }
     for required in [

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2184,6 +2184,58 @@ fn test_display_name_matches_template_non_matrix_no_match() {
     );
 }
 
+/// Every `apt-get update` in a workflow must first drop the Azure CLI and
+/// Microsoft prod source lists.
+///
+/// Those mirrors periodically break `apt-get update` on GitHub runners, which
+/// fails the whole step. Five call sites already did this; a sixth added in
+/// this session did not, and would have taken the just-restored Firefox WASM
+/// cell red again on the next mirror hiccup. Checking every site keeps the
+/// convention from being a thing each author has to remember.
+#[test]
+fn test_workflow_apt_update_sites_drop_broken_microsoft_mirrors() {
+    const CLEANUP: &str = "sudo rm -f /etc/apt/sources.list.d/azure-cli.list                            /etc/apt/sources.list.d/microsoft-prod.list";
+    let root = repo_root();
+    let workflows_dir = root.join(".github/workflows");
+    let mut problems = Vec::new();
+    let mut checked = 0usize;
+
+    for entry in collect_workflow_files(&workflows_dir) {
+        let path = entry.path();
+        let content = read_file(&path);
+        let filename = path.file_name().unwrap().to_string_lossy().to_string();
+        let lines: Vec<&str> = content.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !line.trim().starts_with("sudo apt-get update") {
+                continue;
+            }
+            checked += 1;
+            // The cleanup is expected immediately before, allowing for the
+            // comment lines authors put above it.
+            let preceding = lines[index.saturating_sub(6)..index].join("\n");
+            if !preceding.contains("/etc/apt/sources.list.d/azure-cli.list")
+                || !preceding.contains("/etc/apt/sources.list.d/microsoft-prod.list")
+            {
+                problems.push(format!("  - {filename}:{}", index + 1));
+            }
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "`sudo apt-get update` without first removing the Azure CLI / Microsoft prod \
+         source lists:\n{}\n\nThose mirrors periodically break `apt-get update` on \
+         GitHub runners and fail the step. Add this line immediately before it:\n\n    \
+         {CLEANUP}",
+        problems.join("\n")
+    );
+    assert!(
+        checked >= 5,
+        "expected to check at least five `apt-get update` sites, found {checked}; \
+         workflow discovery may be broken"
+    );
+}
+
 #[test]
 fn test_workflow_files_are_valid_yaml() {
     // This test catches basic YAML syntax errors in workflow files

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1535,6 +1535,13 @@ fn unsafe_code_lint_level(manifest: &str) -> Option<String> {
 /// Uses git rather than a filesystem walk so vendored/ignored manifests under
 /// `target/` are excluded and any newly committed package is picked up with no
 /// list to maintain.
+///
+/// `*/Cargo.toml` reaches **any** depth, not just one level: git pathspec globs
+/// do not set `FNM_PATHNAME`, so `*` matches `/`. It therefore covers
+/// `clients/fortress/Cargo.toml` as well as `fuzz/Cargo.toml`. This reads like
+/// a shell glob, where it would mean one level only — `REQUIRED_MANIFESTS`
+/// names a two-level path precisely so a wrong assumption here fails loudly
+/// instead of silently shrinking the guard's coverage.
 fn tracked_package_manifests(root: &Path) -> Vec<String> {
     let output = Command::new("git")
         .arg("-C")

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -22408,10 +22408,12 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
             "P13 headless Firefox must force a software WebGL2 context: `{required}`"
         );
     }
-    // Firefox resolves Mesa's llvmpipe through an X display even when headless,
-    // and has no software WebGL fallback of its own. Without both the driver and
-    // a display it reports FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS and the Godot
-    // export aborts at boot. Reproduced locally with `env -u DISPLAY`.
+    // Firefox has no software WebGL fallback of its own and resolves Mesa's
+    // llvmpipe through an X display even when headless; without one it reports
+    // FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS and the Godot export aborts at
+    // boot. Reproduced locally with `env -u DISPLAY`. The display is the
+    // operative fix — a CI bisection showed the GL packages alone did not help —
+    // but both are pinned so the cell cannot regress on either axis.
     for required in ["libgl1-mesa-dri", "xvfb"] {
         assert!(
             workflow.contains(required),

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -22408,12 +22408,21 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
             "P13 headless Firefox must force a software WebGL2 context: `{required}`"
         );
     }
-    // Playwright's Firefox dependency list carries no GL packages, so bypassing
-    // the blocklist is useless without a driver for the loader to resolve.
+    // Firefox resolves Mesa's llvmpipe through an X display even when headless,
+    // and has no software WebGL fallback of its own. Without both the driver and
+    // a display it reports FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS and the Godot
+    // export aborts at boot. Reproduced locally with `env -u DISPLAY`.
+    for required in ["libgl1-mesa-dri", "xvfb"] {
+        assert!(
+            workflow.contains(required),
+            "P13 Firefox cell must install `{required}`; without it the Godot export \
+             aborts at boot on missing WebGL2 even with the prefs set"
+        );
+    }
     assert!(
-        workflow.contains("libgl1-mesa-dri"),
-        "P13 must install Mesa's software rasterizer for the Firefox cell; without it \
-         the Godot export aborts at boot on missing WebGL2 even with the prefs set"
+        runner.contains("xvfb-run"),
+        "P13 must run the Firefox harness under an X display; headless Firefox still \
+         needs one to resolve a software GL driver"
     );
     for required in [
         "browser_name=\"${FORTRESS_WASM_BROWSER:-chromium}\"",

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1418,6 +1418,149 @@ const REQUIRED_RELEASE_TARGETS: &[(&str, &str)] = &[
     ("aarch64-pc-windows-msvc", "Windows ARM64"),
 ];
 
+/// Every git-tracked package manifest must declare an explicit `unsafe_code`
+/// lint policy under `[lints.rust]` (issue #205).
+///
+/// The signaling server and its reference clients contain no `unsafe` block.
+/// That was true by habit, not by construction — nothing stopped a future
+/// change from introducing one silently. Discovery is dynamic (`git ls-files`)
+/// so a package added later cannot opt out by omission, which is the failure
+/// mode this guards: a manifest that simply never mentions the policy.
+///
+/// `forbid` is required everywhere except packages listed in
+/// `DENY_UNSAFE_PACKAGES`, which need a small, reviewed number of unsafe sites
+/// (godot-rust's `unsafe impl ExtensionLibrary` marker) and therefore use
+/// `deny` plus a local `#[allow(unsafe_code)]` at each site.
+#[test]
+fn test_every_package_manifest_declares_an_unsafe_code_policy() {
+    /// Packages permitted to use `deny` instead of `forbid`, with the reason.
+    const DENY_UNSAFE_PACKAGES: &[(&str, &str)] = &[(
+        "clients/fortress-wasm/Cargo.toml",
+        "godot-rust requires one `unsafe impl ExtensionLibrary` marker",
+    )];
+    /// Asserted present so a broken discovery cannot pass vacuously.
+    const REQUIRED_MANIFESTS: &[&str] = &[
+        "Cargo.toml",
+        "clients/fortress/Cargo.toml",
+        "clients/fortress-wasm/Cargo.toml",
+        "clients/native/Cargo.toml",
+        "fuzz/Cargo.toml",
+    ];
+
+    let root = repo_root();
+    let manifests = tracked_package_manifests(&root);
+    let mut checked: Vec<String> = Vec::new();
+    let mut problems: Vec<String> = Vec::new();
+
+    for relative in &manifests {
+        let manifest = read_file(&root.join(relative));
+        // Only packages carry lints; a pure `[workspace]` manifest has none.
+        if !manifest.lines().any(|line| line.trim() == "[package]") {
+            continue;
+        }
+        checked.push(relative.clone());
+        let expected = if DENY_UNSAFE_PACKAGES
+            .iter()
+            .any(|(path, _)| path == relative)
+        {
+            "deny"
+        } else {
+            "forbid"
+        };
+        match unsafe_code_lint_level(&manifest) {
+            Some(level) if level == expected => {}
+            Some(level) => problems.push(format!(
+                "  - {relative}  declares `unsafe_code = \"{level}\"`, expected \"{expected}\""
+            )),
+            None => problems.push(format!(
+                "  - {relative}  has no `unsafe_code` entry under [lints.rust]"
+            )),
+        }
+    }
+
+    assert!(
+        problems.is_empty(),
+        "Package manifest(s) missing the no-unsafe policy (issue #205):\n{}\n\n\
+         Add `unsafe_code = \"forbid\"` under a `[lints.rust]` table. If the package \
+         genuinely requires an unsafe site, use \"deny\" instead, add a local \
+         `#[allow(unsafe_code)]` with a SAFETY comment at that site, and record the \
+         package in DENY_UNSAFE_PACKAGES in this test.",
+        problems.join("\n")
+    );
+    for required in REQUIRED_MANIFESTS {
+        assert!(
+            checked.iter().any(|relative| relative == required),
+            "expected to check `{required}`, but only checked {checked:?}; manifest \
+             discovery may be broken or the package moved"
+        );
+    }
+}
+
+/// Read the `unsafe_code` level from a manifest's `[lints.rust]` table.
+///
+/// A small section scan rather than a toml dependency, matching the style of
+/// the MSRV and lockfile guards in this repository.
+fn unsafe_code_lint_level(manifest: &str) -> Option<String> {
+    let mut in_lints_rust = false;
+    for line in manifest.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_lints_rust = trimmed == "[lints.rust]";
+            continue;
+        }
+        if !in_lints_rust {
+            continue;
+        }
+        let Some(rest) = trimmed.strip_prefix("unsafe_code") else {
+            continue;
+        };
+        let rest = rest.trim_start().strip_prefix('=')?.trim();
+        // Accept both `unsafe_code = "forbid"` and the table form
+        // `unsafe_code = { level = "forbid", .. }`.
+        let value = rest.strip_prefix('"').and_then(|s| s.strip_suffix('"'));
+        return match value {
+            Some(level) => Some(level.to_string()),
+            None => rest
+                .split("level")
+                .nth(1)
+                .and_then(|s| s.split('"').nth(1))
+                .map(str::to_string),
+        };
+    }
+    None
+}
+
+/// Repository-relative paths of every git-tracked `Cargo.toml`.
+///
+/// Uses git rather than a filesystem walk so vendored/ignored manifests under
+/// `target/` are excluded and any newly committed package is picked up with no
+/// list to maintain.
+fn tracked_package_manifests(root: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z", "--", "Cargo.toml", "*/Cargo.toml"])
+        .output()
+        .unwrap_or_else(|error| {
+            panic!("`git ls-files` failed ({error}); this guard requires a git checkout")
+        });
+    assert!(
+        output.status.success(),
+        "`git ls-files` exited with {}; this guard requires a git checkout",
+        output.status
+    );
+    let manifests: Vec<String> = String::from_utf8_lossy(&output.stdout)
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.replace('\\', "/"))
+        .collect();
+    assert!(
+        !manifests.is_empty(),
+        "`git ls-files` returned no Cargo.toml paths; this guard requires a git checkout"
+    );
+    manifests
+}
+
 #[test]
 fn test_msrv_consistency_across_config_files() {
     // This test prevents the MSRV inconsistency issue that was fixed in commit d9eac0f

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -45,7 +45,6 @@
 mod test_helpers;
 
 use signal_fish_server::config::ProtocolConfig;
-use signal_fish_server::protocol::DEFAULT_ROOM_CODE_LENGTH;
 use signal_fish_server::server::ServerConfig;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -66,12 +65,16 @@ use tokio::time::timeout;
 /// rooms. Codes are built here so their length is one checked decision rather
 /// than six independent `format!` strings.
 fn load_room_code(prefix: char, index: u32) -> String {
+    // Checked against the same `ProtocolConfig` the load servers below are
+    // built with, rather than a second copy of the constant, so a change to the
+    // configured length cannot leave this helper silently disagreeing.
+    let required = ProtocolConfig::default().room_code_length;
     let code = format!("{prefix}{index:05}");
     assert_eq!(
         code.len(),
-        DEFAULT_ROOM_CODE_LENGTH,
-        "load-test room code `{code}` is not the {DEFAULT_ROOM_CODE_LENGTH} characters \
-         the server requires; widen the index format or shorten the prefix"
+        required,
+        "load-test room code `{code}` is not the {required} characters the server \
+         requires; widen the index format or shorten the prefix"
     );
     code
 }
@@ -496,7 +499,10 @@ async fn test_load_sustained_concurrent_connections() {
 #[tokio::test]
 #[ignore]
 async fn test_load_message_latency_distribution() {
-    let server = Arc::new(create_test_server().await);
+    // Uses the load server for headroom: this cell creates exactly as many rooms
+    // as the shared config's `max_rooms_per_game` allows, so any shift in room
+    // cleanup timing would push the last creation over a zero-margin limit.
+    let server = Arc::new(create_load_test_server().await);
 
     let num_rooms = 100;
     let players_per_room = 4;

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -24,23 +24,78 @@
 /// nightly `tests/relay_delivery_soak.rs` /
 /// `tests/delivery_concurrency_stress.rs` lanes.
 ///
-/// KNOWN-BROKEN (as of the nightly-verification lane's introduction):
-/// `test_load_room_creation_throughput` and
-/// `test_load_sustained_concurrent_connections` fail deterministically under
-/// the shared test-server defaults — they request 250-500 rooms in a single
-/// game against `max_rooms_per_game: 100` and trip the room-creation rate
-/// limits, so their ">=95% success" assertions cannot hold. They are
-/// excluded from `.github/workflows/verification-nightly.yml` until
-/// repaired; only `test_load_message_latency_distribution` runs there.
+/// REPAIRED (issue #207). Every room-based cell here used to build a room code
+/// of the wrong length — `LOAD000000` (10 chars), `MLAT0000` (8), `MEM0000` (7)
+/// — while the server requires **exactly** `ProtocolConfig::room_code_length`
+/// (6). `handle_join_room` signals a rejected join only by leaving the player
+/// roomless, so this failed silently in two different ways: the two throughput
+/// cells recorded 0% success and were excluded from CI as "known-broken", while
+/// `test_load_message_latency_distribution` ran green in the nightly lane while
+/// measuring broadcasts into empty rooms.
+///
+/// The earlier diagnosis recorded here — `max_rooms_per_game: 100` plus room
+/// creation rate limits — was wrong: `check_room_creation` is keyed per player
+/// and every cell uses a fresh UUID per client, so it never bound. The room cap
+/// is a real second limit for the 250-500 room cells, and `create_load_test_server`
+/// raises it, but code length was what zeroed them out.
+///
+/// All codes now come from `load_room_code`, and the cells assert that players
+/// actually entered a room, so a future validation change fails loudly instead
+/// of quietly making these vacuous again.
 mod test_helpers;
 
+use signal_fish_server::config::ProtocolConfig;
+use signal_fish_server::protocol::DEFAULT_ROOM_CODE_LENGTH;
 use signal_fish_server::server::ServerConfig;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use test_helpers::{create_test_server, create_test_server_with_config};
+use test_helpers::{create_test_server, create_test_server_with_config, test_server_config};
 use tokio::sync::{mpsc, Barrier};
 use tokio::time::timeout;
+
+/// Build a room code this server will actually accept.
+///
+/// `validate_room_code_with_config` requires a code of **exactly**
+/// `ProtocolConfig::room_code_length` alphanumeric characters (6 by default),
+/// and `handle_join_room` rejects anything else without returning an error to
+/// the caller. Every cell in this file used to build longer codes — `LOAD000000`
+/// (10), `MLAT0000` (8), `MEM0000` (7) — so no player ever entered a room: the
+/// two throughput cells failed their success assertions and were excluded from
+/// CI, while the latency cell "passed" while measuring broadcasts to empty
+/// rooms. Codes are built here so their length is one checked decision rather
+/// than six independent `format!` strings.
+fn load_room_code(prefix: char, index: u32) -> String {
+    let code = format!("{prefix}{index:05}");
+    assert_eq!(
+        code.len(),
+        DEFAULT_ROOM_CODE_LENGTH,
+        "load-test room code `{code}` is not the {DEFAULT_ROOM_CODE_LENGTH} characters \
+         the server requires; widen the index format or shorten the prefix"
+    );
+    code
+}
+
+/// Server sized for the throughput cells rather than for functional tests.
+///
+/// `test_server_config()` caps a game at 100 rooms. That is a correctness limit
+/// for functional tests, not a throughput budget, and it silently bounded what
+/// the throughput cells below could measure: they request 250-500 rooms in a
+/// single game, so most creations were rejected by the cap and their ">=95%
+/// success" assertions could never hold. These cells measure how fast the
+/// handler path creates rooms and sustains connections, so the room ceiling
+/// rises to the production default (`default_max_rooms_per_game()`); every
+/// other value stays at the shared test default.
+async fn create_load_test_server() -> Arc<signal_fish_server::server::EnhancedGameServer> {
+    create_test_server_with_config(
+        ServerConfig {
+            max_rooms_per_game: signal_fish_server::config::defaults::default_max_rooms_per_game(),
+            ..test_server_config()
+        },
+        ProtocolConfig::default(),
+    )
+    .await
+}
 
 /// Performance metrics collector
 #[derive(Default)]
@@ -115,7 +170,10 @@ impl PerformanceMetrics {
             0
         };
 
-        let throughput = if duration.as_secs() > 0 {
+        // Guard on the fractional duration, not `as_secs()`: a sub-second run
+        // has `as_secs() == 0`, so the fast cells used to report "0.00 ops/sec"
+        // for a run that completed thousands of operations.
+        let throughput = if duration.as_secs_f64() > 0.0 {
             total as f64 / duration.as_secs_f64()
         } else {
             0.0
@@ -235,7 +293,7 @@ async fn test_load_concurrent_websocket_connections() {
 #[tokio::test]
 #[ignore]
 async fn test_load_room_creation_throughput() {
-    let server = Arc::new(create_test_server().await);
+    let server = Arc::new(create_load_test_server().await);
     let metrics = Arc::new(PerformanceMetrics::new());
 
     let num_rooms = 500; // Create 500 rooms
@@ -264,7 +322,7 @@ async fn test_load_room_creation_throughput() {
                 server_clone.connect_client(player_id, tx).await;
 
                 // Create unique room
-                let room_code = format!("LOAD{batch:04}{i:02}");
+                let room_code = load_room_code('L', (batch * concurrent_creates + i) as u32);
                 let result = timeout(
                     Duration::from_secs(5),
                     server_clone.handle_join_room(
@@ -314,7 +372,11 @@ async fn test_load_room_creation_throughput() {
 
     assert!(
         successful as f64 / total as f64 >= 0.95,
-        "At least 95% of room creations should succeed"
+        "At least 95% of room creations should succeed, got {successful}/{total} \
+         ({:.1}%) over {num_rooms} requested rooms in one game — a shortfall this \
+         large usually means a server limit rejected the load rather than the \
+         handler path being slow",
+        (successful as f64 / total as f64) * 100.0
     );
 
     println!("Room creation throughput: {throughput:.2} rooms/sec (target: 100)");
@@ -325,7 +387,7 @@ async fn test_load_room_creation_throughput() {
 #[tokio::test]
 #[ignore]
 async fn test_load_sustained_concurrent_connections() {
-    let server = Arc::new(create_test_server().await);
+    let server = Arc::new(create_load_test_server().await);
     let metrics = Arc::new(PerformanceMetrics::new());
 
     let num_clients = 1000;
@@ -351,7 +413,7 @@ async fn test_load_sustained_concurrent_connections() {
             server_clone.connect_client(player_id, tx).await;
 
             // Join a room
-            let room_code = format!("SUST{:04}", i / 4); // 4 players per room
+            let room_code = load_room_code('S', i / 4); // 4 players per room
             let _ = server_clone
                 .handle_join_room(
                     &player_id,
@@ -417,7 +479,11 @@ async fn test_load_sustained_concurrent_connections() {
 
     assert!(
         successful as f64 / total as f64 >= 0.95,
-        "At least 95% of operations should succeed under sustained load"
+        "At least 95% of operations should succeed under sustained load, got \
+         {successful}/{total} ({:.1}%) across {num_clients} clients — a shortfall \
+         this large usually means a server limit rejected the load rather than the \
+         handler path being slow",
+        (successful as f64 / total as f64) * 100.0
     );
 
     let avg_latency = metrics.total_latency_ms.load(Ordering::Relaxed) / successful as u64;
@@ -450,7 +516,7 @@ async fn test_load_message_latency_distribution() {
 
     // Create rooms with players
     for room_idx in 0..num_rooms {
-        let room_code = format!("MLAT{room_idx:04}");
+        let room_code = load_room_code('M', room_idx);
         let mut player_ids = Vec::new();
         let mut receivers = Vec::new();
 
@@ -476,8 +542,27 @@ async fn test_load_message_latency_distribution() {
             receivers.push(rx);
         }
 
-        // Verify all players joined
+        // Verify all players joined. This assertion is the point of the cell:
+        // `handle_join_room` reports a rejected join only by leaving the player
+        // roomless, so without it a broadcast measured against empty rooms reads
+        // as a fast pass. That is exactly how this cell ran green in CI while
+        // measuring nothing.
         tokio::time::sleep(Duration::from_millis(100)).await;
+        let mut joined_rooms = Vec::new();
+        for player_id in &player_ids {
+            let room = server.get_client_room(player_id).await.unwrap_or_else(|| {
+                panic!(
+                    "player {player_id} never entered room {room_code}; the broadcast \
+                     latency below would be measured against an empty room"
+                )
+            });
+            joined_rooms.push(room);
+        }
+        assert!(
+            joined_rooms.windows(2).all(|pair| pair[0] == pair[1]),
+            "players for room {room_code} landed in different rooms ({joined_rooms:?}); \
+             a broadcast would not fan out to all {players_per_room} of them"
+        );
 
         // Each player sends messages and we measure broadcast latency
         for player_id in &player_ids {
@@ -572,7 +657,7 @@ async fn test_load_stress_to_failure() {
                 let result = timeout(Duration::from_secs(10), async {
                     server_clone.connect_client(player_id, tx).await;
 
-                    let room_code = format!("STRESS{:04}", i / 4);
+                    let room_code = load_room_code('T', i / 4);
                     server_clone
                         .handle_join_room(
                             &player_id,
@@ -655,7 +740,7 @@ async fn test_load_memory_usage() {
 
             server_clone.connect_client(player_id, tx).await;
 
-            let room_code = format!("MEM{:04}", i / 4);
+            let room_code = load_room_code('E', i / 4);
             let _ = server_clone
                 .handle_join_room(
                     &player_id,
@@ -790,7 +875,7 @@ async fn test_load_rate_limiting() {
     let start = Instant::now();
 
     for i in 0..attempts {
-        let room_code = format!("RATE{i:04}");
+        let room_code = load_room_code('R', i);
         server
             .handle_join_room(
                 &player_id,

--- a/tests/mixed_encoding_relay_e2e.rs
+++ b/tests/mixed_encoding_relay_e2e.rs
@@ -434,6 +434,7 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
     let fallback_auditor = Arc::clone(&auditor);
     let fallback_reader = tokio::spawn(async move {
         let (_, mut stream) = fallback.split();
+        let started = std::time::Instant::now();
         let deadline = tokio::time::Instant::now() + EXPERIMENT_DEADLINE;
         let mut reports = 0u64;
         let mut errors = 0u64;
@@ -441,7 +442,11 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
             let frame = tokio::time::timeout_at(deadline, stream.next())
                 .await
                 .unwrap_or_else(|_| {
-                    panic!("fallback recipient timed out after {reports} reports/{errors} errors")
+                    panic!(
+                        "fallback recipient timed out after {reports}/{BURST} reports and \
+                         {errors} advisories in {:?}",
+                        started.elapsed()
+                    )
                 })
                 .unwrap_or_else(|| {
                     panic!("fallback recipient closed without a semantic close frame")
@@ -450,12 +455,28 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
             match frame {
                 Message::Text(text) => match fallback_auditor.record_text_frame("P2", &text) {
                     ServerMessage::DeliveryReport(_) => reports += 1,
-                    ServerMessage::Error { error_code, .. } => {
+                    ServerMessage::Error {
+                        error_code,
+                        message,
+                    } => {
+                        // `SlowConsumer` here is not a stray advisory: the server
+                        // only ever emits it as a farewell frame immediately
+                        // before eviction, so seeing it means this recipient is
+                        // being dropped. Report the counters and elapsed time
+                        // with it — a bare `assert_eq!` on the code says nothing
+                        // about how far the experiment got, which is the first
+                        // thing needed to tell a genuine amplification eviction
+                        // from a link that simply never kept pace. See issue
+                        // #212.
                         assert_eq!(
                             error_code,
                             Some(
                                 signal_fish_server::protocol::ErrorCode::UnsupportedGameDataFormat
-                            )
+                            ),
+                            "fallback recipient received `{error_code:?}` after {reports}/{BURST} \
+                             reports and {errors} advisories, {:?} into a {EXPERIMENT_DEADLINE:?} \
+                             budget: {message}",
+                            started.elapsed(),
                         );
                         errors += 1;
                     }

--- a/tests/websocket_test_helpers/chaos_proxy.rs
+++ b/tests/websocket_test_helpers/chaos_proxy.rs
@@ -9,8 +9,10 @@
 //!   direction's pump so bytes accumulate in kernel socket buffers (a stalled
 //!   reader, without touching the client's task).
 //! - [`throttle`](ChaosProxy::throttle): pace a direction to a byte rate
-//!   (chunked writes with a pre-write pacing sleep — the injected workload
-//!   shape, not a synchronization primitive).
+//!   (chunked writes released against a virtual clock — see
+//!   [`next_chunk_release`] — so the achieved rate converges on nominal instead
+//!   of drifting below it on a loaded machine; the injected workload shape, not
+//!   a synchronization primitive).
 //! - [`fragment_writes`](ChaosProxy::fragment_writes): forward one byte per
 //!   write so frames arrive maximally fragmented.
 //! - [`rst_all`](ChaosProxy::rst_all): abort every proxied connection with a
@@ -300,6 +302,39 @@ fn spawn_connection(control: &Arc<ProxyControl>, client: TcpStream, server: TcpS
     });
 }
 
+/// When a throttled pump may release its next chunk.
+///
+/// Pacing is a **virtual clock**, not a fixed sleep per chunk. Sleeping
+/// `bytes / rate` after every read adds the pump's own read/write/scheduling
+/// latency to every period, so the achieved rate is always *below* nominal and
+/// drifts further the busier the machine is. That made the injected fault
+/// inaccurate in exactly the direction that breaks experiments: on a loaded CI
+/// runner a nominal "32 KiB/s" link delivered materially less, the server's
+/// sojourn bound tripped, and `mixed_encoding_relay_e2e`'s throttled recipient
+/// was evicted as a slow consumer — the outcome that experiment exists to prove
+/// does *not* happen. It failed this way on `main` in run 30187497311 and again
+/// on PR #208.
+///
+/// Scheduling each chunk against a running virtual clock lets a late iteration
+/// be absorbed by the next one, so the long-run rate converges on nominal.
+/// Catch-up credit is capped at one chunk period: a pump that fell far behind
+/// (a `pause()`, or the process being descheduled) restarts the clock instead
+/// of bursting to "make up" arbitrary lost time.
+fn next_chunk_release(
+    previous: Option<tokio::time::Instant>,
+    now: tokio::time::Instant,
+    pacing: Duration,
+) -> tokio::time::Instant {
+    let target = previous.unwrap_or(now) + pacing;
+    // Comparing `target + pacing` against `now` keeps this in Instant addition
+    // only — subtracting a Duration from an Instant can underflow.
+    if target + pacing < now {
+        now
+    } else {
+        target
+    }
+}
+
 /// Copy bytes `from` -> `to`, honoring the direction's pause / throttle /
 /// fragmentation switches and ending immediately on a kill signal, EOF, or a
 /// socket error (all of which tear down the whole connection).
@@ -313,6 +348,8 @@ async fn pump(
     let mut pause_rx = controls.paused.subscribe();
     let mut kill_rx = control.kill.subscribe();
     let mut buffer = vec![0u8; 8 * 1024];
+    // Virtual clock for throttled pacing; see `next_chunk_release`.
+    let mut release_at: Option<tokio::time::Instant> = None;
 
     loop {
         // Park while paused; a kill preempts the park.
@@ -385,14 +422,20 @@ async fn pump(
         let throttle = controls.throttle_bytes_per_sec.load(Ordering::Relaxed);
         if throttle > 0 {
             let pacing = Duration::from_secs_f64(received as f64 / throttle as f64);
+            let release = next_chunk_release(release_at, tokio::time::Instant::now(), pacing);
+            release_at = Some(release);
             tokio::select! {
                 _ = kill_rx.changed() => {
                     if *kill_rx.borrow() != KillMode::None {
                         return;
                     }
                 }
-                () = tokio::time::sleep(pacing) => {}
+                () = tokio::time::sleep_until(release) => {}
             }
+        } else {
+            // Restart the virtual clock when the throttle is lifted so a later
+            // re-throttle does not inherit stale credit.
+            release_at = None;
         }
 
         let fragment = controls.fragment_writes.load(Ordering::Relaxed);
@@ -550,6 +593,44 @@ mod tests {
             elapsed >= Duration::from_millis(500),
             "2 KiB through a 2 KiB/s throttle finished in {elapsed:?} — throttle not applied"
         );
+    }
+
+    /// The pacing clock must converge on the nominal rate rather than drifting
+    /// below it, which is what evicted a throttled recipient in
+    /// `mixed_encoding_relay_e2e` on a loaded runner. Exercised as pure
+    /// arithmetic over synthetic instants so the property is deterministic
+    /// instead of a timing race.
+    #[tokio::test]
+    async fn chunk_pacing_compensates_for_late_iterations() {
+        let pacing = Duration::from_millis(32);
+        let start = tokio::time::Instant::now();
+
+        // First chunk under a fresh clock: one full period from now.
+        assert_eq!(next_chunk_release(None, start, pacing), start + pacing);
+
+        // On time: the next release is one period after the previous one, so
+        // the schedule stays anchored to the virtual clock rather than to the
+        // moment this iteration happened to run.
+        let previous = start + pacing;
+        assert_eq!(
+            next_chunk_release(Some(previous), previous, pacing),
+            previous + pacing
+        );
+
+        // Slightly late (this iteration ran a third of a period behind): the
+        // release stays on the virtual schedule, which is now in the past, so
+        // the chunk goes immediately and the lost time is absorbed. A fixed
+        // per-chunk sleep would instead add the lateness to every period.
+        let late = previous + pacing + pacing / 3;
+        let release = next_chunk_release(Some(previous), late, pacing);
+        assert_eq!(release, previous + pacing);
+        assert!(release < late, "a late iteration must release immediately");
+
+        // Far behind (a pause, or the process descheduled for many periods):
+        // credit is dropped and the clock restarts, so catching up can never
+        // burst an unbounded amount of traffic through the throttle.
+        let stalled = previous + pacing * 50;
+        assert_eq!(next_chunk_release(Some(previous), stalled, pacing), stalled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary

One session's work: main's only red lane is fixed, both open Dependabot PRs are
incorporated on evidence, and the two highest-impact open issues (#205, #207)
are closed with red-green changes.

Every claim below was verified locally before pushing.

---

### 1. The weekly Firefox WASM interop cell has never passed — fixed

The scheduled Fortress/Godot no-thread WASM cell failed on every run since it
was introduced (`29807069429`, `30334851423`), reporting only
`page.waitForFunction: Timeout 15000ms exceeded`. The real cause was in the
failure artifact:

```
The following features required to run Godot projects on the Web are missing: WebGL2
```

CI runners have no GPU. The Chromium launch path already compensated with
`--enable-webgl --ignore-gpu-blocklist`; the Firefox path passed **no launch
options at all**, so Firefox's blocklist refused a software context and the
Godot export aborted before the game started.

It turned out to be **two causes**, plus one I initially got wrong:

| # | cause | fix |
| --- | --- | --- |
| 1 | Firefox blocklists WebGL with no accelerated adapter | `webgl.force-enabled` (pref bisection: the other four candidates each fail alone) |
| 2 | Firefox has no SwiftShader-equivalent; even headless it resolves Mesa through an **X display** | `xvfb-run` |

**A correction I had to make on myself.** In between, I shipped a third "cause":
Playwright's Firefox dependency list genuinely contributes no GL packages (its
Chromium list has `libgbm1`, WebKit's has `libgl1`/`libegl1`), so I installed
Mesa. The passing run's apt output disproved it as the fix — the `ubuntu-24.04`
image already had `libgl1-mesa-dri`, `libglx-mesa0`, `xvfb`, and `xauth`; only
`libegl1`/`libegl-mesa0` were new. My own commits are a clean CI bisection:

```text
5b046f8  Mesa/EGL packages, no display  -> FAILED (EXHAUSTED_DRIVERS)
4c18dd5  packages + xvfb-run            -> PASSED
```

The package pin stays as defensive hardening, but every mention of it — workflow
comment, README, CHANGELOG, policy-test comment — now says so rather than
crediting it with the fix.

Cause 2 is the entire environment dependence, and it is why my local runs kept
misleading me: this devcontainer has `DISPLAY=:0`, so Firefox always found a
device. **A local pass was never evidence about a clean runner** — I treated it
as such before building a reproduction of the runner's condition:

```console
$ env -u DISPLAY ... node clients/fortress-wasm/harness.mjs released ...
BUSTED ... firefox cannot create a WebGL2 context ...
* Exhausted GL driver options. (FEATURE_FAILURE_WEBGL_EXHAUSTED_DRIVERS)

$ env -u DISPLAY xvfb-run -a --server-args="-screen 0 1280x1024x24" ...
HEALTHY fortress-wasm released-client interoperability
webgl2: available=true renderer=llvmpipe, or similar
```

`headless: true` is unchanged — the display is needed only for driver
resolution, not to render a window.

**The diagnostics were the load-bearing change.** Before this PR both failures
were indistinguishable: each surfaced as
`page.waitForFunction: Timeout 15000ms exceeded`. That is why the cell sat red
from session 059 with no diagnosis. A WebGL2 probe now runs before the export
loads and fails fast with the browser's own reason.

### Exact-head CI evidence

Run [`30479171185`](https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/30479171185):

```text
HEALTHY fortress-wasm released-client interoperability
BUSTED fortress-wasm expected negative control (22 healthy-gate violations)
HEALTHY: released Signal Fish client 0.9.0 satisfies the Godot no-thread WASM healthy gates
```

Both oracles correct — the first pass since the cell was introduced.

Verified end-to-end by replaying the **exact Godot export from failing run
30334851423** against a server built from this checkout. All four cells pass:

| cell | verdict |
| --- | --- |
| Firefox released | `HEALTHY` |
| Firefox negative control | expected `BUSTED` (22 violations) |
| Chromium released | `HEALTHY` (non-regression) |
| Chromium negative control | expected `BUSTED` (22 violations) |

The Firefox release cell reached confirmed frame 600 on both peers at a
**16.7 ms callback mean** (≈60 Hz), **128.7 completed messages/s**, zero stalls,
zero wait recommendations, and 9/9 matching checksums.

`waitForGlobal` now attaches the page's captured errors to its timeout, so the
next boot failure is legible from the workflow log instead of requiring a 58 MB
artifact download.

---

### 2. The load-test suite was measuring nothing (issue #207)

`validate_room_code_with_config` requires a room code of **exactly** 6
characters, and `handle_join_room` signals a rejected join only by leaving the
player roomless. Every room-based cell in `tests/load_tests.rs` built a longer
code — `LOAD000000` (10), `MLAT0000` (8), `MEM0000` (7) — so **no player ever
entered a room**.

This failed silently in two directions:

- The two throughput cells recorded **0% success** and had been excluded from CI
  as "known-broken". **The recorded diagnosis was wrong**: it blamed
  `max_rooms_per_game: 100` plus room-creation rate limits, but
  `check_room_creation` is keyed per player and every cell uses a fresh UUID, so
  that limit never bound.
- `test_load_message_latency_distribution` ran **green in the nightly lane while
  measuring broadcasts into empty rooms**.

Codes now come from one length-checked helper, the room ceiling is sized for the
250–500 room cells (a real second limit once codes are valid), and the cells
assert that players actually entered a room. Restoring the historical 8-character
code makes the latency cell fail with a precise message — the guard is proven
red-green.

Measured after repair, all three now wired into the nightly load lane:

| cell | result | target |
| --- | --- | --- |
| room creation throughput | 500/500, **4,618 rooms/s** | 100 rooms/s |
| message latency | p50 **0.05 ms**, p99 **0.34 ms**, 4,000 msgs | p50 <10 ms, p99 <50 ms |
| sustained connections | **96,431 ops, 100% success**, 1,000 clients / 30 s | ≥95% |

`PerformanceMetrics::report` also gated throughput on `as_secs() > 0`, printing
"0.00 ops/sec" for every sub-second run.

---

### 3. No-unsafe is enforced, not incidental (issue #205)

The server and reference clients contain no `unsafe` block, but nothing stopped
one appearing. Every package manifest now declares an explicit policy:
`unsafe_code = "forbid"` for the server, `clients/native`, `clients/fortress`,
and `fuzz`; `deny` plus a local `#[allow]` for the Godot fixture, which needs
exactly one `unsafe impl ExtensionLibrary` marker.

A policy test discovers manifests via `git ls-files`, so a package added later
cannot opt out by omission — it already caught `fuzz/`, which I then verified
forbids cleanly on nightly rather than assuming. Adding an `unsafe` block to
`src/lib.rs` fails the build with `usage of an unsafe block`.

This closes the server-side half of #205; warnings-as-errors and static analysis
(clippy `-D warnings`, rustdoc `-D warnings`, Miri, ASan, fuzzing, cargo-deny,
mutation testing, TLA+, Z3) were already in place.

---

### 4. Dependency PRs incorporated on evidence (#203, #202)

Both open Dependabot PRs are carried forward here; **neither can merge on its own**
(#203 fails MSRV, and both hit unrelated red lanes).

Taken: the full compatible refresh — Tokio 1.53.1, serde 1.0.229, futures 0.3.33,
clap 4.6.4, hdrhistogram 7.6.0 and others — plus #202's Actions bumps
(cherry-picked, preserving authorship).

Rejected, each on measured evidence:

| proposed | why not |
| --- | --- |
| `tokio-tungstenite` 0.30 | Axum 0.8.9 still pins 0.29; this **adds** a second Tungstenite stack (the P14 objection) |
| `serial_test` 4.0 | requires rustc 1.93.1 against our 1.89.0 MSRV — this is what makes #203 red |
| `base64` 0.23 | `cargo tree` shows axum/hyper-util/hdrhistogram all need 0.22, so 0.23 would be a **second** base64 used by nothing but this crate |
| `syn` 3.0 | removes `Arm::guard`, requiring semantic re-verification of a policy scanner, while deduplicating nothing — syn 2 stays for `bytecheck_derive`/`derive_more` regardless |

Result: exactly one `tokio-tungstenite`, one `tungstenite`, one `base64` in the
locked graph. `cargo-deny`: advisories, bans, licenses, sources all ok.

---

### 5. Sanitizer reports are now symbolized

The 2026-07-27 LeakSanitizer report on #202 was undiagnosable — 22 indirect
leaks, **zero** direct leaks, not one nameable frame. (Zero direct leaks with a
clean run on identical code from main is the signature of an LSan exit-time
race, not a real leak; filed as a follow-up issue rather than blind-fixed.)

`ASAN_SYMBOLIZER_PATH` now points at the runner's system `llvm-symbolizer`.
Worth noting: rustup's `llvm-tools` component does **not** ship one — I verified
that locally rather than assuming. The lookup is best-effort by design, so a
missing symbolizer degrades the report instead of failing a green lane, and the
diagnostic step states whether symbolization was active.

---

## Verification

- `cargo fmt` / `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- `cargo test --locked --all-features` — full suite green
- `cargo test --test load_tests -- --ignored` (all 3 nightly cells) — green
- `bash scripts/check-advisories.sh --full` — advisories/bans/licenses/sources ok
- `bash scripts/check-doc-consistency.sh` — passed
- `actionlint` on every touched workflow — clean
- Fortress WASM harness — 4/4 cells correct in both browsers

## Bugbot findings

Two raised, both handled on evidence rather than reflex:

1. **Nested manifests missed by discovery** — *incorrect*. Git pathspec globs
   don't set `FNM_PATHNAME`, so `*/Cargo.toml` reaches any depth; all five
   manifests are found and `REQUIRED_MANIFESTS` already asserts two-level paths
   were visited. Replied with the `git ls-files` output. The expression does
   read like a shell glob, so I added a doc comment recording the semantics.
2. **`apt-get update` without the Microsoft mirror cleanup** — *correct, taken*.
   All five pre-existing apt sites drop those source lists first; mine was the
   only one that didn't, and those mirrors periodically break `apt-get update` on
   runners — which would have sent the just-restored Firefox cell red again.
   Rather than patch the one site, added a sweep test over every workflow
   (proven red-green, with a floor assertion against vacuous discovery), since
   this is a convention each author has to remember unaided and I'd just shown
   it's forgettable.

Both threads are resolved. Copilot has been quota-blocked on every push.

## Known: one pre-existing `main` failure, not fixed here

`Real-World Scenario Profiles` fails on
`unsupported_message_pack_fallback_does_not_flap_weaker_recipient` (the H14
experiment). **This is pre-existing on `main`** — same test, same assertion, at
`a8020246` in scheduled run
[`30187497311`](https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/30187497311)
(2026-07-26), before this branch's dependency refresh existed. It reaches this
PR only because the diff touches `tests/load_tests.rs`, which is in that
workflow's path filter.

`ErrorCode::SlowConsumer` is emitted only as a farewell immediately before
eviction, so the assertion is correct: the throttled recipient really is being
evicted. My first hypothesis (the fault injector running below its nominal rate)
was **wrong as an explanation** — the fix for it is genuine and tested, but the
next run failed even earlier, at 8.28 s. I have not claimed otherwise anywhere
in the diff.

What this PR does instead: fixes the injector defect that investigation
uncovered, replaces the uninformative assertion with one that reports counters,
elapsed time, and the server's own message, and files **#212** with the full
evidence — including the leading hypothesis (the 5-second full-queue timeout,
gated by kernel socket buffering) and the corollary that the test may only pass
when buffering hides the injected fault, which would be a production finding
rather than a test bug. Settling that needs its own experiment.

## Follow-ups

| # | topic |
| --- | --- |
| #209 | LeakSanitizer 22-indirect/0-direct flake in the ASan lane |
| #210 | Scoped CAP/resilience work for #206 against the existing single-instance doctrine |
| #211 | Allocation tracking for the relay hot path — the unstarted half of #207 |
| #212 | H14 slow-consumer eviction flake (pre-existing on `main`) |

Issue #204 (design-system migration: logo + GitHub Pages) is untouched — it is
front-end asset work off the gameplay path, needs the attached design bundle,
and involves a human design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay/load test semantics, WebSocket test shutdown, and a large dependency lockfile refresh; runtime behavior changes are mostly test/CI and fixture fixes, but the lockfile and ASan lane warrant a normal full CI pass.
> 
> **Overview**
> Restores the **Fortress WASM Firefox** interop cell by running the harness under **`xvfb-run`**, adding Firefox WebGL prefs and Mesa/EGL packages, and probing **WebGL2** before load so failures surface the browser’s reason instead of a bare `waitForFunction` timeout. **`waitForGlobal`** now reports captured page errors on timeout.
> 
> **Repairs `tests/load_tests.rs`**: room codes are **6 characters** via a shared helper, the load server raises **`max_rooms_per_game`** for throughput cells, and cells assert players actually joined. The nightly **load-smoke** lane runs all three smoke tests again.
> 
> **Enforces no-unsafe** with **`unsafe_code = forbid`** (or **`deny`** for the Godot fixture’s single `ExtensionLibrary` impl) on every package manifest, plus a **git-discovered policy test**. **`handle_join_room`** integration teardown now mirrors **`RunningTestServer::shutdown`** to avoid LeakSanitizer noise from lingering handlers.
> 
> **CI hygiene**: bumps pinned Actions (`checkout` 7.0.1, `taiki-e/install-action` 2.85.2), **ASan symbolization** via system `llvm-symbolizer`, and a test that every workflow **`apt-get update`** drops broken Microsoft/Azure apt mirrors. **Dependency refresh** in `Cargo.lock` (Tokio, serde, futures, clap, etc.) while rejecting duplicate WebSocket/base64 stacks and MSRV-breaking bumps. **H14 mixed-encoding** assertion reports counters and elapsed time when **`SlowConsumer`** appears (pre-existing flake tracked separately).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e30376ed6aa9e2dec0108119cb66ac65d2bd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->