### PR TITLE
Fix unsupported-format report amplification that evicted the weakest recipient (#212)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,14 +226,14 @@ jobs:
       - name: Install cargo-nextest (attempt 1)
         id: install_nextest
         continue-on-error: true
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       - name: Install cargo-nextest (retry on transient runner failure)
         # Only runs when attempt 1 failed (e.g., the Windows bash-startup flake).
         # No continue-on-error here, so a second failure correctly fails the job.
         if: steps.install_nextest.outcome == 'failure'
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
 
@@ -410,7 +410,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-audit
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-audit
       - name: Run cargo-audit
@@ -560,7 +560,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-llvm-cov
 
@@ -652,7 +652,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-sbom
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-sbom
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -233,7 +233,7 @@ jobs:
         uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.5.1
+        uses: docker/login-action@v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -82,7 +82,7 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-fuzz
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -108,12 +108,12 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-mutants
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
 
@@ -194,14 +194,14 @@ jobs:
           save-if: false
 
       - name: Install cargo-mutants
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-mutants
 
       - name: Install cargo-nextest
         # The mutation oracle uses nextest process isolation plus the dedicated
         # profile's per-test termination for progress-removing mutants.
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,7 @@ jobs:
 
       - name: Configure sccache
         id: sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
         continue-on-error: true
 
       - name: Verify sccache is working
@@ -491,7 +491,7 @@ jobs:
         run: cargo publish --locked
 
       - name: Install cargo-sbom
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-sbom
 

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       - name: Run relay delivery soak
@@ -166,7 +166,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       - name: Run delivery concurrency stress
@@ -214,7 +214,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       # All three room-based smoke cells are activated by name. The two
@@ -286,7 +286,7 @@ jobs:
             .
             clients/native
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       - name: Build the native reference client
@@ -457,7 +457,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       # --run-ignored all: the PR-lane profiles (already covered by the ci.yml
@@ -546,7 +546,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2.85.2
+        uses: taiki-e/install-action@v2.85.4
         with:
           tool: cargo-nextest
       - name: Run split-brain failure catalog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   slow consumer: the weaker peer was evicted after 703 of 5,000 messages while
   the compatible peer was unaffected. Consecutive omissions from one sender and
   delivery class now coalesce into one exact range under the same merge rule the
-  queue already applied to its own gap reports, flushed before the next
-  delivered frame, with the rate-limited advisory, inside an already-queued
+  queue already applied to its own gap reports, written before the next
+  delivered frame, with the rate-limited advisory, immediately after a queued
   report, at most one second after the first omission when the recipient is
-  otherwise idle, or at close. The same burst now costs 2,218 bytes in four
+  otherwise idle, or after the teardown drain. The ranges are retired only once
+  the frame is on the wire, so a write cancelled by the connection's close signal
+  re-reports them instead of losing a whole coalesced burst.
+  The same burst now costs 2,218 bytes in four
   reports (0.01x) with all 5,000 sequences still accounted for exactly, and the
   experiment passes under the single-core contention that reproduced the CI
   failure. Wire-visible for protocol v3 only: reports may now carry several

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Count the teardown's final delivery report as its own registered close-write
+  step, so `REGISTERED_SHUTDOWN_CLOSE_WRITE_STEPS` is 4 and the derived
+  `registered_connection_shutdown_settle_timeout()` (and the binary's graceful
+  shutdown budget) still covers the whole sequence. A wedged socket can therefore
+  take one more `CONNECTION_CLOSE_WRITE_TIMEOUT` (1 s) to reclaim; a healthy one
+  is unaffected.
 - Require every workflow `apt-get update` to first drop the Azure CLI and
   Microsoft prod source lists, enforced by a sweep test over all workflows.
   Those mirrors periodically break `apt-get update` on GitHub runners; five call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single gap per report) and would have rejected the server's own frames as
   accountability violations; they now validate the ranges, with tests proving a
   coalesced range is accepted only when the counters move by exactly the
-  sequences it names.
+  sequences it names. The **published** `signal-fish-client` 0.9.0 carries the
+  same over-strict check and needs the same change
+  (`signal-fish-client-rust` issue #81): `docs/protocol.md` has never promised a
+  shape for these reports — it requires clients to authorize a hole from the
+  union of ranges, and `DeliveryGap` is defined as an inclusive range — so the
+  server now emits what the documented contract always allowed. Until a client
+  release ships, a 0.9.0 client reports an accountability violation instead of
+  recording the gap, and only on the error path that produces these reports at
+  all: a convertible payload is still delivered as a JSON fallback with no
+  report, so this needs an unrepresentable (reserved/`rkyv`) or malformed
+  payload to trigger.
 - Make the chaos proxy's bandwidth fault rate-accurate. Pacing slept a fixed
   interval per chunk, so the pump's own read/write/scheduling latency was added
   to every period and the achieved rate drifted below nominal under load — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   symbolization was active, so an unsymbolized report is self-describing rather
   than an undiagnosable stack of raw addresses.
 - Bump the pinned GitHub Actions group (`actions/checkout` 7.0.1,
-  `taiki-e/install-action` 2.85.2, and `actions/upload-artifact`), carrying
-  Dependabot #202 forward.
+  `taiki-e/install-action` 2.85.4, `docker/login-action` 4.6.0,
+  `mozilla-actions/sccache-action` 0.0.11, and `actions/upload-artifact`),
+  carrying Dependabot #202 and #215 forward.
 - Refresh the compatible dependency set (Tokio 1.53.1, serde 1.0.229, futures
   0.3.33, clap 4.6.4, hdrhistogram 7.6.0 and others). The `tokio-tungstenite`
   0.30, `serial_test` 4.0, `base64` 0.23, and `syn` 3.0 declarations proposed
@@ -37,7 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against a 1.89.0 MSRV, the third adds a second `base64` used by nothing but
   this crate, and the fourth removes `syn::Arm::guard` without deduplicating
   anything. The locked graph keeps exactly one WebSocket and one base64
-  implementation.
+  implementation. Dependabot #214 re-proposes all four; each rejection was
+  re-measured against the current graph rather than carried forward on the
+  earlier note — the PR's own lockfile adds `tokio-tungstenite`/`tungstenite`
+  0.30 beside the 0.29 pair axum still requires and a second `base64`,
+  `serial_test` 4.0.1 declares `rust-version = 1.93.1`, and compiling against
+  `syn` 3.0 fails with `no field 'guard' on type '&Arm'` while syn 2 stays in
+  the graph for `bytecheck_derive`, `derive_more-impl`, and `educe` regardless.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stop unsupported-format accountability from evicting the recipient it exists
+  to protect (issue #212). A binary payload that a peer's negotiated encoding
+  cannot represent was reported with one `DeliveryReport` frame per omitted
+  message, so a JSON peer in a MessagePack room paid **5.4x** the wire bytes of
+  the compact frames its room-mates received (2,096,502 against 389,618 bytes
+  for a 5,000-message burst). Under an equal 32 KiB/s bandwidth fault that
+  difference is the difference between surviving and being disconnected as a
+  slow consumer: the weaker peer was evicted after 703 of 5,000 messages while
+  the compatible peer was unaffected. Consecutive omissions from one sender and
+  delivery class now coalesce into one exact range under the same merge rule the
+  queue already applied to its own gap reports, flushed before the next
+  delivered frame, with the rate-limited advisory, inside an already-queued
+  report, at most one second after the first omission when the recipient is
+  otherwise idle, or at close. The same burst now costs 2,218 bytes in four
+  reports (0.01x) with all 5,000 sequences still accounted for exactly, and the
+  experiment passes under the single-core contention that reproduced the CI
+  failure. Wire-visible for protocol v3 only: reports may now carry several
+  `unsupported_format` ranges, which the documented "union of ranges covers
+  every missing sequence" contract already required clients to handle.
 - Make the chaos proxy's bandwidth fault rate-accurate. Pacing slept a fixed
   interval per chunk, so the pump's own read/write/scheduling latency was added
   to every period and the achieved rate drifted below nominal under load — a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   experiment passes under the single-core contention that reproduced the CI
   failure. Wire-visible for protocol v3 only: reports may now carry several
   `unsupported_format` ranges, which the documented "union of ranges covers
-  every missing sequence" contract already required clients to handle.
+  every missing sequence" contract already required clients to handle. Both
+  in-repo reference clients validated the old shape (`from_seq == to_seq` and a
+  single gap per report) and would have rejected the server's own frames as
+  accountability violations; they now validate the ranges, with tests proving a
+  coalesced range is accepted only when the counters move by exactly the
+  sequences it names.
 - Make the chaos proxy's bandwidth fault rate-accurate. Pacing slept a fixed
   interval per chunk, so the pump's own read/write/scheduling latency was added
   to every period and the achieved rate drifted below nominal under load — a

--- a/clients/browser/src/page/accountability.test.ts
+++ b/clients/browser/src/page/accountability.test.ts
@@ -1078,16 +1078,43 @@ test('unsupported advisory requires a prior report but not adjacency', () => {
   terminal.recordReport(report);
   terminal.observeTerminal();
 
+  // The server coalesces consecutive undeliverable omissions and lets the
+  // resulting range ride along in an already-queued report (server issue #212),
+  // so a mixed-reason report is a frame the current server emits.
   const mixedCounters = countersWithUnsupported(1);
   (mixedCounters['latest'] as Record<string, unknown>)['superseded'] = 1;
-  expectViolation(
-    () =>
-      joinedState().recordReport({
-        per_class: mixedCounters,
-        gaps: [unsupportedGap(1), gap(2, 2)],
-      }),
-    'unsupported-format report must name exactly one sequence',
-  );
+  const mixed = joinedState();
+  mixed.recordReport({
+    per_class: mixedCounters,
+    gaps: [unsupportedGap(1), gap(2, 2)],
+  });
+  mixed.observeServerMessage(true);
+});
+
+test('coalesced unsupported-format ranges are accepted only when counters match', () => {
+  const coalesced = (count: number): Record<string, unknown> => ({
+    per_class: countersWithUnsupported(count),
+    gaps: [
+      {
+        from_player: SENDER,
+        epoch: 1,
+        from_seq: 4,
+        to_seq: 6,
+        reason: 'unsupported_format',
+      },
+    ],
+  });
+
+  const exact = joinedState();
+  exact.recordReport(coalesced(3));
+  exact.observeServerMessage(true);
+
+  for (const understated of [2, 4]) {
+    expectViolation(
+      () => joinedState().recordReport(coalesced(understated)),
+      'do not match exact gap units',
+    );
+  }
 });
 
 test('browser GameData send API validates before invoking the wire callback', () => {

--- a/clients/browser/src/page/accountability.ts
+++ b/clients/browser/src/page/accountability.ts
@@ -345,7 +345,7 @@ export class DeliveryAccountability {
     }
     const reportRanges = new Map<string, ParsedGap[]>();
     const causalCounts = [0, 0, 0, 0];
-    let unsupportedSeen = false;
+    let unsupportedGap: ParsedGap | null = null;
     for (const gap of gaps) {
       this.validateGap(gap);
       const count = gap.toSeq - gap.fromSeq + 1;
@@ -361,10 +361,13 @@ export class DeliveryAccountability {
               ? 2
               : 3;
       if (index === 3) {
-        if (unsupportedSeen || gap.fromSeq !== gap.toSeq || gaps.length !== 1) {
-          violation('unsupported-format report must name exactly one sequence');
-        }
-        unsupportedSeen = true;
+        // A report may carry several coalesced unsupported-format ranges, and
+        // one range may span many sequences: the server merges consecutive
+        // omissions from a sender so accountability does not cost a recipient
+        // one frame per relayed message (server issue #212). Exactness is still
+        // enforced by validateGap, the in-report overlap check below, and the
+        // counter-delta comparison.
+        unsupportedGap = gap;
       }
       causalCounts[index] = (causalCounts[index] ?? 0) + count;
       if (!Number.isSafeInteger(causalCounts[index])) {
@@ -409,8 +412,10 @@ export class DeliveryAccountability {
       pending.sort((left, right) => left.fromSeq - right.fromSeq);
       this.pendingGaps.set(key, pending);
     }
-    if (unsupportedSeen) {
-      this.unadvisedUnsupportedGap = gaps[0] ?? null;
+    if (unsupportedGap !== null) {
+      // The advisory is authorized by an unsupported-format range having been
+      // reported, whichever position it occupied in the report.
+      this.unadvisedUnsupportedGap = unsupportedGap;
     }
     this.counters = nextCounters;
     for (const gap of gaps) {

--- a/clients/native/src/accountability.rs
+++ b/clients/native/src/accountability.rs
@@ -452,7 +452,7 @@ impl DeliveryAccountability {
         // that overlap another range in this same report.
         let mut report_ranges: BTreeMap<(PlayerId, u32), Vec<(u64, u64)>> = BTreeMap::new();
         let mut causal_counts = [0u64; 4];
-        let mut unsupported_seen = false;
+        let mut unsupported_gap = None;
         for gap in &report.gaps {
             self.validate_gap(gap)?;
             let count = gap
@@ -466,11 +466,16 @@ impl DeliveryAccountability {
                 DeliveryGapReason::LatestSuperseded => 0,
                 DeliveryGapReason::LatestDroppedFull => 1,
                 DeliveryGapReason::VolatileDropped => 2,
+                // A report may carry several coalesced unsupported-format
+                // ranges, and one range may span many sequences: the server
+                // merges consecutive omissions from a sender so accountability
+                // does not cost a recipient one frame per relayed message
+                // (server issue #212). Exactness is still enforced — by
+                // `validate_gap`, by the in-report overlap check below, and by
+                // the counter-delta comparison — so nothing here needs to bound
+                // the shape of the ranges.
                 DeliveryGapReason::UnsupportedFormat => {
-                    if unsupported_seen || gap.from_seq != gap.to_seq || report.gaps.len() != 1 {
-                        return Err("delivery accountability violation: unsupported-format report must name exactly one sequence".to_string());
-                    }
-                    unsupported_seen = true;
+                    unsupported_gap = Some(gap.clone());
                     3
                 }
             };
@@ -534,8 +539,10 @@ impl DeliveryAccountability {
             gaps.push(gap.clone());
             gaps.sort_unstable_by_key(|candidate| candidate.from_seq);
         }
-        if unsupported_seen {
-            self.unadvised_unsupported_gap = report.gaps.first().cloned();
+        if unsupported_gap.is_some() {
+            // The advisory is authorized by an unsupported-format range having
+            // been reported, whichever position it occupied in the report.
+            self.unadvised_unsupported_gap = unsupported_gap;
         }
         self.counters = Some(report.per_class);
         for gap in &report.gaps {
@@ -1592,9 +1599,12 @@ mod tests {
         terminal.record_report(&report).unwrap();
         terminal.observe_terminal();
 
+        // The server coalesces consecutive undeliverable omissions and lets the
+        // resulting range ride along in an already-queued report (issue #212),
+        // so a mixed-reason report is a frame the current server emits.
         let mut mixed = DeliveryAccountability::default();
         mixed.note_player_joined(&player(sender, 1)).unwrap();
-        assert!(mixed
+        mixed
             .record_report(&DeliveryReportPayload {
                 per_class: {
                     let mut value = counters_with_unsupported(1);
@@ -1603,7 +1613,66 @@ mod tests {
                 },
                 gaps: vec![unsupported_gap(sender, 1), gap(sender, 2, 2)],
             })
-            .is_err());
+            .unwrap();
+        mixed.observe_server_message(true).unwrap();
+    }
+
+    /// Coalesced ranges keep accountability exact rather than loosening it: a
+    /// multi-sequence unsupported-format range is accepted only when the
+    /// counters move by exactly the sequences it names (issue #212).
+    #[test]
+    fn coalesced_unsupported_ranges_are_accepted_only_when_counters_match() {
+        let sender = id(9);
+        let coalesced = |count: u64| DeliveryReportPayload {
+            per_class: counters_with_unsupported(count),
+            gaps: vec![DeliveryGap {
+                from_player: sender,
+                epoch: 1,
+                from_seq: 4,
+                to_seq: 6,
+                reason: DeliveryGapReason::UnsupportedFormat,
+            }],
+        };
+
+        let mut exact = DeliveryAccountability::default();
+        exact.note_player_joined(&player(sender, 1)).unwrap();
+        exact.record_report(&coalesced(3)).unwrap();
+        exact.observe_server_message(true).unwrap();
+
+        for understated in [2, 4] {
+            let mut skewed = DeliveryAccountability::default();
+            skewed.note_player_joined(&player(sender, 1)).unwrap();
+            assert!(
+                skewed.record_report(&coalesced(understated)).is_err(),
+                "a {understated}-count report for a 3-sequence range must be rejected"
+            );
+        }
+
+        // Two coalesced ranges from one sender in one report, as the pending
+        // report emits when an omission cannot merge into the previous range.
+        let mut split = DeliveryAccountability::default();
+        split.note_player_joined(&player(sender, 1)).unwrap();
+        split
+            .record_report(&DeliveryReportPayload {
+                per_class: counters_with_unsupported(5),
+                gaps: vec![
+                    DeliveryGap {
+                        from_player: sender,
+                        epoch: 1,
+                        from_seq: 1,
+                        to_seq: 2,
+                        reason: DeliveryGapReason::UnsupportedFormat,
+                    },
+                    DeliveryGap {
+                        from_player: sender,
+                        epoch: 1,
+                        from_seq: 7,
+                        to_seq: 9,
+                        reason: DeliveryGapReason::UnsupportedFormat,
+                    },
+                ],
+            })
+            .unwrap();
     }
 
     #[test]

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1727,6 +1727,13 @@ them into additional priority reports. A client must retain prior ranges and
 authorize a hole only when their non-overlapping union covers every missing
 sequence; one report or range need not cover the entire hole alone.
 
+**No reason has a privileged shape.** A range may span any number of sequences,
+one report may carry several ranges of the same reason, and reasons may be mixed
+in one report. A client must not require a single-sequence range or a single gap
+for any reason, `unsupported_format` included: the exactness a client can rely on
+is that the reported ranges never overlap and that each loss counter advances by
+exactly the number of sequences the same report attributes to it.
+
 Gap-bearing reports are event-driven even when
 `websocket.delivery_stats_interval_secs` is zero. Queue-policy reports for
 `latest` / `volatile` travel on the active generation's strict-priority control

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -660,9 +660,13 @@ Practical consequences:
   the equality above holds at quiescence.
 
 A binary game-data payload that cannot be converted for a v3 recipient is not
-silently dropped either: the server first writes an exact `DeliveryReport` gap
-with reason `unsupported_format`, then attempts a supplemental `Error` with code
-`UNSUPPORTED_GAME_DATA_FORMAT`, both before any later data. The supplemental
+silently dropped either: the server accounts the omission as an exact
+`DeliveryReport` gap with reason `unsupported_format`, and attempts a
+supplemental `Error` with code `UNSUPPORTED_GAME_DATA_FORMAT` after it. Both
+precede any later data for that recipient. Consecutive omissions from one sender
+coalesce into one range and one report — at most one per second while the
+recipient is otherwise idle — so a recipient that cannot represent the room's
+encoding is not charged one report frame per relayed message. The supplemental
 error is best effort: if its write fails after the report succeeds, the socket
 disconnects and no successor is exposed. The report, not the aggregate counter
 or error alone, authorizes a gap on a continuing stream. Once the writer has
@@ -1726,12 +1730,17 @@ sequence; one report or range need not cover the entire hole alone.
 Gap-bearing reports are event-driven even when
 `websocket.delivery_stats_interval_secs` is zero. Queue-policy reports for
 `latest` / `volatile` travel on the active generation's strict-priority control
-lane and are committed atomically with the omission. An unsupported-format
-report is written inline before later data can reveal the gap. The supplemental
+lane and are committed atomically with the omission. Unsupported-format ranges
+are coalesced by the socket writer and reach the recipient before any later
+data, when the supplemental advisory is emitted, carried by an already-queued
+report, or at most one second after the first omission if nothing else is
+written; a closing connection flushes them too. Consecutive omissions from one
+sender and delivery class therefore arrive as one range rather than one report
+per message. The supplemental
 `UNSUPPORTED_GAME_DATA_FORMAT` prose `Error` is rate-limited to at most one per
 sender per second for each recipient; a later notice reports how many similar
-advisories were suppressed. Clients MUST use the unthrottled exact reports—not
-advisory errors—to account sequence gaps. If either an exact report or a chosen
+advisories were suppressed. Clients MUST use the exact reports—not advisory
+errors—to account sequence gaps. If either an exact report or a chosen
 supplemental error write fails, the stream disconnects.
 Counter-only snapshots may be periodic. If exact reporting cannot be preserved,
 the server closes the connection with `4002 slow_consumer` before exposing

--- a/docs/reference/error-codes.md
+++ b/docs/reference/error-codes.md
@@ -80,7 +80,7 @@ establishment.
 | `SLOW_CONSUMER` | The delivery contract failed closed: reliable queue/sojourn timed out, a selected socket write stopped progressing within `websocket.max_sojourn_ms`, or the server could not preserve exact report/control ordering. The best-effort error is followed by authoritative close code `4002 slow_consumer`. |
 | `ACTIVITY_TIMEOUT` | The server could not write its WebSocket Ping within the bounded write timeout, the connection missed the matching Pong deadline, or the activity reaper (`server.ping_timeout`) observed no inbound traffic within its window. Distinct from `CONNECTION_IDLE_TIMEOUT` (the socket-level `websocket.idle_timeout_secs` close). Compliant WebSocket stacks answer protocol Pings automatically; clients should still send application `Ping` messages when server probes are disabled. |
 | `SDK_VERSION_UNSUPPORTED` | The SDK version is no longer supported. Upgrade to the latest version. |
-| `UNSUPPORTED_GAME_DATA_FORMAT` | A payload could not be represented in the recipient's negotiated format. For v3, an exact `DeliveryReport` gap with reason `unsupported_format` is written first; this supplemental error is best effort, and a failed error write disconnects without exposing a successor. |
+| `UNSUPPORTED_GAME_DATA_FORMAT` | A payload could not be represented in the recipient's negotiated format. For v3, an exact `DeliveryReport` gap with reason `unsupported_format` covers the omission and is written before this supplemental error; consecutive omissions from one sender coalesce into one range, so the report count does not scale with the relayed message count. This supplemental error is best effort, and a failed error write disconnects without exposing a successor. |
 
 ### Validation Errors (2xxx)
 

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -2696,6 +2696,49 @@ mod tests {
         );
     }
 
+    /// When the pending ranges cannot fit in the report being handed out, the
+    /// report must not advertise an `unsupported_format` delta it carries no
+    /// ranges for — otherwise the following flush would report the same
+    /// omissions again and the counters would regress on the wire.
+    #[tokio::test]
+    async fn a_full_report_leaves_the_pending_ranges_and_the_frontier_alone() {
+        let (tx, mut rx) = channel(1, 2);
+        tx.set_protocol_version(3);
+        // Fill the pending report to its bound with non-mergeable ranges.
+        for index in 0..DELIVERY_REPORT_MAX_GAPS {
+            assert!(rx
+                .record_unsupported_format(unsupported_metadata(
+                    DeliveryClass::Reliable,
+                    4,
+                    (index as u64) * 2
+                ))
+                .is_none());
+        }
+
+        // A queued gap report of its own: one `latest` key superseded.
+        tx.try_enqueue_data(data(2, DeliveryClass::Latest, Some(3), 2))
+            .unwrap();
+        tx.try_enqueue_data(data(3, DeliveryClass::Latest, Some(3), 3))
+            .unwrap();
+
+        let queued = report(rx.recv().await.unwrap().unwrap());
+        assert_eq!(queued.gaps.len(), 1, "no pending range could fit");
+        assert_eq!(queued.gaps[0].reason, DeliveryGapReason::LatestSuperseded);
+        assert_eq!(
+            queued.per_class.reliable.unsupported_format, 0,
+            "the frontier may not advance without the ranges that explain it"
+        );
+
+        let flushed = rx
+            .take_pending_unsupported_report()
+            .expect("the pending ranges survive a report that could not absorb them");
+        assert_eq!(flushed.gaps.len(), DELIVERY_REPORT_MAX_GAPS);
+        assert_eq!(
+            flushed.per_class.reliable.unsupported_format,
+            DELIVERY_REPORT_MAX_GAPS as u64
+        );
+    }
+
     #[tokio::test]
     async fn per_class_metrics_conserve_every_terminal_outcome() {
         let metrics = Arc::new(crate::metrics::ServerMetrics::new());

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -256,14 +256,16 @@ struct QueueState {
     counters: DeliveryCountersByClass,
     wire_counters: DeliveryCountersByClass,
     pending_unsupported: PendingUnsupported,
-    /// A queued report advanced `wire_counters` when it was handed to the writer,
-    /// but that frame has not been confirmed written yet.
+    /// The counter frontier the recipient has actually been shown.
     ///
-    /// While this is set the frontier describes a frame the recipient may never
-    /// receive, so a coalesced unsupported-format report must not be built from
-    /// it: its other counters would carry deltas the recipient was never told
-    /// about. Cleared by [`OutboundReceiver::confirm_report_frontier`].
-    report_frontier_unconfirmed: bool,
+    /// `wire_counters` advances when a queued report is handed to the writer, so
+    /// after a cancelled or failed write it can describe a frame nobody
+    /// received. A coalesced unsupported-format report is therefore built on
+    /// this value instead: its deltas are then exact against the last frame that
+    /// really landed, whatever happened to the one before it. Advanced by
+    /// [`OutboundReceiver::confirm_report_frontier`] and by committing a
+    /// coalesced report.
+    confirmed_wire_counters: DeliveryCountersByClass,
     enqueue_generation: u64,
     receive_generation: u64,
     active_room: Option<RoomId>,
@@ -407,7 +409,7 @@ impl QueueState {
             counters: DeliveryCountersByClass::default(),
             wire_counters: DeliveryCountersByClass::default(),
             pending_unsupported: PendingUnsupported::default(),
-            report_frontier_unconfirmed: false,
+            confirmed_wire_counters: DeliveryCountersByClass::default(),
             enqueue_generation: 0,
             receive_generation: 0,
             active_room: None,
@@ -1790,20 +1792,16 @@ impl OutboundReceiver {
     /// `unsupported_format` counter delta whose exact ranges had not been sent.
     pub fn pending_unsupported_report(&self) -> Option<DeliveryReportPayload> {
         let state = self.shared.state();
-        if state.report_frontier_unconfirmed {
-            // A queued report took the frontier forward and has not been
-            // confirmed written. Building on it would advertise that frame's
-            // counter deltas to a recipient that may never receive it, so this
-            // report waits — the omissions stay recorded either way.
-            return None;
-        }
-        state.pending_unsupported.peek(state.wire_counters)
+        state
+            .pending_unsupported
+            .peek(state.confirmed_wire_counters)
     }
 
-    /// Confirm that the report frame the queue last handed to the writer reached
-    /// the socket, so the wire frontier describes what the recipient has seen.
+    /// Record that the report frame the queue last handed to the writer reached
+    /// the socket, so later reports can build on the counters it carried.
     pub fn confirm_report_frontier(&self) {
-        self.shared.state().report_frontier_unconfirmed = false;
+        let mut state = self.shared.state();
+        state.confirmed_wire_counters = state.wire_counters;
     }
 
     /// Retire the ranges a written report carried and advance the wire frontier
@@ -1812,6 +1810,8 @@ impl OutboundReceiver {
         let mut state = self.shared.state();
         state.pending_unsupported.commit(report);
         state.wire_counters = max_counters(state.wire_counters, report.per_class);
+        state.confirmed_wire_counters =
+            max_counters(state.confirmed_wire_counters, report.per_class);
     }
 
     /// When a coalesced unsupported-format report must reach the recipient even
@@ -2073,8 +2073,6 @@ fn prepare_for_wire(state: &mut QueueState, mut item: QueuedOutbound) -> QueuedO
         report.per_class.volatile.unsupported_format =
             state.wire_counters.volatile.unsupported_format;
         state.wire_counters = report.per_class;
-        // The frontier now describes a frame that has not been written yet.
-        state.report_frontier_unconfirmed = true;
     }
     item
 }
@@ -2670,17 +2668,26 @@ mod tests {
         let reasons: Vec<_> = queued.gaps.iter().map(|gap| gap.reason).collect();
         assert_eq!(reasons, vec![DeliveryGapReason::LatestDroppedFull]);
 
-        // Until that frame is confirmed written, the frontier describes something
-        // the recipient may never see, so no report may be built on it.
-        assert!(
-            rx.pending_unsupported_report().is_none(),
-            "an unconfirmed report frame must not become another report's baseline"
+        // Until that frame is confirmed written it may never reach the
+        // recipient, so a report built now must not inherit its deltas: the
+        // coalesced report is built on the last frame that actually landed.
+        let unconfirmed = rx
+            .pending_unsupported_report()
+            .expect("a teardown must still be able to report the coalesced range");
+        assert_eq!(
+            unconfirmed.per_class.latest.dropped_full, 0,
+            "an unwritten frame's deltas must not ride along on a later report"
         );
-        rx.confirm_report_frontier();
+        assert_eq!(unconfirmed.per_class.reliable.unsupported_format, 1);
 
+        rx.confirm_report_frontier();
         let pending = rx
             .pending_unsupported_report()
             .expect("the coalesced range is still waiting for its own frame");
+        assert_eq!(
+            pending.per_class.latest.dropped_full, 1,
+            "once that frame landed, the report builds on the counters it carried"
+        );
         assert_eq!(pending.per_class.reliable.unsupported_format, 1);
         assert_eq!(pending.gaps.len(), 1);
         assert_eq!(pending.gaps[0].reason, DeliveryGapReason::UnsupportedFormat);

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -255,9 +255,115 @@ struct QueueState {
     permit_count: usize,
     counters: DeliveryCountersByClass,
     wire_counters: DeliveryCountersByClass,
+    pending_unsupported: PendingUnsupported,
     enqueue_generation: u64,
     receive_generation: u64,
     active_room: Option<RoomId>,
+}
+
+/// Exact omissions discovered by the socket writer that have not reached the
+/// wire yet, coalesced under the same merge rule the queue applies to its own
+/// gap reports ([`try_append_gap`]).
+///
+/// `QueueState::wire_counters` deliberately does **not** advance while these are
+/// pending: a recipient must never see an `unsupported_format` counter move
+/// without the exact ranges that explain it, so the increments and their gaps
+/// always reach the socket in the same frame. The per-class counts are carried
+/// alongside the ranges because [`DeliveryGap`] does not name a delivery class,
+/// and the flushed report must advance exactly the counters its ranges explain.
+///
+/// Ranges are bucketed by delivery class for that reason: `UnsupportedFormat`
+/// is the one gap reason every class shares, so a single list could merge two
+/// adjacent omissions of different classes into one range and lose the
+/// attribution the counters need. Merging within a bucket keeps the per-class
+/// totals derivable from the ranges themselves.
+#[derive(Debug, Default)]
+struct PendingUnsupported {
+    reliable: Vec<DeliveryGap>,
+    latest: Vec<DeliveryGap>,
+    volatile: Vec<DeliveryGap>,
+    /// When the oldest unsent range was recorded, so an idle writer still tells
+    /// the recipient about it within a bounded time instead of holding it until
+    /// the next omission or the connection's close.
+    since: Option<Instant>,
+}
+
+impl PendingUnsupported {
+    fn bucket(&mut self, class: DeliveryClass) -> &mut Vec<DeliveryGap> {
+        match class {
+            DeliveryClass::Reliable => &mut self.reliable,
+            DeliveryClass::Latest => &mut self.latest,
+            DeliveryClass::Volatile => &mut self.volatile,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.reliable.len() + self.latest.len() + self.volatile.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Merge one omission into the pending report. `false` means the report
+    /// cannot absorb it and must be flushed first.
+    fn append(&mut self, gap: &DeliveryGap, class: DeliveryClass) -> bool {
+        // One report carries at most `DELIVERY_REPORT_MAX_GAPS` ranges however
+        // they are distributed across classes, so the bound is checked against
+        // the combined length before a bucket is allowed to grow.
+        let would_grow = self
+            .bucket(class)
+            .last()
+            .is_none_or(|previous| !gaps_merge(previous, gap));
+        if would_grow && self.len() >= DELIVERY_REPORT_MAX_GAPS {
+            return false;
+        }
+        if self.is_empty() {
+            self.since = Some(Instant::now());
+        }
+        append_gap(self.bucket(class), gap)
+    }
+
+    /// When this report must reach the recipient even if nothing else is
+    /// written.
+    fn flush_deadline(&self) -> Option<Instant> {
+        self.since
+            .map(|since| since + PENDING_UNSUPPORTED_FLUSH_INTERVAL)
+    }
+
+    /// Take the pending ranges, advancing `wire` by exactly the omissions they
+    /// account for.
+    fn take(&mut self, wire: &mut DeliveryCountersByClass) -> Option<DeliveryReportPayload> {
+        if self.is_empty() {
+            return None;
+        }
+        self.since = None;
+        let mut gaps = Vec::with_capacity(self.len());
+        for (bucket, counter) in [
+            (
+                std::mem::take(&mut self.reliable),
+                &mut wire.reliable.unsupported_format,
+            ),
+            (
+                std::mem::take(&mut self.latest),
+                &mut wire.latest.unsupported_format,
+            ),
+            (
+                std::mem::take(&mut self.volatile),
+                &mut wire.volatile.unsupported_format,
+            ),
+        ] {
+            for gap in bucket {
+                *counter = counter
+                    .saturating_add(gap.to_seq.saturating_sub(gap.from_seq).saturating_add(1));
+                gaps.push(gap);
+            }
+        }
+        Some(DeliveryReportPayload {
+            per_class: *wire,
+            gaps,
+        })
+    }
 }
 
 impl QueueState {
@@ -276,6 +382,7 @@ impl QueueState {
             permit_count: 0,
             counters: DeliveryCountersByClass::default(),
             wire_counters: DeliveryCountersByClass::default(),
+            pending_unsupported: PendingUnsupported::default(),
             enqueue_generation: 0,
             receive_generation: 0,
             active_room: None,
@@ -335,6 +442,13 @@ struct SharedQueue {
 }
 
 const UNSUPPORTED_NOTICE_INTERVAL: Duration = Duration::from_secs(1);
+/// How long the writer may keep coalescing undeliverable omissions before the
+/// recipient is told, when nothing else is being written to it.
+///
+/// Matched to [`UNSUPPORTED_NOTICE_INTERVAL`] so the exact report and its prose
+/// advisory share one cadence: at most one of each per second, instead of one of
+/// each per omitted message.
+const PENDING_UNSUPPORTED_FLUSH_INTERVAL: Duration = UNSUPPORTED_NOTICE_INTERVAL;
 const MAX_UNSUPPORTED_NOTICE_SENDERS: usize = 256;
 
 #[derive(Debug, Default)]
@@ -1295,7 +1409,19 @@ impl OutboundReceiver {
                 Ok(item) => return Ok(Some(item)),
                 Err(PopState::Disconnected) => return Ok(None),
                 Err(PopState::Terminal) => return Err(TryReceiveError::AccountabilityFailed),
-                Err(PopState::Empty) => notified.as_mut().await,
+                Err(PopState::Empty) => match self.pending_unsupported_flush_deadline() {
+                    Some(deadline) => {
+                        tokio::select! {
+                            () = notified.as_mut() => {}
+                            () = tokio::time::sleep_until(deadline) => {
+                                if let Some(item) = self.take_pending_unsupported_item() {
+                                    return Ok(Some(item));
+                                }
+                            }
+                        }
+                    }
+                    None => notified.as_mut().await,
+                },
             }
         }
     }
@@ -1320,11 +1446,37 @@ impl OutboundReceiver {
                 Err(BatchedPopState::Terminal) => {
                     return Err(TryReceiveError::AccountabilityFailed)
                 }
-                Err(BatchedPopState::Empty) => notified.as_mut().await,
+                Err(BatchedPopState::Empty) => match self.pending_unsupported_flush_deadline() {
+                    Some(deadline) => {
+                        tokio::select! {
+                            () = notified.as_mut() => {}
+                            () = tokio::time::sleep_until(deadline) => {
+                                if let Some(item) = self.take_pending_unsupported_item() {
+                                    return Ok(Some(item));
+                                }
+                            }
+                        }
+                    }
+                    None => notified.as_mut().await,
+                },
                 Err(BatchedPopState::WaitUntil(deadline)) => {
+                    // The pending exact report is control traffic and outranks a
+                    // data batch still waiting to coalesce, so whichever
+                    // deadline comes first wins.
+                    let pending_deadline = self.pending_unsupported_flush_deadline();
                     tokio::select! {
-                        _ = notified.as_mut() => {}
-                        _ = tokio::time::sleep_until(deadline) => {}
+                        () = notified.as_mut() => {}
+                        () = tokio::time::sleep_until(deadline) => {}
+                        () = async {
+                            match pending_deadline {
+                                Some(deadline) => tokio::time::sleep_until(deadline).await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            if let Some(item) = self.take_pending_unsupported_item() {
+                                return Ok(Some(item));
+                            }
+                        }
                     }
                 }
             }
@@ -1590,22 +1742,91 @@ impl OutboundReceiver {
         self.shared.record_abandoned(class, count);
     }
 
-    /// Account an encoding failure discovered only by the socket writer. The
-    /// returned report must be written immediately before the replacement Error.
+    /// Account an encoding failure discovered only by the socket writer,
+    /// coalescing contiguous omissions into one pending exact report.
+    ///
+    /// One frame per omitted message made accountability cost the recipient
+    /// least able to afford it several times the bytes of the payload it
+    /// replaced — measured at 5.4x for a MessagePack burst relayed to a JSON
+    /// peer — which is what evicted that peer as a slow consumer under a
+    /// bandwidth fault (issue #212). Contiguous ranges from one sender now
+    /// merge under exactly the rules the queue applies to its own gap reports
+    /// ([`try_append_gap`]), so the accounting stays exact while the wire cost
+    /// collapses to one report per burst.
+    ///
+    /// Returns `Some(report)` when the accumulated accountability must be
+    /// written before this omission can be recorded (the pending report is full
+    /// or the new range cannot merge into it). `None` means the omission merged
+    /// into the pending report, which
+    /// [`take_pending_unsupported_report`](Self::take_pending_unsupported_report)
+    /// emits before the next frame of any other kind, alongside the rate-limited
+    /// advisory, or at close.
     pub fn record_unsupported_format(
         &self,
         metadata: DataDeliveryMetadata,
-    ) -> DeliveryReportPayload {
+    ) -> Option<DeliveryReportPayload> {
         let mut state = self.shared.state();
         increment_unsupported(&mut state.counters, metadata.class);
         self.shared.record_unsupported(metadata.class);
-        let mut wire_counters = state.wire_counters;
-        increment_unsupported(&mut wire_counters, metadata.class);
-        state.wire_counters = wire_counters;
-        DeliveryReportPayload {
-            per_class: wire_counters,
-            gaps: vec![metadata.gap(DeliveryGapReason::UnsupportedFormat)],
+        let gap = metadata.gap(DeliveryGapReason::UnsupportedFormat);
+        // A recipient that never negotiated v3 receives no `DeliveryReport` at
+        // all, so nothing may accumulate for it: the pending buffer must stay
+        // empty or a later flush would emit a v3-only frame on a v2 wire.
+        if !self.shared.v3() {
+            return None;
         }
+        if state.pending_unsupported.append(&gap, metadata.class) {
+            return None;
+        }
+        // The pending report cannot absorb this omission. Flush it and start a
+        // new one from this gap, so the returned report is complete and this
+        // omission is still accounted for exactly once.
+        let mut wire_counters = state.wire_counters;
+        let flushed = state.pending_unsupported.take(&mut wire_counters);
+        state.wire_counters = wire_counters;
+        let appended = state.pending_unsupported.append(&gap, metadata.class);
+        debug_assert!(appended, "an emptied pending report must accept any gap");
+        flushed
+    }
+
+    /// Take the coalesced unsupported-format report so it reaches the wire
+    /// before any other frame, with the advisory that explains it, or at close.
+    ///
+    /// This ordering is required rather than cosmetic: `wire_counters` only
+    /// advances here, so emitting any other report first would advertise an
+    /// `unsupported_format` counter delta whose exact ranges had not been sent.
+    pub fn take_pending_unsupported_report(&self) -> Option<DeliveryReportPayload> {
+        let mut state = self.shared.state();
+        if state.pending_unsupported.is_empty() {
+            return None;
+        }
+        let mut wire_counters = state.wire_counters;
+        let report = state.pending_unsupported.take(&mut wire_counters);
+        state.wire_counters = wire_counters;
+        report
+    }
+
+    /// When a coalesced unsupported-format report must reach the recipient even
+    /// though nothing else is queued for it.
+    fn pending_unsupported_flush_deadline(&self) -> Option<Instant> {
+        self.shared.state().pending_unsupported.flush_deadline()
+    }
+
+    /// The coalesced report as a writable queue item, for the receive paths that
+    /// reach its flush deadline while the lanes are empty. It is synthesized
+    /// rather than enqueued: the accounting is already owned here, so it must not
+    /// depend on control-lane capacity it could be denied.
+    fn take_pending_unsupported_item(&self) -> Option<QueuedOutbound> {
+        let report = self.take_pending_unsupported_report()?;
+        let generation = self.shared.state().receive_generation;
+        Some(QueuedOutbound {
+            payload: OutboundPayload::DeliveryReport(report),
+            delivery_class: None,
+            metadata: None,
+            enqueued_at: Instant::now(),
+            generation,
+            transition_barrier: false,
+        })
     }
 
     pub(crate) fn record_unsupported_class(&self, class: DeliveryClass) {
@@ -1800,17 +2021,26 @@ fn report_can_append(report: &DeliveryReportPayload, gap: &DeliveryGap) -> bool 
 }
 
 fn try_append_gap(report: &mut DeliveryReportPayload, gap: &DeliveryGap) -> bool {
-    if let Some(previous) = report.gaps.last_mut() {
+    append_gap(&mut report.gaps, gap)
+}
+
+/// The single merge rule for exact gap ranges: extend the trailing range when
+/// it is adjacent or overlapping ([`gaps_merge`]), otherwise start a new range
+/// while the bounded report still has room. Shared by the queue's own gap
+/// reports and by the writer's pending unsupported-format report so both
+/// coalesce identically.
+fn append_gap(gaps: &mut Vec<DeliveryGap>, gap: &DeliveryGap) -> bool {
+    if let Some(previous) = gaps.last_mut() {
         if gaps_merge(previous, gap) {
             previous.from_seq = previous.from_seq.min(gap.from_seq);
             previous.to_seq = previous.to_seq.max(gap.to_seq);
             return true;
         }
     }
-    if report.gaps.len() >= DELIVERY_REPORT_MAX_GAPS {
+    if gaps.len() >= DELIVERY_REPORT_MAX_GAPS {
         return false;
     }
-    report.gaps.push(gap.clone());
+    gaps.push(gap.clone());
     true
 }
 
@@ -1838,7 +2068,30 @@ fn enqueue_delivery_report(state: &mut QueueState, gaps: Vec<DeliveryGap>) {
 
 fn prepare_for_wire(state: &mut QueueState, mut item: QueuedOutbound) -> QueuedOutbound {
     if let OutboundPayload::DeliveryReport(report) = &mut item.payload {
+        // The writer's coalesced omissions ride along in this report whenever
+        // they fit, so one frame carries both. That keeps a single owner of the
+        // `unsupported_format` wire frontier: whatever is not absorbed here is
+        // still pending, and the counters below therefore never advertise a
+        // delta whose exact ranges have not been sent.
+        let absorbed =
+            if report.gaps.len() + state.pending_unsupported.len() <= DELIVERY_REPORT_MAX_GAPS {
+                state.pending_unsupported.take(&mut state.wire_counters)
+            } else {
+                None
+            };
         report.per_class = max_counters(report.per_class, state.wire_counters);
+        // `state.counters` may already count omissions that are still pending
+        // (they are counted when discovered, reported when coalesced), so this
+        // counter is clamped to the frontier rather than raised by a report that
+        // carries no ranges for it.
+        report.per_class.reliable.unsupported_format =
+            state.wire_counters.reliable.unsupported_format;
+        report.per_class.latest.unsupported_format = state.wire_counters.latest.unsupported_format;
+        report.per_class.volatile.unsupported_format =
+            state.wire_counters.volatile.unsupported_format;
+        if let Some(absorbed) = absorbed {
+            report.gaps.extend(absorbed.gaps);
+        }
         state.wire_counters = report.per_class;
     }
     item
@@ -2403,8 +2656,11 @@ mod tests {
         assert!(tx.is_closed());
     }
 
+    /// A queued report popped while the writer still holds coalesced omissions
+    /// carries both, so exactly one frame owns the `unsupported_format` wire
+    /// frontier and no frame advertises a counter delta without its ranges.
     #[tokio::test]
-    async fn inline_unsupported_report_precedes_and_advances_queued_frontier() {
+    async fn queued_report_absorbs_the_writers_pending_unsupported_ranges() {
         let (tx, mut rx) = channel(1, 2);
         tx.set_protocol_version(3);
         tx.try_enqueue_data(data(1, DeliveryClass::Reliable, None, 1))
@@ -2417,15 +2673,27 @@ mod tests {
         tx.try_enqueue_data(data(3, DeliveryClass::Latest, Some(3), 3))
             .unwrap();
 
-        let inline = rx.record_unsupported_format(active_metadata);
-        assert_eq!(inline.per_class.reliable.unsupported_format, 1);
-        assert_eq!(inline.per_class.latest.dropped_full, 0);
-        assert_eq!(inline.gaps[0].reason, DeliveryGapReason::UnsupportedFormat);
+        assert!(
+            rx.record_unsupported_format(active_metadata).is_none(),
+            "the first omission coalesces instead of costing its own frame"
+        );
 
         let queued = report(rx.recv().await.unwrap().unwrap());
         assert_eq!(queued.per_class.reliable.unsupported_format, 1);
         assert_eq!(queued.per_class.latest.dropped_full, 1);
-        assert_eq!(queued.gaps[0].reason, DeliveryGapReason::LatestDroppedFull);
+        let reasons: Vec<_> = queued.gaps.iter().map(|gap| gap.reason).collect();
+        assert_eq!(
+            reasons,
+            vec![
+                DeliveryGapReason::LatestDroppedFull,
+                DeliveryGapReason::UnsupportedFormat
+            ],
+            "the absorbed range must ride along with the queued report"
+        );
+        assert!(
+            rx.take_pending_unsupported_report().is_none(),
+            "an absorbed range must not be reported a second time"
+        );
     }
 
     #[tokio::test]
@@ -2929,22 +3197,134 @@ mod tests {
         assert!(closed.unwrap().is_none());
     }
 
-    #[test]
-    fn unsupported_format_report_is_exact_and_class_partitioned() {
-        let (_tx, rx) = channel(1, 1);
-        let metadata = DataDeliveryMetadata {
-            class: DeliveryClass::Volatile,
+    fn unsupported_metadata(
+        class: DeliveryClass,
+        from_player: u128,
+        seq: u64,
+    ) -> DataDeliveryMetadata {
+        DataDeliveryMetadata {
+            class,
             key: None,
-            from_player: PlayerId::from_u128(4),
+            from_player: PlayerId::from_u128(from_player),
             room_id: RoomId::from_u128(5),
             epoch: 6,
-            seq: 7,
-        };
-        let report = rx.record_unsupported_format(metadata);
-        assert_eq!(report.per_class.volatile.unsupported_format, 1);
+            seq,
+        }
+    }
+
+    /// One frame per omitted message made accountability cost the weakest
+    /// recipient several times the payload it replaced (issue #212). Contiguous
+    /// omissions must collapse into one range while the counters stay exact.
+    #[test]
+    fn unsupported_format_reports_coalesce_and_stay_exact_per_class() {
+        let (tx, rx) = channel(1, 1);
+        tx.set_protocol_version(3);
+        for seq in 7..=9 {
+            assert!(
+                rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Volatile, 4, seq))
+                    .is_none(),
+                "contiguous omissions from one sender must coalesce"
+            );
+        }
+        // A different class cannot share a range: `UnsupportedFormat` is the one
+        // gap reason every class uses, so merging across classes would lose the
+        // attribution the per-class counters need.
+        assert!(rx
+            .record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 10))
+            .is_none());
+        // A different sender starts its own range.
+        assert!(rx
+            .record_unsupported_format(unsupported_metadata(DeliveryClass::Volatile, 11, 1))
+            .is_none());
+
+        let report = rx
+            .take_pending_unsupported_report()
+            .expect("pending accountability must flush");
+        assert_eq!(report.per_class.volatile.unsupported_format, 4);
+        assert_eq!(report.per_class.reliable.unsupported_format, 1);
+        let ranges: Vec<_> = report
+            .gaps
+            .iter()
+            .map(|gap| (gap.from_player, gap.from_seq, gap.to_seq, gap.reason))
+            .collect();
         assert_eq!(
-            report.gaps,
-            vec![metadata.gap(DeliveryGapReason::UnsupportedFormat)]
+            ranges,
+            vec![
+                (
+                    PlayerId::from_u128(4),
+                    10,
+                    10,
+                    DeliveryGapReason::UnsupportedFormat
+                ),
+                (
+                    PlayerId::from_u128(4),
+                    7,
+                    9,
+                    DeliveryGapReason::UnsupportedFormat
+                ),
+                (
+                    PlayerId::from_u128(11),
+                    1,
+                    1,
+                    DeliveryGapReason::UnsupportedFormat
+                ),
+            ],
+            "five omissions must be reported as three exact ranges"
+        );
+        assert!(
+            rx.take_pending_unsupported_report().is_none(),
+            "a flushed report leaves nothing pending"
+        );
+    }
+
+    /// The pending report is bounded by the canonical per-report gap maximum,
+    /// and hitting that bound flushes rather than dropping accountability.
+    #[test]
+    fn pending_unsupported_report_is_bounded_and_flushes_when_full() {
+        let (tx, rx) = channel(1, 1);
+        tx.set_protocol_version(3);
+        // Every second sequence is a hole, so no two omissions can merge.
+        let mut flushed = None;
+        for index in 0..=DELIVERY_REPORT_MAX_GAPS {
+            let seq = (index as u64) * 2;
+            let report =
+                rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, seq));
+            if let Some(report) = report {
+                assert!(flushed.is_none(), "only the bounded report may flush");
+                flushed = Some(report);
+            }
+        }
+        let flushed = flushed.expect("the bounded report must flush when it is full");
+        assert_eq!(flushed.gaps.len(), DELIVERY_REPORT_MAX_GAPS);
+        assert_eq!(
+            flushed.per_class.reliable.unsupported_format,
+            DELIVERY_REPORT_MAX_GAPS as u64
+        );
+        let remainder = rx
+            .take_pending_unsupported_report()
+            .expect("the omission that displaced the report is still accounted for");
+        assert_eq!(remainder.gaps.len(), 1);
+        assert_eq!(
+            remainder.per_class.reliable.unsupported_format,
+            DELIVERY_REPORT_MAX_GAPS as u64 + 1,
+            "counters advance monotonically with the ranges that explain them"
+        );
+    }
+
+    /// A recipient that never negotiated v3 receives no `DeliveryReport` at all,
+    /// so nothing may accumulate for it — a later flush would put a v3-only
+    /// frame on a frozen v2 wire.
+    #[test]
+    fn pre_v3_recipients_accumulate_no_delivery_report() {
+        let (_tx, rx) = channel(1, 1);
+        assert!(rx
+            .record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 1))
+            .is_none());
+        assert!(rx.take_pending_unsupported_report().is_none());
+        assert_eq!(
+            rx.shared.state().counters.reliable.unsupported_format,
+            1,
+            "the omission is still counted internally"
         );
     }
 

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -331,38 +331,54 @@ impl PendingUnsupported {
             .map(|since| since + PENDING_UNSUPPORTED_FLUSH_INTERVAL)
     }
 
-    /// Take the pending ranges, advancing `wire` by exactly the omissions they
-    /// account for.
-    fn take(&mut self, wire: &mut DeliveryCountersByClass) -> Option<DeliveryReportPayload> {
+    /// Build the report these ranges would produce, **without** consuming them.
+    ///
+    /// The ranges stay pending until [`Self::commit`] is called with the same
+    /// report, so a write that is cancelled — the send task's close `select!`
+    /// can cancel at any await — leaves the accounting to be re-emitted by a
+    /// later flush or by the connection's teardown instead of losing an entire
+    /// coalesced burst. `wire` is likewise only advanced at commit.
+    fn peek(&self, wire: DeliveryCountersByClass) -> Option<DeliveryReportPayload> {
         if self.is_empty() {
             return None;
         }
-        self.since = None;
-        let mut gaps = Vec::with_capacity(self.len());
+        let mut per_class = wire;
+        let mut gaps = Vec::with_capacity(self.len().min(DELIVERY_REPORT_MAX_GAPS));
         for (bucket, counter) in [
-            (
-                std::mem::take(&mut self.reliable),
-                &mut wire.reliable.unsupported_format,
-            ),
-            (
-                std::mem::take(&mut self.latest),
-                &mut wire.latest.unsupported_format,
-            ),
-            (
-                std::mem::take(&mut self.volatile),
-                &mut wire.volatile.unsupported_format,
-            ),
+            (&self.reliable, &mut per_class.reliable.unsupported_format),
+            (&self.latest, &mut per_class.latest.unsupported_format),
+            (&self.volatile, &mut per_class.volatile.unsupported_format),
         ] {
             for gap in bucket {
+                // `append` already bounds the buffer, so this is belt-and-braces:
+                // it keeps "one report carries at most the canonical maximum"
+                // true by construction, and any remainder stays pending.
+                if gaps.len() >= DELIVERY_REPORT_MAX_GAPS {
+                    break;
+                }
                 *counter = counter
                     .saturating_add(gap.to_seq.saturating_sub(gap.from_seq).saturating_add(1));
-                gaps.push(gap);
+                gaps.push(gap.clone());
             }
         }
-        Some(DeliveryReportPayload {
-            per_class: *wire,
-            gaps,
-        })
+        Some(DeliveryReportPayload { per_class, gaps })
+    }
+
+    /// Drop exactly the ranges a written report carried, in the order
+    /// [`Self::peek`] emitted them.
+    fn commit(&mut self, report: &DeliveryReportPayload) {
+        let mut remaining = report.gaps.len();
+        for bucket in [&mut self.reliable, &mut self.latest, &mut self.volatile] {
+            let taken = remaining.min(bucket.len());
+            bucket.drain(..taken);
+            remaining -= taken;
+            if remaining == 0 {
+                break;
+            }
+        }
+        if self.is_empty() {
+            self.since = None;
+        }
     }
 }
 
@@ -1409,19 +1425,7 @@ impl OutboundReceiver {
                 Ok(item) => return Ok(Some(item)),
                 Err(PopState::Disconnected) => return Ok(None),
                 Err(PopState::Terminal) => return Err(TryReceiveError::AccountabilityFailed),
-                Err(PopState::Empty) => match self.pending_unsupported_flush_deadline() {
-                    Some(deadline) => {
-                        tokio::select! {
-                            () = notified.as_mut() => {}
-                            () = tokio::time::sleep_until(deadline) => {
-                                if let Some(item) = self.take_pending_unsupported_item() {
-                                    return Ok(Some(item));
-                                }
-                            }
-                        }
-                    }
-                    None => notified.as_mut().await,
-                },
+                Err(PopState::Empty) => notified.as_mut().await,
             }
         }
     }
@@ -1446,37 +1450,11 @@ impl OutboundReceiver {
                 Err(BatchedPopState::Terminal) => {
                     return Err(TryReceiveError::AccountabilityFailed)
                 }
-                Err(BatchedPopState::Empty) => match self.pending_unsupported_flush_deadline() {
-                    Some(deadline) => {
-                        tokio::select! {
-                            () = notified.as_mut() => {}
-                            () = tokio::time::sleep_until(deadline) => {
-                                if let Some(item) = self.take_pending_unsupported_item() {
-                                    return Ok(Some(item));
-                                }
-                            }
-                        }
-                    }
-                    None => notified.as_mut().await,
-                },
+                Err(BatchedPopState::Empty) => notified.as_mut().await,
                 Err(BatchedPopState::WaitUntil(deadline)) => {
-                    // The pending exact report is control traffic and outranks a
-                    // data batch still waiting to coalesce, so whichever
-                    // deadline comes first wins.
-                    let pending_deadline = self.pending_unsupported_flush_deadline();
                     tokio::select! {
                         () = notified.as_mut() => {}
                         () = tokio::time::sleep_until(deadline) => {}
-                        () = async {
-                            match pending_deadline {
-                                Some(deadline) => tokio::time::sleep_until(deadline).await,
-                                None => std::future::pending().await,
-                            }
-                        } => {
-                            if let Some(item) = self.take_pending_unsupported_item() {
-                                return Ok(Some(item));
-                            }
-                        }
                     }
                 }
             }
@@ -1761,72 +1739,64 @@ impl OutboundReceiver {
     /// [`take_pending_unsupported_report`](Self::take_pending_unsupported_report)
     /// emits before the next frame of any other kind, alongside the rate-limited
     /// advisory, or at close.
-    pub fn record_unsupported_format(
-        &self,
-        metadata: DataDeliveryMetadata,
-    ) -> Option<DeliveryReportPayload> {
+    /// Returns `false` when the pending report is full or cannot merge this
+    /// range: the caller must write the pending report
+    /// ([`Self::pending_unsupported_report`] +
+    /// [`Self::commit_pending_unsupported_report`]) and then hold this omission
+    /// with [`Self::hold_unsupported_format`]. The omission is counted here
+    /// exactly once either way.
+    pub fn record_unsupported_format(&self, metadata: DataDeliveryMetadata) -> bool {
         let mut state = self.shared.state();
         increment_unsupported(&mut state.counters, metadata.class);
         self.shared.record_unsupported(metadata.class);
-        let gap = metadata.gap(DeliveryGapReason::UnsupportedFormat);
         // A recipient that never negotiated v3 receives no `DeliveryReport` at
         // all, so nothing may accumulate for it: the pending buffer must stay
         // empty or a later flush would emit a v3-only frame on a v2 wire.
         if !self.shared.v3() {
-            return None;
+            return true;
         }
-        if state.pending_unsupported.append(&gap, metadata.class) {
-            return None;
-        }
-        // The pending report cannot absorb this omission. Flush it and start a
-        // new one from this gap, so the returned report is complete and this
-        // omission is still accounted for exactly once.
-        let mut wire_counters = state.wire_counters;
-        let flushed = state.pending_unsupported.take(&mut wire_counters);
-        state.wire_counters = wire_counters;
-        let appended = state.pending_unsupported.append(&gap, metadata.class);
-        debug_assert!(appended, "an emptied pending report must accept any gap");
-        flushed
+        let gap = metadata.gap(DeliveryGapReason::UnsupportedFormat);
+        state.pending_unsupported.append(&gap, metadata.class)
     }
 
-    /// Take the coalesced unsupported-format report so it reaches the wire
-    /// before any other frame, with the advisory that explains it, or at close.
-    ///
-    /// This ordering is required rather than cosmetic: `wire_counters` only
-    /// advances here, so emitting any other report first would advertise an
-    /// `unsupported_format` counter delta whose exact ranges had not been sent.
-    pub fn take_pending_unsupported_report(&self) -> Option<DeliveryReportPayload> {
-        let mut state = self.shared.state();
-        if state.pending_unsupported.is_empty() {
-            return None;
+    /// Hold an already-counted omission whose range could not be coalesced
+    /// until the pending report was written.
+    pub fn hold_unsupported_format(&self, metadata: DataDeliveryMetadata) {
+        if !self.shared.v3() {
+            return;
         }
-        let mut wire_counters = state.wire_counters;
-        let report = state.pending_unsupported.take(&mut wire_counters);
-        state.wire_counters = wire_counters;
-        report
+        let gap = metadata.gap(DeliveryGapReason::UnsupportedFormat);
+        let mut state = self.shared.state();
+        state.pending_unsupported.append(&gap, metadata.class);
+    }
+
+    /// The coalesced unsupported-format report to write before any other frame,
+    /// with the advisory that explains it, or at close.
+    ///
+    /// The ranges remain pending until
+    /// [`Self::commit_pending_unsupported_report`] confirms the write, so a
+    /// cancelled write re-emits them later instead of losing them. That
+    /// ordering is required rather than cosmetic: `wire_counters` advances only
+    /// on commit, so emitting any other report first would advertise an
+    /// `unsupported_format` counter delta whose exact ranges had not been sent.
+    pub fn pending_unsupported_report(&self) -> Option<DeliveryReportPayload> {
+        let state = self.shared.state();
+        state.pending_unsupported.peek(state.wire_counters)
+    }
+
+    /// Retire the ranges a written report carried and advance the wire frontier
+    /// by exactly the omissions it accounted for.
+    pub fn commit_pending_unsupported_report(&self, report: &DeliveryReportPayload) {
+        let mut state = self.shared.state();
+        state.pending_unsupported.commit(report);
+        state.wire_counters = max_counters(state.wire_counters, report.per_class);
     }
 
     /// When a coalesced unsupported-format report must reach the recipient even
-    /// though nothing else is queued for it.
-    fn pending_unsupported_flush_deadline(&self) -> Option<Instant> {
+    /// though nothing else is queued for it. The writer races this against its
+    /// next item so an idle recipient still learns about the last omissions.
+    pub fn pending_unsupported_flush_deadline(&self) -> Option<Instant> {
         self.shared.state().pending_unsupported.flush_deadline()
-    }
-
-    /// The coalesced report as a writable queue item, for the receive paths that
-    /// reach its flush deadline while the lanes are empty. It is synthesized
-    /// rather than enqueued: the accounting is already owned here, so it must not
-    /// depend on control-lane capacity it could be denied.
-    fn take_pending_unsupported_item(&self) -> Option<QueuedOutbound> {
-        let report = self.take_pending_unsupported_report()?;
-        let generation = self.shared.state().receive_generation;
-        Some(QueuedOutbound {
-            payload: OutboundPayload::DeliveryReport(report),
-            delivery_class: None,
-            metadata: None,
-            enqueued_at: Instant::now(),
-            generation,
-            transition_barrier: false,
-        })
     }
 
     pub(crate) fn record_unsupported_class(&self, class: DeliveryClass) {
@@ -2068,30 +2038,18 @@ fn enqueue_delivery_report(state: &mut QueueState, gaps: Vec<DeliveryGap>) {
 
 fn prepare_for_wire(state: &mut QueueState, mut item: QueuedOutbound) -> QueuedOutbound {
     if let OutboundPayload::DeliveryReport(report) = &mut item.payload {
-        // The writer's coalesced omissions ride along in this report whenever
-        // they fit, so one frame carries both. That keeps a single owner of the
-        // `unsupported_format` wire frontier: whatever is not absorbed here is
-        // still pending, and the counters below therefore never advertise a
-        // delta whose exact ranges have not been sent.
-        let absorbed =
-            if report.gaps.len() + state.pending_unsupported.len() <= DELIVERY_REPORT_MAX_GAPS {
-                state.pending_unsupported.take(&mut state.wire_counters)
-            } else {
-                None
-            };
         report.per_class = max_counters(report.per_class, state.wire_counters);
         // `state.counters` may already count omissions that are still pending
-        // (they are counted when discovered, reported when coalesced), so this
-        // counter is clamped to the frontier rather than raised by a report that
-        // carries no ranges for it.
+        // (they are counted when discovered, reported when their coalesced range
+        // reaches the wire), so the unsupported-format frontier is clamped to
+        // what has actually been sent rather than raised by a report carrying no
+        // ranges for it. The writer flushes the pending report immediately
+        // *after* this frame, which keeps both frames monotonic.
         report.per_class.reliable.unsupported_format =
             state.wire_counters.reliable.unsupported_format;
         report.per_class.latest.unsupported_format = state.wire_counters.latest.unsupported_format;
         report.per_class.volatile.unsupported_format =
             state.wire_counters.volatile.unsupported_format;
-        if let Some(absorbed) = absorbed {
-            report.gaps.extend(absorbed.gaps);
-        }
         state.wire_counters = report.per_class;
     }
     item
@@ -2657,10 +2615,11 @@ mod tests {
     }
 
     /// A queued report popped while the writer still holds coalesced omissions
-    /// carries both, so exactly one frame owns the `unsupported_format` wire
-    /// frontier and no frame advertises a counter delta without its ranges.
+    /// must not advertise an `unsupported_format` delta it carries no ranges for:
+    /// the writer flushes those ranges in their own frame immediately after, and
+    /// a counter that moved early would then be reported as lower.
     #[tokio::test]
-    async fn queued_report_absorbs_the_writers_pending_unsupported_ranges() {
+    async fn a_queued_report_never_advances_the_unsupported_frontier() {
         let (tx, mut rx) = channel(1, 2);
         tx.set_protocol_version(3);
         tx.try_enqueue_data(data(1, DeliveryClass::Reliable, None, 1))
@@ -2674,68 +2633,63 @@ mod tests {
             .unwrap();
 
         assert!(
-            rx.record_unsupported_format(active_metadata).is_none(),
+            rx.record_unsupported_format(active_metadata),
             "the first omission coalesces instead of costing its own frame"
         );
 
         let queued = report(rx.recv().await.unwrap().unwrap());
-        assert_eq!(queued.per_class.reliable.unsupported_format, 1);
         assert_eq!(queued.per_class.latest.dropped_full, 1);
-        let reasons: Vec<_> = queued.gaps.iter().map(|gap| gap.reason).collect();
-        assert_eq!(
-            reasons,
-            vec![
-                DeliveryGapReason::LatestDroppedFull,
-                DeliveryGapReason::UnsupportedFormat
-            ],
-            "the absorbed range must ride along with the queued report"
-        );
-        assert!(
-            rx.take_pending_unsupported_report().is_none(),
-            "an absorbed range must not be reported a second time"
-        );
-    }
-
-    /// When the pending ranges cannot fit in the report being handed out, the
-    /// report must not advertise an `unsupported_format` delta it carries no
-    /// ranges for — otherwise the following flush would report the same
-    /// omissions again and the counters would regress on the wire.
-    #[tokio::test]
-    async fn a_full_report_leaves_the_pending_ranges_and_the_frontier_alone() {
-        let (tx, mut rx) = channel(1, 2);
-        tx.set_protocol_version(3);
-        // Fill the pending report to its bound with non-mergeable ranges.
-        for index in 0..DELIVERY_REPORT_MAX_GAPS {
-            assert!(rx
-                .record_unsupported_format(unsupported_metadata(
-                    DeliveryClass::Reliable,
-                    4,
-                    (index as u64) * 2
-                ))
-                .is_none());
-        }
-
-        // A queued gap report of its own: one `latest` key superseded.
-        tx.try_enqueue_data(data(2, DeliveryClass::Latest, Some(3), 2))
-            .unwrap();
-        tx.try_enqueue_data(data(3, DeliveryClass::Latest, Some(3), 3))
-            .unwrap();
-
-        let queued = report(rx.recv().await.unwrap().unwrap());
-        assert_eq!(queued.gaps.len(), 1, "no pending range could fit");
-        assert_eq!(queued.gaps[0].reason, DeliveryGapReason::LatestSuperseded);
         assert_eq!(
             queued.per_class.reliable.unsupported_format, 0,
             "the frontier may not advance without the ranges that explain it"
         );
+        let reasons: Vec<_> = queued.gaps.iter().map(|gap| gap.reason).collect();
+        assert_eq!(reasons, vec![DeliveryGapReason::LatestDroppedFull]);
 
-        let flushed = rx
-            .take_pending_unsupported_report()
-            .expect("the pending ranges survive a report that could not absorb them");
-        assert_eq!(flushed.gaps.len(), DELIVERY_REPORT_MAX_GAPS);
+        let pending = rx
+            .pending_unsupported_report()
+            .expect("the coalesced range is still waiting for its own frame");
+        assert_eq!(pending.per_class.reliable.unsupported_format, 1);
+        assert_eq!(pending.gaps.len(), 1);
+        assert_eq!(pending.gaps[0].reason, DeliveryGapReason::UnsupportedFormat);
+    }
+
+    /// The ranges must survive a write that never completes: the send task's
+    /// close `select!` can cancel between building the report and committing it,
+    /// and coalescing means a lost frame would take a whole burst with it.
+    #[test]
+    fn an_uncommitted_report_leaves_every_range_pending() {
+        let (tx, rx) = channel(1, 1);
+        tx.set_protocol_version(3);
+        for seq in 1..=3 {
+            assert!(rx.record_unsupported_format(unsupported_metadata(
+                DeliveryClass::Reliable,
+                4,
+                seq
+            )));
+        }
+
+        let first = rx
+            .pending_unsupported_report()
+            .expect("a coalesced range is pending");
+        assert_eq!(first.per_class.reliable.unsupported_format, 3);
+
+        // Peeking is idempotent: a cancelled write changes nothing, and the same
+        // report is offered again.
+        let retry = rx
+            .pending_unsupported_report()
+            .expect("an uncommitted report stays pending");
+        assert_eq!(retry, first);
+
+        rx.commit_pending_unsupported_report(&retry);
+        assert!(
+            rx.pending_unsupported_report().is_none(),
+            "a committed report retires its ranges"
+        );
         assert_eq!(
-            flushed.per_class.reliable.unsupported_format,
-            DELIVERY_REPORT_MAX_GAPS as u64
+            rx.shared.state().wire_counters.reliable.unsupported_format,
+            3,
+            "the frontier advances on commit, and only then"
         );
     }
 
@@ -3264,25 +3218,20 @@ mod tests {
         tx.set_protocol_version(3);
         for seq in 7..=9 {
             assert!(
-                rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Volatile, 4, seq))
-                    .is_none(),
+                rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Volatile, 4, seq)),
                 "contiguous omissions from one sender must coalesce"
             );
         }
         // A different class cannot share a range: `UnsupportedFormat` is the one
         // gap reason every class uses, so merging across classes would lose the
         // attribution the per-class counters need.
-        assert!(rx
-            .record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 10))
-            .is_none());
+        assert!(rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 10)));
         // A different sender starts its own range.
-        assert!(rx
-            .record_unsupported_format(unsupported_metadata(DeliveryClass::Volatile, 11, 1))
-            .is_none());
+        assert!(rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Volatile, 11, 1)));
 
         let report = rx
-            .take_pending_unsupported_report()
-            .expect("pending accountability must flush");
+            .pending_unsupported_report()
+            .expect("pending accountability must be reportable");
         assert_eq!(report.per_class.volatile.unsupported_format, 4);
         assert_eq!(report.per_class.reliable.unsupported_format, 1);
         let ranges: Vec<_> = report
@@ -3314,57 +3263,67 @@ mod tests {
             ],
             "five omissions must be reported as three exact ranges"
         );
+        rx.commit_pending_unsupported_report(&report);
         assert!(
-            rx.take_pending_unsupported_report().is_none(),
-            "a flushed report leaves nothing pending"
+            rx.pending_unsupported_report().is_none(),
+            "a committed report leaves nothing pending"
         );
     }
 
     /// The connection's teardown flushes whatever is still coalesced, so closing
-    /// the queue must not strand it: `finalize_closed_connection` takes the
-    /// pending report *after* `rx.close()`, and a cleared or refused buffer there
+    /// the queue must not strand it: `finalize_closed_connection` reports the
+    /// pending ranges *after* `rx.close()`, and a cleared or refused buffer there
     /// would silently drop the last omissions instead of reporting them.
     #[test]
     fn closing_the_queue_preserves_pending_unsupported_accountability() {
         let (tx, mut rx) = channel(1, 1);
         tx.set_protocol_version(3);
-        assert!(rx
-            .record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 1))
-            .is_none());
+        assert!(rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 1)));
         rx.close();
         let report = rx
-            .take_pending_unsupported_report()
+            .pending_unsupported_report()
             .expect("a closing connection must still be able to report its last omissions");
         assert_eq!(report.per_class.reliable.unsupported_format, 1);
         assert_eq!(report.gaps.len(), 1);
     }
 
-    /// The pending report is bounded by the canonical per-report gap maximum,
-    /// and hitting that bound flushes rather than dropping accountability.
+    /// The pending report is bounded by the canonical per-report gap maximum.
+    /// Hitting the bound asks the writer to flush rather than dropping
+    /// accountability, and the displaced omission is held once that write lands.
     #[test]
-    fn pending_unsupported_report_is_bounded_and_flushes_when_full() {
+    fn pending_unsupported_report_is_bounded_and_asks_for_a_flush_when_full() {
         let (tx, rx) = channel(1, 1);
         tx.set_protocol_version(3);
         // Every second sequence is a hole, so no two omissions can merge.
-        let mut flushed = None;
+        let mut needed_flush = 0usize;
+        let mut displaced = None;
         for index in 0..=DELIVERY_REPORT_MAX_GAPS {
-            let seq = (index as u64) * 2;
-            let report =
-                rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, seq));
-            if let Some(report) = report {
-                assert!(flushed.is_none(), "only the bounded report may flush");
-                flushed = Some(report);
+            let metadata = unsupported_metadata(DeliveryClass::Reliable, 4, (index as u64) * 2);
+            if !rx.record_unsupported_format(metadata) {
+                needed_flush += 1;
+                displaced = Some(metadata);
             }
         }
-        let flushed = flushed.expect("the bounded report must flush when it is full");
-        assert_eq!(flushed.gaps.len(), DELIVERY_REPORT_MAX_GAPS);
         assert_eq!(
-            flushed.per_class.reliable.unsupported_format,
+            needed_flush, 1,
+            "only the omission past the bound needs its own frame"
+        );
+
+        let full = rx
+            .pending_unsupported_report()
+            .expect("the bounded report is ready to write");
+        assert_eq!(full.gaps.len(), DELIVERY_REPORT_MAX_GAPS);
+        assert_eq!(
+            full.per_class.reliable.unsupported_format,
             DELIVERY_REPORT_MAX_GAPS as u64
         );
+        rx.commit_pending_unsupported_report(&full);
+
+        // The writer holds the displaced omission only after that write landed.
+        rx.hold_unsupported_format(displaced.expect("an omission was displaced"));
         let remainder = rx
-            .take_pending_unsupported_report()
-            .expect("the omission that displaced the report is still accounted for");
+            .pending_unsupported_report()
+            .expect("the displaced omission is still accounted for");
         assert_eq!(remainder.gaps.len(), 1);
         assert_eq!(
             remainder.per_class.reliable.unsupported_format,
@@ -3379,10 +3338,8 @@ mod tests {
     #[test]
     fn pre_v3_recipients_accumulate_no_delivery_report() {
         let (_tx, rx) = channel(1, 1);
-        assert!(rx
-            .record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 1))
-            .is_none());
-        assert!(rx.take_pending_unsupported_report().is_none());
+        assert!(rx.record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 1)));
+        assert!(rx.pending_unsupported_report().is_none());
         assert_eq!(
             rx.shared.state().counters.reliable.unsupported_format,
             1,

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -3277,6 +3277,25 @@ mod tests {
         );
     }
 
+    /// The connection's teardown flushes whatever is still coalesced, so closing
+    /// the queue must not strand it: `finalize_closed_connection` takes the
+    /// pending report *after* `rx.close()`, and a cleared or refused buffer there
+    /// would silently drop the last omissions instead of reporting them.
+    #[test]
+    fn closing_the_queue_preserves_pending_unsupported_accountability() {
+        let (tx, mut rx) = channel(1, 1);
+        tx.set_protocol_version(3);
+        assert!(rx
+            .record_unsupported_format(unsupported_metadata(DeliveryClass::Reliable, 4, 1))
+            .is_none());
+        rx.close();
+        let report = rx
+            .take_pending_unsupported_report()
+            .expect("a closing connection must still be able to report its last omissions");
+        assert_eq!(report.per_class.reliable.unsupported_format, 1);
+        assert_eq!(report.gaps.len(), 1);
+    }
+
     /// The pending report is bounded by the canonical per-report gap maximum,
     /// and hitting that bound flushes rather than dropping accountability.
     #[test]

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -256,6 +256,14 @@ struct QueueState {
     counters: DeliveryCountersByClass,
     wire_counters: DeliveryCountersByClass,
     pending_unsupported: PendingUnsupported,
+    /// A queued report advanced `wire_counters` when it was handed to the writer,
+    /// but that frame has not been confirmed written yet.
+    ///
+    /// While this is set the frontier describes a frame the recipient may never
+    /// receive, so a coalesced unsupported-format report must not be built from
+    /// it: its other counters would carry deltas the recipient was never told
+    /// about. Cleared by [`OutboundReceiver::confirm_report_frontier`].
+    report_frontier_unconfirmed: bool,
     enqueue_generation: u64,
     receive_generation: u64,
     active_room: Option<RoomId>,
@@ -399,6 +407,7 @@ impl QueueState {
             counters: DeliveryCountersByClass::default(),
             wire_counters: DeliveryCountersByClass::default(),
             pending_unsupported: PendingUnsupported::default(),
+            report_frontier_unconfirmed: false,
             enqueue_generation: 0,
             receive_generation: 0,
             active_room: None,
@@ -1781,7 +1790,20 @@ impl OutboundReceiver {
     /// `unsupported_format` counter delta whose exact ranges had not been sent.
     pub fn pending_unsupported_report(&self) -> Option<DeliveryReportPayload> {
         let state = self.shared.state();
+        if state.report_frontier_unconfirmed {
+            // A queued report took the frontier forward and has not been
+            // confirmed written. Building on it would advertise that frame's
+            // counter deltas to a recipient that may never receive it, so this
+            // report waits — the omissions stay recorded either way.
+            return None;
+        }
         state.pending_unsupported.peek(state.wire_counters)
+    }
+
+    /// Confirm that the report frame the queue last handed to the writer reached
+    /// the socket, so the wire frontier describes what the recipient has seen.
+    pub fn confirm_report_frontier(&self) {
+        self.shared.state().report_frontier_unconfirmed = false;
     }
 
     /// Retire the ranges a written report carried and advance the wire frontier
@@ -2051,6 +2073,8 @@ fn prepare_for_wire(state: &mut QueueState, mut item: QueuedOutbound) -> QueuedO
         report.per_class.volatile.unsupported_format =
             state.wire_counters.volatile.unsupported_format;
         state.wire_counters = report.per_class;
+        // The frontier now describes a frame that has not been written yet.
+        state.report_frontier_unconfirmed = true;
     }
     item
 }
@@ -2645,6 +2669,14 @@ mod tests {
         );
         let reasons: Vec<_> = queued.gaps.iter().map(|gap| gap.reason).collect();
         assert_eq!(reasons, vec![DeliveryGapReason::LatestDroppedFull]);
+
+        // Until that frame is confirmed written, the frontier describes something
+        // the recipient may never see, so no report may be built on it.
+        assert!(
+            rx.pending_unsupported_report().is_none(),
+            "an unconfirmed report frame must not become another report's baseline"
+        );
+        rx.confirm_report_frontier();
 
         let pending = rx
             .pending_unsupported_report()

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,8 +522,9 @@ mod cli_tests {
         );
         assert_eq!(
             websocket::REGISTERED_SHUTDOWN_CLOSE_WRITE_STEPS,
-            3,
-            "registered shutdown close uses flush, semantic close, and sink close budgets"
+            4,
+            "registered shutdown close uses flush, final delivery report, semantic close, \
+             and sink close budgets"
         );
         assert!(
             websocket::REGISTERED_SHUTDOWN_SETTLE_MARGIN > Duration::ZERO,

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -311,6 +311,10 @@ pub(super) async fn send_queued(
         )
         .await?;
         if carries_queued_report {
+            // This report frame is on the wire, so the frontier it advanced at
+            // pop time now describes what the recipient has seen and a coalesced
+            // report may be built on it.
+            receiver.confirm_report_frontier();
             write_pending_unsupported_report(sender, receiver, player_id).await?;
         }
         Ok(disposition)

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -12,8 +12,8 @@ use tokio::time::Instant;
 use crate::server::EnhancedGameServer;
 
 use super::sending::{
-    preflight_binary_fallback, send_single_message, BinaryFallbackPreflight, SendAccounting,
-    SendDisposition,
+    preflight_binary_fallback, send_single_message, send_text_message, BinaryFallbackPreflight,
+    SendAccounting, SendDisposition,
 };
 
 /// Message batcher for WebSocket connections
@@ -272,25 +272,53 @@ pub(super) async fn send_queued(
         write_started_at,
         fallback_preflight.is_unsupported(),
     );
+    let carries_queued_report = matches!(queued.payload, OutboundPayload::DeliveryReport(_));
     let message = match queued.payload {
         OutboundPayload::Message(message) => message,
         OutboundPayload::DeliveryReport(report) => {
             Arc::new(ServerMessage::DeliveryReport(Box::new(report)))
         }
     };
+    // Exact accounting owns the head of the stream: a coalesced
+    // unsupported-format report must reach this recipient before the next
+    // delivered frame, because a recipient may not observe delivered data that
+    // skips sequences it was never told about. Two items are excluded:
+    //
+    // - another undeliverable payload, which keeps coalescing instead — that is
+    //   what collapses a burst into one report;
+    // - a queued `DeliveryReport`, which already absorbed what fitted and had
+    //   its counters stamped against the wire frontier when it was popped.
+    //   Emitting a flush ahead of it would move a counter that the following
+    //   frame then reports as lower.
+    let pending_report = if fallback_preflight.is_unsupported() || carries_queued_report {
+        None
+    } else {
+        receiver.take_pending_unsupported_report()
+    };
     let mut accounting = SendAccounting::new(receiver, server, *player_id, class);
     let recipient_supports_v3 = receiver.supports_v3();
     let recipient_format = receiver.game_data_format();
-    let write = send_single_message(
-        sender,
-        message,
-        player_id,
-        recipient_supports_v3,
-        recipient_format,
-        fallback_preflight,
-        metadata,
-        &mut accounting,
-    );
+    let write = async {
+        if let Some(report) = pending_report {
+            send_text_message(
+                sender,
+                &ServerMessage::DeliveryReport(Box::new(report)),
+                player_id,
+            )
+            .await?;
+        }
+        send_single_message(
+            sender,
+            message,
+            player_id,
+            recipient_supports_v3,
+            recipient_format,
+            fallback_preflight,
+            metadata,
+            &mut accounting,
+        )
+        .await
+    };
     let result = if max_sojourn.is_zero() {
         write.await.map_err(|()| QueueWriteError::SocketClosed)
     } else {

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -12,8 +12,8 @@ use tokio::time::Instant;
 use crate::server::EnhancedGameServer;
 
 use super::sending::{
-    preflight_binary_fallback, send_single_message, send_text_message, BinaryFallbackPreflight,
-    SendAccounting, SendDisposition,
+    preflight_binary_fallback, send_single_message, write_pending_unsupported_report,
+    BinaryFallbackPreflight, SendAccounting, SendDisposition,
 };
 
 /// Message batcher for WebSocket connections
@@ -282,32 +282,24 @@ pub(super) async fn send_queued(
     // Exact accounting owns the head of the stream: a coalesced
     // unsupported-format report must reach this recipient before the next
     // delivered frame, because a recipient may not observe delivered data that
-    // skips sequences it was never told about. Two items are excluded:
+    // skips sequences it was never told about. Two items are handled
+    // differently:
     //
-    // - another undeliverable payload, which keeps coalescing instead — that is
-    //   what collapses a burst into one report;
-    // - a queued `DeliveryReport`, which already absorbed what fitted and had
-    //   its counters stamped against the wire frontier when it was popped.
-    //   Emitting a flush ahead of it would move a counter that the following
+    // - another undeliverable payload keeps coalescing instead, which is what
+    //   collapses a burst into one report;
+    // - a queued `DeliveryReport` had its counters stamped against the wire
+    //   frontier when it was popped, so the flush follows it rather than
+    //   preceding it: a flush in front would move a counter that the very next
     //   frame then reports as lower.
-    let pending_report = if fallback_preflight.is_unsupported() || carries_queued_report {
-        None
-    } else {
-        receiver.take_pending_unsupported_report()
-    };
+    let flush_before = !fallback_preflight.is_unsupported() && !carries_queued_report;
     let mut accounting = SendAccounting::new(receiver, server, *player_id, class);
     let recipient_supports_v3 = receiver.supports_v3();
     let recipient_format = receiver.game_data_format();
     let write = async {
-        if let Some(report) = pending_report {
-            send_text_message(
-                sender,
-                &ServerMessage::DeliveryReport(Box::new(report)),
-                player_id,
-            )
-            .await?;
+        if flush_before {
+            write_pending_unsupported_report(sender, receiver, player_id).await?;
         }
-        send_single_message(
+        let disposition = send_single_message(
             sender,
             message,
             player_id,
@@ -317,7 +309,11 @@ pub(super) async fn send_queued(
             metadata,
             &mut accounting,
         )
-        .await
+        .await?;
+        if carries_queued_report {
+            write_pending_unsupported_report(sender, receiver, player_id).await?;
+        }
+        Ok(disposition)
     };
     let result = if max_sojourn.is_zero() {
         write.await.map_err(|()| QueueWriteError::SocketClosed)

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -22,7 +22,7 @@ use tokio::sync::{mpsc, oneshot, watch, RwLock};
 use tokio::time::Instant;
 
 use super::batching::{send_batch, send_queued, MessageBatcher, QueueWriteError, WritePhase};
-use super::sending::send_immediate_server_message;
+use super::sending::{send_immediate_server_message, write_pending_unsupported_report};
 use super::token_binding::{parse_client_message, TokenBindingHandshake};
 use super::CONNECTION_CLOSE_WRITE_TIMEOUT as CLOSE_WRITE_TIMEOUT;
 
@@ -351,19 +351,23 @@ async fn flush_pending_unsupported_report(
     rx: &OutboundReceiver,
     player_id: &PlayerId,
 ) {
-    let Some(report) = rx.take_pending_unsupported_report() else {
+    let Some(report) = rx.pending_unsupported_report() else {
         return;
     };
-    let report = ServerMessage::DeliveryReport(Box::new(report));
     // Counted as its own step in `RegisteredConnectionCloseStep`, so the derived
-    // shutdown settle timeout covers this budget too.
+    // shutdown settle timeout covers this budget too. The ranges are retired
+    // only after the frame is written, so a timed-out or failed write leaves the
+    // accounting recorded rather than silently dropped.
     match registered_close_write_timeout(
         RegisteredConnectionCloseStep::FinalDeliveryReport,
-        send_immediate_server_message(sender, &report),
+        send_immediate_server_message(
+            sender,
+            &ServerMessage::DeliveryReport(Box::new(report.clone())),
+        ),
     )
     .await
     {
-        Ok(Ok(())) => {}
+        Ok(Ok(())) => rx.commit_pending_unsupported_report(&report),
         Ok(Err(err)) => {
             tracing::debug!(%player_id, error = %err, "Failed to flush final delivery report");
         }
@@ -1135,6 +1139,10 @@ pub(super) async fn handle_socket(
             () = async {
                 let batch_interval = Duration::from_millis(batch_interval_ms.max(1));
                 loop {
+                    // Read outside the `select!`: the arm below only needs the
+                    // deadline value, and borrowing `rx` inside the select would
+                    // conflict with the `&mut` receive arm.
+                    let pending_flush_deadline = rx.pending_unsupported_flush_deadline();
                     let received = tokio::select! {
                         biased;
                         command = ping_command_rx.recv() => {
@@ -1190,6 +1198,31 @@ pub(super) async fn handle_socket(
                                 }
                             }
                             break;
+                        }
+                        // An idle recipient must still learn about coalesced
+                        // omissions within a bounded time: without this the last
+                        // range of a burst would wait for the next omission or
+                        // for the connection to close. `recv`/`recv_batched` are
+                        // cancel-safe, so losing this race costs nothing.
+                        () = async {
+                            match pending_flush_deadline {
+                                Some(deadline) => tokio::time::sleep_until(deadline).await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
+                            let current_player_id =
+                                *effective_player_id_for_send.read().await;
+                            if write_pending_unsupported_report(
+                                &mut sender,
+                                &rx,
+                                &current_player_id,
+                            )
+                            .await
+                            .is_err()
+                            {
+                                break;
+                            }
+                            continue;
                         }
                         received = async {
                             if batching_enabled {

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -370,6 +370,29 @@ async fn finalize_closed_connection(
     #[cfg(feature = "trace-validation")]
     close_signal.record_trace_queue_closed();
 
+    // Emit whatever exact omission accounting is still coalesced for this
+    // recipient before the terminal frames. It is best-effort — a wedged socket
+    // is exactly why this path runs — but on a healthy teardown it means the
+    // last burst of undeliverable data is still reported rather than lost with
+    // the connection.
+    if let Some(report) = rx.take_pending_unsupported_report() {
+        let report = ServerMessage::DeliveryReport(Box::new(report));
+        match tokio::time::timeout(
+            CLOSE_WRITE_TIMEOUT,
+            send_immediate_server_message(sender, &report),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                tracing::debug!(%player_id, error = %err, "Failed to flush final delivery report");
+            }
+            Err(_elapsed) => {
+                tracing::debug!(%player_id, "Timed out flushing final delivery report");
+            }
+        }
+    }
+
     match reason {
         Some(CloseReason::SlowConsumer) => {
             // `send_batch` pops messages one at a time, so a cancelled

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -41,6 +41,9 @@ fn random_ping_nonce() -> u64 {
 #[repr(u32)]
 enum RegisteredConnectionCloseStep {
     FlushQueuedMessages,
+    /// The coalesced unsupported-format report, written after the drain because
+    /// the drain itself can discover further undeliverable payloads.
+    FinalDeliveryReport,
     SemanticCloseFrame,
     SinkClose,
     Count,
@@ -334,6 +337,42 @@ where
     tokio::time::timeout(CLOSE_WRITE_TIMEOUT, operation).await
 }
 
+/// Write whatever exact omission accounting is still coalesced for this
+/// recipient, once no further frame will carry it.
+///
+/// Best-effort by nature — a wedged socket is one reason this path runs — but on
+/// a healthy teardown it means the last burst of undeliverable data is still
+/// reported rather than dying with the connection. Callers must invoke this
+/// after the last queued write on their path, because each write can discover
+/// further undeliverable payloads whose advisory (and therefore whose report
+/// flush) the rate limiter may suppress.
+async fn flush_pending_unsupported_report(
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    rx: &OutboundReceiver,
+    player_id: &PlayerId,
+) {
+    let Some(report) = rx.take_pending_unsupported_report() else {
+        return;
+    };
+    let report = ServerMessage::DeliveryReport(Box::new(report));
+    // Counted as its own step in `RegisteredConnectionCloseStep`, so the derived
+    // shutdown settle timeout covers this budget too.
+    match registered_close_write_timeout(
+        RegisteredConnectionCloseStep::FinalDeliveryReport,
+        send_immediate_server_message(sender, &report),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            tracing::debug!(%player_id, error = %err, "Failed to flush final delivery report");
+        }
+        Err(_elapsed) => {
+            tracing::debug!(%player_id, "Timed out flushing final delivery report");
+        }
+    }
+}
+
 /// Final actions of the send task once a server-side close was requested.
 ///
 /// - Slow consumer: the queue contents are abandoned **by design** (the
@@ -370,31 +409,12 @@ async fn finalize_closed_connection(
     #[cfg(feature = "trace-validation")]
     close_signal.record_trace_queue_closed();
 
-    // Emit whatever exact omission accounting is still coalesced for this
-    // recipient before the terminal frames. It is best-effort — a wedged socket
-    // is exactly why this path runs — but on a healthy teardown it means the
-    // last burst of undeliverable data is still reported rather than lost with
-    // the connection.
-    if let Some(report) = rx.take_pending_unsupported_report() {
-        let report = ServerMessage::DeliveryReport(Box::new(report));
-        match tokio::time::timeout(
-            CLOSE_WRITE_TIMEOUT,
-            send_immediate_server_message(sender, &report),
-        )
-        .await
-        {
-            Ok(Ok(())) => {}
-            Ok(Err(err)) => {
-                tracing::debug!(%player_id, error = %err, "Failed to flush final delivery report");
-            }
-            Err(_elapsed) => {
-                tracing::debug!(%player_id, "Timed out flushing final delivery report");
-            }
-        }
-    }
-
     match reason {
         Some(CloseReason::SlowConsumer) => {
+            // Nothing more will be written from the queue on this path — it is
+            // abandoned below — so the coalesced omissions are flushed here,
+            // before the counters that make the farewell terminal.
+            flush_pending_unsupported_report(sender, rx, player_id).await;
             // `send_batch` pops messages one at a time, so a cancelled
             // in-flight write leaves everything unsent inside the batcher;
             // the count below misses at most the single message that was
@@ -516,6 +536,11 @@ async fn finalize_closed_connection(
                     );
                 }
             }
+            // After the drain, not before it: the drain itself writes queued
+            // items and can discover further undeliverable payloads, and a
+            // suppressed advisory leaves those coalesced. Flushing first would
+            // leave exactly the tail this change exists to preserve unreported.
+            flush_pending_unsupported_report(sender, rx, player_id).await;
         }
     }
 

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -311,11 +311,15 @@ impl<'a> SendAccounting<'a> {
         self.resolved = true;
     }
 
+    /// Account one undeliverable payload. The returned report (if any) is
+    /// accountability that must reach the wire before anything else; `None`
+    /// means it coalesced into the recipient's pending report.
     fn complete_unsupported(
         &mut self,
         metadata: Option<DataDeliveryMetadata>,
     ) -> Option<crate::protocol::DeliveryReportPayload> {
-        let report = metadata.map(|metadata| self.receiver.record_unsupported_format(metadata));
+        let report =
+            metadata.and_then(|metadata| self.receiver.record_unsupported_format(metadata));
         if metadata.is_none() {
             if let Some(class) = self.class {
                 self.receiver.record_unsupported_class(class);
@@ -324,6 +328,11 @@ impl<'a> SendAccounting<'a> {
         self.record_drop_metrics();
         self.resolved = true;
         report
+    }
+
+    /// Flush whatever exact accounting is still coalesced for this recipient.
+    fn take_pending_unsupported(&self) -> Option<crate::protocol::DeliveryReportPayload> {
+        self.receiver.take_pending_unsupported_report()
     }
 
     fn record_drop_metrics(&self) {
@@ -420,20 +429,31 @@ async fn notify_or_close_on_fallback_failure(
                 reason = %reason,
                 "Game data undeliverable to this recipient; sending an error notice instead"
             );
-            let report = accounting.complete_unsupported(metadata);
-            if recipient_supports_v3 {
-                let Some(report) = report else {
-                    tracing::error!(
-                        %player_id,
-                        %from_player,
-                        "Stamped v3 binary fallback lacked delivery metadata; closing fail-closed"
-                    );
-                    return Err(());
-                };
+            let displaced = accounting.complete_unsupported(metadata);
+            if recipient_supports_v3 && metadata.is_none() {
+                tracing::error!(
+                    %player_id,
+                    %from_player,
+                    "Stamped v3 binary fallback lacked delivery metadata; closing fail-closed"
+                );
+                return Err(());
+            }
+            // A displaced report is a completed range this omission could not
+            // join; it goes out now so the pending report stays the only
+            // unsent accounting.
+            if let Some(report) = displaced {
                 let report = ServerMessage::DeliveryReport(Box::new(report));
                 send_text_message(sender, &report, player_id).await?;
             }
             if let Some(suppressed) = accounting.unsupported_notice(from_player) {
+                // The advisory must never precede the exact report that
+                // explains it, so the rate-limited notice is also the pending
+                // report's flush cadence: at most one report per sender per
+                // second instead of one per omitted message.
+                if let Some(report) = accounting.take_pending_unsupported() {
+                    let report = ServerMessage::DeliveryReport(Box::new(report));
+                    send_text_message(sender, &report, player_id).await?;
+                }
                 let suppressed = if suppressed == 0 {
                     String::new()
                 } else {

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -311,15 +311,13 @@ impl<'a> SendAccounting<'a> {
         self.resolved = true;
     }
 
-    /// Account one undeliverable payload. The returned report (if any) is
-    /// accountability that must reach the wire before anything else; `None`
-    /// means it coalesced into the recipient's pending report.
-    fn complete_unsupported(
-        &mut self,
-        metadata: Option<DataDeliveryMetadata>,
-    ) -> Option<crate::protocol::DeliveryReportPayload> {
-        let report =
-            metadata.and_then(|metadata| self.receiver.record_unsupported_format(metadata));
+    /// Account one undeliverable payload, coalescing its exact range. `false`
+    /// means the pending report has to be written before this range can be held
+    /// (see [`Self::hold_unsupported`]); the omission itself is counted either
+    /// way.
+    fn complete_unsupported(&mut self, metadata: Option<DataDeliveryMetadata>) -> bool {
+        let coalesced =
+            metadata.is_none_or(|metadata| self.receiver.record_unsupported_format(metadata));
         if metadata.is_none() {
             if let Some(class) = self.class {
                 self.receiver.record_unsupported_class(class);
@@ -327,12 +325,14 @@ impl<'a> SendAccounting<'a> {
         }
         self.record_drop_metrics();
         self.resolved = true;
-        report
+        coalesced
     }
 
-    /// Flush whatever exact accounting is still coalesced for this recipient.
-    fn take_pending_unsupported(&self) -> Option<crate::protocol::DeliveryReportPayload> {
-        self.receiver.take_pending_unsupported_report()
+    /// Hold an omission whose range only fits once the pending report is written.
+    fn hold_unsupported(&self, metadata: Option<DataDeliveryMetadata>) {
+        if let Some(metadata) = metadata {
+            self.receiver.hold_unsupported_format(metadata);
+        }
     }
 
     fn record_drop_metrics(&self) {
@@ -429,7 +429,7 @@ async fn notify_or_close_on_fallback_failure(
                 reason = %reason,
                 "Game data undeliverable to this recipient; sending an error notice instead"
             );
-            let displaced = accounting.complete_unsupported(metadata);
+            let coalesced = accounting.complete_unsupported(metadata);
             if recipient_supports_v3 && metadata.is_none() {
                 tracing::error!(
                     %player_id,
@@ -438,22 +438,20 @@ async fn notify_or_close_on_fallback_failure(
                 );
                 return Err(());
             }
-            // A displaced report is a completed range this omission could not
-            // join; it goes out now so the pending report stays the only
-            // unsent accounting.
-            if let Some(report) = displaced {
-                let report = ServerMessage::DeliveryReport(Box::new(report));
-                send_text_message(sender, &report, player_id).await?;
+            if !coalesced {
+                // The pending report is full, or this range cannot join it:
+                // write what is pending, then hold this range in the emptied
+                // report. Holding only after the write keeps the two sets
+                // disjoint if the write is cancelled.
+                write_pending_unsupported_report(sender, accounting.receiver, player_id).await?;
+                accounting.hold_unsupported(metadata);
             }
             if let Some(suppressed) = accounting.unsupported_notice(from_player) {
                 // The advisory must never precede the exact report that
                 // explains it, so the rate-limited notice is also the pending
                 // report's flush cadence: at most one report per sender per
                 // second instead of one per omitted message.
-                if let Some(report) = accounting.take_pending_unsupported() {
-                    let report = ServerMessage::DeliveryReport(Box::new(report));
-                    send_text_message(sender, &report, player_id).await?;
-                }
+                write_pending_unsupported_report(sender, accounting.receiver, player_id).await?;
                 let suppressed = if suppressed == 0 {
                     String::new()
                 } else {
@@ -472,6 +470,32 @@ async fn notify_or_close_on_fallback_failure(
             Ok(SendDisposition::AccountedDrop)
         }
     }
+}
+
+/// Write the recipient's coalesced unsupported-format report, if any, and retire
+/// its ranges only once the frame is on the wire.
+///
+/// Peek-write-commit rather than take-then-write: the send task's close
+/// `select!` can cancel this at its await, and losing the only copy of a
+/// coalesced burst would silently drop accountability for every omission in it.
+/// A cancelled write leaves the ranges pending for the next flush or for the
+/// connection's teardown.
+pub(super) async fn write_pending_unsupported_report(
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    receiver: &OutboundReceiver,
+    player_id: &PlayerId,
+) -> Result<(), ()> {
+    let Some(report) = receiver.pending_unsupported_report() else {
+        return Ok(());
+    };
+    send_text_message(
+        sender,
+        &ServerMessage::DeliveryReport(Box::new(report.clone())),
+        player_id,
+    )
+    .await?;
+    receiver.commit_pending_unsupported_report(&report);
+    Ok(())
 }
 
 pub(super) async fn send_text_message(

--- a/tests/mixed_encoding_relay_e2e.rs
+++ b/tests/mixed_encoding_relay_e2e.rs
@@ -18,7 +18,8 @@ use std::time::Duration;
 use futures_util::{SinkExt, StreamExt};
 use signal_fish_server::config::ProtocolConfig;
 use signal_fish_server::protocol::{
-    ClientMessage, GameDataEncoding, PlayerId, ServerMessage, V3BinaryGameDataFrame,
+    ClientMessage, DeliveryGapReason, GameDataEncoding, PlayerId, ServerMessage,
+    V3BinaryGameDataFrame,
 };
 use signal_fish_server::websocket::create_router;
 use tokio_tungstenite::tungstenite::Message;
@@ -321,6 +322,21 @@ async fn mixed_json_and_message_pack_relay_without_error_amplification() {
     running_server.shutdown().await;
 }
 
+/// Everything the throttled JSON recipient observed, so the amplification
+/// oracle can be asserted against measured wire bytes rather than frame counts.
+struct FallbackObservation {
+    /// `DeliveryReport` frames received.
+    reports: u64,
+    /// Rate-limited `UnsupportedGameDataFormat` advisories received.
+    advisories: u64,
+    /// Sequences named by `UnsupportedFormat` gap ranges, summed over reports.
+    accounted: u64,
+    /// Total WebSocket payload bytes this recipient had to drain.
+    wire_bytes: u64,
+    close: Option<(u16, String)>,
+    elapsed: Duration,
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[serial_test::serial]
 #[ignore = "nightly-only (verification-nightly.yml): throttled unsupported-format amplification"]
@@ -398,6 +414,7 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
         let deadline = tokio::time::Instant::now() + EXPERIMENT_DEADLINE;
         let mut delivered = 0u64;
         let mut player_left = 0u64;
+        let mut wire_bytes = 0u64;
         while delivered < BURST {
             let frame = tokio::time::timeout_at(deadline, stream.next())
                 .await
@@ -410,6 +427,7 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
                 .unwrap_or_else(|error| panic!("compatible recipient read failed: {error}"));
             match frame {
                 Message::Binary(bytes) => {
+                    wire_bytes += bytes.len() as u64;
                     let relayed = compatible_auditor.record_binary_frame("P1", &bytes);
                     assert_eq!(relayed.encoding, GameDataEncoding::MessagePack);
                     assert_eq!(relayed.payload.as_slice(), [0xc1]);
@@ -428,7 +446,7 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
                 }
             }
         }
-        (stream, player_left)
+        (stream, player_left, wire_bytes)
     });
 
     let fallback_auditor = Arc::clone(&auditor);
@@ -438,7 +456,9 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
         let deadline = tokio::time::Instant::now() + EXPERIMENT_DEADLINE;
         let mut reports = 0u64;
         let mut errors = 0u64;
-        while reports < BURST {
+        let mut wire_bytes = 0u64;
+        let mut accounted = 0u64;
+        while accounted < BURST {
             let frame = tokio::time::timeout_at(deadline, stream.next())
                 .await
                 .unwrap_or_else(|_| {
@@ -453,44 +473,69 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
                 })
                 .unwrap_or_else(|error| panic!("fallback recipient read failed: {error}"));
             match frame {
-                Message::Text(text) => match fallback_auditor.record_text_frame("P2", &text) {
-                    ServerMessage::DeliveryReport(_) => reports += 1,
-                    ServerMessage::Error {
-                        error_code,
-                        message,
-                    } => {
-                        // `SlowConsumer` here is not a stray advisory: the server
-                        // only ever emits it as a farewell frame immediately
-                        // before eviction, so seeing it means this recipient is
-                        // being dropped. Report the counters and elapsed time
-                        // with it — a bare `assert_eq!` on the code says nothing
-                        // about how far the experiment got, which is the first
-                        // thing needed to tell a genuine amplification eviction
-                        // from a link that simply never kept pace. See issue
-                        // #212.
-                        assert_eq!(
+                Message::Text(text) => {
+                    wire_bytes += text.len() as u64;
+                    match fallback_auditor.record_text_frame("P2", &text) {
+                        ServerMessage::DeliveryReport(report) => {
+                            reports += 1;
+                            // The auditor already proves these ranges never overlap
+                            // and never leave a hole, so summing their lengths is an
+                            // exact count of the sequences accounted for. Counting
+                            // sequences rather than frames is what lets one
+                            // coalesced range stand in for a burst of omissions
+                            // without weakening the accountability oracle.
+                            accounted += report
+                                .gaps
+                                .iter()
+                                .filter(|gap| gap.reason == DeliveryGapReason::UnsupportedFormat)
+                                .map(|gap| gap.to_seq - gap.from_seq + 1)
+                                .sum::<u64>();
+                        }
+                        ServerMessage::Error {
+                            error_code,
+                            message,
+                        } => {
+                            // `SlowConsumer` here is not a stray advisory: the server
+                            // only ever emits it as a farewell frame immediately
+                            // before eviction, so seeing it means this recipient is
+                            // being dropped. Report the counters and elapsed time
+                            // with it — a bare `assert_eq!` on the code says nothing
+                            // about how far the experiment got, which is the first
+                            // thing needed to tell a genuine amplification eviction
+                            // from a link that simply never kept pace. See issue
+                            // #212.
+                            assert_eq!(
                             error_code,
                             Some(
                                 signal_fish_server::protocol::ErrorCode::UnsupportedGameDataFormat
                             ),
-                            "fallback recipient received `{error_code:?}` after {reports}/{BURST} \
-                             reports and {errors} advisories, {:?} into a {EXPERIMENT_DEADLINE:?} \
-                             budget: {message}",
+                            "fallback recipient received `{error_code:?}` after \
+                             {accounted}/{BURST} accounted sequences in {reports} reports and \
+                             {errors} advisories ({wire_bytes} wire bytes), {:?} into a \
+                             {EXPERIMENT_DEADLINE:?} budget: {message}",
                             started.elapsed(),
                         );
-                        errors += 1;
+                            errors += 1;
+                        }
+                        other => {
+                            panic!("fallback recipient observed unexpected message: {other:?}")
+                        }
                     }
-                    other => panic!("fallback recipient observed unexpected message: {other:?}"),
-                },
+                }
                 Message::Close(reason) => {
                     let reason = reason.expect("fallback close must carry code and reason");
                     let code = u16::from(reason.code);
                     fallback_auditor.record_close("P2", code, &reason.reason);
                     return (
                         stream,
-                        reports,
-                        errors,
-                        Some((code, reason.reason.to_string())),
+                        FallbackObservation {
+                            reports,
+                            advisories: errors,
+                            accounted,
+                            wire_bytes,
+                            close: Some((code, reason.reason.to_string())),
+                            elapsed: started.elapsed(),
+                        },
                     );
                 }
                 Message::Ping(_) | Message::Pong(_) => {}
@@ -502,7 +547,17 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
                 }
             }
         }
-        (stream, reports, errors, None)
+        (
+            stream,
+            FallbackObservation {
+                reports,
+                advisories: errors,
+                accounted,
+                wire_bytes,
+                close: None,
+                elapsed: started.elapsed(),
+            },
+        )
     });
 
     for _ in 0..BURST {
@@ -515,35 +570,84 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
             .expect("send unconvertible MessagePack payload");
     }
 
-    let (fallback_stream, reports, errors, close) = fallback_reader
-        .await
-        .expect("fallback recipient task panicked");
+    // Both recipients must complete their streams while the bandwidth fault is
+    // still applied. Lifting the throttle as soon as the fallback recipient
+    // finished would let the compatible recipient drain its remainder on an
+    // unimpaired link, and "the compatible peer survives the same fault" is half
+    // the oracle.
+    let (fallback_result, compatible_result) = tokio::join!(fallback_reader, compatible_reader);
     compatible_proxy.throttle(Direction::ServerToClient, None);
     fallback_proxy.throttle(Direction::ServerToClient, None);
 
-    let (compatible_stream, compatible_player_left) = compatible_reader
-        .await
-        .expect("compatible recipient task panicked");
+    let (fallback_stream, fallback) = fallback_result.expect("fallback recipient task panicked");
+    let (compatible_stream, compatible_player_left, compatible_bytes) =
+        compatible_result.expect("compatible recipient task panicked");
+
+    let backpressure = metrics
+        .websocket_backpressure_events
+        .load(Ordering::Relaxed);
+    // Printed before the oracles so a RED run still reports the numbers that
+    // separate genuine amplification from a link that never kept pace (#212).
+    eprintln!(
+        "mixed-encoding H14: accounted={}/{BURST} reports={} advisories={} \
+         fallback_bytes={} compatible_bytes={compatible_bytes} \
+         amplification={:.2}x elapsed={:?} backpressure_events={backpressure} \
+         slow_consumer_evictions={}",
+        fallback.accounted,
+        fallback.reports,
+        fallback.advisories,
+        fallback.wire_bytes,
+        fallback.wire_bytes as f64 / compatible_bytes.max(1) as f64,
+        fallback.elapsed,
+        metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed),
+    );
 
     // This is the pre-registered falsification oracle. A RED result here means
-    // the per-message advisory doubles the fallback stream enough to evict a
-    // recipient that survives the same throttle on compact binary delivery.
+    // unsupported-format accountability inflates the fallback stream enough to
+    // evict a recipient that survives the same throttle on compact binary
+    // delivery.
     assert!(
-        close.is_none(),
+        fallback.close.is_none(),
         "unsupported-format amplification evicted only the JSON fallback recipient after \
-         {reports} reports/{errors} rate-limited errors ({close:?})"
+         {}/{BURST} accounted sequences and {} advisories ({:?})",
+        fallback.accounted,
+        fallback.advisories,
+        fallback.close
     );
+    // Exactness is a property of the *sequences* named, not of the frame count:
+    // one coalesced range may account for a whole burst of omissions. The
+    // conformance auditor independently proves those ranges never overlap and
+    // never leave a hole.
     assert_eq!(
-        reports, BURST,
-        "every omitted sequence needs an exact report"
+        fallback.accounted, BURST,
+        "every omitted sequence needs exact accounting"
     );
     assert!(
-        errors > 0,
+        fallback.advisories > 0,
         "the first supplemental advisory must be visible"
     );
+    // The advisory limiter admits at most one notice per sender per second;
+    // allow one extra for the immediate first notice and one for rounding.
+    let advisory_ceiling = fallback.elapsed.as_secs() + 2;
     assert!(
-        errors < reports / 100,
-        "advisory rate limiting was ineffective: {errors} errors for {reports} reports"
+        fallback.advisories <= advisory_ceiling,
+        "advisory rate limiting was ineffective: {} advisories in {:?}",
+        fallback.advisories,
+        fallback.elapsed
+    );
+    // The amplification invariant, and the whole point of H14: accounting for
+    // undeliverable game data must not cost the weaker recipient more wire
+    // bytes than delivering the payload costs the compatible one. Before the
+    // reports were coalesced this ratio was ~8x, which is what evicted the
+    // fallback recipient under an equal bandwidth fault.
+    assert!(
+        fallback.wire_bytes <= compatible_bytes,
+        "unsupported-format accountability cost the fallback recipient {} bytes against \
+         {compatible_bytes} bytes of compact binary delivery ({:.2}x amplification)",
+        fallback.wire_bytes,
+        fallback.wire_bytes as f64 / compatible_bytes.max(1) as f64
     );
     assert_eq!(
         compatible_player_left, 0,
@@ -555,11 +659,14 @@ async fn unsupported_message_pack_fallback_does_not_flap_weaker_recipient() {
             .load(Ordering::Relaxed),
         0
     );
-    auditor.assert_conformance(&metrics, &[]).await;
-    eprintln!(
-        "mixed-encoding H14: exact_reports={reports} advisory_errors={errors} \
-         compatible_deliveries={BURST} slow_consumer_evictions=0"
+    // Non-vacuity: the injected bandwidth fault must actually have reached the
+    // server's outbound queues. A run where kernel buffering absorbed the whole
+    // experiment would prove nothing about amplification.
+    assert!(
+        backpressure > 0,
+        "the throttle never produced server-side backpressure; the experiment was vacuous"
     );
+    auditor.assert_conformance(&metrics, &[]).await;
 
     drop(sender);
     drop(compatible_stream);

--- a/tests/websocket_test_helpers/conformance.rs
+++ b/tests/websocket_test_helpers/conformance.rs
@@ -1188,11 +1188,13 @@ impl ConformanceAuditor {
                 DeliveryGapReason::LatestSuperseded => 0,
                 DeliveryGapReason::LatestDroppedFull => 1,
                 DeliveryGapReason::VolatileDropped => 2,
+                // Undeliverable payloads are reported as coalesced ranges, so a
+                // report may carry several of them (issue #212): one frame per
+                // omitted message cost the recipient least able to afford it
+                // ~5.4x the bytes of the payload it replaced. Exactness is
+                // enforced by `validate_and_record_gap` (no overlap, no hole)
+                // and by the counter-delta assertions below, not by frame count.
                 DeliveryGapReason::UnsupportedFormat => {
-                    assert!(
-                        unsupported_gap.is_none() && gap.from_seq == gap.to_seq,
-                        "{receiver}: unsupported-format replacement report must name exactly one sequence"
-                    );
                     unsupported_gap = Some(gap.clone());
                     3
                 }


### PR DESCRIPTION
## Summary

Issue #212 (the H14 nightly "flake") was a **production defect**. Reproducing it
locally and measuring what the two recipients actually drained showed that
unsupported-format accountability charged the recipient least able to afford it
**5.38x** the wire bytes of the payload it replaced — and under an equal
bandwidth fault that is the difference between draining and being evicted as a
slow consumer.

## Root cause

A binary payload whose encoding a peer cannot represent was accounted for with
**one `DeliveryReport` frame per omitted message**, written inline by the socket
writer. For a 5,000-message MessagePack burst relayed into a room with one JSON
peer:

| recipient | frames | wire bytes | per message |
| --- | --- | --- | --- |
| compatible (MessagePack) | 5,000 binary relays | 389,618 | ~78 B |
| fallback (JSON) | 5,000 `DeliveryReport`s | 2,096,502 | ~419 B |

Through the same 32 KiB/s fault the JSON peer was disconnected as a
`SlowConsumer` after 703 of 5,000 messages while the compatible peer was
unaffected. That is precisely the outcome the H14 experiment was registered to
falsify.

## Reproduction, and two corrections to the record

`taskset -c 0` fails on the first attempt at 9.0 s, matching CI's 8.3–8.5 s.
Session 062 had tested two cores and recorded CPU starvation as falsified; one
core is the discriminator.

The recorded leading hypothesis — that the green result was vacuous because the
server's `SO_SNDBUF` absorbed the fault — is falsified: `RunningTestServer`
already bounds the send buffer to 64 KiB through `bind_serve_listener`
(`effective_send_buffer_bytes=131072`), which cannot absorb a 2.1 MB burst, and
the run reports real backpressure throughout (`backpressure_events=28`).

## Fix

Consecutive omissions from one sender and delivery class coalesce into one exact
range, under the same merge rule the queue has always applied to its own gap
reports (`DeliveryGap` is a range). The coalesced report reaches the recipient:

- before the next delivered frame,
- with the rate-limited advisory (so a notice never precedes its report),
- immediately after a queued report,
- at most one second after the first omission when the recipient is idle,
- and after the teardown drain.

Two invariants make that safe, and both came out of review (see the thread):

- **Peek/write/commit.** The ranges are retired and the counter frontier advances
  only after the frame is on the wire, so a write cancelled by the connection's
  close signal re-reports them instead of losing an entire coalesced burst.
- **Confirmed frontier.** A coalesced report is built on the counters the
  recipient has actually been shown (`confirmed_wire_counters`), not on the
  frontier a queued report advanced when it was popped — so a cancelled report
  write cannot leave a later frame advertising deltas nobody received, and no
  flush point is ever suppressed.

## Red → green

| condition | before | after |
| --- | --- | --- |
| unconstrained | PASS 64.6 s, 5.38x, 5,000 reports | PASS 12.2 s, 0.01x, 4 reports |
| `taskset -c 0` | **FAIL** at 9.0 s (evicted) | PASS 12.2 s |

```text
mixed-encoding H14: accounted=5000/5000 reports=4 advisories=2
  fallback_bytes=2218 compatible_bytes=389618 amplification=0.01x
  backpressure_events=21 slow_consumer_evictions=0
```

5,000 omissions, 4 report frames, every sequence still accounted for exactly.

## Oracles restated so neither outcome can be vacuous

The old assertions counted frames (`reports == BURST`,
`errors < reports / 100`), which measured the defect rather than the property:

- `accounted == BURST` — sequences named by ranges, not frame counts. The
  conformance auditor independently proves the ranges never overlap and never
  leave a hole.
- `fallback_bytes <= compatible_bytes` — the amplification invariant.
- `advisories <= elapsed_secs + 2` — anchored to the 1/s limiter.
- `backpressure_events > 0` — a run where buffering absorbed the fault now fails
  loudly instead of passing quietly.

Both recipients are now awaited before the throttles are lifted, because the
fallback peer finishes first after the fix and half the oracle is "the
compatible peer survives the same fault".

## Wire contract (v3 only)

A `DeliveryReport` may now carry several `unsupported_format` ranges, and a range
may span more than one sequence. `docs/protocol.md` already required clients to
authorize a hole only when the non-overlapping union of ranges covers every
missing sequence, so this is inside the documented contract. The conformance
auditor's "must name exactly one sequence" assertion was encoding the
implementation rather than the contract. v2 wire bytes are untouched: a pre-v3
recipient accumulates nothing (asserted).

## Dependency PRs

- **#215 taken** — `taiki-e/install-action` 2.85.4, `docker/login-action` 4.6.0,
  `mozilla-actions/sccache-action` 0.0.11 (cherry-picked, Dependabot authorship
  preserved).
- **#214 rejected**, each bump re-measured against the current graph rather than
  carried forward on the earlier note: the PR's own lockfile adds
  `tokio-tungstenite`/`tungstenite` 0.30 beside the 0.29 pair axum 0.8.9 still
  pins and a second `base64` (axum, hyper-util and hdrhistogram all need
  0.22.1); `serial_test` 4.0.1 declares `rust-version = 1.93.1` against MSRV
  1.89.0; and compiling against `syn` 3.0 fails with
  `no field 'guard' on type '&Arm'` while syn 2 stays in the graph for
  `bytecheck_derive` / `derive_more-impl` / `educe` regardless.

## Local verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features` — 80 binaries, 1,864 tests, zero failures
- H14 nightly cell, unconstrained and `taskset -c 0`, twice each
- `bash scripts/check-markdown.sh`, `bash scripts/check-doc-consistency.sh`

Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core WebSocket delivery accountability, graceful shutdown timing, and v3 client validation for `DeliveryReport` gaps; published `signal-fish-client` 0.9.0 still rejects coalesced ranges until updated.
> 
> **Overview**
> Fixes **issue #212**: per-message `DeliveryReport` frames for `unsupported_format` gaps inflated wire cost for JSON peers in mixed-encoding rooms (~5.4× vs compact binary), which could evict them as slow consumers under bandwidth limits.
> 
> The server now **coalesces** consecutive undeliverable omissions from one sender and delivery class into inclusive ranges (same merge rule as queue gap reports), emits them via a pending buffer with peek/commit semantics so cancelled writes do not drop accountability, and advances `wire_counters` only when ranges are actually sent. Reports are flushed before the next data frame, after queued reports, on a 1s idle deadline, and at connection teardown—including a new **fourth** registered shutdown close-write step for a final delivery report.
> 
> **Reference clients** (browser and native) and the conformance auditor no longer require a single-sequence `unsupported_format` gap; they accept coalesced ranges with counter-delta checks. **Docs** (`protocol.md`, error codes) and **CHANGELOG** describe the v3 wire behavior. The H14 nightly e2e test asserts sequence-level accounting and `fallback_bytes <= compatible_bytes` instead of one report per message.
> 
> Workflow bumps: `taiki-e/install-action` 2.85.4, `docker/login-action` 4.6.0, `mozilla-actions/sccache-action` 0.0.11.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2ba6595743a95b7b5f0578b4be8bd0491e7ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->