### PR TITLE
Confirm delivery-report counters only after successful writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep protocol-v3 delivery counters tied to frames successfully written and
+  flushed to the recipient socket (issue #218). Cancelling or failing a queued
+  `DeliveryReport` send no longer advances the counter frontier used by the
+  teardown's final unsupported-format report, so that final report cannot
+  inherit counters from a frame whose socket send/flush never completed.
 - Stop unsupported-format accountability from evicting the recipient it exists
   to protect (issue #212). A binary payload that a peer's negotiated encoding
   cannot represent was reported with one `DeliveryReport` frame per omitted

--- a/progress/session-064-report-frontier-on-write.md
+++ b/progress/session-064-report-frontier-on-write.md
@@ -1,0 +1,85 @@
+# Session 064 — Confirm the delivery-report frontier on write
+
+**Branch:** `dev/wallstop/session-064-report-frontier-on-write`
+**Base:** `bfd9e2c` (PR #216, session 063)
+
+## Objective
+
+Advance `PLAN.md` to a green PR by carrying forward the highest-priority open
+delivery-correctness defect, issue #218. A queued `DeliveryReport` moved the
+successful socket-write counter frontier when it was popped, even though the
+socket send/flush could still be cancelled or fail.
+
+## GitHub state at start
+
+- No open or draft PRs.
+- No open Dependabot PR required incorporation. Dependency PR #215 was already
+  incorporated into #216; #214 was rejected on measured graph/MSRV evidence.
+- PR #216's exact final head was green across all 18 applicable workflows. The
+  new `main` push at `bfd9e2c` was still running with no observed failures when
+  audited.
+- Gameplay-impact order: #218, #217, #211, then the research/tooling and design
+  issues.
+
+## Red evidence
+
+The regression assertion
+`a_queued_report_never_advances_the_unsupported_frontier` inspected
+`wire_counters` immediately after popping a queued report. It failed:
+
+```text
+left:  latest.dropped_full = 1
+right: latest.dropped_full = 0
+popping a report must not advance the frontier before its write succeeds
+```
+
+No socket write had occurred. This proves the queue state described a frame the
+socket sink had not successfully sent and flushed.
+
+## Implementation
+
+- `OutboundReceiver::prepare_report_for_wire` stamps a queued report against
+  the last successful socket-write frontier immediately before the writer
+  sends it. It is a read-only peek.
+- `OutboundReceiver::confirm_report_written` advances the frontier only after
+  the socket sink's send/flush future returns success.
+- `write_queued_report`, the production seam used by `send_queued`, keeps
+  prepare/send/confirm indivisible. A deterministic controlled-future
+  regression proves the frontier stays unchanged while the send is pending,
+  after send failure, a non-written disposition, and cancellation, then
+  advances on successful send/flush.
+- `pending_unsupported_report` builds directly on that one confirmed
+  `wire_counters` value.
+- `commit_pending_unsupported_report` retains its existing
+  peek/write/commit behavior.
+- The compensating `confirmed_wire_counters` field and pop-time
+  `prepare_for_wire` mutation are removed.
+
+## Verification
+
+- Red regression reproduced before the fix.
+- Focused queue and production-writer regressions pass after the fix.
+- `cargo test --locked --all-features --lib`: 627 passed.
+- `cargo fmt --check` and
+  `cargo clippy --locked --all-targets --all-features -- -D warnings`: passed.
+- `cargo test --locked --all-features`: passed across all non-ignored unit,
+  integration, and documentation tests.
+- The ignored H14 causal experiment passed with all 5,000 messages accounted
+  for, four advisories, two fallback transmissions, and no slow-consumer
+  eviction.
+- `cargo deny --all-features check`, CI/MSRV/document/workflow/LLM policy
+  scripts, hook-readiness, worktree pre-commit/pre-push checks, hook policy
+  tests, and all 289 applicable `ci_config_tests` passed.
+- Adversarial review initially required a production send/flush seam and
+  deterministic pending/failure/cancellation coverage. The revised code added
+  both; re-review reported zero code, test, or wording findings.
+
+The remaining PR/reviewer and hosted-CI evidence will be recorded before the
+session is complete.
+
+## Next gameplay work
+
+Issue #217 is next: use a paced-sender experiment to distinguish a genuinely
+stalled recipient from a weak but steadily progressing one, then either make
+that distinction explicit in production behavior or document the measured
+operator-sizing decision.

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -254,18 +254,13 @@ struct QueueState {
     sender_count: usize,
     permit_count: usize,
     counters: DeliveryCountersByClass,
+    /// The counter frontier successfully written and flushed to the socket.
+    ///
+    /// A queued report is stamped against this frontier immediately before its
+    /// socket write and advances it only after that write succeeds. A cancelled
+    /// or failed write therefore cannot influence any later report.
     wire_counters: DeliveryCountersByClass,
     pending_unsupported: PendingUnsupported,
-    /// The counter frontier the recipient has actually been shown.
-    ///
-    /// `wire_counters` advances when a queued report is handed to the writer, so
-    /// after a cancelled or failed write it can describe a frame nobody
-    /// received. A coalesced unsupported-format report is therefore built on
-    /// this value instead: its deltas are then exact against the last frame that
-    /// really landed, whatever happened to the one before it. Advanced by
-    /// [`OutboundReceiver::confirm_report_frontier`] and by committing a
-    /// coalesced report.
-    confirmed_wire_counters: DeliveryCountersByClass,
     enqueue_generation: u64,
     receive_generation: u64,
     active_room: Option<RoomId>,
@@ -409,7 +404,6 @@ impl QueueState {
             counters: DeliveryCountersByClass::default(),
             wire_counters: DeliveryCountersByClass::default(),
             pending_unsupported: PendingUnsupported::default(),
-            confirmed_wire_counters: DeliveryCountersByClass::default(),
             enqueue_generation: 0,
             receive_generation: 0,
             active_room: None,
@@ -1498,8 +1492,7 @@ impl OutboundReceiver {
             state.control.pop_front()
         } else {
             None
-        }
-        .map(|item| prepare_for_wire(&mut state, item));
+        };
         drop(state);
         if item.is_some() {
             self.shared.capacity_available.notify_waiters();
@@ -1543,7 +1536,7 @@ impl OutboundReceiver {
             None
         };
         let result = match item {
-            Some(item) => Ok(prepare_for_wire(&mut state, item)),
+            Some(item) => Ok(item),
             None if state.receiver_open && state.producers_open() => Err(PopState::Empty),
             None => Err(PopState::Disconnected),
         };
@@ -1652,7 +1645,7 @@ impl OutboundReceiver {
                     self.batch_remaining = 0;
                     state.receive_generation = item.generation;
                 }
-                Ok(prepare_for_wire(&mut state, item))
+                Ok(item)
             }
             None if state.receiver_open && state.producers_open() => Err(BatchedPopState::Empty),
             None => Err(BatchedPopState::Disconnected),
@@ -1792,16 +1785,31 @@ impl OutboundReceiver {
     /// `unsupported_format` counter delta whose exact ranges had not been sent.
     pub fn pending_unsupported_report(&self) -> Option<DeliveryReportPayload> {
         let state = self.shared.state();
-        state
-            .pending_unsupported
-            .peek(state.confirmed_wire_counters)
+        state.pending_unsupported.peek(state.wire_counters)
     }
 
-    /// Record that the report frame the queue last handed to the writer reached
-    /// the socket, so later reports can build on the counters it carried.
-    pub fn confirm_report_frontier(&self) {
+    /// Stamp a queued report against the last counter frontier successfully
+    /// sent and flushed to the socket, without advancing that frontier.
+    pub(crate) fn prepare_report_for_wire(&self, report: &mut DeliveryReportPayload) {
+        let state = self.shared.state();
+        report.per_class = max_counters(report.per_class, state.wire_counters);
+        // `state.counters` may already count omissions that are still pending
+        // (they are counted when discovered, reported when their coalesced range
+        // reaches the wire), so clamp unsupported-format counters to the
+        // frontier whose exact ranges were already written. The writer flushes
+        // the pending ranges immediately after this report.
+        report.per_class.reliable.unsupported_format =
+            state.wire_counters.reliable.unsupported_format;
+        report.per_class.latest.unsupported_format = state.wire_counters.latest.unsupported_format;
+        report.per_class.volatile.unsupported_format =
+            state.wire_counters.volatile.unsupported_format;
+    }
+
+    /// Advance the successful socket-write frontier after a queued report
+    /// send/flush succeeds.
+    pub(crate) fn confirm_report_written(&self, per_class: DeliveryCountersByClass) {
         let mut state = self.shared.state();
-        state.confirmed_wire_counters = state.wire_counters;
+        state.wire_counters = max_counters(state.wire_counters, per_class);
     }
 
     /// Retire the ranges a written report carried and advance the wire frontier
@@ -1810,8 +1818,6 @@ impl OutboundReceiver {
         let mut state = self.shared.state();
         state.pending_unsupported.commit(report);
         state.wire_counters = max_counters(state.wire_counters, report.per_class);
-        state.confirmed_wire_counters =
-            max_counters(state.confirmed_wire_counters, report.per_class);
     }
 
     /// When a coalesced unsupported-format report must reach the recipient even
@@ -2056,25 +2062,6 @@ fn enqueue_delivery_report(state: &mut QueueState, gaps: Vec<DeliveryGap>) {
         generation: state.enqueue_generation,
         transition_barrier: false,
     });
-}
-
-fn prepare_for_wire(state: &mut QueueState, mut item: QueuedOutbound) -> QueuedOutbound {
-    if let OutboundPayload::DeliveryReport(report) = &mut item.payload {
-        report.per_class = max_counters(report.per_class, state.wire_counters);
-        // `state.counters` may already count omissions that are still pending
-        // (they are counted when discovered, reported when their coalesced range
-        // reaches the wire), so the unsupported-format frontier is clamped to
-        // what has actually been sent rather than raised by a report carrying no
-        // ranges for it. The writer flushes the pending report immediately
-        // *after* this frame, which keeps both frames monotonic.
-        report.per_class.reliable.unsupported_format =
-            state.wire_counters.reliable.unsupported_format;
-        report.per_class.latest.unsupported_format = state.wire_counters.latest.unsupported_format;
-        report.per_class.volatile.unsupported_format =
-            state.wire_counters.volatile.unsupported_format;
-        state.wire_counters = report.per_class;
-    }
-    item
 }
 
 fn max_counters(
@@ -2659,8 +2646,14 @@ mod tests {
             "the first omission coalesces instead of costing its own frame"
         );
 
-        let queued = report(rx.recv().await.unwrap().unwrap());
+        let mut queued = report(rx.recv().await.unwrap().unwrap());
         assert_eq!(queued.per_class.latest.dropped_full, 1);
+        assert_eq!(
+            rx.shared.state().wire_counters,
+            DeliveryCountersByClass::default(),
+            "popping a report must not advance the frontier before its write succeeds"
+        );
+        rx.prepare_report_for_wire(&mut queued);
         assert_eq!(
             queued.per_class.reliable.unsupported_format, 0,
             "the frontier may not advance without the ranges that explain it"
@@ -2680,7 +2673,7 @@ mod tests {
         );
         assert_eq!(unconfirmed.per_class.reliable.unsupported_format, 1);
 
-        rx.confirm_report_frontier();
+        rx.confirm_report_written(queued.per_class);
         let pending = rx
             .pending_unsupported_report()
             .expect("the coalesced range is still waiting for its own frame");
@@ -2802,8 +2795,11 @@ mod tests {
             .unwrap();
         tx.try_enqueue_report_snapshot().unwrap();
 
-        let first = report(rx.recv().await.unwrap().unwrap());
-        let second = report(rx.recv().await.unwrap().unwrap());
+        let mut first = report(rx.recv().await.unwrap().unwrap());
+        rx.prepare_report_for_wire(&mut first);
+        rx.confirm_report_written(first.per_class);
+        let mut second = report(rx.recv().await.unwrap().unwrap());
+        rx.prepare_report_for_wire(&mut second);
         assert_eq!(first.per_class.latest.superseded, 2);
         assert_eq!(second.per_class.latest.superseded, 2);
         assert_eq!(first.gaps.len(), 2);

--- a/src/websocket/batching.rs
+++ b/src/websocket/batching.rs
@@ -2,9 +2,10 @@ use crate::coordination::outbound_queue::{
     OutboundPayload, OutboundReceiver, QueuedOutbound, TryReceiveError,
 };
 use crate::coordination::{CloseReason, ConnectionCloseSignal};
-use crate::protocol::{PlayerId, ServerMessage};
+use crate::protocol::{DeliveryReportPayload, PlayerId, ServerMessage};
 use axum::extract::ws::{Message, WebSocket};
 use std::collections::VecDeque;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
@@ -235,6 +236,30 @@ fn queued_write_deadline(
     }
 }
 
+/// Materialize and write one queued delivery report, advancing its counter
+/// frontier only after the sink's send/flush future succeeds.
+///
+/// Keeping prepare/write/confirm in one production seam makes cancellation
+/// safe by construction: dropping this future while `write` is pending leaves
+/// the frontier unchanged.
+async fn write_queued_report<F, Fut>(
+    receiver: &OutboundReceiver,
+    mut report: DeliveryReportPayload,
+    write: F,
+) -> Result<SendDisposition, ()>
+where
+    F: FnOnce(Arc<ServerMessage>) -> Fut,
+    Fut: Future<Output = Result<SendDisposition, ()>>,
+{
+    receiver.prepare_report_for_wire(&mut report);
+    let per_class = report.per_class;
+    let disposition = write(Arc::new(ServerMessage::DeliveryReport(Box::new(report)))).await?;
+    if disposition == SendDisposition::Written {
+        receiver.confirm_report_written(per_class);
+    }
+    Ok(disposition)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn send_queued(
     sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
@@ -273,12 +298,6 @@ pub(super) async fn send_queued(
         fallback_preflight.is_unsupported(),
     );
     let carries_queued_report = matches!(queued.payload, OutboundPayload::DeliveryReport(_));
-    let message = match queued.payload {
-        OutboundPayload::Message(message) => message,
-        OutboundPayload::DeliveryReport(report) => {
-            Arc::new(ServerMessage::DeliveryReport(Box::new(report)))
-        }
-    };
     // Exact accounting owns the head of the stream: a coalesced
     // unsupported-format report must reach this recipient before the next
     // delivered frame, because a recipient may not observe delivered data that
@@ -287,8 +306,8 @@ pub(super) async fn send_queued(
     //
     // - another undeliverable payload keeps coalescing instead, which is what
     //   collapses a burst into one report;
-    // - a queued `DeliveryReport` had its counters stamped against the wire
-    //   frontier when it was popped, so the flush follows it rather than
+    // - a queued `DeliveryReport` is stamped against the wire frontier
+    //   immediately before this write, so the flush follows it rather than
     //   preceding it: a flush in front would move a counter that the very next
     //   frame then reports as lower.
     let flush_before = !fallback_preflight.is_unsupported() && !carries_queued_report;
@@ -299,24 +318,38 @@ pub(super) async fn send_queued(
         if flush_before {
             write_pending_unsupported_report(sender, receiver, player_id).await?;
         }
-        let disposition = send_single_message(
-            sender,
-            message,
-            player_id,
-            recipient_supports_v3,
-            recipient_format,
-            fallback_preflight,
-            metadata,
-            &mut accounting,
-        )
-        .await?;
-        if carries_queued_report {
-            // This report frame is on the wire, so the frontier it advanced at
-            // pop time now describes what the recipient has seen and a coalesced
-            // report may be built on it.
-            receiver.confirm_report_frontier();
-            write_pending_unsupported_report(sender, receiver, player_id).await?;
-        }
+        let disposition = match queued.payload {
+            OutboundPayload::Message(message) => {
+                send_single_message(
+                    sender,
+                    message,
+                    player_id,
+                    recipient_supports_v3,
+                    recipient_format,
+                    fallback_preflight,
+                    metadata,
+                    &mut accounting,
+                )
+                .await?
+            }
+            OutboundPayload::DeliveryReport(report) => {
+                let disposition = write_queued_report(receiver, report, |message| {
+                    send_single_message(
+                        sender,
+                        message,
+                        player_id,
+                        recipient_supports_v3,
+                        recipient_format,
+                        fallback_preflight,
+                        metadata,
+                        &mut accounting,
+                    )
+                })
+                .await?;
+                write_pending_unsupported_report(sender, receiver, player_id).await?;
+                disposition
+            }
+        };
         Ok(disposition)
     };
     let result = if max_sojourn.is_zero() {
@@ -370,8 +403,9 @@ mod tests {
     use super::*;
 
     use crate::coordination::outbound_queue::{channel, DataDeliveryMetadata, OutboundData};
-    use crate::protocol::{DeliveryClass, GameDataEncoding, RoomId};
+    use crate::protocol::{DeliveryClass, DeliveryCountersByClass, GameDataEncoding, RoomId};
     use serde_json::json;
+    use std::sync::Mutex;
 
     fn data(class: DeliveryClass, seq: u64) -> OutboundData {
         let from_player = PlayerId::from_u128(1);
@@ -416,6 +450,123 @@ mod tests {
                 seq,
             },
         )
+    }
+
+    fn report_frontier(receiver: &OutboundReceiver) -> DeliveryCountersByClass {
+        let mut probe = DeliveryReportPayload::default();
+        receiver.prepare_report_for_wire(&mut probe);
+        probe.per_class
+    }
+
+    /// Issue #218: exercise the production seam used by `send_queued` with a
+    /// deterministically controlled socket-send future. The first poll proves
+    /// preparation has happened while confirmation has not; success confirms,
+    /// while both an explicit send error and cancellation leave the frontier
+    /// untouched.
+    #[tokio::test]
+    async fn queued_report_frontier_confirms_only_after_send_flush_success() {
+        let (_tx, receiver) = channel(1, 1);
+        let mut baseline = DeliveryCountersByClass::default();
+        baseline.latest.superseded = 7;
+        receiver.confirm_report_written(baseline);
+
+        let mut successful_report = DeliveryReportPayload::default();
+        successful_report.per_class.latest.dropped_full = 3;
+        let expected_success = DeliveryCountersByClass {
+            latest: crate::protocol::LatestDeliveryCounters {
+                superseded: 7,
+                dropped_full: 3,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let observed = Arc::new(Mutex::new(None));
+        let observed_by_write = Arc::clone(&observed);
+        let (release_send, await_send) = tokio::sync::oneshot::channel();
+        let mut write = Box::pin(write_queued_report(
+            &receiver,
+            successful_report,
+            move |message| {
+                let observed = Arc::clone(&observed_by_write);
+                async move {
+                    let ServerMessage::DeliveryReport(report) = message.as_ref() else {
+                        panic!("queued-report seam wrote a non-report message");
+                    };
+                    *observed.lock().expect("observed-report mutex poisoned") =
+                        Some(report.per_class);
+                    await_send.await.expect("test send gate released");
+                    Ok(SendDisposition::Written)
+                }
+            },
+        ));
+
+        assert!(
+            futures_util::poll!(&mut write).is_pending(),
+            "the controlled socket send must remain in flight"
+        );
+        assert_eq!(
+            *observed.lock().expect("observed-report mutex poisoned"),
+            Some(expected_success),
+            "the report must be prepared before its socket write starts"
+        );
+        assert_eq!(
+            report_frontier(&receiver),
+            baseline,
+            "the frontier must not move while send/flush is pending"
+        );
+
+        release_send.send(()).expect("release controlled send");
+        assert_eq!(write.await, Ok(SendDisposition::Written));
+        assert_eq!(
+            report_frontier(&receiver),
+            expected_success,
+            "a successful send/flush must confirm the prepared frontier"
+        );
+
+        let before_failure = report_frontier(&receiver);
+        let mut failed_report = DeliveryReportPayload::default();
+        failed_report.per_class.volatile.dropped = 2;
+        assert_eq!(
+            write_queued_report(&receiver, failed_report, |_| async { Err(()) }).await,
+            Err(())
+        );
+        assert_eq!(
+            report_frontier(&receiver),
+            before_failure,
+            "a failed socket send must not confirm its report"
+        );
+
+        let mut accounted_drop = DeliveryReportPayload::default();
+        accounted_drop.per_class.volatile.dropped = 4;
+        assert_eq!(
+            write_queued_report(&receiver, accounted_drop, |_| async {
+                Ok(SendDisposition::AccountedDrop)
+            })
+            .await,
+            Ok(SendDisposition::AccountedDrop)
+        );
+        assert_eq!(
+            report_frontier(&receiver),
+            before_failure,
+            "a non-written disposition must not confirm its report"
+        );
+
+        let mut cancelled_report = DeliveryReportPayload::default();
+        cancelled_report.per_class.reliable.abandoned = 5;
+        let mut cancelled_write =
+            Box::pin(write_queued_report(&receiver, cancelled_report, |_| {
+                std::future::pending()
+            }));
+        assert!(
+            futures_util::poll!(&mut cancelled_write).is_pending(),
+            "the cancellation boundary must be reached without timing"
+        );
+        drop(cancelled_write);
+        assert_eq!(
+            report_frontier(&receiver),
+            before_failure,
+            "cancelling an in-flight socket send must not confirm its report"
+        );
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

- stop advancing protocol-v3 delivery-report counters when a queued report is merely popped
- prepare reports immediately before the socket send/flush and confirm the frontier only for `Written` results
- add deterministic production-seam coverage for pending, failed, non-written, cancelled, and successful sends
- remove the compensating second counter frontier and keep teardown reports based on one confirmed frontier

## Verification

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- ignored H14 causal experiment: 5,000/5,000 accounted, no slow-consumer eviction
- repository CI/MSRV/doc/workflow/LLM scripts and Git hook policy suites
- two-pass adversarial review; final pass reported zero findings

Closes #218

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes protocol-v3 delivery accountability on the hot WebSocket write path; incorrect frontier timing could mis-state gaps on teardown, but the change is narrowly scoped with deterministic writer and queue regressions.
> 
> **Overview**
> Fixes **issue #218** by tying protocol-v3 **`DeliveryReport`** counter frontiers to frames that actually complete a socket send/flush, not to queue pop.
> 
> **Outbound queue:** popping a queued report no longer mutates **`wire_counters`** or stamps counters via **`prepare_for_wire`**. **`prepare_report_for_wire`** clamps/stamps the report against the last confirmed frontier immediately before the writer sends it; **`confirm_report_written`** advances **`wire_counters`** only when the send path returns **`Written`**. The compensating **`confirmed_wire_counters`** field is removed—teardown **`pending_unsupported_report`** and coalesced unsupported-format logic use the single confirmed **`wire_counters`**.
> 
> **WebSocket writer:** **`write_queued_report`** (used from **`send_queued`**) keeps prepare → send → confirm in one seam so a pending, failed, non-**`Written`**, or cancelled flush cannot advance the frontier. **`confirm_report_frontier`** after pop is dropped.
> 
> **Tests:** queue regressions assert pop does not advance the frontier; **`queued_report_frontier_confirms_only_after_send_flush_success`** exercises the production seam with a controlled future.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 659b77dcd6837f8831ca0f0191647f2a5491774d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->