### PR TITLE
Enforce control deadlines and audit logical Docker healthchecks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep every control-message capacity wait bounded by the configured
+  slow-consumer grace. Queue capacity that returns at or after the deadline can
+  no longer revive an expired room-join/reconnect baseline, lifecycle
+  notification, session plan, replan, or room transaction. Otherwise-live,
+  still-eligible recipients whose timeout initiates closure now follow the
+  documented `4002 slow_consumer` path.
 - Fix false `4003 activity_timeout` disconnects for bandwidth-constrained
   recipients that are still draining application traffic (issue #217).
   Successful outbound application writes now supersede redundant WebSocket

--- a/progress/session-070-relay-synchronous-fast-path.md
+++ b/progress/session-070-relay-synchronous-fast-path.md
@@ -223,3 +223,12 @@ findings.
 This publication-only follow-up records the immutable implementation-head
 evidence. Its own exact head must independently complete hosted workflows and
 reviewer retriggers before the session is closed.
+
+## Closure
+
+PR #232 completed at final reviewed head
+`65256bb495c2f6ec586e7cb47d2e1eaec645a56d`. All 14 applicable workflows
+passed, reviewer feedback was resolved, and the pull request merged as
+`664f415bd90376237f860ffe65d500de1d1dd536`. That merge is the session's
+canonical production state; the implementation head above remains the
+immutable measurement reference.

--- a/progress/session-071-control-deadlines-and-healthcheck-audit.md
+++ b/progress/session-071-control-deadlines-and-healthcheck-audit.md
@@ -1,0 +1,142 @@
+# Session 071 — Control deadlines and healthcheck audit
+
+## Objective
+
+Advance the highest-value ready in-repository work while carrying the merged
+session-070 state forward to one green pull request.
+
+## Baseline and prioritization
+
+- `main` and `origin/main` began at session 070's merge commit `664f415`.
+- The connected GitHub repository had no open pull request.
+- Open issues were #204, #205, #206, #207, #213, #220, and #226.
+- Main's merge commit was fully green across all 14 applicable workflows.
+- Two independent audits selected #226 as the highest-value fully specified
+  task. A gameplay audit then found a production deadline race in the same
+  delivery boundary P24 had just hardened, so that complete failure class took
+  priority within this session.
+
+## Issue #226 — multiline Docker healthcheck parsing
+
+### Red evidence
+
+`scripts/check-ci-config.sh` exited successfully but warned
+`No HEALTHCHECK directive found in Dockerfile.` The production Dockerfile has a
+live `HEALTHCHECK` split across two physical lines, while the audit searched
+only a single line containing both `HEALTHCHECK` and `localhost`.
+
+### Fix
+
+The audit now assembles Dockerfile logical instructions without shell
+evaluation. It:
+
+- honors default backslash continuations plus CRLF;
+- removes full-line comments before instruction assembly;
+- rejects RUN/COPY heredoc input that it cannot safely inspect;
+- resets healthcheck state at each `FROM`, so only the final runtime stage
+  counts; and
+- accepts only the repository's real `curl` probe of the exact
+  `http://localhost:PORT/v2/health` endpoint.
+
+Missing, disabled, malformed, invalid-host, wrong-path, wrong-command,
+wrong-port, heredoc-only, or builder-stage-only probes are blocking errors.
+The pre-existing `EXPOSE` and authentication checks remain unchanged.
+Black-box tests execute the actual script with stubbed cargo-deny tooling
+across the fixture table and against the checked-in repository.
+
+## Strict control-capacity deadline sweep
+
+### Red evidence
+
+The ordinary relay wait added in P24 already used an absolute timer-first
+deadline because Tokio's `Timeout` polls its inner future before its timer.
+Three control-message paths did not:
+
+1. initial room-join/reconnect transition reservation used
+   `tokio::time::timeout`;
+2. conditional single-recipient delivery used an unbiased `select!`; and
+3. conditional reservation for lifecycle broadcasts, tailored session plans,
+   replans, and two-phase room transactions used another unbiased `select!`.
+
+Paused-time data-driven regressions fill the control queue, poll each wait
+pending, advance to or beyond the deadline without polling it, return capacity,
+and then poll again. The original initial-transition implementation returned
+`Delivered`, proving that expired capacity waits could revive.
+
+### Fix
+
+Every affected full-queue path now uses an explicit biased selection:
+
+1. drain completion, where applicable, preserves cancellation precedence;
+2. closed queues and stale classified generations retain their terminal
+   `ChannelClosed`/`Canceled` classification;
+3. the absolute deadline resolves an otherwise-live, still-eligible wait as
+   `SlowConsumer`; and
+4. only unexpired capacity may reserve the queue.
+
+The matrix covers all three primitives, legacy and classified queues, and exact
+and post-deadline boundaries. It proves no late enqueue, the requested
+`SlowConsumer` close reason, exact accounting, closure precedence, and
+generation-fence precedence. Existing positive capacity recovery,
+drain-cancellation, phased-transaction, and replacement-connection tests remain
+the complementary behavior gates.
+
+## Scope audit
+
+The control-capacity sweep is complete. Adjacent socket-write, authentication,
+and idle-read deadlines also use Tokio timeout/select boundaries, but they own
+different I/O and security policies rather than queue admission. They require
+an explicit inclusive/exclusive contract and deterministic write/read seams;
+issue #233 tracks that broader #205 audit instead of silently expanding P25.
+
+## Changelog classification
+
+The control deadline correction changes observable runtime reliability and is
+recorded under `[Unreleased] / Fixed`. The healthcheck parser is internal CI
+tooling and is not separately release-noted.
+
+## Adversarial review
+
+The first healthcheck review rejected the draft because the repository test
+depended on cargo-deny being installed, builder-stage healthchecks leaked into
+the runtime result, invalid grammar and inert comments could satisfy the port
+substring, hostname boundaries were loose, and the Docker escape directive was
+ignored. The first four failure modes are fixed and fixture-covered. General
+escape-directive support was deliberately excluded when the implementation was
+narrowed to issue #226's default-backslash contract; non-default continuations
+cannot satisfy the audit.
+
+The gameplay audit independently found the three expired-capacity paths,
+verified their production callers, and confirmed that the revised
+drain-deadline-capacity order closes the class without changing cancellation
+semantics.
+
+The full adversarial pass then challenged parser-directive and heredoc edges,
+first-stage `EXPOSE` leakage, arbitrary commands mentioning the URL, terminal
+queue-state precedence at expiry, missing exact/classified/close-reason
+oracles, an overbroad changelog claim, and an incorrect session-070 reviewed
+head. Dedicated healthcheck and runtime passes evaluated every finding. The
+healthcheck implementation was ultimately narrowed back to issue #226's
+verified contract instead of introducing a partial Docker grammar or new
+final-stage `EXPOSE`/`ENV` compatibility policy.
+
+After the final EOF-continuation and documentation corrections, the independent
+healthcheck reviewer, runtime reviewer, and complete-diff reviewer all returned
+explicit zero-revision verdicts.
+
+## Verification
+
+- The new control-capacity regression failed red on the original implementation
+  and passes after the three-site sweep.
+- All 20 message-coordinator tests pass with every feature enabled.
+- All healthcheck audit fixtures and the checked-in repository audit pass.
+- `cargo fmt --all -- --check`, strict all-target/all-feature clippy, and the
+  complete `cargo test --locked --all-features` suite pass on the final diff.
+- Shellcheck, `cargo deny --all-features check`, and `git diff --check` pass.
+- Detailed follow-up issue #233 records the adjacent strict-deadline audit.
+- The remaining repository hook/policy gauntlet and hosted verification are
+  pending.
+
+## Publication
+
+Pending.

--- a/progress/session-071-control-deadlines-and-healthcheck-audit.md
+++ b/progress/session-071-control-deadlines-and-healthcheck-audit.md
@@ -32,7 +32,8 @@ evaluation. It:
 
 - honors default backslash continuations plus CRLF;
 - removes full-line comments before instruction assembly;
-- rejects RUN/COPY heredoc input that it cannot safely inspect;
+- rejects RUN/COPY/ADD heredoc input, including ONBUILD-wrapped forms, that it
+  cannot safely inspect;
 - resets healthcheck state at each `FROM`, so only the final runtime stage
   counts; and
 - accepts only the repository's real `curl` probe of the exact
@@ -123,6 +124,15 @@ final-stage `EXPOSE`/`ENV` compatibility policy.
 After the final EOF-continuation and documentation corrections, the independent
 healthcheck reviewer, runtime reviewer, and complete-diff reviewer all returned
 explicit zero-revision verdicts.
+
+Hosted Cursor Bugbot subsequently identified one additional bypass: `ADD` and
+`ONBUILD ADD` heredoc bodies could still impersonate `FROM` or `HEALTHCHECK`
+instructions because the fail-closed matcher covered only `RUN` and `COPY`.
+The finding was accepted. The matcher now covers `RUN`, `COPY`, and `ADD`, plus
+their `ONBUILD` wrappers, and a compact opener matrix verifies that fake stage
+and healthcheck instructions in every covered heredoc body remain blocking.
+A hosted re-review of that follow-up diff is pending, so no zero-revision
+verdict is claimed for the updated hosted-review state yet.
 
 ## Verification
 

--- a/progress/session-071-control-deadlines-and-healthcheck-audit.md
+++ b/progress/session-071-control-deadlines-and-healthcheck-audit.md
@@ -131,8 +131,12 @@ instructions because the fail-closed matcher covered only `RUN` and `COPY`.
 The finding was accepted. The matcher now covers `RUN`, `COPY`, and `ADD`, plus
 their `ONBUILD` wrappers, and a compact opener matrix verifies that fake stage
 and healthcheck instructions in every covered heredoc body remain blocking.
-A hosted re-review of that follow-up diff is pending, so no zero-revision
-verdict is claimed for the updated hosted-review state yet.
+A hosted re-review of that follow-up diff was pending at that point, so the log
+did not yet claim a zero-revision verdict for the updated hosted-review state.
+
+Cursor Bugbot's hosted re-review of implementation head `2fd062e` found no new
+issues. The accepted finding's inline thread is resolved, and the final thread
+audit found no unresolved feedback.
 
 ## Verification
 
@@ -141,12 +145,34 @@ verdict is claimed for the updated hosted-review state yet.
 - All 20 message-coordinator tests pass with every feature enabled.
 - All healthcheck audit fixtures and the checked-in repository audit pass.
 - `cargo fmt --all -- --check`, strict all-target/all-feature clippy, and the
-  complete `cargo test --locked --all-features` suite pass on the final diff.
+  complete `cargo test --locked --all-features` suite pass on the production
+  implementation.
+- After the hosted follow-ups, strict clippy and the focused healthcheck fixture
+  suite pass; hosted nextest passes on Linux, macOS, and Windows.
 - Shellcheck, `cargo deny --all-features check`, and `git diff --check` pass.
 - Detailed follow-up issue #233 records the adjacent strict-deadline audit.
-- The remaining repository hook/policy gauntlet and hosted verification are
-  pending.
+- The repository documentation, MSRV, workflow-hygiene, markdown, link-text,
+  hook-readiness, pre-commit, and pre-push policy gauntlet passes.
+- The first hosted head exposed a Windows-only denied unused-variable lint in
+  the test helper. Separate Unix/non-Unix definitions preserve chmod/no-op
+  behavior and the corrected Windows clippy lane passes.
 
 ## Publication
 
-Pending.
+- Pull request:
+  [#234](https://github.com/Ambiguous-Interactive/signal-fish-server/pull/234)
+- Green reviewed implementation head:
+  `2fd062e9448430884ae8a30f45afd590109f5cc7`.
+- All 11 applicable workflows succeeded: Advanced Safety, Browser Interop, CI,
+  Documentation Validation, Fortress Interop, Fortress WASM Interop, Link
+  Check, Markdownlint, Spellcheck, Unused Dependencies, and WebRTC Interop.
+  Dependabot auto-merge skipped as intended for the human-authored pull
+  request.
+- Cursor Bugbot found no new issues on the green implementation head, the
+  accepted earlier finding is resolved, and no inline review threads remain.
+  Copilot was triggered through both the review API and tagged comments after
+  each push but reported requester quota exhaustion. The repository has no
+  distinct human contributor available to review a pull request authored by
+  its sole human contributor.
+- The pull request closes #226 and references #205 plus the new detailed
+  follow-up issue #233.

--- a/scripts/check-ci-config.sh
+++ b/scripts/check-ci-config.sh
@@ -102,20 +102,106 @@ if [[ -f Dockerfile ]]; then
         error "Dockerfile missing ENV SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false — server will crash without auth config."
     fi
 
-    # Verify HEALTHCHECK port matches EXPOSE port using portable awk/sed parsing.
-    # gsub strips any CR so EXPOSE_PORT compares equal to the sed-extracted
-    # HEALTH_PORT on a CRLF-checked-out Dockerfile (sed's trailing `.*` already
-    # swallows the CR; awk's `$2` would otherwise retain it).
+    # Dockerfile instructions may span physical lines. Assemble them without
+    # evaluating their contents, then inspect only the final-stage HEALTHCHECK.
+    HEALTHCHECK_RESULT=$(
+        awk '
+            function inspect_instruction(    instruction, lower, arguments) {
+                instruction = logical
+                sub(/^[[:space:]]+/, "", instruction)
+                sub(/[[:space:]]+$/, "", instruction)
+                lower = tolower(instruction)
+                if (lower ~ /^from([[:space:]]|$)/) {
+                    healthcheck = ""
+                    return
+                }
+                if (lower ~ /^(run|copy)([[:space:]]|$)/ && instruction ~ /<</) {
+                    audit_error = "unsupported-heredoc"
+                    return
+                }
+                if (lower !~ /^healthcheck([[:space:]]|$)/) {
+                    return
+                }
+
+                arguments = instruction
+                sub(/^[^[:space:]]+[[:space:]]*/, "", arguments)
+                gsub(/[[:space:]]+/, " ", arguments)
+                if (tolower(arguments) == "none") {
+                    healthcheck = "none"
+                    return
+                }
+                while (arguments ~ /^--[^[:space:]]+[[:space:]]+/) {
+                    sub(/^--[^[:space:]]+[[:space:]]+/, "", arguments)
+                }
+                if (arguments !~ /^CMD([[:space:]]|$)/) {
+                    healthcheck = "malformed"
+                    return
+                }
+                sub(/^CMD[[:space:]]*/, "", arguments)
+                if (arguments ~ /^curl[[:space:]]+-f[[:space:]]+http:\/\/localhost:[0-9][0-9]*\/v2\/health[[:space:]]+[|][|][[:space:]]+exit[[:space:]]+1$/) {
+                    match(arguments, /localhost:[0-9][0-9]*/)
+                    port = substr(arguments, RSTART, RLENGTH)
+                    sub(/^.*:/, "", port)
+                    healthcheck = "port:" port
+                } else {
+                    healthcheck = "unsupported"
+                }
+            }
+
+            {
+                sub(/\r$/, "")
+                line = $0
+                if (line ~ /^[[:space:]]*#/) {
+                    next
+                }
+
+                logical = logical line
+                if (substr(line, length(line), 1) == "\\") {
+                    logical = substr(logical, 1, length(logical) - 1)
+                    continuing = 1
+                    next
+                }
+
+                inspect_instruction()
+                logical = ""
+                continuing = 0
+            }
+
+            END {
+                if (continuing) {
+                    audit_error = "unterminated-continuation"
+                } else if (logical != "") {
+                    inspect_instruction()
+                }
+                if (audit_error != "") {
+                    print audit_error
+                } else {
+                    print healthcheck
+                }
+            }
+        ' Dockerfile
+    )
+
     EXPOSE_PORT=$(awk '/^EXPOSE[[:space:]]+[0-9]+/ { port = $2; sub(/\/.*/, "", port); gsub(/\r/, "", port); print port; exit }' Dockerfile)
-    HEALTH_PORT=$(sed -nE '/HEALTHCHECK.*localhost:/ { s/.*localhost:([0-9]+).*/\1/; p; q; }' Dockerfile)
-    if [[ -n "$HEALTH_PORT" && -n "$EXPOSE_PORT" ]]; then
+    if [[ "$HEALTHCHECK_RESULT" == port:* ]]; then
+        HEALTH_PORT=${HEALTHCHECK_RESULT#port:}
         if [[ "$HEALTH_PORT" == "$EXPOSE_PORT" ]]; then
             success "HEALTHCHECK port ($HEALTH_PORT) matches EXPOSE port ($EXPOSE_PORT)."
         else
             error "HEALTHCHECK port ($HEALTH_PORT) does not match EXPOSE port ($EXPOSE_PORT)."
         fi
-    elif [[ -z "$HEALTH_PORT" ]]; then
-        warn "No HEALTHCHECK directive found in Dockerfile."
+    elif [[ "$HEALTHCHECK_RESULT" == "none" ]]; then
+        error "Dockerfile disables its health probe with 'HEALTHCHECK NONE'."
+    elif [[ "$HEALTHCHECK_RESULT" == "malformed" ]]; then
+        error "Dockerfile HEALTHCHECK must use 'CMD ...' or 'NONE' grammar."
+    elif [[ "$HEALTHCHECK_RESULT" == "unsupported" ]]; then
+        error "Dockerfile HEALTHCHECK must run the supported localhost curl probe."
+    elif [[ "$HEALTHCHECK_RESULT" == "unsupported-heredoc" ]]; then
+        error "Dockerfile healthcheck audit cannot safely inspect heredoc instructions."
+    elif [[ "$HEALTHCHECK_RESULT" == "unterminated-continuation" ]]; then
+        error "Dockerfile HEALTHCHECK has an unterminated backslash continuation."
+    else
+        error "No active HEALTHCHECK directive found in Dockerfile."
     fi
 else
     error "Dockerfile not found."

--- a/scripts/check-ci-config.sh
+++ b/scripts/check-ci-config.sh
@@ -115,7 +115,9 @@ if [[ -f Dockerfile ]]; then
                     healthcheck = ""
                     return
                 }
-                if (lower ~ /^(run|copy)([[:space:]]|$)/ && instruction ~ /<</) {
+                if ((lower ~ /^(run|copy|add)([[:space:]]|$)/ ||
+                        lower ~ /^onbuild[[:space:]]+(run|copy|add)([[:space:]]|$)/) &&
+                        instruction ~ /<</) {
                     audit_error = "unsupported-heredoc"
                     return
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1241,46 +1241,68 @@ impl InMemoryMessageCoordinator {
             Err(DeliveryReserveError::Full) => {}
         }
 
+        let deadline = tokio::time::Instant::now() + self.slow_consumer_timeout;
         self.metrics.increment_websocket_backpressure_events();
         if let Some(stats) = &stats {
             stats
                 .backpressure_events
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
-        match tokio::time::timeout(
-            self.slow_consumer_timeout,
-            delivery.sender.reserve_control(None),
-        )
-        .await
-        {
-            Ok(Ok(permit)) => Ok(permit),
-            Ok(Err(DeliveryReserveError::Canceled)) => {
+        let reserve = delivery.sender.reserve_control(None);
+        tokio::pin!(reserve);
+        let reservation = tokio::select! {
+            // Capacity returning at or after the deadline cannot revive an
+            // expired transition. Tokio's `timeout` polls its inner future
+            // first, so use a timer-first biased select here.
+            biased;
+            _ = tokio::time::sleep_until(deadline) => None,
+            result = &mut reserve => Some(result),
+        };
+        match reservation {
+            Some(Ok(permit)) => Ok(permit),
+            Some(Err(DeliveryReserveError::Canceled)) => {
                 self.record_canceled_delivery(player_id);
                 Err(DeliveryOutcome::Canceled)
             }
-            Ok(Err(DeliveryReserveError::Closed | DeliveryReserveError::Full)) => {
+            Some(Err(DeliveryReserveError::Closed | DeliveryReserveError::Full)) => {
                 self.metrics.increment_websocket_deliveries_channel_closed();
                 Err(DeliveryOutcome::ChannelClosed)
             }
-            Err(_) => {
-                let initiated_close = delivery.close.request_close(CloseReason::SlowConsumer);
-                if initiated_close {
-                    self.metrics.increment_websocket_slow_consumer_disconnects();
+            None => match delivery.sender.try_reserve_control(None) {
+                // A terminal queue state that became observable at the
+                // deadline is more specific than backpressure expiry. In
+                // particular, classified queues use `Canceled` to fence stale
+                // generations; that fence must not be rewritten as a
+                // slow-consumer disconnect merely because the timer is also
+                // ready.
+                Err(DeliveryReserveError::Canceled) => {
+                    self.record_canceled_delivery(player_id);
+                    Err(DeliveryOutcome::Canceled)
                 }
-                self.metrics.increment_websocket_messages_dropped();
-                if let Some(stats) = &stats {
-                    stats
-                        .dropped_for_you
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Err(DeliveryReserveError::Closed) => {
+                    self.metrics.increment_websocket_deliveries_channel_closed();
+                    Err(DeliveryOutcome::ChannelClosed)
                 }
-                tracing::warn!(
-                    %player_id,
-                    timeout_ms = self.slow_consumer_timeout.as_millis() as u64,
-                    initiated_close,
-                    "Initial room transition queue stayed full; closing recipient"
-                );
-                Err(DeliveryOutcome::SlowConsumer)
-            }
+                Ok(_) | Err(DeliveryReserveError::Full) => {
+                    let initiated_close = delivery.close.request_close(CloseReason::SlowConsumer);
+                    if initiated_close {
+                        self.metrics.increment_websocket_slow_consumer_disconnects();
+                    }
+                    self.metrics.increment_websocket_messages_dropped();
+                    if let Some(stats) = &stats {
+                        stats
+                            .dropped_for_you
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    tracing::warn!(
+                        %player_id,
+                        timeout_ms = self.slow_consumer_timeout.as_millis() as u64,
+                        initiated_close,
+                        "Initial room transition queue stayed full; closing recipient"
+                    );
+                    Err(DeliveryOutcome::SlowConsumer)
+                }
+            },
         }
     }
 
@@ -1346,6 +1368,7 @@ impl InMemoryMessageCoordinator {
                 ));
             }
         };
+        let deadline = tokio::time::Instant::now() + self.slow_consumer_timeout;
         let (message, _) = message.into_parts();
 
         self.metrics.increment_websocket_backpressure_events();
@@ -1357,10 +1380,55 @@ impl InMemoryMessageCoordinator {
 
         let reserve = handle.sender.reserve_control(None);
         tokio::pin!(reserve);
-        let timeout = tokio::time::sleep(self.slow_consumer_timeout);
+        let timeout = tokio::time::sleep_until(deadline);
         tokio::pin!(timeout);
 
         tokio::select! {
+            // Drain completion retains cancellation precedence. The timeout
+            // branch then wins when capacity and expiry are both ready.
+            biased;
+            changed = drain.changed() => {
+                if changed.is_ok() && *drain.borrow() {
+                    tracing::debug!(%player_id, "Conditional delivery canceled for shutdown drain");
+                }
+                self.record_canceled_delivery(player_id);
+                None
+            }
+            _ = &mut timeout => {
+                if *drain.borrow() || !should_send() {
+                    self.record_canceled_delivery(player_id);
+                    return None;
+                }
+                match handle.sender.try_reserve_control(None) {
+                    Err(DeliveryReserveError::Canceled) => {
+                        self.record_canceled_delivery(player_id);
+                        return Some(DeliveryOutcome::Canceled);
+                    }
+                    Err(DeliveryReserveError::Closed) => {
+                        self.metrics.increment_websocket_deliveries_channel_closed();
+                        return Some(DeliveryOutcome::ChannelClosed);
+                    }
+                    Ok(_) | Err(DeliveryReserveError::Full) => {}
+                }
+                let initiated_close = handle.close.request_close(CloseReason::SlowConsumer);
+                if initiated_close {
+                    self.metrics.increment_websocket_slow_consumer_disconnects();
+                }
+                self.metrics.increment_websocket_messages_dropped();
+                if let Some(stats) = &connection_stats {
+                    stats
+                        .dropped_for_you
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
+                tracing::warn!(
+                    %player_id,
+                    timeout_ms = self.slow_consumer_timeout.as_millis() as u64,
+                    initiated_close,
+                    "Outbound queue full past the slow-consumer timeout; disconnecting recipient \
+                     instead of silently dropping messages"
+                );
+                Some(DeliveryOutcome::SlowConsumer)
+            }
             result = &mut reserve => match result {
                 Ok(permit) => {
                     if *drain.borrow() || !should_send() {
@@ -1395,37 +1463,6 @@ impl InMemoryMessageCoordinator {
                     Some(DeliveryOutcome::Canceled)
                 }
             },
-            changed = drain.changed() => {
-                if changed.is_ok() && *drain.borrow() {
-                    tracing::debug!(%player_id, "Conditional delivery canceled for shutdown drain");
-                }
-                self.record_canceled_delivery(player_id);
-                None
-            }
-            _ = &mut timeout => {
-                if *drain.borrow() || !should_send() {
-                    self.record_canceled_delivery(player_id);
-                    return None;
-                }
-                let initiated_close = handle.close.request_close(CloseReason::SlowConsumer);
-                if initiated_close {
-                    self.metrics.increment_websocket_slow_consumer_disconnects();
-                }
-                self.metrics.increment_websocket_messages_dropped();
-                if let Some(stats) = &connection_stats {
-                    stats
-                        .dropped_for_you
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                }
-                tracing::warn!(
-                    %player_id,
-                    timeout_ms = self.slow_consumer_timeout.as_millis() as u64,
-                    initiated_close,
-                    "Outbound queue full past the slow-consumer timeout; disconnecting recipient \
-                     instead of silently dropping messages"
-                );
-                Some(DeliveryOutcome::SlowConsumer)
-            }
         }
     }
 
@@ -1464,6 +1501,7 @@ impl InMemoryMessageCoordinator {
                 ConditionalDeliveryReservation::Canceled
             }
             Err(DeliveryReserveError::Full) => {
+                let deadline = tokio::time::Instant::now() + self.slow_consumer_timeout;
                 self.metrics.increment_websocket_backpressure_events();
                 if let Some(stats) = &stats {
                     stats
@@ -1474,10 +1512,61 @@ impl InMemoryMessageCoordinator {
                 let reserved_sender = sender.clone();
                 let reserve = sender.reserve_control(room_id);
                 tokio::pin!(reserve);
-                let timeout = tokio::time::sleep(self.slow_consumer_timeout);
+                let timeout = tokio::time::sleep_until(deadline);
                 tokio::pin!(timeout);
 
                 tokio::select! {
+                    // Drain completion retains cancellation precedence. Expiry
+                    // then wins an exact-boundary race with returned capacity.
+                    biased;
+                    changed = drain.changed() => {
+                        if changed.is_ok() && *drain.borrow() {
+                            tracing::debug!(%player_id, "Conditional delivery reservation canceled for shutdown drain");
+                        }
+                        self.record_canceled_delivery(player_id);
+                        ConditionalDeliveryReservation::Canceled
+                    }
+                    _ = &mut timeout => {
+                        if *drain.borrow() || !should_send() {
+                            self.record_canceled_delivery(player_id);
+                            return ConditionalDeliveryReservation::Canceled;
+                        }
+                        match sender.try_reserve_control(room_id) {
+                            Err(DeliveryReserveError::Canceled) => {
+                                self.record_canceled_delivery(player_id);
+                                return ConditionalDeliveryReservation::Canceled;
+                            }
+                            Err(DeliveryReserveError::Closed) => {
+                                self.metrics.increment_websocket_deliveries_channel_closed();
+                                return ConditionalDeliveryReservation::ChannelClosed {
+                                    player_id,
+                                    sender: reserved_sender,
+                                };
+                            }
+                            Ok(_) | Err(DeliveryReserveError::Full) => {}
+                        }
+                        let initiated_close = handle.close.request_close(CloseReason::SlowConsumer);
+                        if initiated_close {
+                            self.metrics.increment_websocket_slow_consumer_disconnects();
+                        }
+                        self.metrics.increment_websocket_messages_dropped();
+                        if let Some(stats) = &stats {
+                            stats
+                                .dropped_for_you
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        }
+                        tracing::warn!(
+                            %player_id,
+                            timeout_ms = self.slow_consumer_timeout.as_millis() as u64,
+                            initiated_close,
+                            "Outbound queue full past the slow-consumer timeout; disconnecting recipient \
+                             instead of silently dropping messages"
+                        );
+                        ConditionalDeliveryReservation::SlowConsumer {
+                            player_id,
+                            sender: reserved_sender,
+                        }
+                    }
                     result = &mut reserve => match result {
                         Ok(permit) => {
                             if *drain.borrow() || !should_send() {
@@ -1505,40 +1594,6 @@ impl InMemoryMessageCoordinator {
                             ConditionalDeliveryReservation::Canceled
                         }
                     },
-                    changed = drain.changed() => {
-                        if changed.is_ok() && *drain.borrow() {
-                            tracing::debug!(%player_id, "Conditional delivery reservation canceled for shutdown drain");
-                        }
-                        self.record_canceled_delivery(player_id);
-                        ConditionalDeliveryReservation::Canceled
-                    }
-                    _ = &mut timeout => {
-                        if *drain.borrow() || !should_send() {
-                            self.record_canceled_delivery(player_id);
-                            return ConditionalDeliveryReservation::Canceled;
-                        }
-                        let initiated_close = handle.close.request_close(CloseReason::SlowConsumer);
-                        if initiated_close {
-                            self.metrics.increment_websocket_slow_consumer_disconnects();
-                        }
-                        self.metrics.increment_websocket_messages_dropped();
-                        if let Some(stats) = &stats {
-                            stats
-                                .dropped_for_you
-                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        }
-                        tracing::warn!(
-                            %player_id,
-                            timeout_ms = self.slow_consumer_timeout.as_millis() as u64,
-                            initiated_close,
-                            "Outbound queue full past the slow-consumer timeout; disconnecting recipient \
-                             instead of silently dropping messages"
-                        );
-                        ConditionalDeliveryReservation::SlowConsumer {
-                            player_id,
-                            sender: reserved_sender,
-                        }
-                    }
                 }
             }
         }

--- a/src/server/message_coordinator_tests.rs
+++ b/src/server/message_coordinator_tests.rs
@@ -1,7 +1,7 @@
-use super::{ConnectionManager, InMemoryMessageCoordinator};
+use super::{ConditionalDeliveryReservation, ConnectionManager, InMemoryMessageCoordinator};
 use crate::coordination::{
-    ClientDeliveryHandle, ConnectionCloseSignal, MessageCoordinator, RoomMessageTransactionOutcome,
-    RoomRecipientMessages,
+    ClientDeliveryHandle, CloseReason, ConnectionCloseSignal, DeliveryOutcome, MessageCoordinator,
+    RoomMessageTransactionOutcome, RoomRecipientMessages,
 };
 use crate::metrics::ServerMetrics;
 use crate::protocol::{LobbyState, PlayerId, RoomId, ServerMessage, SpectatorJoinedPayload};
@@ -9,6 +9,187 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use tokio::sync::{mpsc, watch, Notify};
 use tokio::time::Duration;
+
+#[derive(Clone, Copy, Debug)]
+enum ControlCapacityWait {
+    InitialTransition,
+    ConditionalDelivery,
+    ConditionalReservation,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ControlQueueKind {
+    Legacy,
+    Classified,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DeadlineBoundary {
+    Exact,
+    Post,
+}
+
+impl DeadlineBoundary {
+    fn elapsed(self) -> Duration {
+        match self {
+            Self::Exact => Duration::from_secs(1),
+            Self::Post => Duration::from_millis(1_001),
+        }
+    }
+}
+
+enum ControlReceiver {
+    Legacy(mpsc::Receiver<Arc<ServerMessage>>),
+    Classified(crate::coordination::outbound_queue::OutboundReceiver),
+}
+
+impl ControlReceiver {
+    fn close(&mut self) {
+        match self {
+            Self::Legacy(receiver) => receiver.close(),
+            Self::Classified(receiver) => receiver.close(),
+        }
+    }
+
+    fn pop_message(&mut self, context: &str) -> Arc<ServerMessage> {
+        match self {
+            Self::Legacy(receiver) => receiver.try_recv().expect(context),
+            Self::Classified(receiver) => {
+                let queued = receiver.try_recv().expect(context);
+                match queued.payload {
+                    crate::coordination::outbound_queue::OutboundPayload::Message(message) => {
+                        message
+                    }
+                    payload => panic!("{context}: expected control message, got {payload:?}"),
+                }
+            }
+        }
+    }
+
+    fn assert_empty(&mut self, context: &str) {
+        match self {
+            Self::Legacy(receiver) => assert!(
+                matches!(receiver.try_recv(), Err(mpsc::error::TryRecvError::Empty)),
+                "{context}: legacy queue must remain open and empty"
+            ),
+            Self::Classified(receiver) => assert!(
+                matches!(
+                    receiver.try_recv(),
+                    Err(crate::coordination::outbound_queue::TryReceiveError::Empty)
+                ),
+                "{context}: classified queue must remain open and empty"
+            ),
+        }
+    }
+
+    fn assert_disconnected(&mut self, context: &str) {
+        match self {
+            Self::Legacy(receiver) => assert!(
+                matches!(
+                    receiver.try_recv(),
+                    Err(mpsc::error::TryRecvError::Disconnected)
+                ),
+                "{context}: legacy queue must be disconnected"
+            ),
+            Self::Classified(receiver) => assert!(
+                matches!(
+                    receiver.try_recv(),
+                    Err(crate::coordination::outbound_queue::TryReceiveError::Disconnected)
+                ),
+                "{context}: classified queue must be disconnected"
+            ),
+        }
+    }
+}
+
+fn full_control_queue(
+    kind: ControlQueueKind,
+) -> (
+    ClientDeliveryHandle,
+    crate::coordination::ConnectionCloseListener,
+    ControlReceiver,
+) {
+    let (close, close_listener) = ConnectionCloseSignal::channel();
+    match kind {
+        ControlQueueKind::Legacy => {
+            let (sender, receiver) = mpsc::channel(1);
+            sender
+                .try_send(Arc::new(ServerMessage::Pong))
+                .expect("prefill must occupy the legacy control queue");
+            (
+                ClientDeliveryHandle::new(sender, close),
+                close_listener,
+                ControlReceiver::Legacy(receiver),
+            )
+        }
+        ControlQueueKind::Classified => {
+            let (sender, receiver) = crate::coordination::outbound_queue::channel(1, 1);
+            sender.set_protocol_version(3);
+            sender
+                .try_enqueue_control_scoped(Arc::new(ServerMessage::Pong), None, 0)
+                .expect("prefill must occupy the classified control lane");
+            (
+                ClientDeliveryHandle::classified(sender, close),
+                close_listener,
+                ControlReceiver::Classified(receiver),
+            )
+        }
+    }
+}
+
+fn start_control_capacity_wait(
+    case: ControlCapacityWait,
+    coordinator: Arc<InMemoryMessageCoordinator>,
+    player_id: PlayerId,
+    handle: ClientDeliveryHandle,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = DeliveryOutcome> + Send>> {
+    match case {
+        ControlCapacityWait::InitialTransition => Box::pin(async move {
+            match coordinator
+                .reserve_initial_transition(player_id, &handle)
+                .await
+            {
+                Ok(_permit) => DeliveryOutcome::Delivered,
+                Err(outcome) => outcome,
+            }
+        }),
+        ControlCapacityWait::ConditionalDelivery => {
+            let (drain_tx, drain) = watch::channel(false);
+            Box::pin(async move {
+                let _drain_tx = drain_tx;
+                coordinator
+                    .deliver_to_one_if(
+                        player_id,
+                        handle,
+                        Arc::new(ServerMessage::Pong),
+                        &|| true,
+                        drain,
+                    )
+                    .await
+                    .unwrap_or(DeliveryOutcome::Canceled)
+            })
+        }
+        ControlCapacityWait::ConditionalReservation => {
+            let (drain_tx, drain) = watch::channel(false);
+            Box::pin(async move {
+                let _drain_tx = drain_tx;
+                match coordinator
+                    .reserve_one_if(player_id, handle, &|| true, drain, None)
+                    .await
+                {
+                    ConditionalDeliveryReservation::SlowConsumer { .. } => {
+                        DeliveryOutcome::SlowConsumer
+                    }
+                    ConditionalDeliveryReservation::ChannelClosed { .. } => {
+                        DeliveryOutcome::ChannelClosed
+                    }
+                    ConditionalDeliveryReservation::Canceled => DeliveryOutcome::Canceled,
+                    ConditionalDeliveryReservation::Reserved { .. } => DeliveryOutcome::Delivered,
+                }
+            })
+        }
+    }
+}
 
 async fn wait_for_counter(context: &str, max_yields: usize, mut condition: impl FnMut() -> bool) {
     for _ in 0..max_yields {
@@ -18,6 +199,243 @@ async fn wait_for_counter(context: &str, max_yields: usize, mut condition: impl 
         tokio::task::yield_now().await;
     }
     panic!("{context}: counter condition never held");
+}
+
+#[tokio::test(start_paused = true)]
+async fn expired_control_capacity_waits_cannot_revive_after_capacity_returns() {
+    let cases = [
+        ControlCapacityWait::InitialTransition,
+        ControlCapacityWait::ConditionalDelivery,
+        ControlCapacityWait::ConditionalReservation,
+    ];
+    let queue_kinds = [ControlQueueKind::Legacy, ControlQueueKind::Classified];
+    let boundaries = [DeadlineBoundary::Exact, DeadlineBoundary::Post];
+
+    for (case_index, case) in cases.into_iter().enumerate() {
+        for (kind_index, kind) in queue_kinds.into_iter().enumerate() {
+            for (boundary_index, boundary) in boundaries.into_iter().enumerate() {
+                let metrics = Arc::new(ServerMetrics::new());
+                let coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(
+                    Duration::from_secs(1),
+                    Arc::clone(&metrics),
+                ));
+                let player_id = PlayerId::from_u128(
+                    0x660B_70BA_DA11_4CE1_8168_DA1A_D311_1000
+                        + (case_index * 100 + kind_index * 10 + boundary_index) as u128,
+                );
+                let (handle, close_listener, mut receiver) = full_control_queue(kind);
+                let mut wait = start_control_capacity_wait(
+                    case,
+                    Arc::clone(&coordinator),
+                    player_id,
+                    handle.clone(),
+                );
+
+                assert!(
+                    futures_util::poll!(wait.as_mut()).is_pending(),
+                    "{case:?}/{kind:?}/{boundary:?} must wait while the control queue is full"
+                );
+                tokio::time::advance(boundary.elapsed()).await;
+                let prefill = receiver.pop_message("capacity must return at the test boundary");
+                assert!(matches!(prefill.as_ref(), ServerMessage::Pong));
+
+                assert_eq!(
+                    wait.await,
+                    DeliveryOutcome::SlowConsumer,
+                    "{case:?}/{kind:?}/{boundary:?} must not use capacity returned at or after its deadline"
+                );
+                receiver.assert_empty(&format!("{case:?}/{kind:?}/{boundary:?}"));
+                assert_eq!(
+                    close_listener.requested_reason(),
+                    Some(CloseReason::SlowConsumer),
+                    "{case:?}/{kind:?}/{boundary:?} must expose the slow-consumer close reason"
+                );
+                assert_eq!(
+                    metrics
+                        .websocket_slow_consumer_disconnects
+                        .load(Ordering::Relaxed),
+                    1,
+                    "{case:?}/{kind:?}/{boundary:?} must request exactly one slow-consumer close"
+                );
+                assert_eq!(
+                    metrics.websocket_messages_dropped.load(Ordering::Relaxed),
+                    1,
+                    "{case:?}/{kind:?}/{boundary:?} must account for exactly one expired delivery"
+                );
+                assert_eq!(
+                    metrics.websocket_delivery_attempts.load(Ordering::Relaxed),
+                    1,
+                    "{case:?}/{kind:?}/{boundary:?} must account for one logical delivery attempt"
+                );
+                assert_eq!(
+                    metrics
+                        .websocket_backpressure_events
+                        .load(Ordering::Relaxed),
+                    1,
+                    "{case:?}/{kind:?}/{boundary:?} must account for one full-queue wait"
+                );
+                assert_eq!(
+                    metrics
+                        .websocket_deliveries_enqueued
+                        .load(Ordering::Relaxed),
+                    0,
+                    "{case:?}/{kind:?}/{boundary:?} must not account an expired delivery as enqueued"
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn queue_closure_at_or_after_the_deadline_precedes_slow_consumer_expiry() {
+    let cases = [
+        ControlCapacityWait::InitialTransition,
+        ControlCapacityWait::ConditionalDelivery,
+        ControlCapacityWait::ConditionalReservation,
+    ];
+    let queue_kinds = [ControlQueueKind::Legacy, ControlQueueKind::Classified];
+    let boundaries = [DeadlineBoundary::Exact, DeadlineBoundary::Post];
+
+    for case in cases {
+        for kind in queue_kinds {
+            for boundary in boundaries {
+                let metrics = Arc::new(ServerMetrics::new());
+                let coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(
+                    Duration::from_secs(1),
+                    Arc::clone(&metrics),
+                ));
+                let player_id = PlayerId::from_u128(0x660B_70BA_DA11_4CE1_8168_DA1A_D311_2000);
+                let (handle, close_listener, mut receiver) = full_control_queue(kind);
+                let mut wait = start_control_capacity_wait(case, coordinator, player_id, handle);
+
+                assert!(
+                    futures_util::poll!(wait.as_mut()).is_pending(),
+                    "{case:?}/{kind:?}/{boundary:?} must enter backpressure"
+                );
+                tokio::time::advance(boundary.elapsed()).await;
+                receiver.close();
+
+                assert_eq!(
+                    wait.await,
+                    DeliveryOutcome::ChannelClosed,
+                    "{case:?}/{kind:?}/{boundary:?} must preserve closure at or after the deadline"
+                );
+                assert_eq!(
+                    close_listener.requested_reason(),
+                    None,
+                    "{case:?}/{kind:?}/{boundary:?} must not misclassify closure as slow consumption"
+                );
+                assert_eq!(
+                    metrics
+                        .websocket_deliveries_channel_closed
+                        .load(Ordering::Relaxed),
+                    1
+                );
+                assert_eq!(
+                    metrics
+                        .websocket_slow_consumer_disconnects
+                        .load(Ordering::Relaxed),
+                    0
+                );
+                assert_eq!(
+                    metrics.websocket_messages_dropped.load(Ordering::Relaxed),
+                    0
+                );
+                let prefill = receiver.pop_message("closed queue retains its existing item");
+                assert!(matches!(prefill.as_ref(), ServerMessage::Pong));
+                receiver.assert_disconnected(&format!("{case:?}/{kind:?}/{boundary:?}"));
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn classified_generation_cancellation_at_the_deadline_precedes_slow_consumer_expiry() {
+    let cases = [
+        ControlCapacityWait::InitialTransition,
+        ControlCapacityWait::ConditionalDelivery,
+        ControlCapacityWait::ConditionalReservation,
+    ];
+
+    for (index, case) in cases.into_iter().enumerate() {
+        let metrics = Arc::new(ServerMetrics::new());
+        let coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(
+            Duration::from_secs(1),
+            Arc::clone(&metrics),
+        ));
+        let player_id =
+            PlayerId::from_u128(0x660B_70BA_DA11_4CE1_8168_DA1A_D311_3000 + index as u128);
+        let (handle, close_listener, mut receiver) =
+            full_control_queue(ControlQueueKind::Classified);
+        let mut wait =
+            start_control_capacity_wait(case, Arc::clone(&coordinator), player_id, handle.clone());
+
+        assert!(
+            futures_util::poll!(wait.as_mut()).is_pending(),
+            "{case:?} must enter classified backpressure"
+        );
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let prefill = receiver.pop_message("release the classified control lane");
+        assert!(matches!(prefill.as_ref(), ServerMessage::Pong));
+
+        // Generation zero may legitimately reserve generation one's
+        // transition. Move initial-transition waits two generations ahead so
+        // every case is unambiguously stale at the exact deadline.
+        let generation_advances = if matches!(case, ControlCapacityWait::InitialTransition) {
+            2
+        } else {
+            1
+        };
+        let mut current_sender = handle.sender.clone();
+        for advance in 0..generation_advances {
+            current_sender = current_sender.next_generation();
+            current_sender
+                .try_send(Arc::new(ServerMessage::RoomLeft), None)
+                .expect("advance classified queue generation at the deadline");
+            if advance + 1 < generation_advances {
+                let transition =
+                    receiver.pop_message("release capacity for the next generation transition");
+                assert!(matches!(transition.as_ref(), ServerMessage::RoomLeft));
+            }
+        }
+
+        assert_eq!(
+            wait.await,
+            DeliveryOutcome::Canceled,
+            "{case:?} must preserve the classified generation fence at the deadline"
+        );
+        assert_eq!(
+            close_listener.requested_reason(),
+            None,
+            "{case:?} must not close a stale classified generation as a slow consumer"
+        );
+        assert_eq!(
+            metrics
+                .websocket_deliveries_canceled
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert_eq!(
+            metrics
+                .websocket_slow_consumer_disconnects
+                .load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            metrics.websocket_messages_dropped.load(Ordering::Relaxed),
+            0
+        );
+        assert_eq!(
+            metrics
+                .websocket_deliveries_enqueued
+                .load(Ordering::Relaxed),
+            0,
+            "{case:?} must not account any late coordinator enqueue"
+        );
+        let transition = receiver.pop_message("only the explicit generation transition remains");
+        assert!(matches!(transition.as_ref(), ServerMessage::RoomLeft));
+        receiver.assert_empty(&format!("{case:?} classified generation cancellation"));
+    }
 }
 
 #[tokio::test]

--- a/tests/ci_config_script_tests.rs
+++ b/tests/ci_config_script_tests.rs
@@ -1,0 +1,245 @@
+#![cfg(test)]
+
+mod common;
+
+use common::{bash_command, repo_root, unique_temp_dir, write_file};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+const REQUIRED_DOCKERFILE_PREFIX: &str = "\
+FROM debian:bookworm-slim AS runtime
+EXPOSE 3536
+ENV SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=false
+ENV SIGNAL_FISH__SECURITY__REQUIRE_WEBSOCKET_AUTH=false
+";
+
+fn copy_validator_script(temp_root: &Path) {
+    let source = repo_root().join("scripts/check-ci-config.sh");
+    let destination = temp_root.join("scripts/check-ci-config.sh");
+    let script = fs::read_to_string(&source)
+        .unwrap_or_else(|error| panic!("Failed to read {}: {error}", source.display()));
+    write_file(&destination, &script);
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(path)
+            .unwrap_or_else(|error| panic!("Failed to stat {}: {error}", path.display()))
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions)
+            .unwrap_or_else(|error| panic!("Failed to chmod {}: {error}", path.display()));
+    }
+}
+
+fn install_fake_cargo_tools(temp_root: &Path) -> PathBuf {
+    let fake_bin = temp_root.join("bin");
+    for name in ["cargo", "cargo-deny"] {
+        let path = fake_bin.join(name);
+        write_file(&path, "#!/usr/bin/env bash\nexit 0\n");
+        make_executable(&path);
+    }
+    fake_bin
+}
+
+fn run_validator_with_dockerfile(dockerfile_tail: &str) -> (i32, String) {
+    let temp_root = unique_temp_dir("ci-config");
+    copy_validator_script(temp_root.path());
+    write_file(
+        &temp_root.path().join("Cargo.lock"),
+        "# synthetic lockfile\nversion = 4\n",
+    );
+    write_file(&temp_root.path().join("deny.toml"), "");
+    write_file(
+        &temp_root.path().join(".github/workflows/ci.yml"),
+        "\
+uses: EmbarkStudios/cargo-deny-action@v2
+- name: Smoke test
+  run: |
+    for i in $(seq 1 3); do retry=true; done
+    docker logs signal-fish
+",
+    );
+    write_file(
+        &temp_root.path().join("Dockerfile"),
+        &format!("{REQUIRED_DOCKERFILE_PREFIX}{dockerfile_tail}"),
+    );
+
+    let fake_bin = install_fake_cargo_tools(temp_root.path());
+    let original_path = env::var_os("PATH").unwrap_or_default();
+    let path = env::join_paths(std::iter::once(fake_bin).chain(env::split_paths(&original_path)))
+        .expect("valid PATH");
+    let output = bash_command()
+        .arg("scripts/check-ci-config.sh")
+        .env("PATH", path)
+        .current_dir(temp_root.path())
+        .output()
+        .expect("CI config validator should execute");
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    (
+        output.status.code().unwrap_or(-1),
+        combined.replace("\r\n", "\n"),
+    )
+}
+
+#[test]
+fn test_ci_config_healthcheck_parser_accepts_logical_instruction_shapes() {
+    let cases = [
+        (
+            "single-line",
+            "HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n",
+        ),
+        (
+            "multiline",
+            "HEALTHCHECK --interval=30s --timeout=5s \\\n\
+                 CMD curl -f http://localhost:3536/v2/health || exit 1\n",
+        ),
+        (
+            "continued-comment",
+            "HEALTHCHECK --interval=30s \\\n\
+                 # ignored full-line comment\n\
+                 CMD curl -f http://localhost:3536/v2/health || exit 1\n",
+        ),
+        (
+            "crlf",
+            "HEALTHCHECK --interval=30s \\\r\n\
+                 CMD curl -f http://localhost:3536/v2/health || exit 1\r\n",
+        ),
+        (
+            "non-heredoc-angle-token",
+            "LABEL documentation=<<not-a-heredoc\n\
+             HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n",
+        ),
+    ];
+
+    for (name, dockerfile_tail) in cases {
+        let (exit_code, output) = run_validator_with_dockerfile(dockerfile_tail);
+        assert_eq!(exit_code, 0, "{name} should pass.\nOutput:\n{output}");
+        assert!(
+            output.contains("HEALTHCHECK port (3536) matches EXPOSE port (3536).")
+                && output.contains("All CI config checks passed."),
+            "{name} should report the matching healthcheck.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn test_ci_config_healthcheck_parser_rejects_inactive_or_unsafe_shapes() {
+    let cases = [
+        (
+            "commented-out",
+            "# HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n",
+            "No active HEALTHCHECK directive found in Dockerfile.",
+        ),
+        (
+            "disabled",
+            "HEALTHCHECK NONE\n",
+            "Dockerfile disables its health probe with 'HEALTHCHECK NONE'.",
+        ),
+        (
+            "absent",
+            "CMD [\"./signal-fish-server\"]\n",
+            "No active HEALTHCHECK directive found in Dockerfile.",
+        ),
+        (
+            "malformed",
+            "HEALTHCHECK http://localhost:3536/v2/health\n",
+            "Dockerfile HEALTHCHECK must use 'CMD ...' or 'NONE' grammar.",
+        ),
+        (
+            "malformed-continuation",
+            "HEALTHCHECK --interval=30s \\ \n\
+             CMD curl -f http://localhost:3536/v2/health || exit 1\n",
+            "Dockerfile HEALTHCHECK must use 'CMD ...' or 'NONE' grammar.",
+        ),
+        (
+            "wrong-port",
+            "HEALTHCHECK CMD curl -f http://localhost:9000/v2/health || exit 1\n",
+            "HEALTHCHECK port (9000) does not match EXPOSE port (3536).",
+        ),
+        (
+            "builder-stage-only",
+            "HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n\
+             FROM scratch\n\
+             CMD [\"./signal-fish-server\"]\n",
+            "No active HEALTHCHECK directive found in Dockerfile.",
+        ),
+        (
+            "arbitrary-command-with-url",
+            "HEALTHCHECK CMD echo http://localhost:3536/v2/health\n",
+            "Dockerfile HEALTHCHECK must run the supported localhost curl probe.",
+        ),
+        (
+            "inert-comment-url",
+            "HEALTHCHECK CMD true # curl -f http://localhost:3536/v2/health || exit 1\n",
+            "Dockerfile HEALTHCHECK must run the supported localhost curl probe.",
+        ),
+        (
+            "different-host",
+            "HEALTHCHECK CMD curl -f http://notlocalhost:3536/v2/health || exit 1\n",
+            "Dockerfile HEALTHCHECK must run the supported localhost curl probe.",
+        ),
+        (
+            "wrong-path",
+            "HEALTHCHECK CMD curl -f http://localhost:3536/metrics || exit 1\n",
+            "Dockerfile HEALTHCHECK must run the supported localhost curl probe.",
+        ),
+        (
+            "eof-after-continuation",
+            "HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1 \\",
+            "Dockerfile HEALTHCHECK has an unterminated backslash continuation.",
+        ),
+        (
+            "heredoc-cannot-fake-healthcheck",
+            "RUN <<EOF\n\
+             HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n\
+             EOF\n",
+            "Dockerfile healthcheck audit cannot safely inspect heredoc instructions.",
+        ),
+    ];
+
+    for (name, dockerfile_tail, expected_diagnostic) in cases {
+        let (exit_code, output) = run_validator_with_dockerfile(dockerfile_tail);
+        assert_eq!(exit_code, 1, "{name} should fail.\nOutput:\n{output}");
+        assert!(
+            output.contains(expected_diagnostic),
+            "{name} should report `{expected_diagnostic}`.\nOutput:\n{output}"
+        );
+    }
+}
+
+#[test]
+fn test_repository_ci_config_has_active_matching_healthcheck() {
+    let temp_root = unique_temp_dir("ci-config-repository-tools");
+    let fake_bin = install_fake_cargo_tools(temp_root.path());
+    let original_path = env::var_os("PATH").unwrap_or_default();
+    let path = env::join_paths(std::iter::once(fake_bin).chain(env::split_paths(&original_path)))
+        .expect("valid PATH");
+    let output = bash_command()
+        .arg("scripts/check-ci-config.sh")
+        .env("PATH", path)
+        .current_dir(repo_root())
+        .output()
+        .expect("repository CI config validator should execute");
+
+    let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+    combined.push_str(&String::from_utf8_lossy(&output.stderr));
+    let combined = combined.replace("\r\n", "\n");
+
+    assert!(
+        output.status.success(),
+        "checked-in CI configuration should pass.\nOutput:\n{combined}"
+    );
+    assert!(
+        combined.contains("HEALTHCHECK port (3536) matches EXPOSE port (3536).")
+            && combined.contains("All CI config checks passed."),
+        "checked-in Dockerfile healthcheck should be recognized.\nOutput:\n{combined}"
+    );
+}

--- a/tests/ci_config_script_tests.rs
+++ b/tests/ci_config_script_tests.rs
@@ -25,17 +25,18 @@ fn copy_validator_script(temp_root: &Path) {
     write_file(&destination, &script);
 }
 
+#[cfg(unix)]
 fn make_executable(path: &Path) {
-    #[cfg(unix)]
-    {
-        let mut permissions = fs::metadata(path)
-            .unwrap_or_else(|error| panic!("Failed to stat {}: {error}", path.display()))
-            .permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(path, permissions)
-            .unwrap_or_else(|error| panic!("Failed to chmod {}: {error}", path.display()));
-    }
+    let mut permissions = fs::metadata(path)
+        .unwrap_or_else(|error| panic!("Failed to stat {}: {error}", path.display()))
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)
+        .unwrap_or_else(|error| panic!("Failed to chmod {}: {error}", path.display()));
 }
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) {}
 
 fn install_fake_cargo_tools(temp_root: &Path) -> PathBuf {
     let fake_bin = temp_root.join("bin");

--- a/tests/ci_config_script_tests.rs
+++ b/tests/ci_config_script_tests.rs
@@ -197,13 +197,6 @@ fn test_ci_config_healthcheck_parser_rejects_inactive_or_unsafe_shapes() {
             "HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1 \\",
             "Dockerfile HEALTHCHECK has an unterminated backslash continuation.",
         ),
-        (
-            "heredoc-cannot-fake-healthcheck",
-            "RUN <<EOF\n\
-             HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n\
-             EOF\n",
-            "Dockerfile healthcheck audit cannot safely inspect heredoc instructions.",
-        ),
     ];
 
     for (name, dockerfile_tail, expected_diagnostic) in cases {
@@ -212,6 +205,31 @@ fn test_ci_config_healthcheck_parser_rejects_inactive_or_unsafe_shapes() {
         assert!(
             output.contains(expected_diagnostic),
             "{name} should report `{expected_diagnostic}`.\nOutput:\n{output}"
+        );
+    }
+
+    for (name, opener) in [
+        ("run", "RUN <<EOF"),
+        ("copy", "COPY <<EOF /tmp/payload"),
+        ("add", "ADD <<EOF /tmp/payload"),
+        ("onbuild-add", "ONBUILD ADD <<EOF /tmp/payload"),
+    ] {
+        let dockerfile_tail = format!(
+            "{opener}\n\
+             FROM scratch\n\
+             HEALTHCHECK CMD curl -f http://localhost:3536/v2/health || exit 1\n\
+             EOF\n"
+        );
+        let (exit_code, output) = run_validator_with_dockerfile(&dockerfile_tail);
+        assert_eq!(
+            exit_code, 1,
+            "{name} heredoc should fail closed.\nOutput:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "Dockerfile healthcheck audit cannot safely inspect heredoc instructions."
+            ),
+            "{name} heredoc body must not impersonate FROM or HEALTHCHECK.\nOutput:\n{output}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Enforce strict absolute delivery deadlines for all control-capacity reservation paths, including initial transitions and predicate-filtered delivery.
- Preserve already-terminal channel-closed and classified-generation-canceled outcomes at the deadline while preventing late delivery to otherwise-live recipients.
- Audit Docker `HEALTHCHECK` as a logical instruction, including continuations, comments, final-stage selection, malformed forms, heredocs, and port consistency.
- Add paused-time runtime matrices and black-box CI-policy fixtures, correct the prior session’s reviewed-head record, and document the follow-up deadline audit in #233.

## Root causes

Tokio timeout/select behavior could let an inner capacity future win at or after the documented deadline, and the existing Docker policy inspected individual physical lines rather than the assembled logical `HEALTHCHECK` instruction.

## Red evidence

Before the runtime fix, the initial-transition path could report `Delivered` after its one-second deadline when capacity returned at the boundary. Before the policy fix, the checked-in continued `HEALTHCHECK` was reported as missing.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny check`
- `bash -n scripts/check-ci-config.sh`
- `shellcheck scripts/check-ci-config.sh`
- Repository documentation, MSRV, workflow-hygiene, markdown, link-text, hook-readiness, pre-commit, and pre-push policy checks
- Three independent adversarial review tracks completed with zero remaining revisions

Closes #226
Refs #205
Refs #233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable disconnect semantics on control-path backpressure (slow consumer vs canceled/closed) and tightens CI Dockerfile validation; runtime paths are heavily regression-tested but affect live WebSocket delivery behavior.
> 
> **Overview**
> Closes a **deadline race** on control-message queue waits: capacity that returns at or after the slow-consumer grace can no longer enqueue after expiry. **Initial room-join/reconnect transitions**, **conditional single-recipient delivery**, and **conditional reservations** (lifecycle broadcasts, session plans, replans, room transactions) now use **timer-first biased `select!`** with an absolute deadline, matching the P24 relay path. At expiry, **channel closed** and **classified generation canceled** still win over **`4002 slow_consumer`**; otherwise-live recipients get the documented slow-consumer disconnect.
> 
> **CI Docker policy** (`scripts/check-ci-config.sh`) now parses **logical `HEALTHCHECK` instructions** (backslash continuations, CRLF, comments, final-stage-only `FROM` reset) and **fails closed** on heredoc `RUN`/`COPY`/`ADD` (including `ONBUILD`) that could spoof probes. Only the supported **`curl` localhost `/v2/health`** probe is accepted, with **port matched to `EXPOSE`**.
> 
> Adds **paused-time regression matrices** for the three wait primitives (legacy/classified queues, exact/post-deadline boundaries) and **black-box healthcheck fixture tests**; changelog and session progress docs updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d30affde6ae966132c561d71c5887a5f7f8113d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->