### PR TITLE
Reduce binary relay envelope allocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@
 # Jobs:
 #   - lint: Cross-OS code formatting (rustfmt) and linting (clippy) matrix
 #   - nextest: Cross-OS test execution via cargo-nextest (doc-tests in doc-validation.yml)
+#   - relay-allocations: Deterministic production-seam allocation ceilings
 #   - doc-consistency: Version/changelog/doc drift checks (diff-aware changelog gate)
 #   - deny: Security audits, license checks, and dependency validation
 #   - audit: Second-opinion vulnerability scan via cargo-audit (RustSec)
@@ -51,7 +52,8 @@ jobs:
   # Fast-fail gate. A single cheap "does it format and compile" pass that the
   # expensive compile/test jobs in this workflow depend on via `needs:
   # quick-check`. A file that does not parse or type-check fails here in seconds,
-  # so the eight gated lanes (lint x3, nextest x3, msrv, coverage) never start —
+  # so the nine gated lanes (lint x3, nextest x3, relay allocations, msrv,
+  # coverage) never start —
   # collapsing what was a redundant per-lane recompile-and-fail into one fast
   # failure. This exists because an unclosed delimiter in a committed test file
   # once failed every one of those lanes independently. (Compile jobs in sibling
@@ -104,6 +106,38 @@ jobs:
       # committed, so dependency drift fails here instead of rewriting it.
       - name: Check fuzz crate compiles
         run: cargo check --manifest-path fuzz/Cargo.toml --bins --locked
+
+  relay-allocations:
+    name: Relay Allocation Ceilings
+    needs: quick-check
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+      - name: Read Rust toolchain
+        id: toolchain
+        shell: bash
+        run: |
+          CHANNEL=$(bash scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
+          if [ -z "$CHANNEL" ]; then
+            echo "ERROR: Could not extract channel from rust-toolchain.toml"
+            exit 1
+          fi
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.channel }}
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      - name: Enforce deterministic relay allocation ceilings
+        run: >-
+          cargo bench --locked --bench relay_serialization_allocations
+          --features allocation-tracking
 
   lint:
     name: Lint (${{ matrix.os }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of 10–11, while 8- and 16-player mixed-format relays use 28 instead of 37.
   Allocated bytes fall by 26–39% for direct binary traffic and 8–9% for mixed
   traffic; emitted wire bytes remain identical, and capacity-overflow errors
-  remain distinct from allocator failures during fallback buffer growth.
+  remain distinct from allocator failures during initial reservation and
+  fallback buffer growth.
 
 ## [0.5.2] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Allocated bytes fall by 26–39% for direct binary traffic and 8–9% for mixed
   traffic; emitted wire bytes remain identical, and capacity-overflow errors
   remain distinct from allocator failures during initial reservation and
-  fallback buffer growth.
+  fallback buffer growth while preserving allocator diagnostic context.
 
 ## [0.5.2] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce binary relay serialization allocation operations by pre-sizing the
+  MessagePack envelope from the known opaque payload length (issue #207).
+  Direct protocol-v3 binary relays now use 5–6 allocation operations instead
+  of 10–11, while 8- and 16-player mixed-format relays use 28 instead of 37.
+  Allocated bytes fall by 26–39% for direct binary traffic and 8–9% for mixed
+  traffic; emitted wire bytes remain identical.
+
 ## [0.5.2] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Direct protocol-v3 binary relays now use 5–6 allocation operations instead
   of 10–11, while 8- and 16-player mixed-format relays use 28 instead of 37.
   Allocated bytes fall by 26–39% for direct binary traffic and 8–9% for mixed
-  traffic; emitted wire bytes remain identical.
+  traffic; emitted wire bytes remain identical, and capacity-overflow errors
+  remain distinct from allocator failures during fallback buffer growth.
 
 ## [0.5.2] - 2026-07-31
 

--- a/benches/relay_serialization_allocations.rs
+++ b/benches/relay_serialization_allocations.rs
@@ -92,6 +92,9 @@ fn assert_allocation_ceiling(scenario: Scenario, room_size: usize, sample: &Samp
             _ => panic!("room-{room_size} has no checked-in allocation baseline"),
         };
     let allocation_operations = sample.stats.allocations + sample.stats.reallocations;
+    // Every 1,024-relay cell has one deterministic sample-scoped operation
+    // (the `.0010` visible in the report), so keep that fixed allowance
+    // separate from the integral per-relay hot-path ceiling.
     let maximum_operations = maximum_operations_per_relay * RELAYS_PER_SAMPLE + 1;
     let maximum_reallocations = maximum_reallocations_per_relay * RELAYS_PER_SAMPLE;
     let maximum_bytes = maximum_bytes_per_relay * RELAYS_PER_SAMPLE;

--- a/benches/relay_serialization_allocations.rs
+++ b/benches/relay_serialization_allocations.rs
@@ -77,6 +77,46 @@ fn print_sample(scenario: Scenario, room_size: usize, sample: &Sample) {
     );
 }
 
+fn assert_allocation_ceiling(scenario: Scenario, room_size: usize, sample: &Sample) {
+    let (maximum_operations_per_relay, maximum_reallocations_per_relay, maximum_bytes_per_relay) =
+        match (scenario, room_size) {
+            (Scenario::V3JsonText, 2) => (8, 3, 2_587),
+            (Scenario::V3JsonText, 8) => (9, 3, 3_507),
+            (Scenario::V3JsonText, 16) => (9, 3, 3_827),
+            (Scenario::V3MessagePackBinary, 2) => (5, 0, 1_581),
+            (Scenario::V3MessagePackBinary, 8) => (6, 0, 2_501),
+            (Scenario::V3MessagePackBinary, 16) => (6, 0, 2_821),
+            (Scenario::MixedMessagePackSource, 2) => (18, 3, 4_450),
+            (Scenario::MixedMessagePackSource, 8) => (28, 6, 9_845),
+            (Scenario::MixedMessagePackSource, 16) => (28, 6, 10_165),
+            _ => panic!("room-{room_size} has no checked-in allocation baseline"),
+        };
+    let allocation_operations = sample.stats.allocations + sample.stats.reallocations;
+    let maximum_operations = maximum_operations_per_relay * RELAYS_PER_SAMPLE + 1;
+    let maximum_reallocations = maximum_reallocations_per_relay * RELAYS_PER_SAMPLE;
+    let maximum_bytes = maximum_bytes_per_relay * RELAYS_PER_SAMPLE;
+    assert!(
+        allocation_operations <= maximum_operations,
+        "{} room-{room_size} projection used {allocation_operations} allocation operations across \
+         {RELAYS_PER_SAMPLE} relays; expected at most {maximum_operations}",
+        scenario.name()
+    );
+    assert!(
+        sample.stats.reallocations <= maximum_reallocations,
+        "{} room-{room_size} projection used {} reallocations across {RELAYS_PER_SAMPLE} relays; \
+         expected at most {maximum_reallocations}",
+        scenario.name(),
+        sample.stats.reallocations
+    );
+    assert!(
+        sample.stats.bytes_allocated <= maximum_bytes,
+        "{} room-{room_size} projection allocated {} bytes across {RELAYS_PER_SAMPLE} relays; \
+         expected at most {maximum_bytes}",
+        scenario.name(),
+        sample.stats.bytes_allocated
+    );
+}
+
 fn main() {
     println!(
         "scenario,room_size,recipients,relays,materialized,text_frames,binary_frames,\
@@ -89,6 +129,7 @@ fn main() {
         for room_size in ROOM_SIZES {
             let mut fixture = Fixture::new(room_size, scenario);
             let sample = repeated_sample(&mut fixture);
+            assert_allocation_ceiling(scenario, room_size, &sample);
             print_sample(scenario, room_size, &sample);
         }
     }

--- a/docs/ci-cd-testing-summary.md
+++ b/docs/ci-cd-testing-summary.md
@@ -135,6 +135,8 @@ This infrastructure prevents **entire categories** of CI/CD issues:
 - Tests check workflows use concurrency groups
 - Tests check workflows have timeouts
 - Tests validate minimal permissions principle
+- A required Linux allocation gate enforces operation, reallocation, and byte
+  ceilings for relay serialization across 2-, 8-, and 16-player rooms
 
 ## Test Coverage Statistics
 

--- a/docs/ci-cd-testing.md
+++ b/docs/ci-cd-testing.md
@@ -193,6 +193,21 @@ Key design decisions:
 **Test that enforces this:** `test_ci_workflow_has_required_jobs`
 (validates the audit job exists in ci.yml)
 
+#### Relay Allocation Ceilings
+
+The CI workflow runs the production-seam relay allocation harness on Linux for
+every push and pull request. The job checks allocation operations,
+reallocations, and allocated bytes for JSON, direct MessagePack, and mixed
+relay projections at room sizes 2, 8, and 16. It is a required branch
+protection check named `CI / Relay Allocation Ceilings`; changes to the
+serializer, allocator accounting, or its ceilings therefore cannot merge while
+the deterministic gate is failing or incomplete. The daily security schedule
+excludes this job because it does not inspect newly published advisories.
+
+**Tests that enforce this:** `test_ci_enforces_relay_allocation_ceilings`,
+`test_ci_workflow_has_required_jobs`, `test_required_check_names_are_consistent`,
+and `test_ci_schedule_only_runs_security_jobs`.
+
 #### 4. Documentation Validation Alignment Tests
 
 Tests that ensure the doc-validation workflow stays aligned with the naming contract and quality standards:

--- a/progress/session-075-binary-relay-envelope-allocation.md
+++ b/progress/session-075-binary-relay-envelope-allocation.md
@@ -84,7 +84,11 @@ evidence and exact wire ledgers; machine-sensitive timing remains observational.
 - Two adversarial passes found and resolved fallible-allocation, measurement,
   byte/reallocation coverage, boundary-test, documentation, and required-check
   contract gaps. The final confirmation pass reported zero remaining diff
-  issues; hosted CI and GitHub reviewer evidence remain pending publication.
+  issues. On the first hosted head the new allocation job passed exactly,
+  Cursor Bugbot reported no issue, and Copilot identified one error-taxonomy
+  gap in fallback writer growth. The follow-up distinguishes capacity overflow
+  (`InvalidInput`) from allocator failure (`OutOfMemory`) and pins that contract
+  directly; final hosted and reviewer evidence remain pending publication.
 
 ## Follow-up
 

--- a/progress/session-075-binary-relay-envelope-allocation.md
+++ b/progress/session-075-binary-relay-envelope-allocation.md
@@ -91,8 +91,10 @@ evidence and exact wire ledgers; machine-sensitive timing remains observational.
   directly. A clean exact-head re-review exposed three suppressed maintenance
   suggestions; the final local head also classifies initial reserve overflow,
   documents the single sample-scoped allocation allowance, and makes the CI
-  contract assertion whitespace-insensitive. Final hosted and reviewer
-  evidence remain pending publication.
+  contract assertion whitespace-insensitive. A subsequent clean exact-head
+  review's only suppressed note was also incorporated by retaining the
+  allocator's reserve-error text. Final hosted and reviewer evidence remain
+  pending publication.
 
 ## Follow-up
 

--- a/progress/session-075-binary-relay-envelope-allocation.md
+++ b/progress/session-075-binary-relay-envelope-allocation.md
@@ -93,8 +93,25 @@ evidence and exact wire ledgers; machine-sensitive timing remains observational.
   documents the single sample-scoped allocation allowance, and makes the CI
   contract assertion whitespace-insensitive. A subsequent clean exact-head
   review's only suppressed note was also incorporated by retaining the
-  allocator's reserve-error text. Final hosted and reviewer evidence remain
-  pending publication.
+  allocator's reserve-error text.
+
+## Publication
+
+PR [#240](https://github.com/Ambiguous-Interactive/signal-fish-server/pull/240)
+reached a fully green implementation head at
+`1d1d9919c8426f63b1a975798e952df5b0280d8c`. All 16 applicable workflows
+succeeded; the Dependabot-only workflow skipped as expected. The `CI` workflow
+passed all 16 jobs, including `Relay Allocation Ceilings`, three-platform lint
+and nextest, MSRV, coverage, both dependency audits, Docker, panic policy,
+SBOM, and document consistency. Advanced Safety passed Miri and ASan;
+Verification Nightly and every browser, WebRTC, Fortress, and Fortress WASM
+interop workflow also passed.
+
+Cursor Bugbot reported no issues on the exact head. Copilot reviewed all 11
+changed files and reported no new or suppressed comments after its surfaced
+reserve-classification thread and four suppressed hardening suggestions were
+implemented. The sole inline thread is resolved. Recent repository history
+exposed no distinct human reviewer beyond the pull-request author.
 
 ## Follow-up
 

--- a/progress/session-075-binary-relay-envelope-allocation.md
+++ b/progress/session-075-binary-relay-envelope-allocation.md
@@ -88,7 +88,11 @@ evidence and exact wire ledgers; machine-sensitive timing remains observational.
   Cursor Bugbot reported no issue, and Copilot identified one error-taxonomy
   gap in fallback writer growth. The follow-up distinguishes capacity overflow
   (`InvalidInput`) from allocator failure (`OutOfMemory`) and pins that contract
-  directly; final hosted and reviewer evidence remain pending publication.
+  directly. A clean exact-head re-review exposed three suppressed maintenance
+  suggestions; the final local head also classifies initial reserve overflow,
+  documents the single sample-scoped allocation allowance, and makes the CI
+  contract assertion whitespace-insensitive. Final hosted and reviewer
+  evidence remain pending publication.
 
 ## Follow-up
 

--- a/progress/session-075-binary-relay-envelope-allocation.md
+++ b/progress/session-075-binary-relay-envelope-allocation.md
@@ -1,0 +1,94 @@
+# Session 075 — Binary relay envelope allocation
+
+## Scope
+
+Advance the open optimization program in issue
+[#207](https://github.com/Ambiguous-Interactive/signal-fish-server/issues/207)
+through one falsifiable relay-serialization increment, starting from clean
+`main` at `09238c3` after release PR #238 merged.
+
+## Baseline and triage
+
+- P28 was audited as complete and merged; there was no carried staged diff or
+  open pull request.
+- Issue #207 remained the highest gameplay-impacting open work. Issue #239 is
+  the next concrete gameplay-path task after this bounded allocation phase.
+- No open dependency pull request was relevant. The visible remote Dependabot
+  refs are stale proposals containing version lines already rejected on MSRV
+  and duplicate-stack evidence.
+- The existing production-seam allocation harness reproduced its recorded
+  baseline exactly: direct protocol-v3 MessagePack used 10.001, 11.001, and
+  11.001 allocation operations per relay at room sizes 2, 8, and 16; mixed
+  MessagePack-source traffic used 18.001, 37.001, and 37.001.
+
+## Failure-first evidence
+
+Before production changed, the checked-in direct-binary ceiling allowed at
+most 7,169 allocation operations across 1,024 relays. The room-size-two cell
+failed deterministically at 10,241. The final data-driven matrix pins operation,
+reallocation, and allocated-byte ceilings for all nine current JSON,
+direct-binary, and mixed-format cells rather than guarding one example.
+
+## Implementation
+
+Named MessagePack relay envelopes now allocate their output buffer from the
+known opaque payload length plus 128 bytes of fixed headroom for field names,
+UUID, encoding, delivery stamps, and container headers. Both the frozen v2
+MessagePack envelope and mandatory v3 envelope use the same helper. Raw v2 JSON
+and rkyv passthrough remains unchanged.
+
+The same growth class was reviewed for JSON projection. A `serde_json::Value`
+does not expose its encoded length, and escaped strings have no safe compact
+upper bound without either a second traversal or large systematic
+over-allocation. That expansion was rejected rather than trading deterministic
+allocation counts for unmeasured CPU or memory cost. Mixed fallback still
+benefits because its direct-binary cohorts use the optimized encoder.
+
+## Measured result
+
+Five exact repeats produced identical frame counts, wire bytes, codec work,
+SHA-256 output digests, accounting, and queue drainage.
+
+| Scenario | Room 2 | Room 8 | Room 16 |
+| --- | ---: | ---: | ---: |
+| Direct v3 MessagePack, before | 10.001 | 11.001 | 11.001 |
+| Direct v3 MessagePack, after | 5.001 | 6.001 | 6.001 |
+| Mixed MessagePack source, before | 18.001 | 37.001 | 37.001 |
+| Mixed MessagePack source, after | 18.001 | 28.001 | 28.001 |
+
+The direct-binary encoder performs zero measured output reallocations after the
+change. Allocated bytes per relay fell from 2,585–3,825 to 1,581–2,821 across
+the direct cells and by 8–9% in the mixed 8-/16-player cells.
+
+The uninstrumented Criterion comparison is recorded as inconclusive rather
+than converted into a release claim. Sequential whole-suite runs showed
+significant drift in unchanged controls (JSON room 8/16 slowed by 23%/17% and
+the mixed room-two negative control slowed by 6%). Target cells moved in both
+directions across reruns. P29 therefore relies on deterministic allocation
+evidence and exact wire ledgers; machine-sensitive timing remains observational.
+
+## Verification
+
+- Frozen v2 and v3 binary wire golden tests pass for all three encodings.
+- The allocation matrix passes all nine checked-in operation, reallocation,
+  and allocated-byte ceilings across five exact local repeats. A dedicated
+  required `CI / Relay Allocation Ceilings` job now enforces the same harness
+  on the pinned Linux toolchain for every push and pull request.
+- Exact pre/post Criterion comparisons cover the same production seam at 2,
+  8, and 16 players; unchanged-control drift is disclosed above and no runtime
+  conclusion is claimed.
+- `cargo fmt --check`, strict all-target/all-feature Clippy, the full
+  all-feature test suite, `cargo deny`, the 298-test CI policy target, document
+  consistency, MSRV consistency, workflow hygiene, tooling parity, LLM policy,
+  hook readiness, and both worktree hook suites pass locally.
+- Two adversarial passes found and resolved fallible-allocation, measurement,
+  byte/reallocation coverage, boundary-test, documentation, and required-check
+  contract gaps. The final confirmation pass reported zero remaining diff
+  issues; hosted CI and GitHub reviewer evidence remain pending publication.
+
+## Follow-up
+
+Issue #207 remains an open measured-optimization umbrella rather than being
+declared exhausted. Issue #239 tracks the next bounded milestone: deterministic
+TURN-only WebRTC interoperability through pinned local coturn, including an
+exact data ledger and the live WebSocket fallback floor.

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -894,6 +894,7 @@ fn encode_named_binary_frame<T: Serialize>(
 
     let capacity = payload_len
         .checked_add(ENVELOPE_HEADROOM)
+        .filter(|capacity| *capacity <= isize::MAX as usize)
         .ok_or_else(|| "binary frame capacity overflow".to_string())?;
     let mut bytes = Vec::new();
     bytes
@@ -1530,9 +1531,11 @@ mod tests {
 
     #[test]
     fn binary_frame_capacity_overflow_is_reported() {
-        let error = encode_named_binary_frame(&0_u8, usize::MAX)
-            .expect_err("capacity arithmetic overflow must fail before allocation");
-        assert!(error.contains("capacity overflow"));
+        for payload_len in [isize::MAX as usize, usize::MAX] {
+            let error = encode_named_binary_frame(&0_u8, payload_len)
+                .expect_err("capacity overflow must fail before allocation");
+            assert!(error.contains("capacity overflow"));
+        }
 
         let mut bytes = Vec::new();
         let error = FallibleVecWriter(&mut bytes)

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -3,8 +3,9 @@ use crate::protocol::{ErrorCode, GameDataEncoding, PlayerId, ServerMessage};
 use crate::server::EnhancedGameServer;
 use axum::extract::ws::{Message, WebSocket};
 use futures_util::SinkExt;
-use rmp_serde::{from_slice, to_vec_named};
+use rmp_serde::{encode::write_named, from_slice};
 use serde::Serialize;
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -810,7 +811,7 @@ impl<'a> BorrowedGameDataEnvelope<'a> {
 /// `{type, data}` envelope. The `ServerMessage::GameDataBinary` variant is only
 /// an *in-memory* carrier used to route the payload through the broadcast layer;
 /// `send_single_message` intercepts it and instead serializes this bare struct
-/// via `rmp_serde::to_vec_named` (see `encode_binary_game_data`). V2 JSON and
+/// via named MessagePack encoding (see `encode_binary_game_data`). V2 JSON and
 /// rkyv frames remain raw payload passthrough; the legacy MessagePack frame is
 /// retained only to preserve the frozen v2 wire contract.
 #[derive(Serialize)]
@@ -864,18 +865,66 @@ pub(super) fn encode_binary_game_data(
                 seq,
                 epoch,
             };
-            to_vec_named(&frame).map_err(|err| err.to_string())
+            encode_named_binary_frame(&frame, payload.len())
         }
         (None, None) => match encoding {
-            GameDataEncoding::MessagePack => to_vec_named(&LegacyBinaryGameDataFrame {
-                from_player,
-                encoding,
-                payload,
-            })
-            .map_err(|err| err.to_string()),
+            GameDataEncoding::MessagePack => encode_named_binary_frame(
+                &LegacyBinaryGameDataFrame {
+                    from_player,
+                    encoding,
+                    payload,
+                },
+                payload.len(),
+            ),
             GameDataEncoding::Json | GameDataEncoding::Rkyv => Ok(payload.to_vec()),
         },
         _ => Err("binary delivery seq and epoch must be present or absent together".to_string()),
+    }
+}
+
+/// Encode a named MessagePack envelope without repeatedly growing its output
+/// buffer. The opaque payload length is known and dominates relay frame size;
+/// 128 bytes covers the fixed field names, UUID, encoding, stamps, and
+/// MessagePack container headers.
+fn encode_named_binary_frame<T: Serialize>(
+    frame: &T,
+    payload_len: usize,
+) -> Result<Vec<u8>, String> {
+    const ENVELOPE_HEADROOM: usize = 128;
+
+    let capacity = payload_len
+        .checked_add(ENVELOPE_HEADROOM)
+        .ok_or_else(|| "binary frame capacity overflow".to_string())?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .map_err(|_| "failed to reserve binary frame capacity".to_string())?;
+    write_named(&mut FallibleVecWriter(&mut bytes), frame).map_err(|err| err.to_string())?;
+    Ok(bytes)
+}
+
+/// Preserve rmp-serde's fallible allocation behavior while supplying a
+/// pre-sized output vector. Writing directly to `Vec<u8>` would use its
+/// infallible `Write` implementation if fixed envelope headroom ever became
+/// insufficient.
+struct FallibleVecWriter<'a>(&'a mut Vec<u8>);
+
+impl Write for FallibleVecWriter<'_> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.write_all(buffer)?;
+        Ok(buffer.len())
+    }
+
+    fn write_all(&mut self, buffer: &[u8]) -> std::io::Result<()> {
+        self.0
+            .try_reserve(buffer.len())
+            .map_err(|_| std::io::ErrorKind::OutOfMemory)?;
+        self.0.extend_from_slice(buffer);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 
@@ -1406,6 +1455,72 @@ mod tests {
                 "epoch": 3
             }),
             "v3 binary frame field-name/casing drift (BREAKING v3 wire change?)"
+        );
+    }
+
+    #[test]
+    fn binary_game_data_encoder_matches_named_encoding_at_bin_boundaries() {
+        for payload_len in [0, 255, 256, 65_535, 65_536] {
+            let payload = vec![0xa5; payload_len];
+            let legacy = LegacyBinaryGameDataFrame {
+                from_player: player_a(),
+                encoding: GameDataEncoding::MessagePack,
+                payload: &payload,
+            };
+            assert_eq!(
+                encode_binary_game_data(
+                    player_a(),
+                    GameDataEncoding::MessagePack,
+                    &payload,
+                    None,
+                    None,
+                )
+                .expect("preallocated legacy binary encode"),
+                rmp_serde::to_vec_named(&legacy).expect("reference legacy binary encode"),
+                "legacy payload length {payload_len} changed named MessagePack bytes"
+            );
+
+            for encoding in [
+                GameDataEncoding::Json,
+                GameDataEncoding::MessagePack,
+                GameDataEncoding::Rkyv,
+            ] {
+                let v3 = V3BinaryGameDataFrame {
+                    from_player: player_a(),
+                    encoding,
+                    payload: &payload,
+                    seq: u64::MAX,
+                    epoch: u32::MAX,
+                };
+                assert_eq!(
+                    encode_binary_game_data(
+                        player_a(),
+                        encoding,
+                        &payload,
+                        Some(u64::MAX),
+                        Some(u32::MAX),
+                    )
+                    .expect("preallocated v3 binary encode"),
+                    rmp_serde::to_vec_named(&v3).expect("reference v3 binary encode"),
+                    "v3 {encoding:?} payload length {payload_len} changed named MessagePack bytes"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn binary_frame_capacity_overflow_is_reported() {
+        let error = encode_named_binary_frame(&0_u8, usize::MAX)
+            .expect_err("capacity arithmetic overflow must fail before allocation");
+        assert!(error.contains("capacity overflow"));
+    }
+
+    #[test]
+    fn binary_frame_growth_preserves_named_encoding() {
+        let body = "x".repeat(256);
+        assert_eq!(
+            encode_named_binary_frame(&body, 0).expect("fallible growth encode"),
+            rmp_serde::to_vec_named(&body).expect("reference growth encode")
         );
     }
 

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -909,6 +909,28 @@ fn encode_named_binary_frame<T: Serialize>(
 /// insufficient.
 struct FallibleVecWriter<'a>(&'a mut Vec<u8>);
 
+impl FallibleVecWriter<'_> {
+    fn reserve_for_write(&mut self, additional_len: usize) -> std::io::Result<()> {
+        let required_len = self
+            .0
+            .len()
+            .checked_add(additional_len)
+            .filter(|required_len| *required_len <= isize::MAX as usize)
+            .ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "binary frame capacity overflow",
+                )
+            })?;
+        if required_len > self.0.capacity() {
+            self.0
+                .try_reserve_exact(additional_len)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::OutOfMemory, error))?;
+        }
+        Ok(())
+    }
+}
+
 impl Write for FallibleVecWriter<'_> {
     fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
         self.write_all(buffer)?;
@@ -916,9 +938,7 @@ impl Write for FallibleVecWriter<'_> {
     }
 
     fn write_all(&mut self, buffer: &[u8]) -> std::io::Result<()> {
-        self.0
-            .try_reserve(buffer.len())
-            .map_err(|_| std::io::ErrorKind::OutOfMemory)?;
+        self.reserve_for_write(buffer.len())?;
         self.0.extend_from_slice(buffer);
         Ok(())
     }
@@ -1513,6 +1533,13 @@ mod tests {
         let error = encode_named_binary_frame(&0_u8, usize::MAX)
             .expect_err("capacity arithmetic overflow must fail before allocation");
         assert!(error.contains("capacity overflow"));
+
+        let mut bytes = Vec::new();
+        let error = FallibleVecWriter(&mut bytes)
+            .reserve_for_write(usize::MAX)
+            .expect_err("writer length overflow must not be reported as allocation failure");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(error.to_string().contains("capacity overflow"));
     }
 
     #[test]

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -899,7 +899,7 @@ fn encode_named_binary_frame<T: Serialize>(
     let mut bytes = Vec::new();
     bytes
         .try_reserve_exact(capacity)
-        .map_err(|_| "failed to reserve binary frame capacity".to_string())?;
+        .map_err(|error| format!("failed to reserve binary frame capacity: {error}"))?;
     write_named(&mut FallibleVecWriter(&mut bytes), frame).map_err(|err| err.to_string())?;
     Ok(bytes)
 }

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1882,10 +1882,13 @@ fn test_ci_quick_check_gate_guards_expensive_jobs() {
 fn test_ci_enforces_relay_allocation_ceilings() {
     let root = repo_root();
     let workflow = read_live_file(&root.join(".github/workflows/ci.yml"));
+    let job = extract_workflow_job_block(&workflow, "relay-allocations")
+        .expect("ci.yml must define the relay-allocations job");
+    let normalized_job = job.split_whitespace().collect::<Vec<_>>().join(" ");
 
     assert!(
-        workflow.contains(
-            "cargo bench --locked --bench relay_serialization_allocations\n          --features allocation-tracking"
+        normalized_job.contains(
+            "cargo bench --locked --bench relay_serialization_allocations --features allocation-tracking"
         ),
         "ci.yml must execute the deterministic production-seam allocation benchmark with its \
          required feature and locked graph"

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1152,6 +1152,7 @@ fn validate_workflow_has_required_jobs(
 //   - CI / Nextest (ubuntu-latest)
 //   - CI / Nextest (windows-latest)
 //   - CI / Nextest (macos-latest)
+//   - CI / Relay Allocation Ceilings
 //   - CI / Dependency Audit
 //   - CI / MSRV Verification
 //   - CI / Docker Build
@@ -1186,6 +1187,11 @@ const REQUIRED_CI_JOBS: &[(&str, &str, &str)] = &[
         "nextest",
         "Nextest (${{ matrix.os }})",
         "Cross-OS test execution via cargo-nextest",
+    ),
+    (
+        "relay-allocations",
+        "Relay Allocation Ceilings",
+        "Deterministic production-seam allocation ceilings",
     ),
     (
         "deny",
@@ -1302,6 +1308,7 @@ const REQUIRED_CHECK_NAMES: &[&str] = &[
     "CI / Nextest (ubuntu-latest)",
     "CI / Nextest (windows-latest)",
     "CI / Nextest (macos-latest)",
+    "CI / Relay Allocation Ceilings",
     "CI / Dependency Audit",
     "CI / Audit (cargo-audit)",
     "CI / MSRV Verification",
@@ -1857,7 +1864,7 @@ fn test_ci_quick_check_gate_guards_expensive_jobs() {
     // Every expensive compile/test job must wait on the gate. `needs:` is declared
     // in the first few lines of a job block, so a bounded window after the header
     // is sufficient and avoids brittle full-block parsing.
-    for job in ["lint", "nextest", "msrv", "coverage"] {
+    for job in ["lint", "nextest", "relay-allocations", "msrv", "coverage"] {
         let header = format!("\n  {job}:");
         let start = workflow
             .find(&header)
@@ -1869,6 +1876,20 @@ fn test_ci_quick_check_gate_guards_expensive_jobs() {
              start until the fail-fast gate passes."
         );
     }
+}
+
+#[test]
+fn test_ci_enforces_relay_allocation_ceilings() {
+    let root = repo_root();
+    let workflow = read_live_file(&root.join(".github/workflows/ci.yml"));
+
+    assert!(
+        workflow.contains(
+            "cargo bench --locked --bench relay_serialization_allocations\n          --features allocation-tracking"
+        ),
+        "ci.yml must execute the deterministic production-seam allocation benchmark with its \
+         required feature and locked graph"
+    );
 }
 
 #[test]
@@ -20885,6 +20906,7 @@ const SCHEDULE_EXCLUSION_GUARD: &str = "github.event_name != 'schedule'";
 const SCHEDULE_EXCLUDED_CI_JOBS: &[&str] = &[
     "lint",
     "nextest",
+    "relay-allocations",
     "msrv",
     "docker",
     "coverage",

--- a/tests/v2_wire_golden.rs
+++ b/tests/v2_wire_golden.rs
@@ -6,9 +6,9 @@
 //!
 //! Two wire formats are locked here, matching production serialization:
 //! - JSON via `serde_json` (the default text-frame encoding).
-//! - MessagePack via `rmp_serde::to_vec_named` (matches the binary send path in
-//!   `src/websocket/sending.rs`, which uses `to_vec_named` so map keys are
-//!   field-named, not positional).
+//! - Named MessagePack via `rmp_serde::to_vec_named` (equivalent to the
+//!   production relay envelope's `rmp_serde::encode::write_named`, so map keys
+//!   are field-named rather than positional).
 //!
 //! Assertion strategy:
 //! - JSON: assert structural equality against a `serde_json::Value` built with
@@ -133,8 +133,8 @@ fn hex(bytes: &[u8]) -> String {
     out
 }
 
-/// Assert that `value` serializes via `rmp_serde::to_vec_named` (production
-/// binary path) to exactly the hex-encoded `expected_hex` bytes.
+/// Assert that `value` serializes via named MessagePack to exactly the
+/// hex-encoded `expected_hex` bytes.
 fn assert_msgpack<T: Serialize>(value: &T, expected_hex: &str) {
     let bytes = rmp_serde::to_vec_named(value).expect("msgpack bytes");
     let actual_hex = hex(&bytes);

--- a/tests/v3_reliability_wire_golden.rs
+++ b/tests/v3_reliability_wire_golden.rs
@@ -12,8 +12,9 @@
 //!
 //! - JSON: structural equality against a `json!` value AND a raw-string
 //!   assertion to catch field-name / casing / ordering drift.
-//! - MessagePack via `rmp_serde::to_vec_named` (the production binary path):
-//!   exact bytes via a hex helper.
+//! - Named MessagePack via `rmp_serde::to_vec_named` (equivalent to the
+//!   production relay envelope's `rmp_serde::encode::write_named`): exact
+//!   bytes via a hex helper.
 //!
 //! The physical v3 binary metadata envelope (which is NOT this enum's envelope)
 //! is frozen for every payload encoding by unit tests in
@@ -100,8 +101,8 @@ fn hex(bytes: &[u8]) -> String {
     out
 }
 
-/// Assert that `value` serializes via `rmp_serde::to_vec_named` (production
-/// binary path) to exactly the hex-encoded `expected_hex` bytes.
+/// Assert that `value` serializes via named MessagePack to exactly the
+/// hex-encoded `expected_hex` bytes.
 fn assert_msgpack<T: Serialize>(value: &T, expected_hex: &str) {
     let bytes = rmp_serde::to_vec_named(value).expect("msgpack bytes");
     let actual_hex = hex(&bytes);

--- a/tests/v3_wire_properties.rs
+++ b/tests/v3_wire_properties.rs
@@ -8,8 +8,8 @@
 //! - `Signal` (client->server and server->client) must round-trip ARBITRARY
 //!   opaque JSON payloads through both wire encodings the server speaks:
 //!   JSON text frames (`serde_json`) and MessagePack binary frames
-//!   (`rmp_serde::to_vec_named`, the production encoder in
-//!   `src/websocket/sending.rs`). The server never inspects `signal`
+//!   (`rmp_serde::to_vec_named`, equivalent to production's named MessagePack
+//!   relay encoding). The server never inspects `signal`
 //!   (ADR-0002), so payload fidelity is the entire contract.
 //!
 //!   FINDING (pinned, not papered over): with the default serde_json feature
@@ -183,8 +183,8 @@ fn json_roundtrip<T: serde::Serialize + serde::de::DeserializeOwned>(value: &T) 
     serde_json::from_str(&encoded).expect("JSON round-trip decodes")
 }
 
-/// MessagePack round trip via `to_vec_named`, the production binary encoder
-/// (`src/websocket/sending.rs`); `from_slice` is the production decoder.
+/// MessagePack round trip via named encoding, equivalent to the production
+/// relay encoder; `from_slice` is the production decoder.
 fn msgpack_roundtrip<T: serde::Serialize + serde::de::DeserializeOwned>(value: &T) -> T {
     let encoded = rmp_serde::to_vec_named(value).expect("MessagePack-encodes");
     rmp_serde::from_slice(&encoded).expect("MessagePack round-trip decodes")


### PR DESCRIPTION
## Summary

- pre-size named MessagePack relay envelopes from the known opaque payload length while preserving fallible allocation behavior
- freeze exact v2/v3 wire equivalence at MessagePack binary-header boundaries and exercise overflow/growth paths
- enforce per-scenario allocation-operation, reallocation, and allocated-byte ceilings in a required Linux CI job
- document the deterministic evidence and explicitly treat noisy sequential Criterion timing as inconclusive

## Measured result

Across 1,024-relay samples at room sizes 2, 8, and 16:

- direct protocol-v3 MessagePack: **10–11 → 5–6** allocation operations per relay
- direct output reallocations: **0**
- direct allocated bytes: **26–39% lower**
- mixed-format rooms 8/16: **37 → 28** allocation operations per relay and **8–9% fewer** allocated bytes
- emitted wire bytes, frame counts, codec work, SHA-256 digests, and queue drainage remain identical

Advances #207. Issue #207 remains open as the measured-optimization umbrella.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- all nine allocation ceiling cells across five exact local repeats
- frozen v2/v3 wire goldens and v3 wire properties
- full `ci_config_tests`, doc consistency, MSRV consistency, workflow hygiene, tooling parity, LLM policy, and hook suites
- two adversarial review passes; final pass found zero remaining diff issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path relay serialization and fallible allocation behavior on every MessagePack binary frame; wire equivalence is heavily tested but this is production WebSocket send-path logic with new CI ceilings that will fail if allocation regresses.
> 
> **Overview**
> Named MessagePack binary relay envelopes now **pre-size** the output buffer from opaque payload length plus fixed headroom, using **`write_named`** through a fallible **`Vec`** writer instead of **`to_vec_named`**. That cuts measured allocation operations on direct v3 MessagePack relays from about **10–11 to 5–6** per relay and mixed 8/16-player rooms from **37 to 28**, with **zero** measured output reallocations on the direct-binary path and **26–39%** lower allocated bytes there; **wire bytes stay identical**.
> 
> The allocation benchmark now **asserts** per-scenario operation, reallocation, and byte ceilings for all nine JSON / direct MessagePack / mixed cells, and CI adds a required **`Relay Allocation Ceilings`** job (after **`quick-check`**) running that harness with **`allocation-tracking`**. Policy tests and docs record the new required check and schedule exclusion.
> 
> Unit tests pin **byte equivalence** to reference **`to_vec_named`** at payload size boundaries, distinguish **capacity overflow** from **allocator failure** on reserve/growth, and changelog documents the optimization (#207).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a14ea63072fa3465f28949e035b49e54bc0ca8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->