### PR TITLE
Reuse v2 relay payloads and refresh nightly analysis

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ FROM mcr.microsoft.com/devcontainers/rust:2-bookworm
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG TARGETARCH
+ARG RUST_NIGHTLY=nightly-2026-08-01
 ARG ACTIONLINT_VERSION=1.7.12
 ARG ACTIONLINT_AMD64_SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
 ARG ACTIONLINT_ARM64_SHA256=325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6
@@ -139,7 +140,7 @@ RUN rustup component add \
 # Nightly toolchain — required only to RUN the coverage-guided fuzz crate
 # (fuzz/, libFuzzer needs -Zsanitizer). Kept minimal and out of the pinned
 # stable build path; see ADR-0003 and fuzz/README.md.
-RUN rustup toolchain install nightly --profile minimal --component rust-src
+RUN rustup toolchain install "$RUST_NIGHTLY" --profile minimal --component rust-src
 
 # Increase Cargo resilience for transient network failures during no-cache image builds.
 ENV CARGO_NET_RETRY=10

--- a/.github/workflows/ci-safety.yml
+++ b/.github/workflows/ci-safety.yml
@@ -29,8 +29,8 @@
 #   unstable compiler internals and runtime instrumentation that are not
 #   available on the stable channel.
 #
-#   Nightly Version: nightly-2026-02-01
-#   Last Updated: 2026-02-22
+#   Nightly Version: nightly-2026-08-01
+#   Last Updated: 2026-08-02
 #
 #   Update Criteria (when to update this nightly version):
 #     - If the nightly version is >6 months old
@@ -121,7 +121,7 @@ jobs:
       - name: Install Rust nightly toolchain with Miri
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2026-02-01
+          toolchain: nightly-2026-08-01
           components: miri, rust-src
 
       - name: Cache Rust dependencies
@@ -135,7 +135,7 @@ jobs:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
       - name: Setup Miri
-        run: cargo +nightly-2026-02-01 miri setup
+        run: cargo +nightly-2026-08-01 miri setup
 
       - name: Run Miri on library tests
         # Isolation is disabled so the interpreter services wall-clock
@@ -154,7 +154,7 @@ jobs:
           echo "Note: Integration tests are excluded because they use networking,"
           echo "async runtimes, and OS-level I/O that Miri cannot interpret."
           echo "CARGO_TARGET_DIR: ${CARGO_TARGET_DIR:-<default>}"
-          cargo +nightly-2026-02-01 miri test --locked --lib --no-fail-fast 2>&1 | tee miri-output.txt
+          cargo +nightly-2026-08-01 miri test --locked --lib --no-fail-fast 2>&1 | tee miri-output.txt
           echo "Miri analysis complete."
 
       - name: Diagnose Miri failures
@@ -220,7 +220,7 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2026-02-01
+          toolchain: nightly-2026-08-01
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2.9.1
@@ -275,7 +275,7 @@ jobs:
           echo "stack buffer overflow, and memory leaks."
           echo "CARGO_TARGET_DIR: ${CARGO_TARGET_DIR:-<default>}"
           RUSTFLAGS="-Z sanitizer=address" \
-            cargo +nightly-2026-02-01 test --locked --target x86_64-unknown-linux-gnu \
+            cargo +nightly-2026-08-01 test --locked --target x86_64-unknown-linux-gnu \
             --all-features --no-fail-fast 2>&1 | tee asan-output.txt
           echo "AddressSanitizer analysis complete."
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       # The fuzz crate is a SEPARATE workspace (fuzz/, out-of-tree per ADR-0003),
       # so the check above never sees it — which let an E1 `register_disconnection`
       # signature change break `fuzz_reconnect_tokens` undetected (fuzz.yml only
-      # runs on narrow paths and builds two other targets). Type-check every fuzz
+      # runs on narrow paths). Type-check every fuzz
       # target here against current library code on every PR. This is a no-codegen
       # `check` (no libFuzzer/sanitizer), so the pinned stable toolchain suffices;
       # the nightly build/run stays in fuzz.yml. The standalone lockfile is

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,9 +3,9 @@
 # The NIGHTLY counterpart to the stable in-suite proptest fuzzer
 # (tests/protocol_fuzz_hardening.rs, run on every `cargo test`). This job builds
 # the out-of-workspace fuzz crate (fuzz/) on the nightly toolchain and smoke-runs
-# each target for a bounded time, seeded from the canonical wire samples. A
-# crash (panic/abort/overflow on the decode or validation surface) fails the job
-# and uploads the reproducing artifact.
+# each target for a bounded time, with protocol decoding seeded from canonical
+# wire samples. A crash or failed state-machine assertion fails the job and
+# uploads the reproducing artifact.
 #
 # Kept off the stable toolchain and out of the workspace so it never perturbs the
 # pinned-stable build (ADR-0003); see fuzz/README.md.
@@ -27,8 +27,9 @@ on:
     paths:
       - "fuzz/**"
       - ".github/workflows/fuzz.yml"
-      - "src/protocol/**"
-      - "src/websocket/token_binding.rs"
+      - "Cargo.toml"
+      - "build.rs"
+      - "src/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -45,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [decode_protocol, validate_inputs]
+        target: [decode_protocol, validate_inputs, fuzz_session_machine, fuzz_reconnect_tokens]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -56,7 +57,8 @@ jobs:
       #   are not available on the pinned stable MSRV. Production artifacts are never
       #   built with nightly (ADR-0003); this nightly is CI-only, for the fuzz crate.
       #
-      #   Nightly Version: nightly-2026-02-01 (kept in sync with unused-deps.yml)
+      #   Nightly Version: nightly-2026-08-01 (kept in sync with unused-deps.yml)
+      #   Last Updated: 2026-08-02
       #
       #   Update Criteria (when to bump this pin):
       #     - If the nightly version is >6 months old
@@ -68,7 +70,7 @@ jobs:
       - name: Install nightly Rust toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2026-02-01
+          toolchain: nightly-2026-08-01
           # Explicitly add the gnu std target for this nightly. The runner is a
           # gnu host (so gnu std is already present via the host toolchain), but
           # pin it here so the `--target x86_64-unknown-linux-gnu` build below is
@@ -76,7 +78,7 @@ jobs:
           targets: x86_64-unknown-linux-gnu
 
       - name: Verify locked fuzz dependency graph
-        run: cargo +nightly-2026-02-01 metadata --manifest-path fuzz/Cargo.toml --locked --format-version 1 >/dev/null
+        run: cargo +nightly-2026-08-01 metadata --manifest-path fuzz/Cargo.toml --locked --format-version 1 >/dev/null
 
       - name: Cache cargo build
         uses: Swatinem/rust-cache@v2.9.1
@@ -116,7 +118,7 @@ jobs:
         # remove. cargo-fuzz rejects `--locked`; the locked metadata preflight
         # above therefore guards the committed graph before this build starts.
         run: |
-          cargo +nightly-2026-02-01 fuzz run ${{ matrix.target }} \
+          cargo +nightly-2026-08-01 fuzz run ${{ matrix.target }} \
             --target x86_64-unknown-linux-gnu -- \
             -max_total_time="${MAX_TOTAL_TIME}" -max_len=65536
 

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -21,8 +21,8 @@
 #   cargo-udeps requires nightly Rust because it uses unstable compiler features
 #   to analyze dependency usage at a deeper level than stable tools can provide.
 #
-#   Nightly Version: nightly-2026-02-01
-#   Last Updated: 2026-02-22
+#   Nightly Version: nightly-2026-08-01
+#   Last Updated: 2026-08-02
 #
 #   Update Criteria (when to update this nightly version):
 #     - If the nightly version is >6 months old
@@ -82,7 +82,7 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2026-02-01
+          toolchain: nightly-2026-08-01
           components: rustc
 
       - name: Cache Rust dependencies
@@ -113,7 +113,7 @@ jobs:
       - name: Install Rust nightly toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly-2026-02-01
+          toolchain: nightly-2026-08-01
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2.9.1
@@ -124,11 +124,11 @@ jobs:
         uses: actions/cache@v6.1.0
         with:
           path: ~/.cargo/bin/cargo-udeps
-          key: ${{ runner.os }}-cargo-udeps-0.1.53
+          key: ${{ runner.os }}-cargo-udeps-0.1.61-nightly-2026-08-01
 
       - name: Install cargo-udeps
         if: steps.cache-udeps.outputs.cache-hit != 'true'
-        run: cargo install cargo-udeps --version 0.1.53 --locked
+        run: cargo +nightly-2026-08-01 install cargo-udeps --version 0.1.61 --locked
 
       - name: Check for unused dependencies (udeps)
         # Note: continue-on-error is enabled because cargo-udeps may report
@@ -137,5 +137,5 @@ jobs:
         #   - Platform-specific dependencies (cfg-gated)
         #   - Build dependencies used only in build.rs
         # Always review udeps output manually before removing dependencies.
-        run: cargo +nightly-2026-02-01 udeps --locked --all-targets
+        run: cargo +nightly-2026-08-01 udeps --locked --all-targets --all-features
         continue-on-error: true

--- a/.llm/skills/ci-cd-troubleshooting/references/ecosystem-and-toolchains.md
+++ b/.llm/skills/ci-cd-troubleshooting/references/ecosystem-and-toolchains.md
@@ -116,7 +116,7 @@ error[E0658]: use of unstable library feature 'foo'
 # CORRECT: Recent nightly (within last 30 days)
 - uses: dtolnay/rust-toolchain@v1
   with:
-    toolchain: nightly-2026-02-01  # recent, acceptable
+    toolchain: nightly-2026-08-01  # recent, acceptable
 ```
 
 For stable MSRV issues, see [MSRV Management](../../msrv-management/SKILL.md).

--- a/.llm/skills/ci-cd-troubleshooting/references/example-stale-nightly-toolchain.md
+++ b/.llm/skills/ci-cd-troubleshooting/references/example-stale-nightly-toolchain.md
@@ -22,7 +22,7 @@ Pinned nightly was not refreshed as dependency and compiler expectations evolved
 ## Resolution
 
 Update pinned nightly to a current validated baseline, for example:
-`nightly-2026-02-01`.
+`nightly-2026-08-01`.
 
 ---
 

--- a/.llm/skills/rust-toolchains/references/nightly-toolchains.md
+++ b/.llm/skills/rust-toolchains/references/nightly-toolchains.md
@@ -9,9 +9,10 @@ See also:
 
 ## TL;DR
 
-- Nightly is **only** for CI-only analysis tools (cargo-udeps, Miri, AddressSanitizer)
+- Nightly is **only** for CI-only analysis tools (cargo-udeps, Miri,
+  AddressSanitizer, cargo-fuzz)
 - **Never** use nightly for production builds, Docker images, or release artifacts
-- Pin to a specific date (`nightly-2026-02-01`) for reproducibility — never use rolling `nightly`
+- Pin to a specific date (`nightly-2026-08-01`) for reproducibility — never use rolling `nightly`
 - Update the nightly pin when it is >6 months old or when upgraded dependencies need a newer nightly
 - Nightly version is **independent** of stable MSRV — update based on tool needs, not MSRV changes
 
@@ -40,9 +41,10 @@ See also:
 
 | Tool | Purpose | Workflow File | Nightly Version |
 |------|---------|--------------|----------------|
-| cargo-udeps | Unused dependency detection | `.github/workflows/unused-deps.yml` | nightly-2026-02-01 |
-| Miri | Undefined behavior detection | `.github/workflows/ci-safety.yml` | nightly-2026-02-01 |
-| AddressSanitizer | Memory error detection | `.github/workflows/ci-safety.yml` | nightly-2026-02-01 |
+| cargo-udeps | Unused dependency detection | `.github/workflows/unused-deps.yml` | nightly-2026-08-01 |
+| Miri | Undefined behavior detection | `.github/workflows/ci-safety.yml` | nightly-2026-08-01 |
+| AddressSanitizer | Memory error detection | `.github/workflows/ci-safety.yml` | nightly-2026-08-01 |
+| cargo-fuzz | Coverage-guided protocol fuzzing | `.github/workflows/fuzz.yml` | nightly-2026-08-01 |
 
 ---
 
@@ -50,7 +52,7 @@ See also:
 
 ### Pinning Strategy
 
-- Pin to a specific nightly date (e.g., `nightly-2026-02-01`)
+- Pin to a specific nightly date (e.g., `nightly-2026-08-01`)
 - Do NOT use rolling `nightly` (always latest)
 - Pinning provides reproducibility and stability
 
@@ -99,7 +101,7 @@ the pinned nightly date. The nightly toolchain is too old for the new version of
 toolchain: nightly-2025-02-21
 
 # ✅ CORRECT: Nightly date matches the dependency's release timeframe
-toolchain: nightly-2026-02-01
+toolchain: nightly-2026-08-01
 ```
 
 **Dependency upgrade checklist (nightly-sensitive deps):**
@@ -109,7 +111,8 @@ toolchain: nightly-2026-02-01
 - [ ] Run `cargo +nightly-YYYY-MM-DD check` locally before pushing
 - [ ] Update all workflow files that reference the nightly date
 
-The test `test_pinned_nightly_staleness_warning` catches nightlies older than 12 months.
+The test `test_pinned_nightly_staleness_warning` catches nightlies older than
+180 days, matching the six-month workflow-hygiene threshold.
 For earlier detection, verify nightly compatibility when upgrading nightly-sensitive dependencies.
 
 ---
@@ -120,18 +123,19 @@ For earlier detection, verify nightly compatibility when upgrading nightly-sensi
 
 ```text
 Production Code (Stable MSRV)
-  → rust-version = "1.88.0" in Cargo.toml
+  → rust-version = "1.89.0" in Cargo.toml
   → Used for: Building binaries, Docker images, production artifacts
 
 CI Analysis Tools (Nightly)
-  → nightly-2026-02-01 in workflow files  ← Independent of MSRV
-  → Used for: cargo-udeps, cargo-miri (analysis only, no artifacts)
+  → nightly-2026-08-01 in workflow files  ← Independent of MSRV
+  → Used for: cargo-udeps, Miri, AddressSanitizer, cargo-fuzz
+  → Produces diagnostics and crash artifacts, never production artifacts
 ```
 
 **Common Confusion (Avoid):**
 
 - "Nightly must be newer than MSRV" (incorrect)
-- "If MSRV is 1.88, nightly must be from after 1.88 release" (incorrect)
+- "If MSRV is 1.89, nightly must be from after 1.89 release" (incorrect)
 - "Nightly is for CI tools only; MSRV is for production code" (correct)
 - "Update nightly based on staleness/tool needs, not MSRV changes" (correct)
 
@@ -162,8 +166,8 @@ Every nightly usage **must** be documented in the workflow file:
 # cargo-udeps requires nightly Rust because it uses unstable compiler features
 # to analyze dependency usage at a deeper level than stable tools can provide.
 #
-# Nightly Version: nightly-2026-02-01
-# Last Updated: 2026-02-22
+# Nightly Version: nightly-2026-08-01
+# Last Updated: 2026-08-02
 #
 # Update Criteria (when to update this nightly version):
 #   - If the nightly version is >6 months old
@@ -182,7 +186,7 @@ Every nightly usage **must** be documented in the workflow file:
 ## Agent Workflow: Nightly Version Updates
 
 1. Verify nightly is still needed: check if the tool still requires nightly
-2. Choose a recent nightly: within last 30 days (e.g., `nightly-2026-02-01`)
+2. Choose a recent nightly: within last 30 days (e.g., `nightly-2026-08-01`)
 3. Update **all occurrences** in the workflow file
 4. Update documentation (change "Last Updated: YYYY-MM-DD" comment)
 5. Ensure workflow file has comprehensive comments explaining why nightly is needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reduce memory-allocation work for frozen-v2 JSON and Rkyv binary relays
+  (issue #207). The server now removes one allocation operation in two-player
+  rooms, two in 8-/16-player rooms, and one payload-sized copy per relay:
+  measured
+  operations fall from 4 to 3 for two-player rooms and from 6 to 4 for 8-/
+  16-player rooms, while allocated bytes fall by 38–70%. Exact wire bytes,
+  delivery accounting, queue drainage, and the v3/MessagePack paths are
+  unchanged.
+- Refresh the pinned nightly analysis toolchain and its local documentation
+  (issue #243). Miri, AddressSanitizer, cargo-udeps, and cargo-fuzz now use
+  `nightly-2026-08-01`; cargo-udeps 0.1.61 validates all targets and features,
+  the fuzz workflow smoke-runs all four declared targets, and policy tests
+  prevent partial pin or fuzz-matrix updates.
 - Reduce binary relay serialization allocation operations by pre-sizing the
   MessagePack envelope from the known opaque payload length (issue #207).
   Direct protocol-v3 binary relays now use 5–6 allocation operations instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,6 @@ checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1083,7 +1082,6 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -2793,7 +2791,6 @@ dependencies = [
  "criterion",
  "dashmap",
  "fastrand",
- "futures",
  "futures-util",
  "getrandom 0.4.3",
  "hdrhistogram",
@@ -2826,7 +2823,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-test",
  "tokio-tungstenite",
  "tower-http 0.7.0",
  "tracing",
@@ -3133,17 +3129,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tokio-test"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6d24790a10a7af737693a3e8f1d03faef7e6ca0cc99aae5066f533766de545"
-dependencies = [
- "futures-core",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,6 @@ rustls = { version = "0.23", default-features = true, optional = true }
 rustls-pki-types = { version = "1.14", optional = true }
 
 [dev-dependencies]
-tokio-test = "0.4"
 # Test-only tokio feature additions (feature-unified with the main dependency
 # for test builds only): `process` drives the spawned server binary in
 # tests/v3_multiprocess_e2e.rs; `test-util` enables the paused-clock runtime
@@ -135,7 +134,6 @@ tokio = { version = "1.52", features = ["process", "test-util"] }
 tempfile = "3.27"
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
-futures = "0.3"
 regex = "1.12"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 reqwest = { version = "0.13", default-features = false, features = [

--- a/benches/relay_serialization_allocations.rs
+++ b/benches/relay_serialization_allocations.rs
@@ -80,6 +80,9 @@ fn print_sample(scenario: Scenario, room_size: usize, sample: &Sample) {
 fn assert_allocation_ceiling(scenario: Scenario, room_size: usize, sample: &Sample) {
     let (maximum_operations_per_relay, maximum_reallocations_per_relay, maximum_bytes_per_relay) =
         match (scenario, room_size) {
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 2) => (3, 0, 425),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 8) => (4, 0, 1_345),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 16) => (4, 0, 1_665),
             (Scenario::V3JsonText, 2) => (8, 3, 2_587),
             (Scenario::V3JsonText, 8) => (9, 3, 3_507),
             (Scenario::V3JsonText, 16) => (9, 3, 3_827),

--- a/benches/support/relay_serialization.rs
+++ b/benches/support/relay_serialization.rs
@@ -28,13 +28,17 @@ const SENDER_ID: PlayerId = PlayerId::from_u128(0x2220);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Scenario {
+    V2JsonBinary,
+    V2RkyvBinary,
     V3JsonText,
     V3MessagePackBinary,
     MixedMessagePackSource,
 }
 
 impl Scenario {
-    pub const ALL: [Self; 3] = [
+    pub const ALL: [Self; 5] = [
+        Self::V2JsonBinary,
+        Self::V2RkyvBinary,
         Self::V3JsonText,
         Self::V3MessagePackBinary,
         Self::MixedMessagePackSource,
@@ -42,6 +46,8 @@ impl Scenario {
 
     pub const fn name(self) -> &'static str {
         match self {
+            Self::V2JsonBinary => "v2_json_binary",
+            Self::V2RkyvBinary => "v2_rkyv_binary",
             Self::V3JsonText => "v3_json_text",
             Self::V3MessagePackBinary => "v3_message_pack_binary",
             Self::MixedMessagePackSource => "mixed_message_pack_source",
@@ -277,6 +283,13 @@ impl Fixture {
         assert!(ledger.wire_bytes > 0, "wire ledger recorded no bytes");
 
         match self.scenario {
+            Scenario::V2JsonBinary | Scenario::V2RkyvBinary => {
+                assert_eq!(ledger.text_frames, 0);
+                assert_eq!(ledger.binary_frames, expected);
+                assert_eq!(ledger.json_encodes, 0);
+                assert_eq!(ledger.message_pack_encodes, 0);
+                assert_eq!(ledger.message_pack_decodes, 0);
+            }
             Scenario::V3JsonText => {
                 assert_eq!(ledger.text_frames, expected);
                 assert_eq!(ledger.binary_frames, 0);
@@ -330,6 +343,14 @@ impl Fixture {
 
 fn recipient_profile(scenario: Scenario, recipient_index: usize) -> RecipientProfile {
     match scenario {
+        Scenario::V2JsonBinary => RecipientProfile {
+            protocol_version: 2,
+            format: GameDataEncoding::Json,
+        },
+        Scenario::V2RkyvBinary => RecipientProfile {
+            protocol_version: 2,
+            format: GameDataEncoding::Rkyv,
+        },
         Scenario::V3JsonText => RecipientProfile {
             protocol_version: 3,
             format: GameDataEncoding::Json,
@@ -411,6 +432,22 @@ fn relay_message(scenario: Scenario, seq: u64) -> Arc<ServerMessage> {
         "tick": seq,
     });
     match scenario {
+        Scenario::V2JsonBinary | Scenario::V2RkyvBinary => {
+            let encoding = match scenario {
+                Scenario::V2JsonBinary => GameDataEncoding::Json,
+                Scenario::V2RkyvBinary => GameDataEncoding::Rkyv,
+                _ => unreachable!("matched v2 raw binary scenario"),
+            };
+            let payload =
+                serde_json::to_vec(&data).expect("representative payload must encode as raw bytes");
+            Arc::new(ServerMessage::GameDataBinary {
+                from_player: SENDER_ID,
+                encoding,
+                payload: payload.into(),
+                seq: Some(seq),
+                epoch: Some(1),
+            })
+        }
         Scenario::V3JsonText => Arc::new(ServerMessage::GameData {
             from_player: SENDER_ID,
             data,

--- a/docs/ci-cd-testing.md
+++ b/docs/ci-cd-testing.md
@@ -698,13 +698,12 @@ The repository includes an advanced safety analysis workflow
 to detect undefined behavior and memory errors that standard tests
 cannot catch.
 
-### Staged / Non-Required Status
+### Failure and Branch-Protection Status
 
-Both jobs use `continue-on-error: true` and are **not** branch-protection
-required checks. They produce actionable diagnostics uploaded as artifacts
-but do not block merges. This staged approach lets us observe failure
-patterns and toolchain stability before gating PRs on these heavyweight
-analyses.
+Miri is staged with `continue-on-error: true`; AddressSanitizer propagates
+failures to the workflow. Neither job is currently a branch-protection required
+check. Both upload actionable diagnostic artifacts so Miri can build an
+operational history while sanitizer regressions still make the workflow red.
 
 ### Jobs
 
@@ -721,7 +720,7 @@ analyses.
 
 ### Nightly Toolchain
 
-Both jobs require nightly Rust (pinned to `nightly-2026-02-01` for
+Both jobs require nightly Rust (pinned to `nightly-2026-08-01` for
 reproducibility). The nightly pin follows the same strategy as
 `unused-deps.yml` — see the workflow header comment for update criteria.
 
@@ -733,7 +732,8 @@ that Miri cannot interpret.
 
 ### Viewing Results
 
-Even when jobs pass (due to `continue-on-error`), output artifacts are always uploaded:
+Output artifacts are uploaded even when Miri reports findings under its staged
+`continue-on-error` policy, and when AddressSanitizer succeeds:
 
 - `miri-output` — Miri analysis output
 - `asan-output` — AddressSanitizer analysis output
@@ -748,20 +748,22 @@ These checks will be promoted to required branch-protection checks when:
 - No nightly toolchain incidents during that window
 - Median runtime stays within the timeout budget
 
-Until promotion, failures are informational and should be triaged weekly.
+Until promotion, Miri findings are informational and should be triaged weekly.
+AddressSanitizer failures already make the workflow fail even though the check
+is not yet required by branch protection.
 
 ### Tests That Enforce This
 
 | Test | What It Validates |
 |------|-------------------|
 | `test_ci_safety_workflow_has_required_jobs` | Both `miri` and `asan` jobs exist |
-| `test_ci_safety_workflow_jobs_are_staged` | All jobs have `continue-on-error: true` |
+| `test_ci_safety_workflow_failure_policy_is_explicit` | Miri is staged and AddressSanitizer is gating |
 | `test_ci_safety_workflow_uses_pinned_nightly` | Pinned nightly toolchain is used |
 | `test_ci_safety_workflow_has_required_triggers` | All four trigger types are present |
 | `test_ci_safety_workflow_uploads_artifacts` | Output artifacts are uploaded |
 | `test_ci_safety_jobs_not_in_required_check_names` | Jobs are NOT in required check names |
 | `test_ci_safety_workflow_artifact_uploads_always_run` | Upload steps use `if: always()` |
-| `test_nightly_version_consistency_across_workflows` | Nightly pins match across workflows |
+| `test_analysis_nightly_version_consistency` | Analysis workflows and the devcontainer share one nightly pin |
 
 ## Architecture Decisions
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -28,24 +28,32 @@ package.
 | ------ | ------- | ------------------ |
 | `decode_protocol` | `ClientMessage` / `ServerMessage` decode (serde_json + rmp-serde), then re-serialize | `assert_decoders_return` |
 | `validate_inputs` | `validate_{game_name,room_code,player_name}_with_config` over arbitrary UTF-8 | name/room-code validation property tests |
+| `fuzz_session_machine` | Structured room/session operation sequences against the in-process server | model-based state-machine tests |
+| `fuzz_reconnect_tokens` | Structured reconnect-token issue/claim/reuse/expiry sequences | reconnection property and integration tests |
 
-The invariant is the same as the stable suite's: **every decode/validate
-returns `Ok`/`Err` and never panics, aborts, or overflows the stack.** libFuzzer
-reports any crash as a finding.
+Every target must avoid panics, aborts, and stack overflows. The protocol and
+validation targets must also return `Ok`/`Err` for arbitrary input; the two
+state-machine targets assert their modeled room/session and reconnect-token
+invariants. libFuzzer reports any crash or failed assertion as a finding.
 
 ## Running
 
-Requires the nightly toolchain and `cargo-fuzz` (both provided in the dev
-container; install with `rustup toolchain install nightly` and
+Requires the pinned `nightly-2026-08-01` toolchain and `cargo-fuzz` (both
+provided in the dev container; install with
+`rustup toolchain install nightly-2026-08-01` and
 `cargo install cargo-fuzz`).
 
 ```bash
+# cargo-fuzz may itself be MUSL-linked, so always override its inferred target
+# with the pinned compiler's GNU host triple.
+FUZZ_TARGET="$(rustc +nightly-2026-08-01 -vV | sed -n 's/^host: //p')"
+
 # Build all targets (instrumented):
-cargo +nightly fuzz build
+cargo +nightly-2026-08-01 fuzz build --target "$FUZZ_TARGET"
 
 # Fuzz one target for 60s (CI smoke uses -max_total_time):
-cargo +nightly fuzz run decode_protocol -- -max_total_time=60
-cargo +nightly fuzz run validate_inputs -- -max_total_time=60
+cargo +nightly-2026-08-01 fuzz run decode_protocol --target "$FUZZ_TARGET" -- -max_total_time=60
+cargo +nightly-2026-08-01 fuzz run validate_inputs --target "$FUZZ_TARGET" -- -max_total_time=60
 ```
 
 ## Seeding the corpus
@@ -69,8 +77,9 @@ done
 A crash artifact lands in `artifacts/<target>/`. Reproduce and minimize:
 
 ```bash
-cargo +nightly fuzz run decode_protocol "artifacts/decode_protocol/crash-<hash>"
-cargo +nightly fuzz tmin decode_protocol "artifacts/decode_protocol/crash-<hash>"
+FUZZ_TARGET="$(rustc +nightly-2026-08-01 -vV | sed -n 's/^host: //p')"
+cargo +nightly-2026-08-01 fuzz run decode_protocol --target "$FUZZ_TARGET" "artifacts/decode_protocol/crash-<hash>"
+cargo +nightly-2026-08-01 fuzz tmin decode_protocol --target "$FUZZ_TARGET" "artifacts/decode_protocol/crash-<hash>"
 ```
 
 Any reproducible finding should be added as a regression case to the **stable**

--- a/fuzz/fuzz_targets/fuzz_session_machine.rs
+++ b/fuzz/fuzz_targets/fuzz_session_machine.rs
@@ -14,10 +14,10 @@
 //!
 //! Invariants, checked after EVERY op (any violation panics = a finding):
 //! - no panic anywhere in the handler paths (implicit);
-//! - the #131 delivery conservation law over `ServerMetrics`: every attempt
-//!   is exactly one of enqueued / channel-closed / dropped (all deliveries
-//!   are awaited inline by the handlers, so the ledger is settled at every
-//!   op boundary);
+//! - the #131 delivery conservation law over `ServerMetrics`: every resolved
+//!   attempt is enqueued, channel-closed, or intentionally canceled, while
+//!   slow-consumer drops provide the upper bound (the assertion uses bounded
+//!   polling so a transient snapshot can self-stabilize at an op boundary);
 //! - routing consistency: no player is ever a member of two rooms at once
 //!   (checked over every room this input has ever created).
 //!
@@ -39,7 +39,9 @@ use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio::time::Instant;
 use uuid::Uuid;
 
 /// Synthetic client pool size (ops address clients by index modulo this).
@@ -206,24 +208,48 @@ impl Harness {
         }
     }
 
-    /// The #131 conservation law: every delivery attempt resolved as exactly
-    /// one of enqueued / channel-closed / dropped. All handler deliveries are
-    /// awaited inline, so the ledger is settled between ops.
-    fn assert_conservation(&self) {
+    /// The #131 conservation law over the exported server-wide counters.
+    ///
+    /// Conditional attempts may be intentionally canceled before enqueue.
+    /// The drop counter also includes messages abandoned after enqueue when a
+    /// connection closes, so it supplies an upper bound rather than a fourth
+    /// mutually exclusive outcome. A snapshot can transiently be unbalanced at
+    /// an op boundary, so mirror the stable suite's bounded self-stabilization
+    /// poll without claiming every background task has fully quiesced.
+    async fn assert_conservation(&self) {
+        const QUIESCENCE_DEADLINE: Duration = Duration::from_secs(10);
+        const POLL_INTERVAL: Duration = Duration::from_millis(25);
+
         let metrics = self.server.metrics();
-        let attempts = metrics.websocket_delivery_attempts.load(Ordering::Relaxed);
-        let enqueued = metrics
-            .websocket_deliveries_enqueued
-            .load(Ordering::Relaxed);
-        let channel_closed = metrics
-            .websocket_deliveries_channel_closed
-            .load(Ordering::Relaxed);
-        let dropped = metrics.websocket_messages_dropped.load(Ordering::Relaxed);
-        assert_eq!(
-            attempts,
-            enqueued + channel_closed + dropped,
-            "delivery conservation violated: attempts={attempts} != \
-             enqueued={enqueued} + channel_closed={channel_closed} + dropped={dropped}"
+        let deadline = Instant::now() + QUIESCENCE_DEADLINE;
+        let (mut attempts, mut enqueued, mut channel_closed, mut canceled, mut dropped);
+        loop {
+            attempts = metrics.websocket_delivery_attempts.load(Ordering::Relaxed);
+            enqueued = metrics
+                .websocket_deliveries_enqueued
+                .load(Ordering::Relaxed);
+            channel_closed = metrics
+                .websocket_deliveries_channel_closed
+                .load(Ordering::Relaxed);
+            canceled = metrics
+                .websocket_deliveries_canceled
+                .load(Ordering::Relaxed);
+            dropped = metrics.websocket_messages_dropped.load(Ordering::Relaxed);
+
+            let resolved = enqueued + channel_closed + canceled;
+            if resolved <= attempts && attempts <= resolved + dropped {
+                return;
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+        panic!(
+            "delivery conservation violated (stable past the {QUIESCENCE_DEADLINE:?} quiescence \
+             deadline): expected enqueued + channel_closed + canceled <= attempts <= enqueued + \
+             channel_closed + canceled + dropped, got attempts={attempts} enqueued={enqueued} \
+             channel_closed={channel_closed} canceled={canceled} dropped={dropped}"
         );
     }
 
@@ -398,7 +424,7 @@ async fn run(plan: Plan) {
 
     for op in plan.ops.into_iter().take(MAX_OPS) {
         harness.apply(op).await;
-        harness.assert_conservation();
+        harness.assert_conservation().await;
         harness.assert_single_room_membership().await;
     }
 }

--- a/progress/session-077-v2-zero-copy-and-nightly-refresh.md
+++ b/progress/session-077-v2-zero-copy-and-nightly-refresh.md
@@ -60,6 +60,34 @@ complete run identified two genuinely unused direct dev-dependencies
 
 ## Validation and publication
 
-In progress. Final evidence will include the complete local gauntlet,
-adversarial review results, exact commit, hosted analysis step outcomes, all
-applicable workflow conclusions, and reviewer state.
+PR #244 carries three coherent implementation/fix commits through reviewed
+implementation head `b189b45d5733d339b230daa0444c9c80fee75df3`.
+
+Local validation completed successfully:
+
+- `cargo fmt --check`, strict all-target/all-feature Clippy, and the complete
+  locked all-feature test suite;
+- all 15 allocation-ceiling cells, with five exact repeats per cell;
+- all four fuzz targets on `aarch64-unknown-linux-gnu`, including saved-crash
+  replay and a fresh session-machine corpus;
+- exact pinned Miri (470 passed, 198 ignored) and cargo-udeps with zero findings;
+- cargo-deny plus CI, workflow, toolchain, documentation, LLM-policy, and both
+  hook preflight suites; and
+- three independent adversarial-review rounds followed by a zero-finding final
+  review.
+
+Hosted validation on that exact head completed with 19 successful workflows
+and the expected Dependabot auto-merge skip. Main CI's 16 jobs all passed,
+including MSRV, three-platform lint/Nextest, coverage, Docker, dependency
+audits, and the relay allocation ceilings. Verification Nightly's seven
+substantive jobs passed. Advanced Safety's actual Miri and AddressSanitizer test
+steps passed. Every declared fuzz target passed independently. The cold-cache
+cargo-udeps 0.1.61 install and its non-gating analysis step both concluded
+success, rather than relying on the enclosing job conclusion.
+
+The first hosted pass caught one MD044 error in this record; marking the
+`rust-src` component as code fixed it, and the exact local Markdown suite plus
+the rerun passed. Cursor Bugbot reviewed the latest head with zero findings and
+there are no review threads. GitHub Copilot was requested after every push but
+reported the reviewer's quota limit both times; the only available human is the
+PR author, whom GitHub correctly refuses as a self-review request.

--- a/progress/session-077-v2-zero-copy-and-nightly-refresh.md
+++ b/progress/session-077-v2-zero-copy-and-nightly-refresh.md
@@ -26,7 +26,7 @@ result is sufficient and no uncontaminated pre-change timing pair was recorded.
 ## Analysis nightly baseline
 
 The `nightly-2026-02-01` analysis pin was 182 days old. The replacement
-`nightly-2026-08-01` is available with Miri, rust-src, and x86_64 GNU standard
+`nightly-2026-08-01` is available with Miri, `rust-src`, and x86_64 GNU standard
 libraries and resolves the locked fuzz graph. Miri, AddressSanitizer,
 cargo-fuzz, cargo-udeps, the devcontainer, local fuzz instructions, and current
 toolchain documentation now share that explicit pin.

--- a/progress/session-077-v2-zero-copy-and-nightly-refresh.md
+++ b/progress/session-077-v2-zero-copy-and-nightly-refresh.md
@@ -1,0 +1,65 @@
+# Session 077 — V2 zero-copy relay and nightly refresh
+
+## Scope
+
+Advance the highest-gameplay-impacting concrete work under issue #207, then
+close issue #243's bounded CI-analysis maintenance in the same session PR.
+
+## V2 raw-binary relay projection
+
+The frozen-v2 JSON and Rkyv binary formats are raw payload passthroughs. Their
+payload already enters the relay as shared `Bytes`, but the socket projector
+called `payload.to_vec()` and then converted that fresh vector back to `Bytes`.
+The universal v2 relay floor therefore paid a full payload copy plus one or two
+allocation operations, depending on relay cohort size.
+
+The production-seam allocation harness now includes JSON and Rkyv v2 binary
+cells at 2, 8, and 16 players. Before the production change those cells used
+4/6/6 allocation operations and 1,419/2,363/2,683 bytes per relay; the checked-
+in zero-copy ceilings failed immediately at the two-player cell. Passing the
+shared handle directly reduces the cells to 3/4/4 operations and
+424/1,344/1,664 bytes. Every pre/post wire-byte ledger and SHA-256 digest is
+identical, while codec-work counters remain zero and delivery/queue ledgers
+remain exact. No runtime claim is made because the deterministic allocation
+result is sufficient and no uncontaminated pre-change timing pair was recorded.
+
+## Analysis nightly baseline
+
+The `nightly-2026-02-01` analysis pin was 182 days old. The replacement
+`nightly-2026-08-01` is available with Miri, rust-src, and x86_64 GNU standard
+libraries and resolves the locked fuzz graph. Miri, AddressSanitizer,
+cargo-fuzz, cargo-udeps, the devcontainer, local fuzz instructions, and current
+toolchain documentation now share that explicit pin.
+
+The prior consistency test inspected only the first date in `ci-safety.yml`
+and `unused-deps.yml`; it omitted `fuzz.yml`, so both a partial workflow update
+and fuzz drift could pass. The replacement scans every live operational
+occurrence across all three workflows and the devcontainer. The separate
+Fortress WASM pin remains excluded because it is coupled to the released Godot/
+Emscripten compatibility matrix. The freshness test now computes real UTC age
+instead of comparing against a frozen February 2026 reference.
+
+The audit also found that stable CI compiled all four fuzz targets while the
+nightly coverage-guided matrix ran only two. The hosted matrix now smoke-runs
+every `[[bin]]` declared by the fuzz manifest, and a manifest-derived policy
+test prevents future targets from silently receiving compile-only coverage.
+
+Executing the restored state-machine lane exposed a stale fuzz oracle from
+before intentional delivery cancellations became a separate outcome. The
+reproducer had ten attempts, eight enqueues, one drop, and one cancellation;
+production satisfied the current two-sided conservation law, while the target
+still enforced the obsolete three-outcome equality. The oracle now includes
+cancellations and uses the same bounded self-stabilizing balance poll as the
+stable suite.
+
+The old cargo-udeps 0.1.53 binary also embedded a Cargo parser too old for an
+Edition 2024 dependency manifest. The workflow now installs and caches 0.1.61
+with the pinned nightly and scans all targets plus all features. Its first
+complete run identified two genuinely unused direct dev-dependencies
+(`futures` and `tokio-test`); removing them leaves a zero-finding analysis.
+
+## Validation and publication
+
+In progress. Final evidence will include the complete local gauntlet,
+adversarial review results, exact commit, hosted analysis step outcomes, all
+applicable workflow conclusions, and reviewer state.

--- a/scripts/check-workflow-hygiene.sh
+++ b/scripts/check-workflow-hygiene.sh
@@ -904,7 +904,7 @@ for workflow in .github/workflows/*.yml .github/workflows/*.yaml; do
         line_no=${match%%:*}
         line_body=${match#*:}
         error "$WORKFLOW_NAME:$line_no: Uses moving Rust toolchain alias in workflow: $line_body"
-        error "  Use a pinned toolchain (e.g., 1.88.0 or nightly-2026-02-01), or omit toolchain to use rust-toolchain.toml."
+        error "  Use a pinned toolchain (e.g., 1.88.0 or nightly-2026-08-01), or omit toolchain to use rust-toolchain.toml."
         TOOLCHAIN_ALIAS_VIOLATIONS=$((TOOLCHAIN_ALIAS_VIOLATIONS + 1))
     done < <(grep -nE '^[[:space:]]*toolchain:[[:space:]]*["'"'"']?(stable|beta|nightly)["'"'"']?[[:space:]]*$' "$workflow" || true)
 done

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -626,6 +626,9 @@ impl ServerMetrics {
         self.active_connections.fetch_add(1, Ordering::Relaxed);
     }
 
+    // `fetch_update` is deprecated only on the analysis nightly in favor of
+    // nightly-only `try_update`; retain the stable API for the supported MSRV.
+    #[allow(deprecated)]
     pub fn decrement_active_connections(&self) {
         // Use fetch_update for atomic check-then-decrement to prevent underflow
         let _ =
@@ -1035,6 +1038,9 @@ impl ServerMetrics {
             .store(value, Ordering::Relaxed);
     }
 
+    // See `decrement_active_connections`: `try_update` is not available on the
+    // stable MSRV, so this analysis-nightly deprecation is intentionally local.
+    #[allow(deprecated)]
     pub fn decrement_reconnection_sessions_active(&self) {
         // Use fetch_update for atomic check-then-decrement to prevent underflow
         // when two threads race to decrement the same counter

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -2,6 +2,7 @@ use crate::coordination::outbound_queue::{DataDeliveryMetadata, OutboundReceiver
 use crate::protocol::{ErrorCode, GameDataEncoding, PlayerId, ServerMessage};
 use crate::server::EnhancedGameServer;
 use axum::extract::ws::{Message, WebSocket};
+use bytes::Bytes;
 use futures_util::SinkExt;
 use rmp_serde::{encode::write_named, from_slice};
 use serde::Serialize;
@@ -268,7 +269,7 @@ fn materialize_game_data_frame_uncached(
                 match encode_binary_game_data(*from_player, *encoding, payload, seq, epoch) {
                     Ok(frame_bytes) => {
                         return Ok(MaterializedFrame {
-                            frame: Message::Binary(frame_bytes.into()),
+                            frame: Message::Binary(frame_bytes),
                             work: SerializationWork {
                                 message_pack_encodes: u64::from(
                                     seq.is_some() || *encoding == GameDataEncoding::MessagePack,
@@ -836,7 +837,7 @@ struct V3BinaryGameDataFrame<'a> {
     epoch: u32,
 }
 
-/// Encodes a binary game-data frame exactly as production puts it on the wire.
+/// Materializes the binary bytes exactly as production puts them on the wire.
 ///
 /// This is the single source of truth for the binary send path. Keep this
 /// private to the websocket module so the wire frame layout can be tested
@@ -845,14 +846,15 @@ struct V3BinaryGameDataFrame<'a> {
 /// `seq`/`epoch` must already be gated per recipient: both present for v3, both
 /// absent for v2. V3 always uses the MessagePack metadata envelope while keeping
 /// `payload` opaque. V2 retains its historical representation byte-for-byte:
-/// the legacy MessagePack envelope or raw JSON/rkyv passthrough.
+/// the legacy MessagePack envelope or raw JSON/rkyv passthrough. Raw passthrough
+/// clones the shared `Bytes` handle, not the payload buffer.
 pub(super) fn encode_binary_game_data(
     from_player: PlayerId,
     encoding: GameDataEncoding,
-    payload: &[u8],
+    payload: &Bytes,
     seq: Option<u64>,
     epoch: Option<u32>,
-) -> Result<Vec<u8>, String> {
+) -> Result<Bytes, String> {
     match (seq, epoch) {
         (Some(seq), Some(epoch)) => {
             if seq == 0 || epoch == 0 {
@@ -865,7 +867,7 @@ pub(super) fn encode_binary_game_data(
                 seq,
                 epoch,
             };
-            encode_named_binary_frame(&frame, payload.len())
+            encode_named_binary_frame(&frame, payload.len()).map(Bytes::from)
         }
         (None, None) => match encoding {
             GameDataEncoding::MessagePack => encode_named_binary_frame(
@@ -875,8 +877,9 @@ pub(super) fn encode_binary_game_data(
                     payload,
                 },
                 payload.len(),
-            ),
-            GameDataEncoding::Json | GameDataEncoding::Rkyv => Ok(payload.to_vec()),
+            )
+            .map(Bytes::from),
+            GameDataEncoding::Json | GameDataEncoding::Rkyv => Ok(payload.clone()),
         },
         _ => Err("binary delivery seq and epoch must be present or absent together".to_string()),
     }
@@ -1076,11 +1079,13 @@ mod tests {
             }
         );
 
-        let payload = rmp_serde::to_vec_named(&data).expect("MessagePack fixture");
+        let payload: Bytes = rmp_serde::to_vec_named(&data)
+            .expect("MessagePack fixture")
+            .into();
         let binary = ServerMessage::GameDataBinary {
             from_player: player_a(),
             encoding: GameDataEncoding::MessagePack,
-            payload: payload.clone().into(),
+            payload: payload.clone(),
             seq: Some(42),
             epoch: Some(3),
         };
@@ -1105,7 +1110,6 @@ mod tests {
                         stamp.map(|value| value.1),
                     )
                     .expect("expected direct binary")
-                    .into()
                 )
             );
             assert_eq!(
@@ -1151,7 +1155,7 @@ mod tests {
                 &ServerMessage::GameDataBinary {
                     from_player: player_a(),
                     encoding: GameDataEncoding::MessagePack,
-                    payload: payload.into(),
+                    payload,
                     seq: Some(42),
                     epoch: None,
                 },
@@ -1370,14 +1374,14 @@ mod tests {
 
     #[test]
     fn binary_game_data_encoder_emits_bare_message_pack_frame() {
-        let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+        let payload = Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]);
         // Pre-v3 form (`seq`/`epoch` both None): bytes are FROZEN — they must
         // never drift, v3 or not (pre-v3 recipients keep receiving exactly this
         // frame).
         let wire = encode_binary_game_data(
             player_a(),
             GameDataEncoding::MessagePack,
-            payload,
+            &payload,
             None,
             None,
         )
@@ -1403,7 +1407,7 @@ mod tests {
         let frame = LegacyBinaryGameDataFrame {
             from_player: player_a(),
             encoding: GameDataEncoding::MessagePack,
-            payload,
+            payload: &payload,
         };
         assert_eq!(
             serde_json::to_value(frame).expect("json value"),
@@ -1420,7 +1424,7 @@ mod tests {
     /// MessagePack remains byte-identical to its previously stamped form.
     #[test]
     fn binary_game_data_encoder_envelopes_every_v3_encoding() {
-        let payload: &[u8] = &[0x01, 0x02, 0x03, 0x04];
+        let payload = Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]);
         let cases = [
             (
                 GameDataEncoding::Json,
@@ -1437,7 +1441,7 @@ mod tests {
         ];
 
         for (encoding, expected_hex) in cases {
-            let wire = encode_binary_game_data(player_a(), encoding, payload, Some(7), Some(3))
+            let wire = encode_binary_game_data(player_a(), encoding, &payload, Some(7), Some(3))
                 .expect("production binary encode with stamp");
             assert_eq!(
                 hex(&wire),
@@ -1462,7 +1466,7 @@ mod tests {
         let frame = V3BinaryGameDataFrame {
             from_player: player_a(),
             encoding: GameDataEncoding::MessagePack,
-            payload,
+            payload: &payload,
             seq: 7,
             epoch: 3,
         };
@@ -1482,7 +1486,7 @@ mod tests {
     #[test]
     fn binary_game_data_encoder_matches_named_encoding_at_bin_boundaries() {
         for payload_len in [0, 255, 256, 65_535, 65_536] {
-            let payload = vec![0xa5; payload_len];
+            let payload = Bytes::from(vec![0xa5; payload_len]);
             let legacy = LegacyBinaryGameDataFrame {
                 from_player: player_a(),
                 encoding: GameDataEncoding::MessagePack,
@@ -1496,8 +1500,11 @@ mod tests {
                     None,
                     None,
                 )
-                .expect("preallocated legacy binary encode"),
-                rmp_serde::to_vec_named(&legacy).expect("reference legacy binary encode"),
+                .expect("preallocated legacy binary encode")
+                .as_ref(),
+                rmp_serde::to_vec_named(&legacy)
+                    .expect("reference legacy binary encode")
+                    .as_slice(),
                 "legacy payload length {payload_len} changed named MessagePack bytes"
             );
 
@@ -1521,8 +1528,11 @@ mod tests {
                         Some(u64::MAX),
                         Some(u32::MAX),
                     )
-                    .expect("preallocated v3 binary encode"),
-                    rmp_serde::to_vec_named(&v3).expect("reference v3 binary encode"),
+                    .expect("preallocated v3 binary encode")
+                    .as_ref(),
+                    rmp_serde::to_vec_named(&v3)
+                        .expect("reference v3 binary encode")
+                        .as_slice(),
                     "v3 {encoding:?} payload length {payload_len} changed named MessagePack bytes"
                 );
             }
@@ -1556,20 +1566,27 @@ mod tests {
 
     #[test]
     fn v2_raw_binary_encodings_return_payload_unchanged() {
-        let payload: &[u8] = br#"{"move":"up"}"#;
+        let payload = Bytes::from_static(br#"{"move":"up"}"#);
 
         for encoding in [GameDataEncoding::Json, GameDataEncoding::Rkyv] {
             assert_eq!(
-                encode_binary_game_data(player_a(), encoding, payload, None, None)
+                encode_binary_game_data(player_a(), encoding, &payload, None, None)
                     .expect("v2 raw passthrough"),
-                payload.to_vec()
+                payload
+            );
+            let projected = encode_binary_game_data(player_a(), encoding, &payload, None, None)
+                .expect("v2 raw passthrough");
+            assert_eq!(
+                projected.as_ptr(),
+                payload.as_ptr(),
+                "v2 raw passthrough must reuse the shared payload allocation"
             );
         }
     }
 
     #[test]
     fn binary_delivery_stamp_must_be_complete_and_nonzero() {
-        let payload = b"opaque";
+        let payload = Bytes::from_static(b"opaque");
         for (seq, epoch) in [
             (Some(1), None),
             (None, Some(1)),
@@ -1577,7 +1594,7 @@ mod tests {
             (Some(1), Some(0)),
         ] {
             assert!(
-                encode_binary_game_data(player_a(), GameDataEncoding::Json, payload, seq, epoch,)
+                encode_binary_game_data(player_a(), GameDataEncoding::Json, &payload, seq, epoch,)
                     .is_err(),
                 "invalid stamp {seq:?}/{epoch:?} was accepted"
             );

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -15918,6 +15918,17 @@ fn test_fuzz_dependency_resolution_is_locked_in_ci() {
 
     let fuzz_path = root.join(".github/workflows/fuzz.yml");
     let fuzz = read_live_file(&fuzz_path);
+    let pull_request_paths: BTreeSet<String> = extract_workflow_event_paths(&fuzz, "pull_request")
+        .into_iter()
+        .collect();
+    for required_path in ["Cargo.toml", "build.rs", "src/**"] {
+        assert!(
+            pull_request_paths.contains(required_path),
+            "fuzz.yml pull_request paths must include {required_path} because the declared \
+             state-machine targets compile and exercise the root package. Narrow filters \
+             silently skip behavioral fuzz coverage when production surfaces change."
+        );
+    }
     let fuzz_documents =
         Yaml::load_from_str(&fuzz).expect("fuzz.yml live configuration must parse as YAML");
     let fuzz_job = fuzz_documents
@@ -15925,6 +15936,90 @@ fn test_fuzz_dependency_resolution_is_locked_in_ci() {
         .and_then(|document| document.as_mapping_get("jobs"))
         .and_then(|jobs| jobs.as_mapping_get("fuzz"))
         .unwrap_or_else(|| panic!("fuzz.yml must define jobs.fuzz"));
+    let matrix_target_sequence = fuzz_job
+        .as_mapping_get("strategy")
+        .and_then(|strategy| strategy.as_mapping_get("matrix"))
+        .and_then(|matrix| matrix.as_mapping_get("target"))
+        .and_then(Yaml::as_sequence)
+        .unwrap_or_else(|| panic!("fuzz.yml must define jobs.fuzz.strategy.matrix.target"));
+    let matrix_target_list: Vec<String> = matrix_target_sequence
+        .iter()
+        .map(|target| {
+            target
+                .as_str()
+                .unwrap_or_else(|| panic!("every fuzz matrix target must be a string"))
+                .to_string()
+        })
+        .collect();
+    let matrix_targets: BTreeSet<String> = matrix_target_list.iter().cloned().collect();
+    assert_eq!(
+        matrix_target_list.len(),
+        matrix_targets.len(),
+        "fuzz.yml must list every fuzz matrix target exactly once"
+    );
+    let fuzz_manifest = read_file(&root.join("fuzz/Cargo.toml"));
+    let mut in_bin = false;
+    let mut current_bin_has_name = false;
+    let mut manifest_bin_count = 0usize;
+    let mut manifest_targets = BTreeSet::new();
+    for raw_line in fuzz_manifest.lines() {
+        let line = raw_line.split('#').next().unwrap_or_default().trim();
+        if line == "[[bin]]" {
+            assert!(
+                !in_bin || current_bin_has_name,
+                "every fuzz [[bin]] block must declare exactly one non-empty name"
+            );
+            in_bin = true;
+            current_bin_has_name = false;
+            manifest_bin_count += 1;
+            continue;
+        }
+        if line.starts_with('[') {
+            assert!(
+                !in_bin || current_bin_has_name,
+                "every fuzz [[bin]] block must declare exactly one non-empty name"
+            );
+            in_bin = false;
+            continue;
+        }
+        if !in_bin {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if key.trim() == "name" {
+            assert!(
+                !current_bin_has_name,
+                "every fuzz [[bin]] block must declare exactly one name"
+            );
+            let name = value.trim().trim_matches(['"', '\'']);
+            assert!(!name.is_empty(), "every fuzz [[bin]] must declare a name");
+            assert!(
+                manifest_targets.insert(name.to_string()),
+                "fuzz/Cargo.toml must not declare duplicate [[bin]] name '{name}'"
+            );
+            current_bin_has_name = true;
+        }
+    }
+    assert!(
+        !in_bin || current_bin_has_name,
+        "every fuzz [[bin]] block must declare exactly one non-empty name"
+    );
+    assert!(
+        !manifest_targets.is_empty(),
+        "fuzz/Cargo.toml must declare [[bin]] fuzz targets"
+    );
+    assert_eq!(
+        manifest_bin_count,
+        manifest_targets.len(),
+        "every fuzz [[bin]] block must contribute one unique matrix target"
+    );
+    assert_eq!(
+        matrix_targets, manifest_targets,
+        "fuzz.yml must smoke-run every fuzz/Cargo.toml [[bin]] target. A compile-only stable \
+         check cannot replace nightly libFuzzer execution."
+    );
     let fuzz_steps = fuzz_job
         .as_mapping_get("steps")
         .and_then(Yaml::as_sequence)
@@ -15943,7 +16038,7 @@ fn test_fuzz_dependency_resolution_is_locked_in_ci() {
         .unwrap_or_else(|| panic!("the locked fuzz dependency preflight must define `run`"));
     assert!(
         locked_preflight
-            == "cargo +nightly-2026-02-01 metadata --manifest-path fuzz/Cargo.toml --locked \
+            == "cargo +nightly-2026-08-01 metadata --manifest-path fuzz/Cargo.toml --locked \
                 --format-version 1 >/dev/null",
         "fuzz.yml must run a locked metadata preflight before cargo-fuzz. cargo-fuzz itself \
          does not accept `--locked`, so the preflight is the reproducibility gate."
@@ -16986,7 +17081,7 @@ fn test_run_step_full_suite_classifier() {
         // Runners that execute every test target → DO trigger trybuild.
         ("cargo nextest run --profile ci --locked --all-features", true),
         ("cargo test --locked --all-features --no-fail-fast", true),
-        ("cargo +nightly-2026-02-01 test --locked --all-features", true),
+        ("cargo +nightly-2026-08-01 test --locked --all-features", true),
         (
             "cargo llvm-cov --locked --all-features --workspace --lcov --output-path lcov.info",
             true,
@@ -16994,12 +17089,12 @@ fn test_run_step_full_suite_classifier() {
         // Line-continuation: a narrowing flag on the continued line must still count.
         ("cargo test --locked --all-features \\\n  --lib --no-fail-fast", false),
         (
-            "RUSTFLAGS=-Zx \\\n  cargo +nightly-2026-02-01 test --locked \\\n  --all-features 2>&1 | tee out.txt",
+            "RUSTFLAGS=-Zx \\\n  cargo +nightly-2026-08-01 test --locked \\\n  --all-features 2>&1 | tee out.txt",
             true,
         ),
         // Restricted runs that do NOT execute the integration tests → no trybuild.
         ("cargo test --locked --lib", false),
-        ("cargo +nightly-2026-02-01 miri test --locked --lib --no-fail-fast", false),
+        ("cargo +nightly-2026-08-01 miri test --locked --lib --no-fail-fast", false),
         ("cargo test --locked --doc --all-features", false),
         ("cargo test --locked --test browser_interop_e2e", false),
         ("cargo test --locked --all-features --no-run", false),
@@ -17008,10 +17103,13 @@ fn test_run_step_full_suite_classifier() {
         // Non-test subcommands.
         ("cargo build --lib --locked --all-features", false),
         ("cargo clippy --locked --all-targets --all-features -- -D warnings", false),
-        ("cargo +nightly-2026-02-01 udeps --locked --all-targets", false),
+        (
+            "cargo +nightly-2026-08-01 udeps --locked --all-targets --all-features",
+            false,
+        ),
         ("cargo machete", false),
         ("cargo fmt --check", false),
-        ("cargo +nightly-2026-02-01 fuzz run protocol_target", false),
+        ("cargo +nightly-2026-08-01 fuzz run protocol_target", false),
         ("bash scripts/run-webrtc-interop.sh", false),
         // Per-segment flag isolation: a flag from one command must not bleed into another.
         ("cargo build && cargo test --all-features", true),
@@ -17036,9 +17134,9 @@ fn test_ci_safety_keeps_full_miri_and_asan_coverage() {
 
     for required in [
         "Run Miri on library tests",
-        "cargo +nightly-2026-02-01 miri test --locked --lib --no-fail-fast",
+        "cargo +nightly-2026-08-01 miri test --locked --lib --no-fail-fast",
         "Run tests with AddressSanitizer",
-        "cargo +nightly-2026-02-01 test --locked --target x86_64-unknown-linux-gnu",
+        "cargo +nightly-2026-08-01 test --locked --target x86_64-unknown-linux-gnu",
         "--all-features --no-fail-fast 2>&1 | tee asan-output.txt",
     ] {
         assert!(
@@ -17202,69 +17300,71 @@ fn test_ci_safety_failure_diagnostics_include_markers() {
 }
 
 #[test]
-fn test_nightly_version_consistency_across_workflows() {
-    // Validates that all workflows using a pinned nightly toolchain use
-    // the same nightly version. If someone updates one workflow's nightly
-    // pin without updating others, they silently diverge, causing
-    // inconsistent CI results and confusion about which nightly to update.
+fn test_analysis_nightly_version_consistency() {
+    // The analysis workflows and devcontainer intentionally share one pin.
+    // Inspect every live occurrence so a partially updated workflow cannot
+    // pass merely because its first date still matches the baseline.
 
     let root = repo_root();
-    let workflows_dir = root.join(".github/workflows");
-
-    // Workflows known to use pinned nightly toolchains
-    let nightly_workflows = ["ci-safety.yml", "unused-deps.yml"];
+    let nightly_files = [
+        ".github/workflows/ci-safety.yml",
+        ".github/workflows/fuzz.yml",
+        ".github/workflows/unused-deps.yml",
+        ".devcontainer/Dockerfile",
+    ];
+    let nightly_pattern =
+        Regex::new(r"nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}").expect("valid nightly regex");
 
     let mut nightly_versions: Vec<(String, String)> = Vec::new();
-    // Count the workflows that actually exist so we can assert below that each
-    // one yielded a pin. Without this, a parser regression or a moved nightly
-    // pin would empty `nightly_versions`, and the `len() > 1` drift check would
-    // pass vacuously — silently disabling the very guard it implements.
-    let mut existing_nightly_workflows = 0usize;
-
-    for workflow_file in &nightly_workflows {
-        let workflow_path = workflows_dir.join(workflow_file);
-        if !workflow_path.exists() {
-            continue;
-        }
-        existing_nightly_workflows += 1;
-        let content = read_file(&workflow_path);
-
-        // Extract all pinned nightly versions (e.g., "nightly-2026-01-15")
-        for line in content.lines() {
-            let trimmed = line.trim();
-            // Match lines like "toolchain: nightly-YYYY-MM-DD" or
-            // "cargo +nightly-YYYY-MM-DD ..."
-            if let Some(pos) = trimmed.find("nightly-20") {
-                let version_start = pos;
-                // Extract the nightly-YYYY-MM-DD portion
-                let rest = &trimmed[version_start..];
-                let version_end = rest
-                    .find(|c: char| c != '-' && !c.is_ascii_alphanumeric())
-                    .unwrap_or(rest.len());
-                let version = &rest[..version_end];
-
-                // Only record if it looks like a valid pinned nightly
-                if version.len() >= "nightly-2026-01-15".len() {
-                    nightly_versions.push((workflow_file.to_string(), version.to_string()));
-                    break; // One version per workflow is enough
-                }
+    for relative_path in nightly_files {
+        let path = root.join(relative_path);
+        let content = strip_comment_lines(&read_file(&path));
+        let versions: BTreeSet<String> = nightly_pattern
+            .find_iter(&content)
+            .map(|found| found.as_str().to_string())
+            .collect();
+        assert_eq!(
+            versions.len(),
+            1,
+            "{relative_path} must contain exactly one operational date-pinned nightly, \
+             repeated consistently at every install/command site.\nObserved: {versions:?}"
+        );
+        let version = versions
+            .into_iter()
+            .next()
+            .expect("one pinned nightly was asserted");
+        for operational_line in content.lines().filter(|line| {
+            line.contains("toolchain: nightly")
+                || line.contains("cargo +nightly")
+                || line.contains("ARG RUST_NIGHTLY=")
+                || line.contains("rustup toolchain install")
+        }) {
+            if relative_path == ".devcontainer/Dockerfile"
+                && operational_line.contains("rustup toolchain install")
+            {
+                assert!(
+                    operational_line.contains("\"$RUST_NIGHTLY\""),
+                    "{relative_path} must install the date-pinned $RUST_NIGHTLY argument, not a \
+                     rolling or duplicated literal: {operational_line}"
+                );
+            } else {
+                assert!(
+                    operational_line.contains(&version),
+                    "{relative_path} has an unpinned or partially updated nightly operation: \
+                     {operational_line}\nExpected pin: {version}"
+                );
             }
         }
+        if relative_path == ".devcontainer/Dockerfile" {
+            assert!(
+                content.lines().any(|line| {
+                    line.contains("rustup toolchain install") && line.contains("\"$RUST_NIGHTLY\"")
+                }),
+                ".devcontainer/Dockerfile must install its date-pinned RUST_NIGHTLY argument"
+            );
+        }
+        nightly_versions.push((relative_path.to_string(), version));
     }
-
-    // Every workflow that exists and is declared to pin a nightly must have
-    // actually produced a pin; otherwise the extraction silently regressed.
-    assert_eq!(
-        nightly_versions.len(),
-        existing_nightly_workflows,
-        "Expected a pinned nightly from each of the {existing_nightly_workflows} known \
-         nightly workflow(s), but extracted {}.\n\
-         Parsed pins: {:?}\n\
-         This means the nightly-pin extractor regressed or a workflow stopped \
-         pinning nightly — the drift check below would otherwise pass vacuously.",
-        nightly_versions.len(),
-        nightly_versions
-    );
 
     // All extracted versions should be the same
     if nightly_versions.len() > 1 {
@@ -17281,13 +17381,26 @@ fn test_nightly_version_consistency_across_workflows() {
             panic!(
                 "Nightly toolchain versions are inconsistent across workflows:\n\n\
                  Baseline: {} uses {first_version}\n{}\n\n\
-                 All workflows using pinned nightly must use the same version.\n\
-                 To fix: Update all nightly pins to the same version.\n\
-                 See the Nightly Toolchain Strategy in each workflow's header.",
+                 All analysis workflows and the devcontainer must use the same version.\n\
+                 To fix: update every operational pin together.\n\
+                 The separate Fortress WASM toolchain is compatibility-pinned and excluded.",
                 nightly_versions[0].0,
                 mismatches.join("\n")
             );
         }
+    }
+
+    let unused_deps = read_live_file(&root.join(".github/workflows/unused-deps.yml"));
+    for required in [
+        "cargo-udeps-0.1.61-nightly-2026-08-01",
+        "cargo +nightly-2026-08-01 install cargo-udeps --version 0.1.61 --locked",
+        "cargo +nightly-2026-08-01 udeps --locked --all-targets --all-features",
+    ] {
+        assert!(
+            unused_deps.contains(required),
+            "unused-deps.yml must install cargo-udeps 0.1.61 with the analysis nightly and key \
+             its binary cache by the same version; missing '{required}'"
+        );
     }
 }
 
@@ -20321,53 +20434,42 @@ fn test_pinned_nightly_staleness_warning() {
         return; // ci-safety.yml is optional
     }
 
-    let content = read_file(&workflow_path);
+    let content = strip_comment_lines(&read_file(&workflow_path));
+    let nightly_pattern =
+        Regex::new(r"nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}").expect("valid nightly regex");
+    let operational_versions: BTreeSet<String> = nightly_pattern
+        .find_iter(&content)
+        .map(|found| found.as_str().to_string())
+        .collect();
+    assert_eq!(
+        operational_versions.len(),
+        1,
+        "ci-safety.yml must use exactly one operational date-pinned nightly; comments do not \
+         satisfy the freshness policy. Observed: {operational_versions:?}"
+    );
+    let nightly_version = operational_versions
+        .into_iter()
+        .next()
+        .expect("one operational nightly was asserted");
 
-    // Extract the first nightly-YYYY-MM-DD pattern
-    let nightly_re_prefix = "nightly-20";
-    let nightly_version: Option<String> = content.lines().find_map(|line| {
-        let trimmed = line.trim();
-        trimmed.find(nightly_re_prefix).map(|pos| {
-            let rest = &trimmed[pos..];
-            // Take chars while they match the nightly-YYYY-MM-DD pattern
-            let end = rest
-                .find(|c: char| !c.is_ascii_alphanumeric() && c != '-')
-                .unwrap_or(rest.len());
-            rest[..end].to_string()
-        })
-    });
-
-    let nightly_version = nightly_version
-        .expect("ci-safety.yml must contain a pinned nightly date (e.g., nightly-2026-02-01)");
-
-    // Extract YYYY and MM
+    // Compare the actual date to UTC today. The former frozen reference month
+    // let this test remain green while the workflow-hygiene gate correctly
+    // reported the same pin as 182 days old.
     let date_part = nightly_version
         .strip_prefix("nightly-")
         .expect("nightly version must start with 'nightly-'");
-    let parts: Vec<&str> = date_part.split('-').collect();
+    let nightly_date = chrono::NaiveDate::parse_from_str(date_part, "%Y-%m-%d")
+        .unwrap_or_else(|error| panic!("Invalid nightly date '{date_part}': {error}"));
+    let today = chrono::Utc::now().date_naive();
+    let age_days = today.signed_duration_since(nightly_date).num_days();
     assert!(
-        parts.len() >= 2,
-        "Nightly date '{date_part}' must have at least YYYY-MM format"
+        age_days >= 0,
+        "Pinned nightly '{nightly_version}' is {age_days} days in the future relative to {today}."
     );
-
-    let year: u32 = parts[0]
-        .parse()
-        .unwrap_or_else(|_| panic!("Invalid year in nightly version: {}", parts[0]));
-    let month: u32 = parts[1]
-        .parse()
-        .unwrap_or_else(|_| panic!("Invalid month in nightly version: {}", parts[1]));
-
-    // Approximate staleness check: compare to build date
-    // This uses a rough heuristic - the test will need updating when the year changes
-    let nightly_months = year * 12 + month;
-    // Use 2026-02 as reference (current date)
-    let reference_months: u32 = 2026 * 12 + 2;
-    let age_months = reference_months.saturating_sub(nightly_months);
-
     assert!(
-        age_months <= 12,
-        "Pinned nightly '{nightly_version}' is approximately {age_months} months old.\n\
-         Consider testing a newer nightly and updating the pin.\n\
+        age_days <= 180,
+        "Pinned nightly '{nightly_version}' is {age_days} days old.\n\
+         Test a current date-pinned nightly and update every analysis-tool pin.\n\
          See ci-safety.yml header for update criteria."
     );
 }
@@ -20543,7 +20645,7 @@ fn test_workflow_toolchain_fields_do_not_use_moving_aliases() {
                 violations.push(format!(
                     "{filename}:{}: toolchain: {value}\n  \
                      Moving toolchain aliases are not allowed.\n  \
-                     Use a pinned toolchain (e.g., 1.88.0 or nightly-2026-02-01),\n  \
+                     Use a pinned toolchain (e.g., 1.88.0 or nightly-2026-08-01),\n  \
                      or omit toolchain to use rust-toolchain.toml.",
                     line_num + 1
                 ));

--- a/tests/websocket_test_helpers/chaos_proxy.rs
+++ b/tests/websocket_test_helpers/chaos_proxy.rs
@@ -802,6 +802,9 @@ async fn pump(
 }
 
 /// Write `data` completely to `to`, ending early (`Err`) on kill or error.
+// `fetch_update` is deprecated only on the analysis nightly in favor of
+// nightly-only `try_update`; retain the stable API for the supported MSRV.
+#[allow(deprecated)]
 async fn write_fully(
     to: &TcpStream,
     data: &[u8],


### PR DESCRIPTION
## Summary

- reuse the existing shared `Bytes` allocation for frozen v2 JSON and rkyv binary relay frames instead of copying each payload
- add production-seam allocation coverage for v2 JSON/rkyv at 2, 8, and 16 players
- refresh all operational analysis jobs and the devcontainer to `nightly-2026-08-01`
- restore all four declared fuzz targets to CI, harden drift guards, and update cargo-udeps to 0.1.61
- remove the two direct dev-dependencies that cargo-udeps proved unused

## Why

The frozen v2 raw-binary path converted a shared `Bytes` payload into a fresh `Vec` for every materialized relay frame. That copy was unnecessary because Axum's binary websocket frame already owns `Bytes`.

Separately, the repository's pinned analysis nightly was stale. Exercising the refreshed toolchain exposed two maintenance gaps: the state-machine fuzz oracle did not account for canceled deliveries, and cargo-udeps 0.1.53 could not parse the workspace's Edition 2024 manifest.

## Results

The v2 benchmark cells preserve the exact wire hashes while reducing allocation bytes per relay by 38–70%:

| Room | Before operations / bytes | After operations / bytes |
| ---: | ---: | ---: |
| 2 | 4.001 / 1418.98 | 3.001 / 424.06 |
| 8 | 6.001 / 2362.98 | 4.001 / 1344.06 |
| 16 | 6.001 / 2682.98 | 4.001 / 1664.06 |

All 15 allocation-ceiling cells pass. The refreshed fuzz matrix also passed locally for every declared target, including the restored session-machine target, and cargo-udeps reports that all remaining dependencies are used.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- allocation ceiling benchmark, all 15 cells
- `cargo +nightly-2026-08-01 udeps --locked --all-targets --all-features`
- all four cargo-fuzz targets on the host GNU target
- exact pinned Miri suite: 470 passed, 198 ignored
- `cargo deny --all-features check`
- repository CI/workflow/toolchain/doc/hook policy checks

Advances #207.
Closes #243.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path websocket relay materialization for legacy v2 clients (wire-identical but different memory behavior) alongside broad CI/nightly workflow updates; production MSRV builds remain on stable.
> 
> **Overview**
> **V2 frozen JSON/rkyv binary relays** no longer copy each payload through `to_vec()` when materializing websocket frames. `encode_binary_game_data` now takes shared `Bytes` and, for v2 raw passthrough, clones the handle instead of duplicating the buffer—wire bytes stay frozen while allocation work drops (benchmark harness adds v2 JSON/rkyv cells at 2/8/16 players with updated ceilings).
> 
> **Analysis toolchain** moves from `nightly-2026-02-01` to **`nightly-2026-08-01`** across Miri, AddressSanitizer, cargo-fuzz, cargo-udeps, and the devcontainer, with docs and hygiene scripts aligned. Policy tests now scan every operational nightly occurrence (including `fuzz.yml` and the Dockerfile) and enforce real UTC staleness instead of a frozen reference date.
> 
> **Fuzz CI** smoke-runs all four manifest `[[bin]]` targets (adds `fuzz_session_machine` and `fuzz_reconnect_tokens`), broadens PR path filters to `src/**` / root `Cargo.toml` / `build.rs`, and fixes `fuzz_session_machine` delivery conservation to count **cancellations** with the same bounded quiescence poll as stable tests. **cargo-udeps** upgrades to 0.1.61 with `--all-features`; unused direct dev-deps `futures` and `tokio-test` are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06779919e34859dede20b9be1fb4eeaedd27ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->