### PR TITLE
Harden relay allocation, retry bounds, and release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,7 @@ jobs:
           } > release_notes.md
 
       - name: Validate an existing GitHub Release
+        id: existing-release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -547,6 +548,7 @@ jobs:
               exit 1
             fi
             echo "Existing GitHub Release for $TAG will be completed idempotently."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             status=$(gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1 \
               | sed -n 's/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' | head -n 1 || true)
@@ -554,14 +556,20 @@ jobs:
               echo "ERROR: Could not verify whether GitHub Release $TAG exists (HTTP ${status:-unknown})." >&2
               exit 1
             fi
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create GitHub Release
+        if: steps.existing-release.outputs.exists != 'true'
         uses: softprops/action-gh-release@v3.0.2
         with:
+          # ensure-tag already created or verified this immutable annotated tag.
+          # Do not pass target_commitish here: GitHub only needs it when the tag
+          # does not exist, and a historical retry whose source changed workflow
+          # files relative to today's default branch would otherwise require a
+          # workflows:write token that GITHUB_TOKEN cannot receive.
           tag_name: ${{ needs.resolve-release.outputs.tag }}
           name: ${{ needs.resolve-release.outputs.tag }}
-          target_commitish: ${{ needs.resolve-release.outputs.source_revision }}
           body_path: source/release_notes.md
           draft: false
           prerelease: false
@@ -570,12 +578,11 @@ jobs:
 
       - name: Attach SBOM to release
         if: steps.sbom.outcome == 'success'
-        uses: softprops/action-gh-release@v3.0.2
-        with:
-          tag_name: ${{ needs.resolve-release.outputs.tag }}
-          files: source/sbom.cdx.json
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: gh release upload "$TAG" source/sbom.cdx.json --clobber
 
       - name: Verify GitHub Release identity
         shell: bash
@@ -816,20 +823,17 @@ jobs:
 
       - name: Attach binaries to release
         if: steps.binary-artifacts.outputs.count != '0'
-        uses: softprops/action-gh-release@v3.0.2
-        with:
-          tag_name: ${{ needs.resolve-release.outputs.tag }}
-          files: |
-            dist/*.tar.gz
-            dist/*.zip
-            dist/*.sha256
-          # MUST be false: action-gh-release evaluates fail_on_unmatched_files
-          # PER glob, so `true` would fail the whole attach (stripping every
-          # binary) whenever an entire format class is absent — e.g. if both
-          # Windows legs (the only *.zip producers, sharing windows-latest) fail
-          # together. That directly contradicts the fail-fast:false /
-          # partial-success intent above. Per-artifact presence is already
-          # enforced upstream by `if-no-files-found: error` on each upload.
-          fail_on_unmatched_files: false
+        shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -d '' assets < <(find dist -type f \( \
+            -name '*.tar.gz' -o -name '*.zip' -o -name '*.sha256' \
+          \) -print0)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "ERROR: Binary artifacts were reported but no archives or checksums were downloaded." >&2
+            exit 1
+          fi
+          gh release upload "$TAG" "${assets[@]}" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reduce relay allocation work for the universal WebSocket fallback (issue
+  #207). MessagePack-to-JSON projection now pre-sizes its output and eliminates
+  all 3/6 growth reallocations in 2-/8-/16-player mixed-format rooms, reducing
+  allocation operations from 18/28/28 to 15/22/22 and allocated bytes by
+  17–20%. Repeated frozen-v2 JSON and Rkyv relays also skip a no-op frame cache,
+  reducing 8-/16-player operations from 4 to 3 and bytes by 51%/41%. Exact wire
+  bytes and delivery accounting are unchanged; the runtime benchmark now keeps
+  whole-frame SHA-256 validation outside its timed loop.
 - Reduce memory-allocation work for frozen-v2 JSON and Rkyv binary relays
   (issue #207). The server now removes one allocation operation in two-player
   rooms, two in 8-/16-player rooms, and one payload-sized copy per relay:
@@ -43,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep retry sleeps within the configured maximum after jitter is applied
+  (issue #205). Persistent in-memory lock contention can no longer turn the
+  default 5-second maximum into a 6-second sleep; sub-millisecond precision is
+  preserved and extreme duration/factor combinations saturate safely.
+- Make GitHub Release retries work after the default branch's workflow files
+  advance. The release job now publishes the already-verified immutable tag
+  without redundantly passing its historical source as `target_commitish`,
+  skips identity mutation when the Release already exists, and retries SBOM or
+  binary attachments through asset-only uploads. This avoids a workflow-write
+  permission that `GITHUB_TOKEN` cannot receive.
 - Keep spectator-occupied rooms alive during garbage collection (issue #241).
   Spectator-only rooms now use the inactive-room timeout, spectator join,
   detach, and live connection traffic refresh room activity, and the normal

--- a/benches/relay_serialization_allocations.rs
+++ b/benches/relay_serialization_allocations.rs
@@ -9,7 +9,9 @@
 #[path = "support/relay_serialization.rs"]
 mod relay_serialization;
 
-use relay_serialization::{Fixture, Ledger, Scenario, RELAYS_PER_SAMPLE, ROOM_SIZES};
+use relay_serialization::{
+    assert_expected_output_digest, Fixture, Ledger, Scenario, RELAYS_PER_SAMPLE, ROOM_SIZES,
+};
 use stats_alloc::{Region, Stats, StatsAlloc, INSTRUMENTED_SYSTEM};
 use std::alloc::System;
 
@@ -81,17 +83,17 @@ fn assert_allocation_ceiling(scenario: Scenario, room_size: usize, sample: &Samp
     let (maximum_operations_per_relay, maximum_reallocations_per_relay, maximum_bytes_per_relay) =
         match (scenario, room_size) {
             (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 2) => (3, 0, 425),
-            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 8) => (4, 0, 1_345),
-            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 16) => (4, 0, 1_665),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 8) => (3, 0, 665),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 16) => (3, 0, 985),
             (Scenario::V3JsonText, 2) => (8, 3, 2_587),
             (Scenario::V3JsonText, 8) => (9, 3, 3_507),
             (Scenario::V3JsonText, 16) => (9, 3, 3_827),
             (Scenario::V3MessagePackBinary, 2) => (5, 0, 1_581),
             (Scenario::V3MessagePackBinary, 8) => (6, 0, 2_501),
             (Scenario::V3MessagePackBinary, 16) => (6, 0, 2_821),
-            (Scenario::MixedMessagePackSource, 2) => (18, 3, 4_450),
-            (Scenario::MixedMessagePackSource, 8) => (28, 6, 9_845),
-            (Scenario::MixedMessagePackSource, 16) => (28, 6, 10_165),
+            (Scenario::MixedMessagePackSource, 2) => (15, 0, 3_572),
+            (Scenario::MixedMessagePackSource, 8) => (22, 0, 8_090),
+            (Scenario::MixedMessagePackSource, 16) => (22, 0, 8_410),
             _ => panic!("room-{room_size} has no checked-in allocation baseline"),
         };
     let allocation_operations = sample.stats.allocations + sample.stats.reallocations;
@@ -135,6 +137,7 @@ fn main() {
         for room_size in ROOM_SIZES {
             let mut fixture = Fixture::new(room_size, scenario);
             let sample = repeated_sample(&mut fixture);
+            assert_expected_output_digest(scenario, room_size, &sample.ledger);
             assert_allocation_ceiling(scenario, room_size, &sample);
             print_sample(scenario, room_size, &sample);
         }

--- a/benches/relay_serialization_runtime.rs
+++ b/benches/relay_serialization_runtime.rs
@@ -8,7 +8,9 @@
 mod relay_serialization;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use relay_serialization::{Fixture, Scenario, RELAYS_PER_SAMPLE, ROOM_SIZES};
+use relay_serialization::{
+    assert_expected_output_digest, Fixture, Scenario, RELAYS_PER_SAMPLE, ROOM_SIZES,
+};
 use std::hint::black_box;
 use std::time::Duration;
 
@@ -19,7 +21,12 @@ fn relay_serialization_runtime(criterion: &mut Criterion) {
     for scenario in Scenario::ALL {
         for room_size in ROOM_SIZES {
             let mut fixture = Fixture::new(room_size, scenario);
-            let expected = fixture.run_sample();
+            // Exact wire hashing is validated before measurement. Timed
+            // iterations retain the production projection and cheap ledger,
+            // but omit SHA-256 work the server never performs.
+            let validated = fixture.run_sample();
+            assert_expected_output_digest(scenario, room_size, &validated);
+            let expected = fixture.run_timed_sample();
             group.throughput(Throughput::Elements(
                 (RELAYS_PER_SAMPLE * (room_size - 1)) as u64,
             ));
@@ -28,7 +35,7 @@ fn relay_serialization_runtime(criterion: &mut Criterion) {
                 &room_size,
                 |bencher, _| {
                     bencher.iter(|| {
-                        let observed = fixture.run_sample();
+                        let observed = fixture.run_timed_sample();
                         assert_eq!(
                             observed, expected,
                             "timed production projection changed its non-vacuity ledger"

--- a/benches/support/relay_serialization.rs
+++ b/benches/support/relay_serialization.rs
@@ -55,6 +55,59 @@ impl Scenario {
     }
 }
 
+pub fn assert_expected_output_digest(scenario: Scenario, room_size: usize, ledger: &Ledger) {
+    let expected = match (scenario, room_size) {
+        (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 2) => {
+            "6ed4ed0eb9160a5355d0715e16f015fc221dfe9051f854a87c62bb2c0fa95c6f"
+        }
+        (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 8) => {
+            "93019166377ed5d8626c6686eed0d2a6d28217d242693ff410271ca6dc4261fa"
+        }
+        (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 16) => {
+            "21d58310cb589e36b24318278b7cd268788c593f825347bccd7dfff84cf53cdc"
+        }
+        (Scenario::V3JsonText, 2) => {
+            "62d00507ecc1a67fc1ed211ced5a98baab6e5f4201b17530c96e59a1ac2404ea"
+        }
+        (Scenario::V3JsonText, 8) => {
+            "7b9cfb3ca7b90be7977093b3ef4d88db29987b07e776415e18cb6fce8a9b1f28"
+        }
+        (Scenario::V3JsonText, 16) => {
+            "0b5c7c01bdc82181ba8396b82ce7b33f19c079ef4946aa7b75198c9977df52d9"
+        }
+        (Scenario::V3MessagePackBinary, 2) => {
+            "bc4bbff551e662c7d5392af2ffdd3bb5bbff93c5d5d3e59b2ae37bf2c39da65f"
+        }
+        (Scenario::V3MessagePackBinary, 8) => {
+            "985df9bddb2264627da2a9fed3dafcdc62f8c5b620e889906b92a13ebad9364d"
+        }
+        (Scenario::V3MessagePackBinary, 16) => {
+            "713b6cc49acf584f3ba10188262aca9e49dc075c9680cf4eb07cc7ec5292487a"
+        }
+        (Scenario::MixedMessagePackSource, 2) => {
+            "8ee28a2f5fa4828a9f56cb88ca5c672b1ac82739c298875affc68265da280bf5"
+        }
+        (Scenario::MixedMessagePackSource, 8) => {
+            "27eb27a2ca4a7975f67e50a2ad7c9892510c01fcf656322fb79ca98e36e30648"
+        }
+        (Scenario::MixedMessagePackSource, 16) => {
+            "1c461f688ee193d43e61695e07536caad92f8e46254787641ac59dc7db012658"
+        }
+        _ => panic!("room-{room_size} has no checked-in wire digest"),
+    };
+    let actual: String = ledger
+        .output_sha256
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    assert_eq!(
+        actual,
+        expected,
+        "{} room-{room_size} exact relay wire digest changed",
+        scenario.name()
+    );
+}
+
 #[derive(Debug, Clone, Copy)]
 struct RecipientProfile {
     protocol_version: u16,
@@ -143,20 +196,36 @@ impl Fixture {
         };
 
         let warm_message = relay_message(scenario, RELAYS_PER_SAMPLE as u64 + 1);
-        let warmed = fixture.run_messages(std::slice::from_ref(&warm_message));
+        let warmed = fixture.run_messages(std::slice::from_ref(&warm_message), true);
         fixture.assert_non_vacuous(&warmed, 1);
         fixture
     }
 
     pub fn run_sample(&mut self) -> Ledger {
         let messages = std::mem::take(&mut self.messages);
-        let ledger = self.run_messages(&messages);
+        let ledger = self.run_messages(&messages, true);
         self.messages = messages;
         self.assert_non_vacuous(&ledger, RELAYS_PER_SAMPLE);
         ledger
     }
 
-    fn run_messages(&mut self, messages: &[Arc<ServerMessage>]) -> Ledger {
+    /// Run the production seam without hashing every emitted byte.
+    ///
+    /// The allocation harness uses [`Self::run_sample`] so exact wire output
+    /// remains validated. Criterion uses this variant because production does
+    /// not SHA-256 relay frames and timing that work obscures the code under
+    /// measurement, especially in larger rooms.
+    #[allow(dead_code)] // Shared support is compiled separately for the allocation benchmark.
+    pub fn run_timed_sample(&mut self) -> Ledger {
+        let messages = std::mem::take(&mut self.messages);
+        let ledger = self.run_messages(&messages, false);
+        self.messages = messages;
+        self.assert_non_vacuous(&ledger, RELAYS_PER_SAMPLE);
+        debug_assert_eq!(ledger.output_sha256, [0; 32]);
+        ledger
+    }
+
+    fn run_messages(&mut self, messages: &[Arc<ServerMessage>], hash_output: bool) -> Ledger {
         let attempts_before = self
             .metrics
             .websocket_delivery_attempts
@@ -226,16 +295,24 @@ impl Fixture {
                         Message::Text(text) => {
                             ledger.text_frames += 1;
                             ledger.wire_bytes += text.len() as u64;
-                            digest.update([0]);
-                            digest.update((text.len() as u64).to_le_bytes());
-                            digest.update(text.as_bytes());
+                            if hash_output {
+                                digest.update([0]);
+                                digest.update((text.len() as u64).to_le_bytes());
+                                digest.update(text.as_bytes());
+                            } else {
+                                std::hint::black_box(&text);
+                            }
                         }
                         Message::Binary(bytes) => {
                             ledger.binary_frames += 1;
                             ledger.wire_bytes += bytes.len() as u64;
-                            digest.update([1]);
-                            digest.update((bytes.len() as u64).to_le_bytes());
-                            digest.update(&bytes);
+                            if hash_output {
+                                digest.update([1]);
+                                digest.update((bytes.len() as u64).to_le_bytes());
+                                digest.update(&bytes);
+                            } else {
+                                std::hint::black_box(&bytes);
+                            }
                         }
                         other => panic!("game-data projector emitted non-data frame: {other:?}"),
                     }
@@ -249,7 +326,9 @@ impl Fixture {
                     "serialization fixture left queued frames behind"
                 );
             }
-            ledger.output_sha256 = digest.finalize().into();
+            if hash_output {
+                ledger.output_sha256 = digest.finalize().into();
+            }
             ledger
         });
         ledger.attempts = self

--- a/docs/ci-cd-testing.md
+++ b/docs/ci-cd-testing.md
@@ -136,7 +136,7 @@ Key design decisions:
   redundant for an existing tag and can make a historical retry require
   workflow-write permission when release workflows have since changed on the
   default branch; the workflow-scoped token cannot receive that permission.
-  A validated existing Release is never PATCHed during a retry, and SBOM/binary
+  A validated existing Release is never modified during a retry, and SBOM/binary
   recovery uses asset-only uploads with replacement enabled.
 
 | Test | What It Validates |

--- a/docs/ci-cd-testing.md
+++ b/docs/ci-cd-testing.md
@@ -130,11 +130,20 @@ Key design decisions:
   job checks the same workflows listed in the `REQUIRED_WORKFLOW_NAMES`
   constant in `tests/ci_config_tests.rs`, keeping the source of truth
   consistent.
+- **Release the verified tag, without retargeting it**: `ensure-tag` creates or
+  verifies the immutable annotated tag before publication. The GitHub Release
+  step therefore supplies only that tag name. Supplying `target_commitish` is
+  redundant for an existing tag and can make a historical retry require
+  workflow-write permission when release workflows have since changed on the
+  default branch; the workflow-scoped token cannot receive that permission.
+  A validated existing Release is never PATCHed during a retry, and SBOM/binary
+  recovery uses asset-only uploads with replacement enabled.
 
 | Test | What It Validates |
 |------|-------------------|
 | `test_release_workflow_conventions` | Name, permissions, timeout, concurrency settings |
 | `test_release_workflow_requires_preflight` | Preflight job exists, publish depends on it, required workflow names referenced |
+| `test_release_identity_fails_closed_across_artifacts` | Immutable source identity is shared across artifacts without retargeting an existing release tag |
 
 #### SBOM (Software Bill of Materials)
 

--- a/progress/session-078-release-and-relay-integrity.md
+++ b/progress/session-078-release-and-relay-integrity.md
@@ -1,0 +1,94 @@
+# Session 078 — Release, relay, and retry integrity
+
+## Scope
+
+Continue the highest-impact bounded work from open issues #207 and #205, then
+recover the incomplete v0.5.2 publication and prevent the same historical
+GitHub Release retry failure from recurring.
+
+## Release recovery and root cause
+
+The first manual v0.5.2 publication attempt ran before the release commit's CI
+and documentation workflows had finished, so preflight correctly failed. By the
+time all required checks were green, `main` contained three later sessions and
+its `[Unreleased]` metadata no longer described v0.5.2. Retrying directly from
+that head would therefore have been unsafe.
+
+The release resolver already supported this state. An annotated `v0.5.2` tag
+was created at the merged release commit `09238c36`, whose required workflows
+had passed, and pushed without moving any existing reference. Release run
+30763742198 then reused that exact source: crate publication, the versioned
+multi-architecture GHCR manifest, and all six platform binary builds succeeded.
+crates.io now contains the unyanked 0.5.2 package.
+
+GitHub Release creation alone failed with HTTP 403. The workflow passed the
+historical source SHA as `target_commitish` even though `ensure-tag` had already
+created and verified the immutable annotated tag. Because workflow files had
+changed between that commit and the current default branch, GitHub classified
+the redundant target operation as requiring workflow-write permission;
+workflow-scoped `GITHUB_TOKEN` cannot receive it. The fix releases the verified
+existing tag without passing `target_commitish`. A workflow-policy regression
+test and the CI/CD runbook record why that omission is part of source-identity
+integrity rather than a weaker check.
+
+The adversarial pass then found a second-order retry hazard: the release action
+PATCHes an already-existing Release with its stored target even when no new
+target input is supplied, including calls whose apparent purpose is only asset
+attachment. The corrected workflow skips creation/mutation after validating an
+existing Release and uses `gh release upload --clobber` for SBOM and binary
+recovery. Those commands touch assets only and preserve partial-success binary
+semantics when one platform class is unavailable.
+
+## Relay allocation and measurement integrity
+
+Failure-first ceilings showed the MessagePack-to-JSON fallback growing its
+output three times in two-player rooms and six times in 8-/16-player rooms.
+Pre-sizing the fallible JSON writer from the opaque payload length plus fixed
+envelope headroom removes those reallocations. Mixed-room allocation operations
+move from 18/28/28 to 15/22/22 at 2/8/16 players, while allocated bytes move
+from 4,449/9,844/10,164 to 3,572/8,090/8,410. Exact output digests, bytes,
+frames, delivery counts, and drained queues are unchanged.
+
+The same audit found a no-op `RelayFrameCache` allocated for repeated frozen-v2
+JSON/Rkyv raw passthrough. Those frames already clone a shared `Bytes` handle,
+so skipping the cache removes one operation and about 680 bytes at 8/16 players:
+3 operations and 664/984 bytes remain, versus 4 and 1,344/1,664 previously.
+
+Criterion's timed relay loop also hashed every emitted byte with SHA-256 solely
+to prevent optimizer elision. At 16 players that measured 15–17 MiB of hashing
+per sample that production never performs. Exact hashes remain mandatory in a
+validation sample, while timed samples black-box frames and retain the cheap
+work/accounting ledger without hashing.
+
+## Strict retry cap
+
+Both retry executor paths previously capped exponential backoff and then added
+up to 20% jitter. A persistent retry at the documented five-second maximum
+could therefore sleep for six seconds. The shared calculation now bounds the
+complete jittered delay, caps an overlarge initial delay, preserves fractional
+`Duration` precision, and saturates invalid or overflowing factors without
+panicking. Deterministic tests cover cap-before-jitter, remaining headroom,
+ordinary jitter, sub-millisecond delay, initial-cap, and overflow boundaries.
+
+## Validation and publication
+
+Mandatory local validation completed successfully:
+
+- formatting, strict all-target/all-feature Clippy, and the complete locked
+  all-feature test suite;
+- all 15 allocation cells across five exact repeats, including checked-in wire
+  digests and the tightened operation/reallocation/byte ceilings;
+- cargo-deny plus CI configuration, workflow hygiene, tooling parity, MSRV,
+  documentation consistency, Markdown, internal-link, LLM-policy, and hook
+  preflight suites; and
+- two independent adversarial-review rounds.
+
+The first hostile review identified the existing-Release PATCH hazard and the
+initially unasserted pre-timing digest; both were fixed and regression-guarded.
+It also prompted tighter mixed-room byte ceilings and a fractional-jitter
+boundary check during parent review. The second hostile review reported zero
+findings after rerunning the focused release, retry, allocation, actionlint,
+formatting, and Clippy checks.
+
+Hosted CI, GitHub review, and the final v0.5.2 GitHub Release retry remain in
+progress.

--- a/progress/session-078-release-and-relay-integrity.md
+++ b/progress/session-078-release-and-relay-integrity.md
@@ -90,5 +90,16 @@ boundary check during parent review. The second hostile review reported zero
 findings after rerunning the focused release, retry, allocation, actionlint,
 formatting, and Clippy checks.
 
-Hosted CI, GitHub review, and the final v0.5.2 GitHub Release retry remain in
-progress.
+Hosted validation completed on PR #245 implementation head `31cb0d5`: all 19
+workflow runs reached terminal state, with 18 successes and the expected
+Dependabot auto-merge skip. The first head exposed one spelling false positive
+in release prose; the corrected head passed Spellcheck and every Rust, safety,
+fuzz, interop, formal, documentation, and workflow-policy lane. Cursor Bugbot
+reported zero findings on that exact head, no review threads remained, and
+Copilot's two requested passes were unavailable only because its account quota
+was exhausted.
+
+The final v0.5.2 GitHub Release retry remains gated on merging the corrected
+workflow to the default branch. It is intentionally not attempted from the PR
+branch because the resolver requires the workflow definition on `main` and the
+session target is a fully green PR rather than an unreviewed merge.

--- a/progress/session-078-release-and-relay-integrity.md
+++ b/progress/session-078-release-and-relay-integrity.md
@@ -90,14 +90,29 @@ boundary check during parent review. The second hostile review reported zero
 findings after rerunning the focused release, retry, allocation, actionlint,
 formatting, and Clippy checks.
 
-Hosted validation completed on PR #245 implementation head `31cb0d5`: all 19
-workflow runs reached terminal state, with 18 successes and the expected
-Dependabot auto-merge skip. The first head exposed one spelling false positive
-in release prose; the corrected head passed Spellcheck and every Rust, safety,
-fuzz, interop, formal, documentation, and workflow-policy lane. Cursor Bugbot
-reported zero findings on that exact head, no review threads remained, and
-Copilot's two requested passes were unavailable only because its account quota
-was exhausted.
+Hosted aggregate validation completed on PR #245 implementation head
+`31cb0d5`: all 19 workflow runs reached terminal state, with 18 successes and
+the expected Dependabot auto-merge skip. The first head exposed one spelling
+false positive in release prose. Cursor Bugbot reported zero findings, no
+review threads remained, and Copilot's requested passes were unavailable only
+because its account quota was exhausted.
+
+Postflight job-level inspection then found that the informational Miri job was
+red even though its `continue-on-error` Advanced Safety workflow was green. In
+the full interpreter suite,
+`initial_room_transitions_wait_for_capacity_before_taking_routing_locks`
+occasionally consumed its real one-second slow-consumer timeout while the test
+queue was intentionally full, returning `SlowConsumer` instead of `Delivered`.
+The same test passed in isolation, proving that host scheduling rather than the
+production delivery path controlled the result. The test now owns a paused
+Tokio clock, as the adjacent deadline-boundary tests already do, so its 10 ms
+pending probe advances exactly 10 ms of virtual time.
+
+The corrected test passed five consecutive focused runs under pinned
+`nightly-2026-08-01` Miri and the complete CI-equivalent Miri library suite:
+474 passed, 198 ignored, zero failed. Formatting, strict Clippy, and the full
+locked all-feature test suite also passed after the correction. Hosted
+verification of the corrected PR head remains in progress.
 
 The final v0.5.2 GitHub Release retry remains gated on merging the corrected
 workflow to the default branch. It is intentionally not attempted from the PR

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -135,7 +135,7 @@ impl RetryExecutor {
         E: From<RetryableError> + std::fmt::Debug,
     {
         let mut attempt = 1;
-        let mut delay = self.config.initial_delay;
+        let mut delay = bounded_initial_delay(&self.config);
 
         loop {
             if let Some(metrics) = &self.metrics {
@@ -195,19 +195,7 @@ impl RetryExecutor {
 
                     sleep(delay).await;
 
-                    // Calculate next delay with exponential backoff and jitter
-                    let next_delay = Duration::from_millis(
-                        (delay.as_millis() as f64 * self.config.backoff_multiplier) as u64,
-                    );
-
-                    delay = std::cmp::min(next_delay, self.config.max_delay);
-
-                    // Add jitter
-                    if self.config.jitter_factor > 0.0 {
-                        let jitter = (delay.as_millis() as f64 * self.config.jitter_factor) as u64;
-                        let jitter_amount = fastrand::u64(0..=jitter);
-                        delay = Duration::from_millis(delay.as_millis() as u64 + jitter_amount);
-                    }
+                    delay = bounded_next_delay(&self.config, delay, fastrand::f64());
 
                     attempt += 1;
                 }
@@ -230,7 +218,7 @@ impl RetryExecutor {
         E: std::fmt::Debug,
     {
         let mut attempt = 1;
-        let mut delay = self.config.initial_delay;
+        let mut delay = bounded_initial_delay(&self.config);
 
         loop {
             if let Some(metrics) = &self.metrics {
@@ -290,18 +278,7 @@ impl RetryExecutor {
 
                     sleep(delay).await;
 
-                    // Calculate next delay
-                    let next_delay = Duration::from_millis(
-                        (delay.as_millis() as f64 * self.config.backoff_multiplier) as u64,
-                    );
-                    delay = std::cmp::min(next_delay, self.config.max_delay);
-
-                    // Add jitter
-                    if self.config.jitter_factor > 0.0 {
-                        let jitter = (delay.as_millis() as f64 * self.config.jitter_factor) as u64;
-                        let jitter_amount = fastrand::u64(0..=jitter);
-                        delay = Duration::from_millis(delay.as_millis() as u64 + jitter_amount);
-                    }
+                    delay = bounded_next_delay(&self.config, delay, fastrand::f64());
 
                     attempt += 1;
                 }
@@ -342,6 +319,51 @@ impl RetryExecutor {
         }
 
         false
+    }
+}
+
+/// Calculate one backoff step while treating `max_delay` as a strict bound on
+/// the complete sleep, including jitter. Invalid public configuration factors
+/// degrade to a bounded zero/cap value instead of panicking or overflowing.
+fn bounded_next_delay(
+    config: &RetryConfig,
+    current_delay: Duration,
+    jitter_fraction: f64,
+) -> Duration {
+    let base = scale_duration_capped(current_delay, config.backoff_multiplier, config.max_delay);
+    let jitter_factor = if config.jitter_factor.is_finite() {
+        config.jitter_factor.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let available = config.max_delay.saturating_sub(base);
+    let jitter_limit = scale_duration_capped(base, jitter_factor, available);
+    let fraction = if jitter_fraction.is_finite() {
+        jitter_fraction.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let jitter = scale_duration_capped(jitter_limit, fraction, jitter_limit);
+    base.saturating_add(jitter).min(config.max_delay)
+}
+
+fn bounded_initial_delay(config: &RetryConfig) -> Duration {
+    std::cmp::min(config.initial_delay, config.max_delay)
+}
+
+fn scale_duration_capped(duration: Duration, factor: f64, cap: Duration) -> Duration {
+    if cap.is_zero() || factor.is_nan() || factor <= 0.0 {
+        return Duration::ZERO;
+    }
+    if factor.is_infinite() {
+        return cap;
+    }
+
+    let scaled_secs = duration.as_secs_f64() * factor;
+    if !scaled_secs.is_finite() || scaled_secs >= cap.as_secs_f64() {
+        cap
+    } else {
+        Duration::try_from_secs_f64(scaled_secs).unwrap_or(cap)
     }
 }
 
@@ -525,6 +547,114 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 2);
+    }
+
+    #[test]
+    fn retry_delay_caps_the_complete_jittered_sleep() {
+        let cases = [
+            (
+                "backoff reaches cap before jitter",
+                RetryConfig {
+                    max_delay: Duration::from_secs(5),
+                    backoff_multiplier: 2.0,
+                    jitter_factor: 0.2,
+                    ..RetryConfig::persistent()
+                },
+                Duration::from_secs(4),
+                1.0,
+                Duration::from_secs(5),
+            ),
+            (
+                "jitter consumes only remaining headroom",
+                RetryConfig {
+                    max_delay: Duration::from_secs(1),
+                    backoff_multiplier: 1.0,
+                    jitter_factor: 1.0,
+                    ..RetryConfig::default()
+                },
+                Duration::from_millis(750),
+                1.0,
+                Duration::from_secs(1),
+            ),
+            (
+                "jitter factor applies before remaining headroom cap",
+                RetryConfig {
+                    max_delay: Duration::from_secs(5),
+                    backoff_multiplier: 1.0,
+                    jitter_factor: 0.2,
+                    ..RetryConfig::default()
+                },
+                Duration::from_secs(4),
+                1.0,
+                Duration::from_millis(4_800),
+            ),
+            (
+                "ordinary jitter remains additive",
+                RetryConfig {
+                    max_delay: Duration::from_secs(1),
+                    backoff_multiplier: 2.0,
+                    jitter_factor: 0.5,
+                    ..RetryConfig::default()
+                },
+                Duration::from_millis(100),
+                1.0,
+                Duration::from_millis(300),
+            ),
+            (
+                "sub-millisecond precision is preserved",
+                RetryConfig {
+                    max_delay: Duration::from_secs(1),
+                    backoff_multiplier: 2.0,
+                    jitter_factor: 0.0,
+                    ..RetryConfig::default()
+                },
+                Duration::from_micros(250),
+                0.0,
+                Duration::from_micros(500),
+            ),
+            (
+                "fractional backoff may decrease a delay at the cap",
+                RetryConfig {
+                    max_delay: Duration::from_secs(5),
+                    backoff_multiplier: 0.5,
+                    jitter_factor: 0.0,
+                    ..RetryConfig::default()
+                },
+                Duration::from_secs(5),
+                0.0,
+                Duration::from_millis(2_500),
+            ),
+            (
+                "duration overflow saturates at cap",
+                RetryConfig {
+                    max_delay: Duration::from_secs(5),
+                    backoff_multiplier: f64::MAX,
+                    jitter_factor: 1.0,
+                    ..RetryConfig::default()
+                },
+                Duration::MAX,
+                1.0,
+                Duration::from_secs(5),
+            ),
+        ];
+
+        for (context, config, current, fraction, expected) in cases {
+            assert_eq!(
+                bounded_next_delay(&config, current, fraction),
+                expected,
+                "{context}"
+            );
+        }
+    }
+
+    #[test]
+    fn retry_initial_delay_respects_the_configured_maximum() {
+        let config = RetryConfig {
+            initial_delay: Duration::from_secs(6),
+            max_delay: Duration::from_secs(5),
+            ..RetryConfig::persistent()
+        };
+        assert_eq!(bounded_initial_delay(&config), Duration::from_secs(5));
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1007,6 +1007,17 @@ fn relay_projection_cohort(
     Some(match message {
         ServerMessage::GameData { .. } if supports_v3 => RelayProjectionCohort::TextV3,
         ServerMessage::GameData { .. } => RelayProjectionCohort::TextV2,
+        // Frozen-v2 JSON and Rkyv binary frames already own shared `Bytes` and
+        // project by cloning that handle. There is no serialization/decode
+        // work to reuse, so a relay-wide frame cache would only add an
+        // allocation in rooms with multiple compatible recipients.
+        ServerMessage::GameDataBinary { encoding, .. }
+            if !supports_v3
+                && *encoding == recipient_format
+                && matches!(encoding, GameDataEncoding::Json | GameDataEncoding::Rkyv) =>
+        {
+            return None;
+        }
         ServerMessage::GameDataBinary { encoding, .. }
             if *encoding == recipient_format && supports_v3 =>
         {
@@ -2839,6 +2850,26 @@ mod relay_projection_cache_tests {
             relay_projection_cohort(&binary, true, GameDataEncoding::Json),
             Some(BinaryFallbackV3)
         );
+
+        for encoding in [GameDataEncoding::Json, GameDataEncoding::Rkyv] {
+            let raw_v2 = ServerMessage::GameDataBinary {
+                from_player: Uuid::nil(),
+                encoding,
+                payload: vec![0x01].into(),
+                seq: Some(1),
+                epoch: Some(1),
+            };
+            assert_eq!(
+                relay_projection_cohort(&raw_v2, false, encoding),
+                None,
+                "v2 {encoding:?} raw passthrough has no reusable projection work"
+            );
+            assert_eq!(
+                relay_projection_cohort(&raw_v2, true, encoding),
+                Some(BinaryDirectV3),
+                "v3 {encoding:?} still needs its stamped MessagePack envelope cached"
+            );
+        }
     }
 
     fn legacy_delivery_handle(

--- a/src/server/message_coordinator_tests.rs
+++ b/src/server/message_coordinator_tests.rs
@@ -654,8 +654,10 @@ async fn registration_replaces_the_players_room_routing_scope() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn initial_room_transitions_wait_for_capacity_before_taking_routing_locks() {
+    // This test owns the deadline boundary. Full-suite Miri execution can
+    // consume a real one-second timeout while the queue is intentionally full.
     for async_builder in [false, true] {
         let metrics = Arc::new(ServerMetrics::new());
         let coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -301,8 +301,8 @@ fn materialize_game_data_frame_uncached(
                 }
             };
             let fallback = BorrowedGameDataEnvelope::new(*from_player, data.as_ref(), seq, epoch);
-            let frame = serialize_json_frame(&fallback)
-                .map_err(|error| GameDataMaterializationError::Serialization(error.to_string()))?;
+            let frame = serialize_json_fallback_frame(&fallback, payload.len())
+                .map_err(GameDataMaterializationError::Serialization)?;
             Ok(MaterializedFrame {
                 frame,
                 work: SerializationWork {
@@ -736,6 +736,35 @@ fn serialize_json_frame<T: Serialize>(message: &T) -> Result<Message, serde_json
     serialize_json_text(message).map(|json| Message::Text(json.into()))
 }
 
+/// Serialize a decoded binary fallback without repeatedly growing the JSON
+/// output buffer. MessagePack is normally denser than JSON, so its opaque
+/// payload length is a useful lower bound; fixed headroom covers the relay
+/// envelope and common representation expansion. Unusually compact inputs can
+/// still grow through the fallible writer without changing wire bytes.
+fn serialize_json_fallback_frame<T: Serialize>(
+    message: &T,
+    payload_len: usize,
+) -> Result<Message, String> {
+    const JSON_FALLBACK_HEADROOM: usize = 256;
+
+    let capacity = payload_len
+        .checked_add(JSON_FALLBACK_HEADROOM)
+        .filter(|capacity| *capacity <= isize::MAX as usize)
+        .ok_or_else(|| "JSON fallback frame capacity overflow".to_string())?;
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(capacity)
+        .map_err(|error| format!("failed to reserve JSON fallback frame capacity: {error}"))?;
+    serde_json::to_writer(
+        &mut FallibleVecWriter::new(&mut bytes, "JSON fallback"),
+        message,
+    )
+    .map_err(|error| error.to_string())?;
+    String::from_utf8(bytes)
+        .map(|json| Message::Text(json.into()))
+        .map_err(|error| format!("JSON serializer emitted invalid UTF-8: {error}"))
+}
+
 /// Borrowed wire shadow of a `ServerMessage::GameData` frame WITHOUT the v3
 /// `seq` stamp, used to serialize a stamped shared-`Arc` relay message for a
 /// pre-v3 recipient without cloning the payload.
@@ -903,7 +932,8 @@ fn encode_named_binary_frame<T: Serialize>(
     bytes
         .try_reserve_exact(capacity)
         .map_err(|error| format!("failed to reserve binary frame capacity: {error}"))?;
-    write_named(&mut FallibleVecWriter(&mut bytes), frame).map_err(|err| err.to_string())?;
+    write_named(&mut FallibleVecWriter::new(&mut bytes, "binary"), frame)
+        .map_err(|err| err.to_string())?;
     Ok(bytes)
 }
 
@@ -911,25 +941,37 @@ fn encode_named_binary_frame<T: Serialize>(
 /// pre-sized output vector. Writing directly to `Vec<u8>` would use its
 /// infallible `Write` implementation if fixed envelope headroom ever became
 /// insufficient.
-struct FallibleVecWriter<'a>(&'a mut Vec<u8>);
+struct FallibleVecWriter<'a> {
+    bytes: &'a mut Vec<u8>,
+    frame_kind: &'static str,
+}
 
 impl FallibleVecWriter<'_> {
+    fn new<'a>(bytes: &'a mut Vec<u8>, frame_kind: &'static str) -> FallibleVecWriter<'a> {
+        FallibleVecWriter { bytes, frame_kind }
+    }
+
     fn reserve_for_write(&mut self, additional_len: usize) -> std::io::Result<()> {
         let required_len = self
-            .0
+            .bytes
             .len()
             .checked_add(additional_len)
             .filter(|required_len| *required_len <= isize::MAX as usize)
             .ok_or_else(|| {
                 std::io::Error::new(
                     std::io::ErrorKind::InvalidInput,
-                    "binary frame capacity overflow",
+                    format!("{} frame capacity overflow", self.frame_kind),
                 )
             })?;
-        if required_len > self.0.capacity() {
-            self.0
+        if required_len > self.bytes.capacity() {
+            self.bytes
                 .try_reserve_exact(additional_len)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::OutOfMemory, error))?;
+                .map_err(|error| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::OutOfMemory,
+                        format!("failed to grow {} frame buffer: {error}", self.frame_kind),
+                    )
+                })?;
         }
         Ok(())
     }
@@ -943,7 +985,7 @@ impl Write for FallibleVecWriter<'_> {
 
     fn write_all(&mut self, buffer: &[u8]) -> std::io::Result<()> {
         self.reserve_for_write(buffer.len())?;
-        self.0.extend_from_slice(buffer);
+        self.bytes.extend_from_slice(buffer);
         Ok(())
     }
 
@@ -1540,6 +1582,34 @@ mod tests {
     }
 
     #[test]
+    fn json_fallback_preallocation_preserves_wire_bytes_across_growth_paths() {
+        let data = serde_json::json!({
+            "escaped": "\"\\\n".repeat(300),
+            "values": [0, 1, 127, 128, 255, 256, u32::MAX],
+        });
+        let fallback = BorrowedGameDataEnvelope::new(player_a(), &data, Some(7), Some(3));
+        let expected = serialize_json_frame(&fallback).expect("reference JSON fallback encode");
+
+        for estimated_payload_len in [0, 1, 127, 128, 255, 256, 1_024, 4_096] {
+            assert_eq!(
+                serialize_json_fallback_frame(&fallback, estimated_payload_len)
+                    .expect("preallocated JSON fallback encode"),
+                expected,
+                "estimated payload length {estimated_payload_len} changed JSON fallback bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn json_fallback_capacity_overflow_is_reported() {
+        for payload_len in [isize::MAX as usize, usize::MAX] {
+            let error = serialize_json_fallback_frame(&0_u8, payload_len)
+                .expect_err("capacity overflow must fail before allocation");
+            assert!(error.contains("capacity overflow"));
+        }
+    }
+
+    #[test]
     fn binary_frame_capacity_overflow_is_reported() {
         for payload_len in [isize::MAX as usize, usize::MAX] {
             let error = encode_named_binary_frame(&0_u8, payload_len)
@@ -1548,7 +1618,7 @@ mod tests {
         }
 
         let mut bytes = Vec::new();
-        let error = FallibleVecWriter(&mut bytes)
+        let error = FallibleVecWriter::new(&mut bytes, "binary")
             .reserve_for_write(usize::MAX)
             .expect_err("writer length overflow must not be reported as allocation failure");
         assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4682,11 +4682,21 @@ fn test_release_workflow_attaches_binaries_with_checksums() {
     let root = repo_root();
     let live = read_live_file(&root.join(".github/workflows/release.yml"));
 
-    assert!(
-        live.contains("softprops/action-gh-release"),
-        "release.yml must upload built binaries to the GitHub Release \
-         (softprops/action-gh-release)."
-    );
+    let attach = extract_workflow_job_block(&live, "attach-binaries")
+        .expect("release.yml must define attach-binaries");
+    let upload = extract_named_workflow_step(&attach, "Attach binaries to release")
+        .expect("attach-binaries must define one correlated upload step");
+    for required in [
+        "mapfile -d '' assets",
+        "find dist -type f",
+        "gh release upload \"$TAG\" \"${assets[@]}\" --clobber",
+    ] {
+        assert!(
+            upload.contains(required),
+            "release.yml must upload the discovered binary/checksum set with `{required}` without \
+             PATCHing release identity.\nStep:\n{upload}"
+        );
+    }
     // A checksum must actually be COMPUTED for each archive...
     assert!(
         live.contains("sha256sum") || live.contains("shasum -a 256"),
@@ -4703,16 +4713,12 @@ fn test_release_workflow_attaches_binaries_with_checksums() {
         live.contains(".tar.gz") && live.contains(".zip"),
         "release.yml must produce and upload both `.tar.gz` (unix) and `.zip` (windows) archives."
     );
-    // The attach step must NOT use `fail_on_unmatched_files: true`: that flag is
-    // evaluated per-glob, so a single absent format class (e.g. both Windows
-    // legs failing -> no *.zip) would fail the whole upload and strip EVERY
-    // binary off the release — defeating the fail-fast:false partial-success
-    // design. Per-artifact presence is guarded by `if-no-files-found: error`.
     assert!(
-        !live.contains("fail_on_unmatched_files: true"),
-        "release.yml attach step must not set `fail_on_unmatched_files: true`; a correlated \
-         leg failure would then strip all binaries off the release instead of attaching the \
-         ones that built."
+        upload.contains("-name '*.tar.gz'")
+            && upload.contains("-name '*.zip'")
+            && upload.contains("-name '*.sha256'"),
+        "release.yml must discover every available archive/checksum class in one partial-success \
+         upload instead of requiring every glob class to exist.\nStep:\n{upload}"
     );
 }
 
@@ -4802,7 +4808,7 @@ fn test_release_workflow_skips_binary_attach_when_no_artifacts_exist() {
     }
 
     assert!(
-        attach_job.contains("tag_name: ${{ needs.resolve-release.outputs.tag }}"),
+        attach_job.contains("TAG: ${{ needs.resolve-release.outputs.tag }}"),
         "attach-binaries must consume the canonical tag from resolve-release instead of \
          re-deriving it from event-specific state.\nJob block:\n{attach_job}"
     );
@@ -4952,6 +4958,15 @@ fn test_release_identity_fails_closed_across_artifacts() {
     let verifier = read_live_file(&root.join("scripts/verify-release-image.sh"));
     let resolver = read_live_file(&root.join("scripts/resolve-release-source.sh"));
     let crate_check = read_live_file(&root.join("scripts/check-crates-io-release.sh"));
+    let publish =
+        extract_workflow_job_block(&release, "publish").expect("release.yml must define publish");
+    let create_release = extract_named_workflow_step(&publish, "Create GitHub Release")
+        .expect("publish must define the GitHub Release creation step");
+    let validate_release =
+        extract_named_workflow_step(&publish, "Validate an existing GitHub Release")
+            .expect("publish must define the existing GitHub Release gate");
+    let attach_sbom = extract_named_workflow_step(&publish, "Attach SBOM to release")
+        .expect("publish must define the SBOM attachment step");
 
     let required_by_file = [
         (
@@ -4961,7 +4976,6 @@ fn test_release_identity_fails_closed_across_artifacts() {
                 "scripts/resolve-release-source.sh",
                 "git cat-file -t \"refs/tags/${TAG}\"",
                 "refusing to move it",
-                "target_commitish: ${{ needs.resolve-release.outputs.source_revision }}",
                 "Verify GitHub Release identity",
             ],
         ),
@@ -5022,6 +5036,41 @@ fn test_release_identity_fails_closed_across_artifacts() {
             );
         }
     }
+
+    assert!(
+        create_release.contains("tag_name: ${{ needs.resolve-release.outputs.tag }}"),
+        "GitHub Release creation must use the tag whose annotated identity was verified before \
+         publication.\nStep:\n{create_release}"
+    );
+    assert!(
+        !create_release.contains("target_commitish:"),
+        "GitHub Release creation must not pass target_commitish after ensure-tag has created or \
+         verified the immutable annotated tag. Re-supplying a historical commit makes GitHub \
+         treat workflow-file drift from the default branch as a workflow mutation and reject \
+         GITHUB_TOKEN retries even though the tag already exists.\nStep:\n{create_release}"
+    );
+    for required in [
+        "id: existing-release",
+        "echo \"exists=true\" >> \"$GITHUB_OUTPUT\"",
+        "echo \"exists=false\" >> \"$GITHUB_OUTPUT\"",
+    ] {
+        assert!(
+            validate_release.contains(required),
+            "The existing-release gate must publish `{required}` so retries never PATCH an old \
+             release target.\nStep:\n{validate_release}"
+        );
+    }
+    assert!(
+        create_release.contains("if: steps.existing-release.outputs.exists != 'true'"),
+        "Release creation must be skipped after a validated existing Release is found.\n\
+         Step:\n{create_release}"
+    );
+    assert!(
+        attach_sbom.contains("gh release upload \"$TAG\" source/sbom.cdx.json --clobber")
+            && !attach_sbom.contains("softprops/action-gh-release"),
+        "SBOM retries must use the asset-only upload API rather than PATCHing Release identity.\n\
+         Step:\n{attach_sbom}"
+    );
 }
 
 #[test]
@@ -17741,11 +17790,12 @@ fn test_release_workflow_attaches_sbom_to_release() {
         release_yml.display()
     );
 
-    // The attach step must reference sbom.cdx.json
+    // The attach step must use an asset-only upload so an idempotent historical
+    // retry never PATCHes the Release's stored target commit.
     assert!(
-        content.contains("files: source/sbom.cdx.json"),
+        content.contains("gh release upload \"$TAG\" source/sbom.cdx.json --clobber"),
         "release.yml must attach sbom.cdx.json to the GitHub release.\n\
-         Add 'files: source/sbom.cdx.json' to the 'Attach SBOM to release' step.\n\
+         Use an idempotent asset-only upload in the 'Attach SBOM to release' step.\n\
          This allows release consumers to download the SBOM for audit purposes.\n\
          File: {}",
         release_yml.display()


### PR DESCRIPTION
## Summary

- pre-size MessagePack-to-JSON relay fallback output and skip no-op shared caches for frozen-v2 raw passthrough
- keep runtime benchmark SHA-256 validation outside the timed production path while enforcing checked-in wire digests
- make retry `max_delay` a strict bound including jitter, with sub-millisecond and overflow-safe arithmetic
- make historical GitHub Release retries idempotent without workflow-write permission by releasing the verified tag, skipping existing-Release mutation, and using asset-only SBOM/binary uploads

Advances #207 and #205.

## Measured results

- mixed MessagePack-source rooms (2/8/16): allocation operations `18/28/28 -> 15/22/22`, reallocations `3/6/6 -> 0/0/0`, bytes `4449/9844/10164 -> 3572/8090/8410`
- frozen-v2 JSON/Rkyv rooms (8/16): operations `4 -> 3`, bytes `1344/1664 -> 664/984`
- all 15 cells retain their exact checked-in frame/length/byte/order digests and accounting ledgers

## Release recovery

The v0.5.2 recovery published the exact tagged crate, GHCR manifest, and built all six binaries. GitHub Release creation then failed because the redundant historical `target_commitish` required workflow-write permission that `GITHUB_TOKEN` cannot receive. This PR removes that redundant target and prevents later asset retries from PATCHing an existing Release identity.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- all 15 allocation-ceiling cells across five exact repeats
- `cargo deny --all-features check`
- CI/workflow/MSRV/tooling/documentation/Markdown/link/LLM/hook policy suites
- two hostile independent review rounds; final round reported zero findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s GitHub API behavior and retry sleep semantics on the hot relay path; wire output is guarded by digests and allocation ceilings, but mistaken release or retry logic could still block publication or alter backoff under lock contention.
> 
> **Overview**
> Cuts **relay fan-out allocation work** without changing wire bytes: MessagePack→JSON fallback now **pre-sizes** the JSON buffer from opaque payload length plus headroom (removing repeated growth reallocations in mixed-format rooms), and **frozen-v2 JSON/Rkyv raw passthrough** skips a no-op relay frame cache when recipients already share `Bytes`. Allocation benchmarks enforce **checked-in wire SHA-256 digests** and lower operation/byte ceilings; the **runtime** benchmark validates digests once then times a path that omits per-frame hashing production never does.
> 
> **Retry backoff** treats `max_delay` as a cap on the **full jittered sleep** (including sub-millisecond precision and overflow-safe scaling), so a 5s maximum cannot become ~6s after jitter.
> 
> **GitHub Release retries** publish the already-verified immutable tag **without** `target_commitish`, skip creating/patching a Release when one already exists, and attach SBOM/binaries via **`gh release upload --clobber`** so asset recovery does not need workflow-write permission on `GITHUB_TOKEN`. CI/docs tests lock in that policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4446a85a34eee3b54aaa1c6efd2b31285309b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->