### PR TITLE
Fix historical release retry integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -407,6 +407,8 @@ jobs:
     needs: [resolve-release, publication-readiness, publish-container]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      release_notes_sha256: ${{ steps.changelog.outputs.notes_sha256 }}
 
     steps:
       - name: Checkout publication tooling
@@ -417,6 +419,7 @@ jobs:
           path: publication-tools
           sparse-checkout: |
             scripts/check-clean-release-worktree.sh
+            scripts/check-github-release.sh
             scripts/read-toml-string.sh
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -532,6 +535,8 @@ jobs:
             echo ""
             echo "Source revision: \`${{ needs.resolve-release.outputs.source_revision }}\`"
           } > release_notes.md
+          notes_sha256=$(sha256sum release_notes.md | awk '{print $1}')
+          echo "notes_sha256=$notes_sha256" >> "$GITHUB_OUTPUT"
 
       - name: Validate an existing GitHub Release
         id: existing-release
@@ -539,25 +544,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.resolve-release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null); then
-            actual_tag=$(printf '%s' "$release" | jq -r '.tag_name // empty')
-            if [ "$actual_tag" != "$TAG" ]; then
-              echo "ERROR: Existing GitHub Release tag '$actual_tag' disagrees with '$TAG'." >&2
-              exit 1
-            fi
-            echo "Existing GitHub Release for $TAG will be completed idempotently."
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            status=$(gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1 \
-              | sed -n 's/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' | head -n 1 || true)
-            if [ "$status" != "404" ]; then
-              echo "ERROR: Could not verify whether GitHub Release $TAG exists (HTTP ${status:-unknown})." >&2
-              exit 1
-            fi
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          RELEASE_NAME: ${{ needs.resolve-release.outputs.tag }}
+          RELEASE_SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
+          RELEASE_IMAGE_DIGEST: ${{ needs.publish-container.outputs.digest }}
+          RELEASE_NOTES_FILE: source/release_notes.md
+        run: bash publication-tools/scripts/check-github-release.sh
 
       - name: Create GitHub Release
         if: steps.existing-release.outputs.exists != 'true'
@@ -576,6 +567,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Verify GitHub Release metadata before asset uploads
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+          RELEASE_NAME: ${{ needs.resolve-release.outputs.tag }}
+          RELEASE_SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
+          RELEASE_IMAGE_DIGEST: ${{ needs.publish-container.outputs.digest }}
+          RELEASE_NOTES_FILE: source/release_notes.md
+          RELEASE_OUTPUT_FILE: /dev/null
+          RELEASE_REQUIRE_EXISTING: true
+        run: bash publication-tools/scripts/check-github-release.sh
+
       - name: Attach SBOM to release
         if: steps.sbom.outcome == 'success'
         shell: bash
@@ -583,21 +587,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.resolve-release.outputs.tag }}
         run: gh release upload "$TAG" source/sbom.cdx.json --clobber
-
-      - name: Verify GitHub Release identity
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ needs.resolve-release.outputs.tag }}
-        run: |
-          set -euo pipefail
-          release=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")
-          actual_tag=$(printf '%s' "$release" | jq -r '.tag_name // empty')
-          is_draft=$(printf '%s' "$release" | jq -r '.draft')
-          if [ "$actual_tag" != "$TAG" ] || [ "$is_draft" != "false" ]; then
-            echo "ERROR: GitHub Release identity is inconsistent (tag=$actual_tag, draft=$is_draft)." >&2
-            exit 1
-          fi
 
   # ---------------------------------------------------------------------------
   # Cross-platform standalone binaries
@@ -612,10 +601,9 @@ jobs:
   #     It starts after the immutable tag exists, in PARALLEL with container and
   #     crate publication.
   #   - `attach-binaries` (below): a single job that downloads every artifact
-  #     and performs ONE `action-gh-release` upload. Funnelling all assets
-  #     through one release API call avoids the race where N parallel matrix
-  #     jobs PATCH/upload to the same Release concurrently (intermittent 422s /
-  #     clobbering).
+  #     and performs ONE asset-only `gh release upload`. Funnelling all assets
+  #     through one upload avoids the race where N parallel matrix jobs upload
+  #     to the same Release concurrently (intermittent 422s / clobbering).
   #
   # Binaries are built with DEFAULT features (no `tls`) to match the published
   # container image and to keep cross-compilation free of C-crypto toolchain
@@ -780,7 +768,7 @@ jobs:
   # ---------------------------------------------------------------------------
   attach-binaries:
     name: Attach binaries to release
-    needs: [resolve-release, publish, build-binaries]
+    needs: [resolve-release, publish-container, publish, build-binaries]
     if: ${{ !cancelled() && needs.publish.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -812,6 +800,20 @@ jobs:
       - name: Checkout repository
         if: steps.binary-artifacts.outputs.count != '0'
         uses: actions/checkout@v7.0.1
+
+      - name: Validate GitHub Release before binary asset uploads
+        if: steps.binary-artifacts.outputs.count != '0'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
+          RELEASE_NAME: ${{ needs.resolve-release.outputs.tag }}
+          RELEASE_SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}
+          RELEASE_IMAGE_DIGEST: ${{ needs.publish-container.outputs.digest }}
+          RELEASE_NOTES_SHA256: ${{ needs.publish.outputs.release_notes_sha256 }}
+          RELEASE_OUTPUT_FILE: /dev/null
+          RELEASE_REQUIRE_EXISTING: true
+        run: bash scripts/check-github-release.sh
 
       - name: Download all binary artifacts
         if: steps.binary-artifacts.outputs.count != '0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without redundantly passing its historical source as `target_commitish`,
   skips identity mutation when the Release already exists, and retries SBOM or
   binary attachments through asset-only uploads. This avoids a workflow-write
-  permission that `GITHUB_TOKEN` cannot receive.
+  permission that `GITHUB_TOKEN` cannot receive. Registry retry validation also
+  recognizes Cargo's canonical clean VCS metadata, where the `dirty` field is
+  omitted, while still rejecting dirty or source-mismatched packages. Existing
+  Releases must also retain the expected public state, exact notes, source
+  revision, and image digest before any SBOM or binary asset is replaced.
 - Keep spectator-occupied rooms alive during garbage collection (issue #241).
   Spectator-only rooms now use the inactive-room timeout, spectator join,
   detach, and live connection traffic refresh room activity, and the normal

--- a/docs/ci-cd-testing.md
+++ b/docs/ci-cd-testing.md
@@ -136,8 +136,11 @@ Key design decisions:
   redundant for an existing tag and can make a historical retry require
   workflow-write permission when release workflows have since changed on the
   default branch; the workflow-scoped token cannot receive that permission.
-  A validated existing Release is never modified during a retry, and SBOM/binary
-  recovery uses asset-only uploads with replacement enabled.
+  A validated existing Release is never modified during a retry. Before any
+  asset replacement, the workflow fails closed unless the Release is public,
+  has the expected name and notes, and records the exact source revision and
+  image digest. SBOM/binary recovery then uses asset-only uploads with
+  replacement enabled.
 
 | Test | What It Validates |
 |------|-------------------|

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -52,7 +52,7 @@ Publication proceeds in this order:
 4. create or validate the immutable annotated tag;
 5. build and verify the versioned multi-architecture GHCR manifest;
 6. verify the source checkout is still clean and publish the crate idempotently;
-7. create or complete the GitHub Release and record the image digest;
+7. create or validate the public GitHub Release and record the image digest;
 8. attach the SBOM and available platform binaries.
 
 If a run stops after creating one artifact, rerun the same version. The retry
@@ -61,6 +61,12 @@ tags are never moved; missing aliases are repaired from the verified digest.
 Resolver, container, publication, and binary jobs load policy helpers from the
 dispatched workflow revision in a checkout separate from the immutable tagged
 source, so a workflow-only recovery fix can safely complete an older release.
+The GitHub Release step reuses the already-verified tag without passing
+`target_commitish`, never patches an existing Release's identity or notes, and
+requires the expected public name, non-draft/non-prerelease state, exact notes,
+source revision, and GHCR digest before replacing any SBOM asset. Binary
+recovery repeats the public identity and provenance check immediately before
+its asset-only `gh release upload --clobber` operation.
 Registry responses and downloaded `.crate` files remain under `RUNNER_TEMP`,
 and the final untracked-aware cleanliness gate prevents publication probes from
 silently changing the package contents. Never bypass that boundary with

--- a/progress/session-079-historical-release-retry.md
+++ b/progress/session-079-historical-release-retry.md
@@ -1,0 +1,50 @@
+# Session 079 — Historical release retry completion
+
+## Scope
+
+Complete P36 by exercising the merged historical GitHub Release retry against
+v0.5.2, fixing any newly exposed integrity defect, and verifying the public
+Release artifact set.
+
+## Registry retry root cause
+
+The first post-merge retry, Release workflow run 30769058595, resolved the
+immutable annotated v0.5.2 tag and passed its CI preflight, then failed in the
+crates.io idempotency probe before any publication or asset mutation. The
+published archive had the expected registry checksum and exact source revision
+`09238c36ab8b086b13a5e50d679df51e32376134`, but its clean Cargo VCS metadata
+omitted `git.dirty`. The probe incorrectly required an explicit `false`.
+
+Cargo's canonical clean package form omits that optional field; dirty package
+metadata emits `true`. The corrected probe accepts an omitted field or explicit
+`false`, while retaining fail-closed checks for `true`, non-boolean values,
+malformed metadata, source-revision drift, registry checksum drift, lookup
+outages, and archive-download failures. A data-driven failure-first regression
+test uses the real clean metadata shape, and the corrected script succeeds
+against the immutable crates.io 0.5.2 archive.
+
+## Adversarial Release audit
+
+The first hostile review found that the inline existing-Release gate checked
+only its tag before replacing the SBOM. A draft Release could therefore be
+mutated before the later public-state check failed, while a prerelease or stale
+body could finish green without recording the expected source revision and
+GHCR digest. Token-presence policy tests did not execute those states.
+
+The gate is now a fixture-testable helper that distinguishes an absent Release
+from API failures and validates the expected tag, name, non-draft/non-prerelease
+state, exact notes, source revision, and image digest. The publish job invokes
+it before SBOM replacement, and binary recovery repeats the public identity and
+provenance check before uploading archives. Data-driven cases cover absence,
+success, every metadata mismatch, stale notes that retain provenance tokens,
+malformed API data, and non-404 failure. The Release Runbook and workflow
+commentary now describe the asset-only retry behavior directly.
+
+## Validation and publication
+
+Focused release-publish tests and a live read-only registry probe pass locally.
+The full Rust and repository policy suites pass on the settled worktree. Three
+adversarial review rounds exercised registry metadata, public Release identity,
+exact-byte notes integrity, retry ordering, and binary recovery; the final pass
+reported zero findings. Hosted PR validation, the final default-branch retry,
+and public Release asset verification remain in progress.

--- a/scripts/check-crates-io-release.sh
+++ b/scripts/check-crates-io-release.sh
@@ -56,13 +56,17 @@ case "$status" in
             echo "ERROR: signal-fish-server ${VERSION} already exists on crates.io from revision '${published_revision}', expected '${SOURCE_REVISION}'." >&2
             exit 1
         fi
+        # Cargo omits `git.dirty` for clean packages and serializes it only
+        # when the source is dirty. Accept an explicit false for compatibility,
+        # but reject true and every non-boolean value.
         published_dirty=$(printf '%s' "$vcs_info" | jq -r \
-            'if (.git | type) != "object" or (.git | has("dirty") | not) then "missing"
+            'if (.git | type) != "object" then "missing-git"
+             elif (.git | has("dirty") | not) then "clean-omitted"
              elif (.git.dirty | type) != "boolean" then "invalid-type"
              else (.git.dirty | tostring) end' \
             2>/dev/null || true)
-        if [ "$published_dirty" != "false" ]; then
-            echo "ERROR: signal-fish-server ${VERSION} has invalid cargo VCS cleanliness metadata '${published_dirty:-unreadable}'; expected dirty=false." >&2
+        if [ "$published_dirty" != "clean-omitted" ] && [ "$published_dirty" != "false" ]; then
+            echo "ERROR: signal-fish-server ${VERSION} has invalid cargo VCS cleanliness metadata '${published_dirty:-unreadable}'; expected clean Cargo metadata (dirty absent or false)." >&2
             exit 1
         fi
         echo "Crate ${VERSION} already exists from ${SOURCE_REVISION}; retry is safe."

--- a/scripts/check-github-release.sh
+++ b/scripts/check-github-release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Classify an absent GitHub Release or fail closed unless its public identity
+# and provenance match the already-verified tag, source, and container.
+set -euo pipefail
+
+TAG=${TAG:-}
+RELEASE_NAME=${RELEASE_NAME:-}
+SOURCE_REVISION=${RELEASE_SOURCE_REVISION:-}
+IMAGE_DIGEST=${RELEASE_IMAGE_DIGEST:-}
+NOTES_FILE=${RELEASE_NOTES_FILE:-}
+NOTES_SHA256=${RELEASE_NOTES_SHA256:-}
+REQUIRE_EXISTING=${RELEASE_REQUIRE_EXISTING:-false}
+OUTPUT_FILE=${RELEASE_OUTPUT_FILE:-${GITHUB_OUTPUT:-}}
+GH_CLI=${GH_CLI:-gh}
+
+if [[ ! "$TAG" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] \
+    || [ -z "$RELEASE_NAME" ] \
+    || [[ ! "$SOURCE_REVISION" =~ ^[0-9a-f]{40}$ ]] \
+    || [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || [[ ! "$REQUIRE_EXISTING" =~ ^(true|false)$ ]] \
+    || [ -z "$OUTPUT_FILE" ] \
+    || [ -z "${GITHUB_REPOSITORY:-}" ]; then
+    echo "ERROR: Release tag, name, source revision, image digest, repository, and output file are required." >&2
+    exit 2
+fi
+
+if { [ -z "$NOTES_FILE" ] && [ -z "$NOTES_SHA256" ]; } \
+    || { [ -n "$NOTES_FILE" ] && [ -n "$NOTES_SHA256" ]; }; then
+    echo "ERROR: Exactly one expected Release notes file or SHA-256 digest is required." >&2
+    exit 2
+fi
+if [ -n "$NOTES_FILE" ] && [ ! -f "$NOTES_FILE" ]; then
+    echo "ERROR: Expected Release notes file does not exist: $NOTES_FILE" >&2
+    exit 2
+fi
+if [ -n "$NOTES_SHA256" ] && [[ ! "$NOTES_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "ERROR: Expected Release notes SHA-256 digest is invalid." >&2
+    exit 2
+fi
+
+if [ -n "$NOTES_FILE" ]; then
+    NOTES_SHA256=$(sha256sum "$NOTES_FILE" | awk '{print $1}')
+fi
+
+api_path="repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}"
+if ! release=$($GH_CLI api "$api_path" 2>/dev/null); then
+    status=$($GH_CLI api --include "$api_path" 2>&1 \
+        | sed -n 's/^HTTP\/[^ ]* \([0-9][0-9][0-9]\).*/\1/p' \
+        | head -n 1 || true)
+    if [ "$status" != "404" ]; then
+        echo "ERROR: Could not verify whether GitHub Release $TAG exists (HTTP ${status:-unknown})." >&2
+        exit 1
+    fi
+    if [ "$REQUIRE_EXISTING" = "true" ]; then
+        echo "ERROR: GitHub Release $TAG does not exist before asset upload." >&2
+        exit 1
+    fi
+    echo "exists=false" >> "$OUTPUT_FILE"
+    exit 0
+fi
+
+expected_source_line="Source revision: \`${SOURCE_REVISION}\`"
+expected_digest_line="Multi-architecture manifest digest: \`${IMAGE_DIGEST}\`"
+if ! mismatches=$(printf '%s' "$release" | jq -r \
+    --arg tag "$TAG" \
+    --arg name "$RELEASE_NAME" \
+    --arg source_line "$expected_source_line" \
+    --arg digest_line "$expected_digest_line" \
+    '
+        [
+          if .tag_name != $tag then "tag_name" else empty end,
+          if .name != $name then "name" else empty end,
+          if .draft != false then "draft" else empty end,
+          if .prerelease != false then "prerelease" else empty end,
+          if (.body | type) != "string" then "source revision note"
+            elif (.body | contains($source_line) | not) then "source revision note"
+            else empty end,
+          if (.body | type) != "string" then "image digest note"
+            elif (.body | contains($digest_line) | not) then "image digest note"
+            else empty end
+        ] | join(", ")
+    ' 2>/dev/null); then
+    echo "ERROR: GitHub Release $TAG returned malformed metadata." >&2
+    exit 1
+fi
+
+if [ -n "$mismatches" ]; then
+    echo "ERROR: Existing GitHub Release $TAG disagrees on: $mismatches." >&2
+    exit 1
+fi
+
+actual_notes_sha256=$(printf '%s' "$release" | jq -j '.body' | sha256sum | awk '{print $1}')
+if [ "$actual_notes_sha256" != "$NOTES_SHA256" ]; then
+    echo "ERROR: Existing GitHub Release $TAG disagrees on: release notes body." >&2
+    exit 1
+fi
+
+echo "Existing GitHub Release for $TAG has verified public identity and provenance."
+echo "exists=true" >> "$OUTPUT_FILE"

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4732,10 +4732,10 @@ fn test_release_binary_attach_job_preserves_partial_success_gate() {
         .expect("attach-binaries must define an explicit job-level if condition");
 
     assert!(
-        attach_job.contains("needs: [resolve-release, publish, build-binaries]"),
-        "attach-binaries must depend on release identity, `publish`, and `build-binaries` so \
-         the Release exists and all binary matrix legs have finished before the \
-         single release upload starts.\nJob block:\n{attach_job}"
+        attach_job.contains("needs: [resolve-release, publish-container, publish, build-binaries]"),
+        "attach-binaries must depend on release identity, the verified container digest, \
+         `publish`, and `build-binaries` so the Release can be revalidated and all binary matrix \
+         legs have finished before the single asset upload starts.\nJob block:\n{attach_job}"
     );
     assert!(
         attach_if.contains("!cancelled()")
@@ -4958,6 +4958,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
     let verifier = read_live_file(&root.join("scripts/verify-release-image.sh"));
     let resolver = read_live_file(&root.join("scripts/resolve-release-source.sh"));
     let crate_check = read_live_file(&root.join("scripts/check-crates-io-release.sh"));
+    let release_check = read_live_file(&root.join("scripts/check-github-release.sh"));
     let publish =
         extract_workflow_job_block(&release, "publish").expect("release.yml must define publish");
     let create_release = extract_named_workflow_step(&publish, "Create GitHub Release")
@@ -4965,8 +4966,20 @@ fn test_release_identity_fails_closed_across_artifacts() {
     let validate_release =
         extract_named_workflow_step(&publish, "Validate an existing GitHub Release")
             .expect("publish must define the existing GitHub Release gate");
+    let verify_release = extract_named_workflow_step(
+        &publish,
+        "Verify GitHub Release metadata before asset uploads",
+    )
+    .expect("publish must verify Release metadata before asset uploads");
     let attach_sbom = extract_named_workflow_step(&publish, "Attach SBOM to release")
         .expect("publish must define the SBOM attachment step");
+    let attach_binaries = extract_workflow_job_block(&release, "attach-binaries")
+        .expect("release.yml must define attach-binaries");
+    let validate_binary_release = extract_named_workflow_step(
+        &attach_binaries,
+        "Validate GitHub Release before binary asset uploads",
+    )
+    .expect("attach-binaries must validate Release metadata before uploading assets");
 
     let required_by_file = [
         (
@@ -4976,7 +4989,7 @@ fn test_release_identity_fails_closed_across_artifacts() {
                 "scripts/resolve-release-source.sh",
                 "git cat-file -t \"refs/tags/${TAG}\"",
                 "refusing to move it",
-                "Verify GitHub Release identity",
+                "Verify GitHub Release metadata before asset uploads",
             ],
         ),
         (
@@ -4995,6 +5008,21 @@ fn test_release_identity_fails_closed_across_artifacts() {
             "check-crates-io-release.sh",
             &crate_check,
             vec![".cargo_vcs_info.json", "published_revision", "RUNNER_TEMP"],
+        ),
+        (
+            "check-github-release.sh",
+            &release_check,
+            vec![
+                "tag_name",
+                "prerelease",
+                "source revision note",
+                "image digest note",
+                "release notes body",
+                "RELEASE_NOTES_SHA256",
+                "RELEASE_REQUIRE_EXISTING",
+                "exists=false",
+                "exists=true",
+            ],
         ),
         (
             "docker-publish.yml",
@@ -5051,13 +5079,15 @@ fn test_release_identity_fails_closed_across_artifacts() {
     );
     for required in [
         "id: existing-release",
-        "echo \"exists=true\" >> \"$GITHUB_OUTPUT\"",
-        "echo \"exists=false\" >> \"$GITHUB_OUTPUT\"",
+        "RELEASE_SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}",
+        "RELEASE_IMAGE_DIGEST: ${{ needs.publish-container.outputs.digest }}",
+        "RELEASE_NOTES_FILE: source/release_notes.md",
+        "run: bash publication-tools/scripts/check-github-release.sh",
     ] {
         assert!(
             validate_release.contains(required),
-            "The existing-release gate must publish `{required}` so retries never PATCH an old \
-             release target.\nStep:\n{validate_release}"
+            "The existing-release gate must contain `{required}` so retries validate public \
+             identity and provenance without PATCHing an old Release.\nStep:\n{validate_release}"
         );
     }
     assert!(
@@ -5071,6 +5101,35 @@ fn test_release_identity_fails_closed_across_artifacts() {
         "SBOM retries must use the asset-only upload API rather than PATCHing Release identity.\n\
          Step:\n{attach_sbom}"
     );
+    assert!(
+        verify_release.contains("run: bash publication-tools/scripts/check-github-release.sh")
+            && verify_release.contains("RELEASE_OUTPUT_FILE: /dev/null")
+            && verify_release.contains("RELEASE_REQUIRE_EXISTING: true"),
+        "The created or existing Release must be revalidated immediately before the SBOM can be \
+         mutated.\nStep:\n{verify_release}"
+    );
+    let verify_position = publish
+        .find("- name: Verify GitHub Release metadata before asset uploads")
+        .expect("publish validation position");
+    let sbom_position = publish
+        .find("- name: Attach SBOM to release")
+        .expect("publish SBOM position");
+    assert!(
+        verify_position < sbom_position,
+        "Release metadata validation must run before the first asset mutation."
+    );
+    for required in [
+        "RELEASE_SOURCE_REVISION: ${{ needs.resolve-release.outputs.source_revision }}",
+        "RELEASE_IMAGE_DIGEST: ${{ needs.publish-container.outputs.digest }}",
+        "RELEASE_NOTES_SHA256: ${{ needs.publish.outputs.release_notes_sha256 }}",
+        "RELEASE_REQUIRE_EXISTING: true",
+        "run: bash scripts/check-github-release.sh",
+    ] {
+        assert!(
+            validate_binary_release.contains(required),
+            "Binary asset recovery must revalidate `{required}` before uploading.\nStep:\n{validate_binary_release}"
+        );
+    }
 }
 
 #[test]

--- a/tests/release_publish_tests.rs
+++ b/tests/release_publish_tests.rs
@@ -443,17 +443,17 @@ fn crates_io_probe_is_idempotent_and_never_dirties_the_checkout() {
             published_dirty: "true",
             succeeds: false,
             expected_output: "",
-            diagnostic: "expected dirty=false",
+            diagnostic: "expected clean Cargo metadata",
         },
         Case {
-            name: "missing source cleanliness metadata",
+            name: "clean cargo metadata omits dirty flag",
             status: "200",
             response_checksum: "actual",
             published_revision: expected_revision,
             published_dirty: "missing",
-            succeeds: false,
-            expected_output: "",
-            diagnostic: "expected dirty=false",
+            succeeds: true,
+            expected_output: "exists=true",
+            diagnostic: "",
         },
         Case {
             name: "wrong type source cleanliness metadata",
@@ -612,6 +612,247 @@ fn crates_io_probe_is_idempotent_and_never_dirties_the_checkout() {
             "{} dirtied the release checkout",
             case.name
         );
+    }
+}
+
+#[test]
+fn github_release_probe_validates_public_identity_before_asset_mutation() {
+    struct Case {
+        name: &'static str,
+        status: &'static str,
+        mutation: &'static str,
+        succeeds: bool,
+        expected_output: &'static str,
+        diagnostic: &'static str,
+    }
+
+    let cases = [
+        Case {
+            name: "absent release",
+            status: "404",
+            mutation: "none",
+            succeeds: true,
+            expected_output: "exists=false",
+            diagnostic: "",
+        },
+        Case {
+            name: "matching public release",
+            status: "200",
+            mutation: "none",
+            succeeds: true,
+            expected_output: "exists=true",
+            diagnostic: "",
+        },
+        Case {
+            name: "matching public release by notes digest",
+            status: "200",
+            mutation: "hash",
+            succeeds: true,
+            expected_output: "exists=true",
+            diagnostic: "",
+        },
+        Case {
+            name: "required release is absent",
+            status: "404",
+            mutation: "require-existing",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "does not exist before asset upload",
+        },
+        Case {
+            name: "tag mismatch",
+            status: "200",
+            mutation: "tag",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "tag_name",
+        },
+        Case {
+            name: "name mismatch",
+            status: "200",
+            mutation: "name",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "name",
+        },
+        Case {
+            name: "draft release",
+            status: "200",
+            mutation: "draft",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "draft",
+        },
+        Case {
+            name: "prerelease",
+            status: "200",
+            mutation: "prerelease",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "prerelease",
+        },
+        Case {
+            name: "missing source provenance",
+            status: "200",
+            mutation: "source",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "source revision note",
+        },
+        Case {
+            name: "missing image provenance",
+            status: "200",
+            mutation: "digest",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "image digest note",
+        },
+        Case {
+            name: "stale notes with provenance tokens",
+            status: "200",
+            mutation: "body",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "release notes body",
+        },
+        Case {
+            name: "trailing newline drift",
+            status: "200",
+            mutation: "trailing-newline",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "release notes body",
+        },
+        Case {
+            name: "malformed response",
+            status: "200",
+            mutation: "malformed",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "malformed metadata",
+        },
+        Case {
+            name: "api outage",
+            status: "503",
+            mutation: "none",
+            succeeds: false,
+            expected_output: "",
+            diagnostic: "HTTP 503",
+        },
+    ];
+
+    let source_revision = "0123456789abcdef0123456789abcdef01234567";
+    let image_digest = format!("sha256:{}", "a".repeat(64));
+    let expected_body = format!(
+        "Release notes\n\nMulti-architecture manifest digest: `{image_digest}`\n\nSource revision: `{source_revision}`\n"
+    );
+
+    for case in cases {
+        let root = unique_temp_dir(&format!("github-release-{}", case.name.replace(' ', "-")));
+        let bin = root.path().join("bin");
+        fs::create_dir_all(&bin).expect("create mock bin");
+        let notes = root.path().join("release-notes.md");
+        write_file(&notes, &expected_body);
+
+        let mut response = serde_json::json!({
+            "tag_name": "v1.2.3",
+            "name": "v1.2.3",
+            "draft": false,
+            "prerelease": false,
+            "body": expected_body,
+        });
+        match case.mutation {
+            "none" | "hash" | "require-existing" | "malformed" => {}
+            "tag" => response["tag_name"] = serde_json::json!("v1.2.2"),
+            "name" => response["name"] = serde_json::json!("wrong release"),
+            "draft" => response["draft"] = serde_json::json!(true),
+            "prerelease" => response["prerelease"] = serde_json::json!(true),
+            "source" => response["body"] = serde_json::json!(format!(
+                "Release notes\n\nMulti-architecture manifest digest: `{image_digest}`\n"
+            )),
+            "digest" => response["body"] = serde_json::json!(format!(
+                "Release notes\n\nSource revision: `{source_revision}`\n"
+            )),
+            "body" => response["body"] = serde_json::json!(format!(
+                "Stale notes\n\nMulti-architecture manifest digest: `{image_digest}`\n\nSource revision: `{source_revision}`\n"
+            )),
+            "trailing-newline" => {
+                response["body"] = serde_json::json!(format!("{expected_body}\n"));
+            }
+            mutation => panic!("unknown release mutation {mutation}"),
+        }
+        let response_file = root.path().join("response.json");
+        if case.mutation == "malformed" {
+            write_file(&response_file, "not-json");
+        } else {
+            write_file(&response_file, &response.to_string());
+        }
+
+        let gh = bin.join("gh");
+        write_file(
+            &gh,
+            "#!/usr/bin/env bash\nset -euo pipefail\nif [[ \"$*\" == *\"--include\"* ]]; then\n  printf 'HTTP/2 %s\\n' \"$MOCK_STATUS\"\n  exit 1\nfi\nif [ \"$MOCK_STATUS\" = 200 ]; then\n  cat \"$MOCK_RESPONSE\"\n  exit 0\nfi\nexit 1\n",
+        );
+        let mut permissions = fs::metadata(&gh).expect("gh metadata").permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            permissions.set_mode(0o755);
+        }
+        fs::set_permissions(&gh, permissions).expect("make mock gh executable");
+
+        let output_file = root.path().join("outputs");
+        let expected_notes_sha256 = git_style_sha256(&notes);
+        let mut command = Command::new("bash");
+        command
+            .arg(repo_root().join("scripts/check-github-release.sh"))
+            .env("GH_CLI", &gh)
+            .env("MOCK_STATUS", case.status)
+            .env("MOCK_RESPONSE", &response_file)
+            .env(
+                "GITHUB_REPOSITORY",
+                "Ambiguous-Interactive/signal-fish-server",
+            )
+            .env("TAG", "v1.2.3")
+            .env("RELEASE_NAME", "v1.2.3")
+            .env("RELEASE_SOURCE_REVISION", source_revision)
+            .env("RELEASE_IMAGE_DIGEST", &image_digest)
+            .env("RELEASE_OUTPUT_FILE", &output_file);
+        if case.mutation == "hash" {
+            command.env("RELEASE_NOTES_SHA256", expected_notes_sha256);
+        } else {
+            command.env("RELEASE_NOTES_FILE", &notes);
+        }
+        if case.mutation == "require-existing" {
+            command.env("RELEASE_REQUIRE_EXISTING", "true");
+        }
+        let output = command.output().expect("run GitHub Release probe");
+        assert_eq!(
+            output.status.success(),
+            case.succeeds,
+            "{}:\nstdout:\n{}\nstderr:\n{}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        if case.succeeds {
+            assert_eq!(
+                fs::read_to_string(&output_file)
+                    .expect("probe output")
+                    .trim(),
+                case.expected_output,
+                "{}",
+                case.name
+            );
+        } else {
+            assert!(
+                String::from_utf8_lossy(&output.stderr).contains(case.diagnostic),
+                "{} missing diagnostic `{}`: {}",
+                case.name,
+                case.diagnostic,
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- accept Cargo's canonical clean `.cargo_vcs_info.json` shape when retrying an already-published crates.io version
- validate an existing or newly created GitHub Release's exact public identity, notes bytes, source revision, and GHCR digest before any asset mutation
- repeat that validation before binary recovery uploads and document the asset-only retry contract
- add data-driven failure-first coverage for malformed, missing, stale, draft, prerelease, and API-failure states

## Root cause

Historical Release run 30769058595 resolved the immutable v0.5.2 source and passed preflight, but the crates.io idempotency probe rejected the published archive because clean Cargo metadata omits the optional `git.dirty` field. The audit also found that retries could replace assets before fully validating an existing public Release.

## Impact

The v0.5.2 retry can safely recognize the already-published crate while failing closed on source or checksum drift. GitHub Release retries are now asset-only and cannot mutate a draft, prerelease, stale-notes, wrong-source, or wrong-image Release.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- repository CI, MSRV, staged-doc, workflow-hygiene, LLM policy, hook-readiness, pre-commit, and pre-push gates
- `shellcheck` for both release probes and `actionlint` for the Release workflow
- three adversarial review rounds; final review reported zero findings

The final default-branch historical retry and public v0.5.2 artifact verification follow after this PR is green and merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release publication and retry paths (crates.io idempotency and GitHub asset replacement); mistakes could block legitimate retries or allow wrong provenance, but behavior is fail-closed with broad fixture tests.
> 
> **Overview**
> Hardens **historical release retries** so idempotent recovery cannot accept the wrong crate metadata or mutate a GitHub Release before provenance is verified.
> 
> **crates.io retry probe** now treats Cargo’s canonical clean VCS metadata as valid when `git.dirty` is **omitted** (not only when it is explicitly `false`), while still rejecting dirty packages, revision drift, and checksum mismatch—the fix that blocked the v0.5.2 retry after merge.
> 
> **GitHub Release handling** moves inline `gh api` checks into **`scripts/check-github-release.sh`**, which classifies an absent release vs. API failure and **fails closed** on tag/name, draft/prerelease state, exact notes body (file or SHA-256), and embedded source revision + GHCR digest lines. The publish job records **`release_notes_sha256`**, validates before create, **re-validates with `RELEASE_REQUIRE_EXISTING`** immediately before SBOM upload, and drops the old post-upload identity step. **`attach-binaries`** now depends on **`publish-container`** and repeats the same gate (notes digest) before binary **`gh release upload --clobber`**.
> 
> Docs, changelog, session notes, and data-driven tests (`ci_config_tests`, `release_publish_tests`) document and lock the asset-only retry contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e16b8f77134beb67050b0433b11350b3e67af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->