### PR TITLE
Make Release asset uploads repository-explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,7 +586,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.resolve-release.outputs.tag }}
-        run: gh release upload "$TAG" source/sbom.cdx.json --clobber
+        run: >-
+          gh release upload "$TAG" source/sbom.cdx.json --clobber
+          --repo "$GITHUB_REPOSITORY"
 
   # ---------------------------------------------------------------------------
   # Cross-platform standalone binaries
@@ -838,4 +840,5 @@ jobs:
             echo "ERROR: Binary artifacts were reported but no archives or checksums were downloaded." >&2
             exit 1
           fi
-          gh release upload "$TAG" "${assets[@]}" --clobber
+          gh release upload "$TAG" "${assets[@]}" --clobber \
+            --repo "$GITHUB_REPOSITORY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recognizes Cargo's canonical clean VCS metadata, where the `dirty` field is
   omitted, while still rejecting dirty or source-mismatched packages. Existing
   Releases must also retain the expected public state, exact notes, source
-  revision, and image digest before any SBOM or binary asset is replaced.
+  revision, and image digest before any SBOM or binary asset is replaced. Asset
+  uploads also name the repository explicitly, so split-checkout publication
+  jobs never depend on an ambient Git worktree for repository discovery.
 - Keep spectator-occupied rooms alive during garbage collection (issue #241).
   Spectator-only rooms now use the inactive-room timeout, spectator join,
   detach, and live connection traffic refresh room activity, and the normal

--- a/progress/session-079-historical-release-retry.md
+++ b/progress/session-079-historical-release-retry.md
@@ -48,3 +48,11 @@ adversarial review rounds exercised registry metadata, public Release identity,
 exact-byte notes integrity, retry ordering, and binary recovery; the final pass
 reported zero findings. Hosted PR validation, the final default-branch retry,
 and public Release asset verification remain in progress.
+
+The first retry after PR #246, Release run 30770844614, passed the corrected
+registry probe, all six binary builds, immutable GHCR digest reuse, public
+Release creation, and exact metadata validation. It then failed before the
+first asset mutation because `gh release upload` ran from the parent of the
+split checkouts and attempted repository discovery through an absent `.git`
+directory. The follow-up passes `--repo "$GITHUB_REPOSITORY"` to both SBOM and
+binary asset-only uploads and locks that independence into workflow policy.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -4689,7 +4689,8 @@ fn test_release_workflow_attaches_binaries_with_checksums() {
     for required in [
         "mapfile -d '' assets",
         "find dist -type f",
-        "gh release upload \"$TAG\" \"${assets[@]}\" --clobber",
+        "gh release upload \"$TAG\" \"${assets[@]}\" --clobber \\",
+        "--repo \"$GITHUB_REPOSITORY\"",
     ] {
         assert!(
             upload.contains(required),
@@ -5097,8 +5098,10 @@ fn test_release_identity_fails_closed_across_artifacts() {
     );
     assert!(
         attach_sbom.contains("gh release upload \"$TAG\" source/sbom.cdx.json --clobber")
+            && attach_sbom.contains("--repo \"$GITHUB_REPOSITORY\"")
             && !attach_sbom.contains("softprops/action-gh-release"),
-        "SBOM retries must use the asset-only upload API rather than PATCHing Release identity.\n\
+        "SBOM retries must use the asset-only upload API with an explicit repository rather than \
+         PATCHing Release identity.\n\
          Step:\n{attach_sbom}"
     );
     assert!(


### PR DESCRIPTION
## Summary

- pass the repository explicitly to both GitHub Release asset upload sites
- preserve split-checkout publication jobs without depending on an ambient Git worktree
- add policy coverage for the repository-explicit upload contract

## Hosted failure addressed

Historical Release run `30770844614` completed publication preflight, validated the existing crates.io package, rebuilt all six binaries, reused the immutable GHCR digest, created and validated the exact public `v0.5.2` GitHub Release, then failed before its first asset mutation because `gh release upload` could not discover a repository from the split-checkout parent directory.

The public Release is valid and currently has zero assets, so retrying this change is safe and idempotent.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- repository CI/config, MSRV, docs, workflow-hygiene, LLM-policy, hook, actionlint, and policy-test gates
- adversarial review: zero findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow and policy-test changes; no server runtime, auth, or data-handling paths are modified.
> 
> **Overview**
> Fixes **GitHub Release asset retries** when publication jobs use **split checkouts** (immutable `source/` plus `publication-tools/` without a parent `.git`). Both **SBOM** and **binary** `gh release upload` calls now pass **`--repo "$GITHUB_REPOSITORY"`**, so uploads no longer depend on ambient Git worktree discovery.
> 
> **CHANGELOG** and workflow policy tests in **`tests/ci_config_tests.rs`** document and lock the explicit-repository contract for those upload steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d8499897f271b5a477688d07c71dfe55f758da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->