### PR TITLE
perf: remove relay recipient snapshot allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   17–20%. Repeated frozen-v2 JSON and Rkyv relays also skip a no-op frame cache,
   reducing 8-/16-player operations from 4 to 3 and bytes by 51%/41%. The
   ingress-to-queue handoff now borrows its one-shot builder instead of heap
-  boxing it while retaining the original public boxed compatibility seam. The
-  isolated handoff measures 2/3/3 operations and 400/1,320/1,640 allocated
-  bytes at 2/8/16 players; separate JSON and binary production-ingress cells,
-  including message-envelope construction, measure 3/4/4 operations. Exact
-  message variants, delivery accounting, and cancellation behavior are
+  boxing it while retaining the original public boxed compatibility seam, and
+  the healthy path walks the guarded routing snapshot directly instead of
+  copying every recipient into a temporary vector. The isolated handoff now
+  measures 1/2/2 operations and 352/1,032/1,032 allocated bytes at 2/8/16
+  players; separate JSON and binary production-ingress cells, including
+  message-envelope construction, measure 2/3/3 operations and
+  648/1,328/1,328 bytes. Exact message variants, delivery accounting,
+  backpressure concurrency, routing snapshots, and cancellation behavior are
   checked, and no relay-latency improvement is claimed without an independent
   timing measurement.
 - Reduce memory-allocation work for frozen-v2 JSON and Rkyv binary relays

--- a/benches/relay_allocations.rs
+++ b/benches/relay_allocations.rs
@@ -150,8 +150,9 @@ impl FanoutFixture {
         };
 
         // Warm Tokio and every classified queue's backing storage before
-        // taking a steady-state allocator snapshot. Recipient and join_all
-        // storage is intentionally rebuilt inside each measured fan-out.
+        // taking a steady-state allocator snapshot. The healthy path walks
+        // the guarded routing snapshot directly; exceptional backpressure
+        // storage is intentionally not exercised by this baseline.
         let expected = room_size - 1;
         let warmed = fixture.relay_ingress_batch(vec![fixture.payload.clone()]);
         assert_eq!(
@@ -503,14 +504,13 @@ fn repeated_samples(mut measure: impl FnMut() -> Sample) -> Sample {
 fn assert_healthy_fanout_uses_synchronous_fast_path(room_size: usize, sample: Sample) {
     let allocation_operations = sample.stats.allocations + sample.stats.reallocations;
     let maximum_operations_per_relay = match room_size {
-        2 => 2,
-        8 | 16 => 3,
+        2 => 1,
+        8 | 16 => 2,
         _ => panic!("room-{room_size} has no checked-in allocation baseline"),
     };
     let maximum_bytes_per_relay = match room_size {
-        2 => 416,
-        8 => 1_336,
-        16 => 1_656,
+        2 => 368,
+        8 | 16 => 1_048,
         _ => panic!("room-{room_size} has no checked-in allocation baseline"),
     };
     let maximum_operations =
@@ -521,29 +521,28 @@ fn assert_healthy_fanout_uses_synchronous_fast_path(room_size: usize, sample: Sa
         "healthy {room_size}-player fan-out used {allocation_operations} allocation operations \
          across {RELAYS_PER_SAMPLE} relays; expected at most \
          {maximum_operations_per_relay} operations per relay plus one fixed sample operation \
-         after removing the boxed builder handoff"
+         after removing the routed-recipient snapshot"
     );
     assert!(
         sample.stats.bytes_allocated <= maximum_bytes,
         "healthy {room_size}-player fan-out allocated {} bytes across {RELAYS_PER_SAMPLE} \
          relays; expected at most {maximum_bytes_per_relay} bytes per relay plus \
-         {SAMPLE_FIXED_ALLOCATED_BYTES} fixed sample bytes after removing the eight-byte \
-         builder box",
+         {SAMPLE_FIXED_ALLOCATED_BYTES} fixed sample bytes after removing the routed-recipient \
+         snapshot",
         sample.stats.bytes_allocated
     );
 }
 
 fn assert_production_ingress_ceiling(room_size: usize, sample: Sample) {
     let maximum_operations_per_relay = match room_size {
-        2 => 3,
-        8 | 16 => 4,
+        2 => 2,
+        8 | 16 => 3,
         _ => panic!("room-{room_size} has no checked-in allocation baseline"),
     };
     let allocation_operations = sample.stats.allocations + sample.stats.reallocations;
     let maximum_bytes_per_relay = match room_size {
-        2 => 696,
-        8 => 1_616,
-        16 => 1_936,
+        2 => 648,
+        8 | 16 => 1_328,
         _ => panic!("room-{room_size} has no checked-in allocation baseline"),
     };
     assert!(

--- a/progress/session-079-historical-release-retry.md
+++ b/progress/session-079-historical-release-retry.md
@@ -56,3 +56,12 @@ first asset mutation because `gh release upload` ran from the parent of the
 split checkouts and attempted repository discovery through an absent `.git`
 directory. The follow-up passes `--repo "$GITHUB_REPOSITORY"` to both SBOM and
 binary asset-only uploads and locks that independence into workflow policy.
+
+PR #247 merged that correction at `6d8499897f271b5a477688d07c71dfe55f758da6`.
+Historical Release run 30772076461 then completed successfully from the later
+default branch while preserving the immutable source revision
+`09238c36ab8b086b13a5e50d679df51e32376134` and GHCR digest
+`sha256:efede9dbed5cba2d7f1c09b2143d568a91bc731e6510fd8fbdc81fe66d800d4c`.
+Independent public verification matched the exact Release notes, opened all
+six platform archives, checked all six checksum files, and confirmed the
+CycloneDX SBOM. P36 is therefore complete.

--- a/progress/session-080-relay-builder-handoff.md
+++ b/progress/session-080-relay-builder-handoff.md
@@ -67,4 +67,11 @@ file discovery plus 809 ms Rust panic scanning); no hook implementation changed
 in this session. Adversarial review additionally moved missing-stamp,
 terminal-unroute, and reconnect-baseline races onto the new borrowed production
 seam, added production-ingress byte ceilings, and corrected CSV recipient
-reporting. Hosted PR review is recorded after publication.
+reporting.
+
+PR #248 passed hosted validation and merged at reviewed head
+`f98ca3dadc224751539ea976cf6665d5533e3984` as merge commit
+`2900b53e09a3595b6e8c43eb2976be50a8656ba5`. Cursor Bugbot reported no
+issues on the exact head and GitHub exposed no review threads. Copilot was
+requested twice but reported that the requester's review quota was exhausted;
+it supplied no actionable feedback. P37 is complete.

--- a/progress/session-081-routed-recipient-traversal.md
+++ b/progress/session-081-routed-recipient-traversal.md
@@ -82,5 +82,16 @@ adversarial diff review reported zero major or minor findings after independentl
 checking delivery semantics, guarded traversal, backpressure, snapshot isolation,
 shared-cache activation, benchmark attribution, and documentation consistency.
 
-Hosted CI and exact-head publication evidence remain pending; P38 is not marked
-complete until that final review loop is green.
+## Hosted publication evidence
+
+Draft PR #252 passed all 14 pull-request workflows on code head
+`7b8b7bf7b8b65b96a13e28d1e835c5e62640b330`, including the exact allocation
+ceiling, three-platform lint and Nextest matrix, MSRV, coverage, Miri, ASan,
+four fuzz targets, dependency audits, and every browser/native/Fortress/TURN
+interop lane. Cursor Bugbot reported no issue on that exact head and GitHub
+exposed no inline review threads. Copilot was explicitly requested but returned
+only that the requester's review quota was exhausted; it supplied no actionable
+feedback.
+
+P38 is complete. The final evidence-only head remains subject to the same green
+workflow and explicit review loop before the PR leaves draft state.

--- a/progress/session-081-routed-recipient-traversal.md
+++ b/progress/session-081-routed-recipient-traversal.md
@@ -1,0 +1,86 @@
+# Session 081 — Allocation-free routed-recipient traversal
+
+## Scope
+
+Advance issue #207 with P38: remove the healthy game-data handoff's temporary
+routed-recipient vector while preserving the stamp/snapshot ordering boundary,
+backpressure concurrency, and exact delivery set.
+
+## Failure-first baseline and prediction
+
+The unchanged P37 harness relayed 4,096 messages at 2, 8, and 16 players across
+five exact allocator samples. The isolated borrowed coordinator handoff used
+2/3/3 operations and 400/1,320/1,640 bytes per relay; JSON and binary production
+ingress used 3/4/4 operations and 696/1,616/1,936 bytes.
+
+The only room-size-dependent allocation left at this seam was the recipient
+snapshot `Vec`: 48, 288, and 608 bytes. The pre-registered prediction was that
+walking the already-guarded routing maps directly through synchronous delivery
+start would remove exactly one allocation and those bytes at every room size.
+Only exceptional full queues should retain owned backpressure state, after the
+routing guards are released.
+
+## Implementation and measured result
+
+Projection-cohort discovery and healthy delivery now make two allocation-free
+passes over the guarded room membership. The first decides whether compatible
+recipients share a relay frame cache; the second clones each delivery handle
+directly into queue delivery. The routing guards are dropped before any
+backpressured delivery future is awaited. Boxed downstream-compatible builders
+and the borrowed production builder use the same start/finish state machine.
+
+Five exact repeats confirm the prediction for both JSON and binary ingress:
+
+| Room size | Isolated before | Isolated after | Production before | Production after |
+| --- | --- | --- | --- | --- |
+| 2 | 2 ops / 400 B | 1 op / 352 B | 3 ops / 696 B | 2 ops / 648 B |
+| 8 | 3 ops / 1,320 B | 2 ops / 1,032 B | 4 ops / 1,616 B | 3 ops / 1,328 B |
+| 16 | 3 ops / 1,640 B | 2 ops / 1,032 B | 4 ops / 1,936 B | 3 ops / 1,328 B |
+
+The checked-in ceilings retain a 16-byte isolated-handoff margin while the
+production ceilings equal the deterministic observed values. Delivery
+attempts, enqueues, receiver drains, message variants, and five-repeat allocator
+identity remain non-vacuous gates. No latency improvement is claimed.
+
+## Concurrency proof and validation
+
+A paused-time, data-driven regression fills the original recipient's queue for
+both boxed and borrowed builders. A late same-room registration must complete
+while the relay awaits capacity, proving routing guards are not held across the
+wait, while the late joiner must not receive the already-started relay. The
+existing missing-stamp, terminal-unroute, reconnect-baseline, slow-consumer,
+wire-output, and accounting suites remain required gates.
+
+## Adversarial audit follow-ups
+
+The session-wide audit confirmed two unrelated P0 contract gaps and one P1
+interop gap. They remain outside this focused performance diff and have
+complete follow-up scopes:
+
+- issue #249: atomically enforce persisted application room ownership plus
+  configured per-app room/player limits across seated join, spectator join,
+  reconnect, creation, cleanup, and legacy unowned rooms;
+- issue #250: decide and enforce a truthful client-authentication trust boundary
+  because production accepts the public app ID while docs describe the unused
+  configured app secret as active authentication; and
+- issue #251: select `Host + Direct` only when the authoritative plan is
+  executable and the client has usable endpoint information.
+
+The same audit disproved a proposed reconnect rate-limit defect: token reconnect
+restores the original logical player ID, so its limiter window survives. Fresh
+anonymous identity churn is an explicit threat-model/design question rather
+than a demonstrated reconnect regression, and no misleading bug was filed.
+
+## Local completion evidence
+
+The exact allocation benchmark passed every JSON and binary cell across five
+repeats. `cargo fmt --check`, all-target/all-feature Clippy with warnings denied,
+the complete all-feature test suite, `cargo deny --all-features check`, the CI,
+MSRV, documentation, workflow, and LLM policy scripts, the explicit policy-test
+targets, hook readiness, and both worktree hook preflights all passed. The final
+adversarial diff review reported zero major or minor findings after independently
+checking delivery semantics, guarded traversal, backpressure, snapshot isolation,
+shared-cache activation, benchmark attribution, and documentation consistency.
+
+Hosted CI and exact-head publication evidence remain pending; P38 is not marked
+complete until that final review loop is green.

--- a/src/server.rs
+++ b/src/server.rs
@@ -974,6 +974,14 @@ enum RoomBatchReservation {
     Canceled,
 }
 
+#[derive(Default)]
+struct StartedDeliveries {
+    // Healthy queues leave both vectors empty. Only exceptional outcomes own
+    // state past the routing-guarded synchronous start phase.
+    pending: Vec<crate::coordination::BackpressuredDelivery>,
+    slow_consumers: Vec<(PlayerId, DeliverySender)>,
+}
+
 fn room_message_for_recipient(
     message: &Arc<ServerMessage>,
     player_id: &PlayerId,
@@ -1120,17 +1128,27 @@ impl InMemoryMessageCoordinator {
         .then(|| {
             crate::coordination::outbound_queue::DeliveryMessage::shared_relay(Arc::clone(&message))
         });
+        let started = self.start_deliveries(recipients, &message, room_id, shared_relay);
+        self.finish_deliveries(started).await;
+    }
+
+    fn start_deliveries(
+        &self,
+        recipients: impl IntoIterator<Item = (PlayerId, ClientDeliveryHandle)>,
+        message: &Arc<ServerMessage>,
+        room_id: Option<RoomId>,
+        shared_relay: Option<crate::coordination::outbound_queue::DeliveryMessage>,
+    ) -> StartedDeliveries {
         // The negotiated queue policy normally resolves through `try_send`.
         // Start every recipient synchronously and build async machinery only
         // for queues that are actually full. Waiting recipients still enter
         // one join_all below, so waits remain concurrent and each grace
         // deadline begins when that queue first reports `Full`.
-        let mut pending = Vec::new();
-        let mut slow_consumers = Vec::new();
+        let mut started = StartedDeliveries::default();
         for (player_id, handle) in recipients {
             let delivery = shared_relay.clone().unwrap_or_else(|| {
                 crate::coordination::outbound_queue::DeliveryMessage::new(
-                    room_message_for_recipient(&message, &player_id),
+                    room_message_for_recipient(message, &player_id),
                 )
             });
             match crate::coordination::start_message_delivery_in_room(
@@ -1143,26 +1161,28 @@ impl InMemoryMessageCoordinator {
             ) {
                 crate::coordination::DeliveryStart::Complete(outcome) => {
                     if outcome == DeliveryOutcome::SlowConsumer {
-                        slow_consumers.push((player_id, handle.sender));
+                        started.slow_consumers.push((player_id, handle.sender));
                     }
                 }
                 crate::coordination::DeliveryStart::Backpressured(delivery) => {
-                    pending.push(delivery);
+                    started.pending.push(delivery);
                 }
             }
         }
+        started
+    }
 
-        if !pending.is_empty() {
+    async fn finish_deliveries(&self, mut started: StartedDeliveries) {
+        if !started.pending.is_empty() {
             let outcomes =
-                futures_util::future::join_all(pending.into_iter().map(|delivery| async move {
+                futures_util::future::join_all(started.pending.into_iter().map(|delivery| {
                     crate::coordination::finish_backpressured_delivery_in_room(
                         &self.metrics,
                         delivery,
                     )
-                    .await
                 }))
                 .await;
-            slow_consumers.extend(
+            started.slow_consumers.extend(
                 outcomes
                     .into_iter()
                     .filter(|(_, _, outcome)| *outcome == DeliveryOutcome::SlowConsumer)
@@ -1170,13 +1190,13 @@ impl InMemoryMessageCoordinator {
             );
         }
 
-        if !slow_consumers.is_empty() {
+        if !started.slow_consumers.is_empty() {
             // Remove immediately so senders stop paying the timeout for a
             // connection that is already closing; the connection's own
             // unregister flow performs the full cleanup (room membership,
             // reconnection window, peer notifications).
             let mut clients = self.local_clients.write().await;
-            for (player_id, attempted_sender) in &slow_consumers {
+            for (player_id, attempted_sender) in &started.slow_consumers {
                 let still_attempted_connection = clients
                     .get(player_id)
                     .is_some_and(|current| current.sender.same_channel(attempted_sender));
@@ -1185,6 +1205,46 @@ impl InMemoryMessageCoordinator {
                 }
             }
         }
+    }
+
+    /// Start one exact routing snapshot without copying its recipients.
+    ///
+    /// The caller holds both routing read guards throughout this synchronous
+    /// function. Any capacity wait is returned as owned state and must be
+    /// awaited only after those guards are dropped.
+    fn start_routed_deliveries(
+        &self,
+        room_players: &HashMap<RoomId, HashSet<PlayerId>>,
+        clients: &HashMap<PlayerId, ClientDeliveryHandle>,
+        room_id: &RoomId,
+        except_player: Option<&PlayerId>,
+        message: &Arc<ServerMessage>,
+    ) -> StartedDeliveries {
+        let Some(players) = room_players.get(room_id) else {
+            return StartedDeliveries::default();
+        };
+        let shared_relay = relay_projection_work_repeats(
+            players
+                .iter()
+                .filter(|player_id| Some(*player_id) != except_player)
+                .filter_map(|player_id| clients.get(player_id))
+                .filter_map(|handle| handle.sender.relay_projection())
+                .filter_map(|(supports_v3, format)| {
+                    relay_projection_cohort(message, supports_v3, format)
+                }),
+        )
+        .then(|| {
+            crate::coordination::outbound_queue::DeliveryMessage::shared_relay(Arc::clone(message))
+        });
+        let recipients = players
+            .iter()
+            .filter(|player_id| Some(*player_id) != except_player)
+            .filter_map(|player_id| {
+                clients
+                    .get(player_id)
+                    .map(|handle| (*player_id, handle.clone()))
+            });
+        self.start_deliveries(recipients, message, Some(*room_id), shared_relay)
     }
 
     fn collect_routed_recipients(
@@ -2586,14 +2646,19 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
     ) -> anyhow::Result<()> {
         let room_players = self.room_players.read().await;
         let clients = self.local_clients.read().await;
-        let recipients =
-            Self::collect_routed_recipients(&room_players, &clients, room_id, Some(except_player));
-        let message = build_message();
+        let started = build_message().map(|message| {
+            self.start_routed_deliveries(
+                &room_players,
+                &clients,
+                room_id,
+                Some(except_player),
+                &message,
+            )
+        });
         drop(clients);
         drop(room_players);
-        if let Some(message) = message {
-            self.deliver_to_all(recipients, message, Some(*room_id))
-                .await;
+        if let Some(started) = started {
+            self.finish_deliveries(started).await;
         }
         Ok(())
     }
@@ -2604,19 +2669,21 @@ impl MessageCoordinator for InMemoryMessageCoordinator {
         except_player: &PlayerId,
         build_message: &'a mut (dyn FnMut() -> Option<Arc<ServerMessage>> + Send),
     ) -> anyhow::Result<()> {
-        // Keep this body direct: an extra async helper would enlarge the
-        // async-trait future allocation on every relay even though it would
-        // not add an allocation operation.
         let room_players = self.room_players.read().await;
         let clients = self.local_clients.read().await;
-        let recipients =
-            Self::collect_routed_recipients(&room_players, &clients, room_id, Some(except_player));
-        let message = build_message();
+        let started = build_message().map(|message| {
+            self.start_routed_deliveries(
+                &room_players,
+                &clients,
+                room_id,
+                Some(except_player),
+                &message,
+            )
+        });
         drop(clients);
         drop(room_players);
-        if let Some(message) = message {
-            self.deliver_to_all(recipients, message, Some(*room_id))
-                .await;
+        if let Some(started) = started {
+            self.finish_deliveries(started).await;
         }
         Ok(())
     }

--- a/src/server/message_coordinator_tests.rs
+++ b/src/server/message_coordinator_tests.rs
@@ -4,7 +4,10 @@ use crate::coordination::{
     RoomMessageTransactionOutcome, RoomRecipientMessages,
 };
 use crate::metrics::ServerMetrics;
-use crate::protocol::{LobbyState, PlayerId, RoomId, ServerMessage, SpectatorJoinedPayload};
+use crate::protocol::{
+    DeliveryClass, GameDataEncoding, LobbyState, PlayerId, RoomId, ServerMessage,
+    SpectatorJoinedPayload,
+};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use tokio::sync::{mpsc, watch, Notify};
@@ -475,6 +478,198 @@ async fn missing_sender_stamp_cancels_broadcast_before_any_delivery_attempt() {
         0,
         "cancellation happens before recipient delivery accounting"
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn builder_broadcast_backpressure_releases_routing_locks_and_keeps_snapshot() {
+    for borrowed_builder in [false, true] {
+        let metrics = Arc::new(ServerMetrics::new());
+        let coordinator = Arc::new(InMemoryMessageCoordinator::with_delivery_policy(
+            Duration::from_secs(5),
+            Arc::clone(&metrics),
+        ));
+        let room_id = RoomId::new_v4();
+        let sender_id = PlayerId::new_v4();
+        let recipient_id = PlayerId::new_v4();
+        let healthy_id = PlayerId::new_v4();
+        let late_joiner_id = PlayerId::new_v4();
+        let mut classified_receivers = Vec::new();
+        for player_id in [recipient_id, healthy_id] {
+            let (sender, mut receiver) = crate::coordination::outbound_queue::channel(1, 1);
+            sender.set_protocol_version(3);
+            sender.set_game_data_format(GameDataEncoding::Json);
+            assert!(sender.delivery_classes_enabled());
+            let mut handle =
+                ClientDeliveryHandle::classified(sender, ConnectionCloseSignal::detached());
+            handle.sender = handle.sender.next_generation();
+            assert_eq!(
+                handle.sender.relay_projection(),
+                Some((true, GameDataEncoding::Json))
+            );
+            let transition = Arc::new(ServerMessage::SpectatorJoined(Box::new(
+                SpectatorJoinedPayload {
+                    room_id,
+                    room_code: "CACHE1".to_string(),
+                    spectator_id: player_id,
+                    game_name: "relay-cache-test".to_string(),
+                    current_players: Vec::new(),
+                    current_spectators: Vec::new(),
+                    lobby_state: LobbyState::Waiting,
+                    reason: None,
+                },
+            )));
+            let transition_outcome = handle
+                .sender
+                .try_send(transition, Some(room_id))
+                .expect("establish the classified recipient's room scope");
+            assert!(transition_outcome.enqueued);
+            let transition = receiver
+                .try_recv()
+                .expect("drain the classified room-scope transition");
+            assert!(matches!(
+                transition.payload,
+                crate::coordination::outbound_queue::OutboundPayload::Message(_)
+            ));
+            if player_id == recipient_id {
+                let prefill_outcome = handle
+                    .sender
+                    .try_send(
+                        Arc::new(ServerMessage::GameData {
+                            from_player: sender_id,
+                            data: serde_json::json!({"seq": 1}),
+                            seq: Some(1),
+                            epoch: Some(1),
+                            class: Some(DeliveryClass::Reliable),
+                            key: None,
+                        }),
+                        Some(room_id),
+                    )
+                    .expect("prefill the selected recipient's classified data queue");
+                assert!(prefill_outcome.enqueued);
+            }
+            coordinator
+                .register_local_client(player_id, Some(room_id), handle)
+                .await
+                .expect("register a classified relay recipient");
+            classified_receivers.push((player_id, receiver));
+        }
+
+        let mut broadcast = {
+            let coordinator = Arc::clone(&coordinator);
+            tokio::spawn(async move {
+                if borrowed_builder {
+                    let mut build_message = || {
+                        Some(Arc::new(ServerMessage::GameData {
+                            from_player: sender_id,
+                            data: serde_json::json!({"seq": 2}),
+                            seq: Some(2),
+                            epoch: Some(1),
+                            class: Some(DeliveryClass::Reliable),
+                            key: None,
+                        }))
+                    };
+                    coordinator
+                        .broadcast_to_room_except_with_borrowed_message(
+                            &room_id,
+                            &sender_id,
+                            &mut build_message,
+                        )
+                        .await
+                } else {
+                    coordinator
+                        .broadcast_to_room_except_with_message(
+                            &room_id,
+                            &sender_id,
+                            Box::new(|| {
+                                Some(Arc::new(ServerMessage::GameData {
+                                    from_player: sender_id,
+                                    data: serde_json::json!({"seq": 2}),
+                                    seq: Some(2),
+                                    epoch: Some(1),
+                                    class: Some(DeliveryClass::Reliable),
+                                    key: None,
+                                }))
+                            }),
+                        )
+                        .await
+                }
+            })
+        };
+        wait_for_counter("builder broadcast reached backpressure", 10_000, || {
+            metrics
+                .websocket_backpressure_events
+                .load(Ordering::Relaxed)
+                == 1
+        })
+        .await;
+
+        let (late_joiner_tx, mut late_joiner_rx) = mpsc::channel(1);
+        tokio::time::timeout(
+            Duration::from_millis(10),
+            coordinator.register_local_client(
+                late_joiner_id,
+                Some(room_id),
+                ClientDeliveryHandle::new(late_joiner_tx, ConnectionCloseSignal::detached()),
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "{} builder held routing locks across its capacity wait",
+                if borrowed_builder {
+                    "borrowed"
+                } else {
+                    "boxed"
+                }
+            )
+        })
+        .expect("late joiner registration must succeed during capacity wait");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut broadcast)
+                .await
+                .is_err(),
+            "builder broadcast must still be waiting for the original recipient"
+        );
+
+        let (_, recipient_rx) = classified_receivers
+            .iter_mut()
+            .find(|(player_id, _)| *player_id == recipient_id)
+            .expect("backpressured recipient receiver must exist");
+        let prefill = recipient_rx
+            .try_recv()
+            .expect("original recipient prefill must still be queued");
+        assert_eq!(prefill.class(), Some(DeliveryClass::Reliable));
+        assert!(
+            matches!(
+                prefill.payload,
+                crate::coordination::outbound_queue::OutboundPayload::Message(message)
+                    if matches!(message.as_ref(), ServerMessage::GameData { seq: Some(1), .. })
+            ),
+            "original recipient prefill changed while the relay waited"
+        );
+        broadcast
+            .await
+            .expect("builder broadcast task must not panic")
+            .expect("builder broadcast must complete after capacity returns");
+        for (player_id, receiver) in &mut classified_receivers {
+            let relayed = receiver
+                .try_recv()
+                .unwrap_or_else(|error| panic!("recipient {player_id} lost relay: {error:?}"));
+            assert!(matches!(
+                relayed.payload,
+                crate::coordination::outbound_queue::OutboundPayload::Data(data)
+                    if matches!(
+                        data.message(),
+                        ServerMessage::GameData { seq: Some(2), .. }
+                    )
+            ));
+        }
+        let unexpected = late_joiner_rx.try_recv();
+        assert!(
+            matches!(unexpected, Err(mpsc::error::TryRecvError::Empty)),
+            "late joiner must not enter the already-started routing snapshot"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## Summary

- walk guarded room membership directly for projection-cohort discovery and synchronous delivery start
- retain owned state only for exceptional backpressure or slow-consumer paths, after releasing both routing guards
- tighten the exact relay-allocation benchmark and add classified backpressure/snapshot/cache-sharing coverage
- record completed publication evidence for sessions 079/080 and the P38 work in session 081

## Measured result

Five exact allocator samples for JSON and binary production ingress:

| Players | Isolated before | Isolated after | Production before | Production after |
| --- | --- | --- | --- | --- |
| 2 | 2 ops / 400 B | 1 op / 352 B | 3 ops / 696 B | 2 ops / 648 B |
| 8 | 3 ops / 1,320 B | 2 ops / 1,032 B | 4 ops / 1,616 B | 3 ops / 1,328 B |
| 16 | 3 ops / 1,640 B | 2 ops / 1,032 B | 4 ops / 1,936 B | 3 ops / 1,328 B |

No latency improvement is claimed.

## Concurrency contract

The routing guards cover projection discovery and synchronous delivery start only. They are dropped before any capacity await. A paused-time regression proves a late same-room registration completes during backpressure without entering the already-started snapshot, for boxed and borrowed builders, while two compatible v3 recipients receive the shared-cache relay.

## Validation

- exact allocation benchmark, five repeats per JSON/binary cell
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- CI/MSRV/doc/workflow/LLM repository scripts and explicit policy tests
- hook readiness plus pre-commit/pre-push worktree gates
- two adversarial review passes; final result: zero major or minor findings

Progresses #207.

Audit follow-ups are tracked separately in #249, #250, and #251.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core relay fan-out and lock/backpressure ordering on a hot path; regression and allocation tests mitigate semantic risk, but any mistake could affect delivery set or deadlock behavior under load.
> 
> **Overview**
> **Healthy room relays no longer copy every recipient into a temporary vector.** Under the existing routing read guards, the coordinator walks room membership twice: once to decide shared relay frame caching, then again to start synchronous per-recipient queue delivery. Owned state is kept only for backpressure waits and slow-consumer handling, and those async steps run only after both guards are released.
> 
> **Broadcast entry points** (`broadcast_to_room_except_with_message` and the borrowed builder path) now use `start_routed_deliveries` plus `finish_deliveries` instead of `collect_routed_recipients` followed by `deliver_to_all`.
> 
> **Allocation benchmarks and docs** tighten checked-in ceilings for isolated handoff and JSON/binary production ingress (e.g. 2-player production: 3→2 ops / 696→648 B per relay). A paused-time regression proves late same-room registration can complete during backpressure without joining an already-started snapshot, for both boxed and borrowed builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ffa6f9227444e0394b4c946e04bf28def6218d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->