### PR TITLE
Fix transport status dedup across memberships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix protocol-v3 peer transport health after room changes (issue #260). The
+  first `TransportStatus` report in each seated membership now fans out even
+  when it matches prior room or spectator state. Spectator entry and leave also
+  reset deduplication so the next accepted report is counted again, but remain
+  roomless and do not fan out;
+  same-generation duplicates stay suppressed and protocol-v2 bytes unchanged.
 - Reject clients whose declared protocol maximum is below the deployment
   minimum instead of silently upgrading them (issue #257). The authentication
   response now uses `UNSUPPORTED_PROTOCOL_VERSION`, including auth-disabled

--- a/docs/architecture/transport-fallback.md
+++ b/docs/architecture/transport-fallback.md
@@ -143,9 +143,11 @@ transport reports are ignored and do not update stored state or metrics. It is
 purely informational and never causes the relay floor to close.
 
 Server-side interpretation (drives the metrics below): duplicate reports of the
-same `(transport, connected)` state are ignored; they leave stored
-per-connection state unchanged and do not move counters. Counters move on the
-first report for a connection and on later real per-connection state transitions.
+same `(transport, connected)` state in one room/spectator membership generation
+are ignored; they leave stored state unchanged and do not move counters. A room
+join, leave, same-room rejoin, spectator-role transition, or reconnect starts a
+fresh generation. Counters move on the first report for that generation and on
+later real state transitions within it.
 
 - `connected: true` with a P2P transport (`direct` or `webrtc`) — a peer-to-peer
   data path came up; counts as **P2P established** when it is a first report or a
@@ -159,9 +161,10 @@ first report for a connection and on later real per-connection state transitions
 
 ## `PeerTransportStatus` peer fan-out (v3 only)
 
-When an accepted report records a **real state change** (the first report on a
-connection, or a `(transport, connected)` transition — the same dedup gate the
-metrics use), the server fans it out to the reporter's current room as
+When an accepted report records a **real state change** (the first report in a
+membership generation, or a `(transport, connected)` transition — the same
+dedup gate the metrics use), the server fans it out to the reporter's current
+room as
 
 ```json
 { "type": "PeerTransportStatus", "data": { "peer_id": "<player-uuid>", "transport": "webrtc", "connected": true } }
@@ -170,7 +173,11 @@ metrics use), the server fans it out to the reporter's current room as
 so peers learn, for example, that the host's WebRTC path died and relay-path
 traffic from it should be expected. The reporter itself is excluded; a duplicate
 report fans out nothing; a report from a room-less client is recorded but fans
-out nothing. Delivery is per-recipient v3-gated (a v2 member never observes it,
+out nothing. Spectators are roomless in connection routing: spectator entry and
+leave reset deduplication, so the next accepted report is counted again, but
+reports made while spectating do not produce `PeerTransportStatus`. A later seated join starts another fresh
+generation, so prior roomless or spectator state never suppresses the first
+in-room report. Delivery is per-recipient v3-gated (a v2 member never observes it,
 Appendix K) but deliberately **not** gated on the recipient's own transport
 capabilities — it is informational status about a _peer_, useful to any v3
 client, not an instruction to use that transport. Like the report it relays, it

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1408,11 +1408,12 @@ Fields:
 
 `TransportStatus` lets a client report its current data-path transport state, so the server can distinguish
 P2P-connected peers from relay-fallback peers (this drives metrics). It is **purely informational**: the relay
-floor never closes regardless of what is reported. Metrics count the first report for a connection and real
-per-connection state transitions; duplicate `(transport, connected)` reports do not move counters. The server
-accepts a report only from a negotiated v3 connection and only when `transport` is in that connection's
-negotiated transport set. Reports from non-v3 clients or for unnegotiated transports are ignored and do not
-update per-connection state or metrics.
+floor never closes regardless of what is reported. Metrics count the first report in a room/spectator membership
+generation and real state transitions within that generation; duplicate `(transport, connected)`
+reports in that generation do not move counters. Room joins, leaves, same-room rejoins, spectator-role changes,
+and reconnects start fresh generations. The server accepts a report only from a negotiated v3 connection and
+only when `transport` is in that connection's negotiated transport set. Reports from non-v3 clients or for
+unnegotiated transports are ignored and do not update stored state or metrics.
 
 ```json
 {
@@ -1440,12 +1441,15 @@ message's fields, plus the reporting peer's id:
 
 Semantics:
 
-- **Deduplicated.** A fan-out fires only when the report records a real per-connection state change — the first
-  report on a connection, or a `(transport, connected)` transition. A duplicate report is dropped at the server
-  and fans out nothing. (A reconnect clears the stored state, so a reconnected client's first re-report fans out
-  again.)
+- **Deduplicated per membership generation.** Accepted state and metrics move only for the first report after a
+  room or spectator membership transition or reconnect, or for a later `(transport, connected)` transition in
+  that generation. When the reporter has a seated room, that accepted change fans out. A same-generation duplicate
+  is dropped and fans out nothing. Leaving and rejoining the same room still creates a fresh generation.
 - **Sender excluded; room scoped.** Only the reporter's current room members hear it, never the reporter itself.
-  A report from a client that is not in a room is still recorded but fans out nothing.
+  A report from a client that is not seated in a room is still recorded but fans out nothing. This includes a
+  spectator: spectator entry and leave reset deduplication, so the next accepted report is counted again, but
+  reports made while spectating have no seated-room fan-out. The next seated join starts a fresh generation, so
+  roomless or spectator state cannot suppress the first report seen by new peers.
 - **v3-gated per recipient.** Like every v3-only message, it is delivered only to members that negotiated v3
   (Appendix K); a v2 member observes nothing. Deliberately, delivery is **not** gated on the recipient's own
   transport capabilities (unlike `NewPeer` / plan-peer pairing, which apply the full session predicate): this is

--- a/progress/session-086-transport-status-generations.md
+++ b/progress/session-086-transport-status-generations.md
@@ -62,4 +62,8 @@ The definitive local gauntlet passed:
   hook-readiness, pre-commit, and pre-push checks
 
 Two independent adversarial review loops finished with zero actionable findings.
-Hosted exact-head CI and GitHub reviewer evidence remain pending publication.
+Cursor Bugbot also found no issues at implementation commit `ef1c867`; Copilot
+terminated without findings because the requester's review quota was exhausted.
+PR #263's final evidence comment is the canonical exact-head record for hosted
+CI, reviewer state, and unresolved-thread count: committing that attestation
+here would change the head it is meant to identify.

--- a/progress/session-086-transport-status-generations.md
+++ b/progress/session-086-transport-status-generations.md
@@ -1,0 +1,65 @@
+# Session 086 — Membership-scoped transport status generations
+
+## Scope and prioritization
+
+Session 085 and merged PR #262 left two concrete follow-ups. Remote triage found
+no open or draft pull requests and no dependency updates. Issue #260 is the
+higher gameplay-impact defect: a player changing rooms on one WebSocket could
+have its new room's first transport-health report suppressed by identical state
+remembered from the old room. Issue #261 remains a separate specification task.
+
+P43 fixes #260 across every room and spectator membership boundary without
+changing protocol-v2 wire behavior.
+
+## Red-green evidence and implementation
+
+The failure-first real-WebSocket test connected one protocol-v3 reporter and an
+observer in room A, accepted `TransportStatus { webrtc, true }`, left, and joined
+room B on the same socket. The identical first report in B timed out waiting for
+`PeerTransportStatus`; only Ping traffic arrived. This directly reproduced the
+issue before production code changed.
+
+`ClientConnection` now carries an explicit membership generation and tags the
+stored transport state with it. Seated join/leave, spectator enter/leave, and
+reconnect advance the generation; failed prepared room or spectator transitions
+roll it back. The status getter exposes only the current generation. This keeps
+same-generation duplicates suppressed while making roomless-to-room, A-to-B,
+same-room rejoin, spectator-role, and reconnect reports fresh.
+
+The handler's existing lifecycle lock serializes status processing against join,
+leave, spectator, and reconnect transactions. A deterministic internal test
+holds a status operation inside that gate before starting a concurrent leave,
+then asserts the exact peer-status / membership-event order. The socket test
+separately proves same-room and cross-room production joins reset dedup.
+
+Spectators remain roomless in connection routing, so their accepted reports
+increment status metrics but do not fan out. A real-socket test proves successful
+spectator entry and leave each accept an identical first report, suppress an
+immediate duplicate, and leave a later seated join fresh. An injected
+post-admission routing failure proves the spectator service rolls its provisional
+generation and persistence entry back exactly.
+
+## Validation evidence
+
+- Red: `cargo test --locked --test v3_transport_status_e2e
+  room_change_resets_transport_status_generation -- --exact --nocapture` timed
+  out at room B's first identical report before the implementation.
+- Green: the same real-WebSocket regression passes after generation scoping.
+- Green: focused unit/service/socket coverage exercises roomless, prepared
+  rollback, lifecycle ordering, seated A-to-B, production same-room rejoin,
+  successful and rolled-back spectator transitions, reconnect, opaque-token
+  replacement, and same-generation duplicate suppression.
+
+The definitive local gauntlet passed:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy --locked --all-targets --all-features -- -D warnings`
+- `cargo test --locked --all-features`
+- `cargo deny --all-features check`
+- focused protocol-v2 wire goldens, room/spectator/reconnect socket tests,
+  spectator rollback, and lifecycle-ordering tests
+- documentation, Markdown, CI configuration, workflow hygiene, LLM policy,
+  hook-readiness, pre-commit, and pre-push checks
+
+Two independent adversarial review loops finished with zero actionable findings.
+Hosted exact-head CI and GitHub reviewer evidence remain pending publication.

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -546,15 +546,17 @@ pub enum ServerMessage {
     /// A same-room peer's reported data-path transport state changed (v3 only).
     ///
     /// Fan-out of an accepted [`ClientMessage::TransportStatus`]: when a v3
-    /// client's report is recorded as a real per-connection state change (the
-    /// first report, or a `(transport, connected)` transition — duplicates are
-    /// dropped at the handler), every **other** member of its current room that
-    /// negotiated v3 is told the new state, e.g. "the host's WebRTC path died,
-    /// expect relay-path traffic from it". Delivery is gated on the recipient's
+    /// seated client's report is recorded as a real state change in its current
+    /// membership generation (the first report, or a `(transport, connected)`
+    /// transition — duplicates are dropped at the handler), every **other**
+    /// member of its current room that negotiated v3 is told the new state,
+    /// e.g. "the host's WebRTC path died, expect relay-path traffic from it".
+    /// Roomless and spectator reports can update accepted state and metrics but
+    /// have no room fan-out. Delivery is gated on the recipient's
     /// negotiated protocol version only — deliberately NOT on the recipient's
-    /// own transport capabilities, because this is informational status about a
-    /// peer, not an instruction to use that transport. Like the report itself it
-    /// is purely informational: the relay floor never closes.
+    /// own transport capabilities, because this is informational status about
+    /// a peer, not an instruction to use that transport. Like the report itself
+    /// it is purely informational: the relay floor never closes.
     PeerTransportStatus {
         peer_id: PlayerId,
         transport: Transport,

--- a/src/server/connection_manager.rs
+++ b/src/server/connection_manager.rs
@@ -71,9 +71,23 @@ pub(crate) struct ClientConnection {
     pub protocol: NegotiatedProtocol,
     /// Last data-path transport state this client reported via
     /// [`ClientMessage::TransportStatus`](crate::protocol::ClientMessage::TransportStatus)
-    /// (v3 only). `None` until the client reports — the relay floor is the implicit
-    /// default and never closes regardless of what is (or is not) reported.
-    pub transport_status: Option<(Transport, bool)>,
+    /// (v3 only), tagged with the room/spectator membership generation in which
+    /// it was observed. `None` until the client reports — the relay floor is the
+    /// implicit default and never closes regardless of what is (or is not)
+    /// reported. A status from an older generation is retained only so a failed
+    /// prepared transition can roll back without losing its dedup baseline.
+    pub transport_status: Option<(Uuid, Transport, bool)>,
+    /// Opaque room/spectator membership token for transport-status
+    /// deduplication. Every committed or prepared role transition replaces it
+    /// with a fresh token; a failed prepared transition restores the exact
+    /// prior token. This is deliberately
+    /// independent of `game_data_epoch`, which models seated sender
+    /// incarnations only and does not advance for spectators.
+    pub membership_generation: Uuid,
+    /// Exact rollback state for the latest prepared membership transition.
+    /// A later transition supersedes it; replacements are collision-resistant
+    /// UUIDs explicitly distinct from the current and retained-status tokens.
+    pub prior_membership_generation: Option<Uuid>,
     /// Last relay sequence number stamped on this client's outbound game data
     /// (protocol v3): the per-(sender, room) counter behind
     /// [`ServerMessage::GameData::seq`](crate::protocol::ServerMessage). `0`
@@ -200,6 +214,34 @@ pub(crate) struct ConnectionManager {
 }
 
 impl ConnectionManager {
+    fn fresh_membership_generation(
+        current: Uuid,
+        retained_status: Option<(Uuid, Transport, bool)>,
+    ) -> Uuid {
+        loop {
+            let candidate = Uuid::new_v4();
+            if candidate != current
+                && retained_status.is_none_or(|(generation, _, _)| candidate != generation)
+            {
+                return candidate;
+            }
+        }
+    }
+
+    fn advance_membership_generation(client: &mut ClientConnection) {
+        client.prior_membership_generation = Some(client.membership_generation);
+        client.membership_generation = Self::fresh_membership_generation(
+            client.membership_generation,
+            client.transport_status,
+        );
+    }
+
+    fn rollback_membership_generation(client: &mut ClientConnection) {
+        if let Some(prior) = client.prior_membership_generation.take() {
+            client.membership_generation = prior;
+        }
+    }
+
     pub fn new(
         max_connections_per_ip: usize,
         metrics: Arc<ServerMetrics>,
@@ -272,6 +314,8 @@ impl ConnectionManager {
             app_info: None,
             protocol: NegotiatedProtocol::default(),
             transport_status: None,
+            membership_generation: Uuid::nil(),
+            prior_membership_generation: None,
             game_data_seq: 0,
             game_data_epoch: 0,
         };
@@ -314,6 +358,8 @@ impl ConnectionManager {
             app_info: None,
             protocol: NegotiatedProtocol::default(),
             transport_status: None,
+            membership_generation: Uuid::nil(),
+            prior_membership_generation: None,
             game_data_seq: 0,
             game_data_epoch: 0,
         };
@@ -362,6 +408,7 @@ impl ConnectionManager {
     ) -> Option<(ClientDeliveryHandle, RelayStamp)> {
         let mut client = self.clients.get_mut(player_id)?;
         client.room_id = Some(room_id);
+        Self::advance_membership_generation(&mut client);
         // Fresh room membership => fresh per-(sender, room) relay stamp stream.
         client.game_data_seq = 0;
         // Saturation cannot regress an epoch, unlike wrapping at u32::MAX.
@@ -388,6 +435,7 @@ impl ConnectionManager {
             return None;
         }
         client.room_id = None;
+        Self::rollback_membership_generation(&mut client);
         client.game_data_seq = 0;
         client.sender = client.sender.previous_generation();
         Some(client.delivery_handle())
@@ -447,7 +495,7 @@ impl ConnectionManager {
                 return TransportStatusUpdate::UnsupportedTransport;
             }
 
-            let new_status = Some((transport, connected));
+            let new_status = Some((connection.membership_generation, transport, connected));
             if connection.transport_status == new_status {
                 return TransportStatusUpdate::Duplicate;
             }
@@ -467,7 +515,14 @@ impl ConnectionManager {
     pub fn transport_status(&self, player_id: &PlayerId) -> Option<(Transport, bool)> {
         self.clients
             .get(player_id)
-            .and_then(|conn| conn.transport_status)
+            .and_then(|conn| match conn.transport_status {
+                Some((generation, transport, connected))
+                    if generation == conn.membership_generation =>
+                {
+                    Some((transport, connected))
+                }
+                _ => None,
+            })
     }
 
     /// Whether the client negotiated protocol v3+ (the single unshipped
@@ -520,6 +575,7 @@ impl ConnectionManager {
                 epoch: client.game_data_epoch,
             };
             client.room_id = None;
+            Self::advance_membership_generation(&mut client);
             // Membership ended: the next room (same or different) starts a
             // fresh stamp stream (see the `game_data_seq` field doc).
             client.game_data_seq = 0;
@@ -535,6 +591,7 @@ impl ConnectionManager {
 
     pub async fn advance_delivery_generation(&self, player_id: &PlayerId) {
         let delivery = self.clients.get_mut(player_id).map(|mut client| {
+            Self::advance_membership_generation(&mut client);
             client.sender = client.sender.next_generation();
             client.delivery_handle()
         });
@@ -553,6 +610,7 @@ impl ConnectionManager {
     /// generation to the coordinator.
     pub async fn rollback_delivery_generation(&self, player_id: &PlayerId) {
         let delivery = self.clients.get_mut(player_id).map(|mut client| {
+            Self::rollback_membership_generation(&mut client);
             client.sender = client.sender.previous_generation();
             client.delivery_handle()
         });
@@ -708,6 +766,11 @@ impl ConnectionManager {
         if let Some((_, old_connection)) = self.clients.remove(current_player_id) {
             let mut delivery = old_connection.delivery_handle();
             delivery.sender = delivery.sender.next_generation();
+            let prior_membership_generation = old_connection.membership_generation;
+            let membership_generation = Self::fresh_membership_generation(
+                prior_membership_generation,
+                old_connection.transport_status,
+            );
             let new_client = ClientConnection {
                 room_id: Some(room_id),
                 lifecycle: Arc::clone(&old_connection.lifecycle),
@@ -719,11 +782,13 @@ impl ConnectionManager {
                 game_data_format: old_connection.game_data_format,
                 app_info: old_connection.app_info,
                 protocol: old_connection.protocol,
-                // The negotiated protocol survives a reconnect, but the reported
-                // data-path transport state does not: a reconnecting client must
-                // re-establish (and re-report) its P2P path, so the stale status is
-                // cleared rather than carried over.
-                transport_status: None,
+                // Preserve any roomless transient-socket status only as rollback
+                // state. Advancing the membership generation below makes it
+                // ineligible for reconnect deduplication, so the restored player
+                // must establish and report its P2P path afresh.
+                transport_status: old_connection.transport_status,
+                membership_generation,
+                prior_membership_generation: Some(prior_membership_generation),
                 // Restart-on-rejoin: a reconnecting sender's relay stamp
                 // stream starts over at 1; recipients treat its
                 // `PlayerReconnected` as a seq reset (field doc above).
@@ -773,6 +838,9 @@ impl ConnectionManager {
 
         let mut delivery = reassigned_connection.delivery_handle();
         delivery.sender = delivery.sender.previous_generation();
+        let membership_generation = reassigned_connection
+            .prior_membership_generation
+            .unwrap_or(reassigned_connection.membership_generation);
         let restored_client = ClientConnection {
             room_id: None,
             lifecycle: Arc::clone(&reassigned_connection.lifecycle),
@@ -784,7 +852,9 @@ impl ConnectionManager {
             game_data_format: reassigned_connection.game_data_format,
             app_info: reassigned_connection.app_info,
             protocol: reassigned_connection.protocol,
-            transport_status: None,
+            transport_status: reassigned_connection.transport_status,
+            membership_generation,
+            prior_membership_generation: None,
             game_data_seq: 0,
             game_data_epoch: 0,
         };

--- a/src/server/message_router.rs
+++ b/src/server/message_router.rs
@@ -1,8 +1,32 @@
 use std::sync::Arc;
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(test)]
+use std::sync::LazyLock;
+
 use crate::protocol::{ClientMessage, PlayerId, ServerMessage};
 
 use super::{EnhancedGameServer, TransportStatusUpdate};
+
+#[cfg(test)]
+static TRANSPORT_STATUS_LIFECYCLE_PROBES: LazyLock<
+    dashmap::DashMap<crate::protocol::PlayerId, Arc<AtomicBool>>,
+> = LazyLock::new(dashmap::DashMap::new);
+
+#[cfg(test)]
+pub(super) fn arm_transport_status_lifecycle_probe(
+    player_id: crate::protocol::PlayerId,
+) -> Arc<AtomicBool> {
+    let probe = Arc::new(AtomicBool::new(false));
+    TRANSPORT_STATUS_LIFECYCLE_PROBES.insert(player_id, Arc::clone(&probe));
+    probe
+}
+
+#[cfg(test)]
+pub(super) fn disarm_transport_status_lifecycle_probe(player_id: &crate::protocol::PlayerId) {
+    TRANSPORT_STATUS_LIFECYCLE_PROBES.remove(player_id);
+}
 
 impl EnhancedGameServer {
     /// Handle incoming client message with enhanced coordination.
@@ -122,10 +146,10 @@ impl EnhancedGameServer {
     /// — this only drives observability and, in future, targeted relay for stuck
     /// peers.
     ///
-    /// Duplicate reports of the same `(transport, connected)` pair update no
-    /// counters and fan nothing out; the metrics and the `PeerTransportStatus`
-    /// fan-out below are emitted only for the first report or a real
-    /// per-connection state transition.
+    /// Duplicate reports of the same `(transport, connected)` pair in one
+    /// membership generation update no counters and fan nothing out; the
+    /// metrics and the `PeerTransportStatus` fan-out below are emitted only for
+    /// the generation's first report or a real state transition.
     ///
     /// Metric interpretation:
     /// - `connected == true` AND a P2P transport (`Direct` / `WebRtc`) ⇒
@@ -134,19 +158,21 @@ impl EnhancedGameServer {
     ///   the relay floor), regardless of which transport it names.
     /// - `connected == true` with `transport: relay` is just "I am on the floor":
     ///   it is not a P2P establishment and not a fallback event, so it moves no
-    ///   counter — only the per-connection state is updated. (Documented here and in
-    ///   `docs/architecture/transport-fallback.md`.)
+    ///   counter — only the current generation's stored state is updated.
+    ///   (Documented here and in `docs/architecture/transport-fallback.md`.)
     async fn handle_transport_status(
         &self,
         player_id: &PlayerId,
         transport: crate::protocol::Transport,
         connected: bool,
     ) {
-        use crate::protocol::Transport;
-
         let Some(lifecycle) = self.connection_manager.client_lifecycle(player_id) else {
             return;
         };
+        #[cfg(test)]
+        if let Some(probe) = TRANSPORT_STATUS_LIFECYCLE_PROBES.get(player_id) {
+            probe.store(true, Ordering::Release);
+        }
         let _lifecycle_guard = lifecycle.lock().await;
         if lifecycle.player_id() != *player_id
             || !self
@@ -155,6 +181,20 @@ impl EnhancedGameServer {
         {
             return;
         }
+
+        self.handle_transport_status_under_lifecycle(player_id, transport, connected)
+            .await;
+    }
+
+    /// Process a transport report after the caller has fixed the connection
+    /// identity and membership with its lifecycle guard.
+    async fn handle_transport_status_under_lifecycle(
+        &self,
+        player_id: &PlayerId,
+        transport: crate::protocol::Transport,
+        connected: bool,
+    ) {
+        use crate::protocol::Transport;
 
         match self.set_client_transport_status(player_id, transport, connected) {
             TransportStatusUpdate::Changed => {}
@@ -211,9 +251,9 @@ impl EnhancedGameServer {
         // `PeerTransportStatus`, so peers learn e.g. that
         // the host's WebRTC path died and relay-path traffic should be
         // expected. Duplicate reports returned early above, so a fan-out fires
-        // once per real per-connection state change (including the first
-        // report). No room ⇒ nothing to fan out — the per-connection state was
-        // still recorded above.
+        // once per real state change in the current membership generation
+        // (including its first report). No room ⇒ nothing to fan out — the
+        // generation-scoped state was still recorded above.
         let Some(room_id) = self.get_client_room(player_id).await else {
             return;
         };

--- a/src/server/message_router_tests.rs
+++ b/src/server/message_router_tests.rs
@@ -3,7 +3,7 @@ use crate::config::{
     TransportSecurityConfig, TurnConfig,
 };
 use crate::database::DatabaseConfig;
-use crate::protocol::{ClientMessage, PlayerId, ServerMessage, Topology, Transport};
+use crate::protocol::{ClientMessage, PlayerId, RoomId, ServerMessage, Topology, Transport};
 use crate::server::{EnhancedGameServer, NegotiatedProtocol, ServerConfig, TransportStatusUpdate};
 use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
@@ -26,6 +26,33 @@ async fn create_test_server() -> Arc<EnhancedGameServer> {
     )
     .await
     .expect("failed to construct test server")
+}
+
+async fn next_routed_test_message(
+    receiver: &mut mpsc::Receiver<Arc<ServerMessage>>,
+    context: &str,
+) -> Arc<ServerMessage> {
+    timeout(Duration::from_secs(1), receiver.recv())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {context}"))
+        .unwrap_or_else(|| panic!("channel closed waiting for {context}"))
+}
+
+async fn drain_until_routed_player_joined(
+    receiver: &mut mpsc::Receiver<Arc<ServerMessage>>,
+    player_id: PlayerId,
+    context: &str,
+) {
+    loop {
+        let message = next_routed_test_message(receiver, context).await;
+        match message.as_ref() {
+            ServerMessage::PlayerJoined { player } if player.id == player_id => return,
+            ServerMessage::PeerTransportStatus { .. } => {
+                panic!("unexpected PeerTransportStatus while waiting for {context}: {message:?}")
+            }
+            _ => {}
+        }
+    }
 }
 
 #[tokio::test]
@@ -345,6 +372,231 @@ async fn transport_status_update_results_are_distinct() {
         server.set_client_transport_status(&player_id, Transport::WebRtc, false),
         TransportStatusUpdate::Changed
     );
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn transport_status_dedup_is_scoped_to_membership_generation() {
+    let server = create_test_server().await;
+    let (sender, _receiver) = mpsc::channel(4);
+    let addr: SocketAddr = "127.0.0.1:50063".parse().unwrap();
+    let player_id = server
+        .connection_manager
+        .register_client(
+            sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            addr,
+            server.instance_id,
+        )
+        .await
+        .expect("client registration succeeds");
+    server.set_client_protocol(
+        &player_id,
+        NegotiatedProtocol {
+            version: 3,
+            transports: vec![Transport::Relay, Transport::WebRtc],
+            topologies: vec![Topology::Relay, Topology::Mesh],
+        },
+    );
+
+    let status = (Transport::WebRtc, true);
+    assert_eq!(
+        server.set_client_transport_status(&player_id, status.0, status.1),
+        TransportStatusUpdate::Changed
+    );
+    assert_eq!(
+        server.set_client_transport_status(&player_id, status.0, status.1),
+        TransportStatusUpdate::Duplicate,
+        "same-generation duplicate must remain suppressed"
+    );
+
+    let room_a = RoomId::new_v4();
+    let (_, prepared_stamp) = server
+        .connection_manager
+        .prepare_client_to_room(&player_id, room_a)
+        .expect("prepare room A membership");
+    assert_eq!(
+        server.client_transport_status(&player_id),
+        None,
+        "a prepared membership must not expose the prior generation's status"
+    );
+    server
+        .connection_manager
+        .rollback_prepared_room_assignment(&player_id, room_a, prepared_stamp.epoch)
+        .expect("roll back unpublished room A membership");
+    assert_eq!(
+        server.client_transport_status(&player_id),
+        Some(status),
+        "a failed prepared membership must restore the prior dedup generation"
+    );
+    assert_eq!(
+        server.set_client_transport_status(&player_id, status.0, status.1),
+        TransportStatusUpdate::Duplicate
+    );
+
+    server
+        .connection_manager
+        .assign_client_to_room(&player_id, room_a)
+        .await;
+    assert_eq!(
+        server.set_client_transport_status(&player_id, status.0, status.1),
+        TransportStatusUpdate::Changed,
+        "room A's first report must be fresh"
+    );
+    assert_eq!(
+        server.set_client_transport_status(&player_id, status.0, status.1),
+        TransportStatusUpdate::Duplicate
+    );
+
+    server
+        .connection_manager
+        .clear_room_assignment(&player_id)
+        .expect("leave room A");
+    assert_eq!(server.client_transport_status(&player_id), None);
+    assert_eq!(
+        server.set_client_transport_status(&player_id, status.0, status.1),
+        TransportStatusUpdate::Changed,
+        "roomless membership generation starts with no dedup baseline"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(miri, ignore)]
+async fn transport_status_is_ordered_before_concurrent_leave() {
+    let server = create_test_server().await;
+    let protocol = NegotiatedProtocol {
+        version: 3,
+        transports: vec![Transport::Relay, Transport::WebRtc],
+        topologies: vec![Topology::Relay, Topology::Mesh],
+    };
+
+    let (observer_sender, mut observer_rx) = mpsc::channel(16);
+    let observer = server
+        .connection_manager
+        .register_client(
+            observer_sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            "127.0.0.1:50064".parse().unwrap(),
+            server.instance_id,
+        )
+        .await
+        .expect("observer registration succeeds");
+    server.set_client_protocol(&observer, protocol.clone());
+    server
+        .handle_client_message(
+            &observer,
+            ClientMessage::JoinRoom {
+                game_name: "transport-ordering".to_string(),
+                room_code: None,
+                player_name: "Observer".to_string(),
+                max_players: Some(3),
+                supports_authority: Some(false),
+                relay_transport: None,
+            },
+        )
+        .await;
+    let room_code = match next_routed_test_message(&mut observer_rx, "observer RoomJoined")
+        .await
+        .as_ref()
+    {
+        ServerMessage::RoomJoined(payload) => payload.room_code.clone(),
+        message => panic!("expected observer RoomJoined, got {message:?}"),
+    };
+
+    let (reporter_sender, mut reporter_rx) = mpsc::channel(16);
+    let reporter = server
+        .connection_manager
+        .register_client(
+            reporter_sender,
+            crate::coordination::ConnectionCloseSignal::detached(),
+            "127.0.0.1:50065".parse().unwrap(),
+            server.instance_id,
+        )
+        .await
+        .expect("reporter registration succeeds");
+    server.set_client_protocol(&reporter, protocol);
+    let join_message = || ClientMessage::JoinRoom {
+        game_name: "transport-ordering".to_string(),
+        room_code: Some(room_code.clone()),
+        player_name: "Reporter".to_string(),
+        max_players: Some(3),
+        supports_authority: Some(false),
+        relay_transport: None,
+    };
+    server
+        .handle_client_message(&reporter, join_message())
+        .await;
+    assert!(matches!(
+        next_routed_test_message(&mut reporter_rx, "reporter RoomJoined")
+            .await
+            .as_ref(),
+        ServerMessage::RoomJoined(_)
+    ));
+    drain_until_routed_player_joined(&mut observer_rx, reporter, "observer PlayerJoined").await;
+    server
+        .handle_client_message(
+            &reporter,
+            ClientMessage::TransportStatus {
+                transport: Transport::WebRtc,
+                connected: true,
+            },
+        )
+        .await;
+    assert!(matches!(
+        next_routed_test_message(&mut observer_rx, "initial PeerTransportStatus").await.as_ref(),
+        ServerMessage::PeerTransportStatus { peer_id, connected: true, .. } if *peer_id == reporter
+    ));
+
+    // Poll both production handlers to their lifecycle wait point in a known
+    // order while the gate is held. Tokio's FIFO mutex then makes the oracle
+    // independent of executor scheduling: status must publish before leave can
+    // clear membership.
+    let lifecycle = server
+        .connection_manager
+        .client_lifecycle(&reporter)
+        .expect("reporter lifecycle");
+    let lifecycle_probe = super::message_router::arm_transport_status_lifecycle_probe(reporter);
+    let lifecycle_guard = lifecycle.lock().await;
+    let status_before_leave = server.handle_client_message(
+        &reporter,
+        ClientMessage::TransportStatus {
+            transport: Transport::WebRtc,
+            connected: false,
+        },
+    );
+    tokio::pin!(status_before_leave);
+    assert!(matches!(
+        futures_util::poll!(&mut status_before_leave),
+        std::task::Poll::Pending
+    ));
+    assert!(
+        lifecycle_probe.load(Ordering::Acquire),
+        "status handler must reach its lifecycle-lock request before leave is polled"
+    );
+    let leave_after_status = server.handle_client_message(&reporter, ClientMessage::LeaveRoom);
+    tokio::pin!(leave_after_status);
+    assert!(matches!(
+        futures_util::poll!(&mut leave_after_status),
+        std::task::Poll::Pending
+    ));
+    drop(lifecycle_guard);
+    tokio::join!(status_before_leave, leave_after_status);
+    super::message_router::disarm_transport_status_lifecycle_probe(&reporter);
+
+    assert!(matches!(
+        next_routed_test_message(&mut observer_rx, "ordered PeerTransportStatus").await.as_ref(),
+        ServerMessage::PeerTransportStatus { peer_id, connected: false, .. } if *peer_id == reporter
+    ));
+    assert!(matches!(
+        next_routed_test_message(&mut observer_rx, "ordered PlayerLeft").await.as_ref(),
+        ServerMessage::PlayerLeft { player_id, .. } if *player_id == reporter
+    ));
+    assert!(matches!(
+        next_routed_test_message(&mut reporter_rx, "ordered RoomLeft")
+            .await
+            .as_ref(),
+        ServerMessage::RoomLeft
+    ));
 }
 
 #[tokio::test]

--- a/src/server/room_service_tests.rs
+++ b/src/server/room_service_tests.rs
@@ -557,6 +557,7 @@ enum DrainTrigger {
     PlayerLeftBroadcast,
     FirstFarewellTrySend,
     MissingTerminalTail,
+    SpectatorRoutingLookupFailure,
 }
 
 struct DrainTriggerCoordinator {
@@ -877,6 +878,19 @@ impl MessageCoordinator for DrainTriggerCoordinator {
         }
         self.clients.write().await.insert(player_id, delivery);
         Ok(())
+    }
+
+    async fn routed_player_ids(&self, room_id: &RoomId) -> anyhow::Result<Option<Vec<PlayerId>>> {
+        if self.trigger == DrainTrigger::SpectatorRoutingLookupFailure {
+            anyhow::bail!("injected spectator routing lookup failure");
+        }
+        let room_players = self.room_players.read().await;
+        Ok(Some(
+            room_players
+                .get(room_id)
+                .map(|players| players.iter().copied().collect())
+                .unwrap_or_default(),
+        ))
     }
 
     async fn unroute_local_client_with_tail<'a>(
@@ -1295,6 +1309,94 @@ async fn spectator_join_waits_for_one_slot_baseline_capacity() {
         Some(ServerMessage::NewSpectatorJoined { .. })
     ));
     assert!(server.spectator_service.is_spectating(&spectator));
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn failed_spectator_publication_restores_transport_status_generation() {
+    let coordinator = Arc::new(DrainTriggerCoordinator::new(
+        DrainTrigger::SpectatorRoutingLookupFailure,
+    ));
+    let message_coordinator: Arc<dyn MessageCoordinator> = coordinator.clone();
+    let server =
+        create_test_server_with_message_coordinator(ServerConfig::default(), message_coordinator)
+            .await;
+
+    let (creator, _creator_rx) = register_client(&server, "127.0.0.1:47988".parse().unwrap()).await;
+    let room = server
+        .database
+        .create_room(
+            "spectator-rollback".to_string(),
+            Some("SPRLBK".to_string()),
+            4,
+            true,
+            creator,
+            "udp".to_string(),
+            "region-a".to_string(),
+            None,
+        )
+        .await
+        .expect("room creation succeeds");
+    server
+        .connection_manager
+        .assign_client_to_room(&creator, room.id)
+        .await;
+
+    let (spectator, _spectator_rx) =
+        register_client(&server, "127.0.0.1:47989".parse().unwrap()).await;
+    server.set_client_protocol(
+        &spectator,
+        NegotiatedProtocol {
+            version: 3,
+            transports: vec![
+                crate::protocol::Transport::Relay,
+                crate::protocol::Transport::WebRtc,
+            ],
+            topologies: vec![
+                crate::protocol::Topology::Relay,
+                crate::protocol::Topology::Mesh,
+            ],
+        },
+    );
+    let status = (crate::protocol::Transport::WebRtc, true);
+    assert_eq!(
+        server.set_client_transport_status(&spectator, status.0, status.1),
+        TransportStatusUpdate::Changed
+    );
+
+    let result = server
+        .spectator_service
+        .join(
+            &spectator,
+            room.game_name.clone(),
+            room.code.clone(),
+            "rollback-watcher".to_string(),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "injected routed-member lookup must fail admission"
+    );
+    assert!(!server.spectator_service.is_spectating(&spectator));
+    assert!(
+        server
+            .database
+            .get_room_spectators(&room.id)
+            .await
+            .expect("spectator roster remains readable")
+            .is_empty(),
+        "failed publication must remove the provisional spectator"
+    );
+    assert_eq!(
+        server.client_transport_status(&spectator),
+        Some(status),
+        "failed spectator publication restores the prior dedup baseline"
+    );
+    assert_eq!(
+        server.set_client_transport_status(&spectator, status.0, status.1),
+        TransportStatusUpdate::Duplicate
+    );
 }
 
 #[tokio::test]

--- a/tests/v3_transport_status_e2e.rs
+++ b/tests/v3_transport_status_e2e.rs
@@ -18,23 +18,30 @@
 //!    byte-identical duplicate fans out nothing.
 //! 4. `state_transitions_each_fan_out_once` — `{webrtc,true}` -> `{webrtc,false}`
 //!    -> `{webrtc,true}` yields exactly three ordered `PeerTransportStatus`.
-//! 5. `reconnect_clears_stored_transport_status` — a re-report of the same state
+//! 5. `room_change_resets_transport_status_generation` — leaving and rejoining
+//!    the same room, then changing rooms on one socket, lets the same first
+//!    state fan out in every seated membership.
+//! 6. `spectator_transitions_reset_status_without_room_fan_out` — real
+//!    spectator entry/leave resets accepted state while remaining roomless;
+//!    a later seated join starts fresh and fans out.
+//! 7. `reconnect_clears_stored_transport_status` — a re-report of the same state
 //!    after a drop+reconnect fans out AGAIN (reconnect cleared stored state).
-//! 6. `peer_transport_status_v3_gated_not_capability_gated` — in a mixed room a
+//! 8. `peer_transport_status_v3_gated_not_capability_gated` — in a mixed room a
 //!    v3 reporter's accepted report reaches a relay-only v3 member but NOT the
 //!    v2 member.
-//! 7. `reporter_excluded_and_roomless_report_is_noop` — the reporter never
+//! 9. `reporter_excluded_and_roomless_report_is_noop` — the reporter never
 //!    receives its own status; a client not in a room records but fans out
 //!    nothing (no panic).
-//! 8. `finalization_race_single_plan_per_member` — both members of a 2-seat
-//!    room send `PlayerReady` concurrently; finalization happens exactly once
-//!    and both receive identical (mirrored) `SessionPlan`s.
+//! 10. `finalization_race_single_plan_per_member` — both members of a 2-seat
+//!     room send `PlayerReady` concurrently; finalization happens exactly once
+//!     and both receive identical (mirrored) `SessionPlan`s.
 
 mod test_helpers;
 mod v3_conformance_helpers;
 mod websocket_test_helpers;
 
 use std::collections::BTreeSet;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use signal_fish_server::config::{AppAuthEntry, SessionConfig, TurnConfig};
@@ -265,6 +272,16 @@ async fn report_transport_status(ws: &mut WsStream, transport: Transport, connec
     .await;
 }
 
+/// Put a protocol `Ping` behind the preceding client frame and wait for its
+/// `Pong`, proving the server processed that frame before state is inspected.
+async fn await_client_message_barrier(ws: &mut WsStream) {
+    send(ws, &ClientMessage::Ping).await;
+    next_matching_server_message_within(ws, SERVER_MESSAGE_TIMEOUT, "Pong barrier", |message| {
+        matches!(message, ServerMessage::Pong).then_some(())
+    })
+    .await;
+}
+
 /// Await a `PeerTransportStatus` naming exactly `(peer, transport, connected)`,
 /// skipping unrelated join-phase backlog.
 async fn expect_peer_transport_status(
@@ -321,8 +338,8 @@ async fn drain_until_player_joined(ws: &mut WsStream, last_joiner: PlayerId, who
 
     // The room-full `PlayerJoined` is followed by a `LobbyStateChanged`
     // room-full transition; sweep it (and any trailing lobby updates) so the
-    // stream sits exactly at the post-fill baseline. Bounded: a v3-only fan-out
-    // would NOT match and is left in place to trip the strict silence check.
+    // stream sits exactly at the post-fill baseline. The helper consumes every
+    // frame it inspects, so a v3-only fan-out is rejected explicitly above.
     while maybe_next_matching_server_message_within(
         ws,
         SILENCE_WINDOW,
@@ -605,7 +622,283 @@ async fn state_transitions_each_fan_out_once() {
 }
 
 // ---------------------------------------------------------------------------
-// 5. A reconnect clears stored transport status -> a re-report fans out again.
+// 5. A room-membership change resets deduplication for the new generation.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn room_change_resets_transport_status_generation() {
+    // Issue #260: one physical socket reports {webrtc,true} in room A, leaves,
+    // then joins room B under the same player id. Room B must not inherit room
+    // A's dedup state: its first identical report is a fresh observation and
+    // fans out. The room-B observer must also receive no old-room report before
+    // that fresh report, pinning the lifecycle/room-event ordering boundary.
+    let (running_server, _server) = start_server_with_session(mesh_session_config()).await;
+    let addr = running_server.addr();
+
+    let mut reporter = connect(addr).await;
+    authenticate_v3_full(&mut reporter).await;
+    let joined_a = join_room(&mut reporter, "tstatus-room-a", None, "Reporter", 2).await;
+    let reporter_id = joined_a.player_id;
+    let room_a_code = joined_a.room_code.clone();
+
+    let mut observer_a = connect(addr).await;
+    authenticate_v3_full(&mut observer_a).await;
+    join_room(
+        &mut observer_a,
+        "tstatus-room-a",
+        Some(room_a_code.clone()),
+        "ObserverA",
+        2,
+    )
+    .await;
+
+    report_transport_status(&mut reporter, Transport::WebRtc, true).await;
+    expect_peer_transport_status(
+        &mut observer_a,
+        "observer_a initial membership",
+        reporter_id,
+        Transport::WebRtc,
+        true,
+    )
+    .await;
+
+    send(&mut reporter, &ClientMessage::LeaveRoom).await;
+    next_matching_server_message_within(
+        &mut reporter,
+        SERVER_MESSAGE_TIMEOUT,
+        "RoomLeft(room A)",
+        |message| matches!(message, ServerMessage::RoomLeft).then_some(()),
+    )
+    .await;
+    next_matching_server_message_within(
+        &mut observer_a,
+        SERVER_MESSAGE_TIMEOUT,
+        "PlayerLeft(reporter from room A)",
+        |message| match message {
+            ServerMessage::PlayerLeft { player_id, .. } if player_id == reporter_id => Some(()),
+            _ => None,
+        },
+    )
+    .await;
+
+    let rejoined_a = join_room(
+        &mut reporter,
+        "tstatus-room-a",
+        Some(room_a_code),
+        "Reporter",
+        2,
+    )
+    .await;
+    assert_eq!(rejoined_a.player_id, reporter_id);
+    drain_until_player_joined(&mut observer_a, reporter_id, "observer_a rejoin").await;
+    report_transport_status(&mut reporter, Transport::WebRtc, true).await;
+    expect_peer_transport_status(
+        &mut observer_a,
+        "observer_a after same-room rejoin",
+        reporter_id,
+        Transport::WebRtc,
+        true,
+    )
+    .await;
+
+    send(&mut reporter, &ClientMessage::LeaveRoom).await;
+    next_matching_server_message_within(
+        &mut reporter,
+        SERVER_MESSAGE_TIMEOUT,
+        "RoomLeft(room A after rejoin)",
+        |message| matches!(message, ServerMessage::RoomLeft).then_some(()),
+    )
+    .await;
+    next_matching_server_message_within(
+        &mut observer_a,
+        SERVER_MESSAGE_TIMEOUT,
+        "PlayerLeft(reporter after room A rejoin)",
+        |message| match message {
+            ServerMessage::PlayerLeft { player_id, .. } if player_id == reporter_id => Some(()),
+            _ => None,
+        },
+    )
+    .await;
+
+    let mut observer_b = connect(addr).await;
+    authenticate_v3_full(&mut observer_b).await;
+    let joined_b = join_room(&mut observer_b, "tstatus-room-b", None, "ObserverB", 2).await;
+    let rejoined = join_room(
+        &mut reporter,
+        "tstatus-room-b",
+        Some(joined_b.room_code),
+        "Reporter",
+        2,
+    )
+    .await;
+    assert_eq!(
+        rejoined.player_id, reporter_id,
+        "changing rooms on one socket must preserve the connection identity"
+    );
+    drain_until_player_joined(&mut observer_b, reporter_id, "observer_b").await;
+
+    expect_no_server_message_within(
+        &mut observer_b,
+        SILENCE_WINDOW,
+        "observer_b before its generation's first TransportStatus",
+    )
+    .await;
+
+    report_transport_status(&mut reporter, Transport::WebRtc, true).await;
+    expect_peer_transport_status(
+        &mut observer_b,
+        "observer_b",
+        reporter_id,
+        Transport::WebRtc,
+        true,
+    )
+    .await;
+
+    // A new-room report must never be attributed to peers left behind in A.
+    expect_no_server_message_within(
+        &mut observer_a,
+        SILENCE_WINDOW,
+        "observer_a after reporter joined room B",
+    )
+    .await;
+    running_server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Spectator role changes reset accepted state but remain roomless for fan-out.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread")]
+async fn spectator_transitions_reset_status_without_room_fan_out() {
+    let (running_server, server) = start_server_with_session(mesh_session_config()).await;
+    let addr = running_server.addr();
+
+    let mut seated = connect(addr).await;
+    authenticate_v3_full(&mut seated).await;
+    let room = join_room(&mut seated, "tstatus-spectator", None, "Seated", 2).await;
+
+    let mut spectator = connect(addr).await;
+    authenticate_v3_full(&mut spectator).await;
+
+    // Establish an identical roomless baseline before the real spectator
+    // workflow. Each subsequent accepted report increments this counter once.
+    report_transport_status(&mut spectator, Transport::WebRtc, true).await;
+    await_client_message_barrier(&mut spectator).await;
+    assert_eq!(server.metrics().p2p_established.load(Ordering::Relaxed), 1);
+
+    send(
+        &mut spectator,
+        &ClientMessage::JoinAsSpectator {
+            game_name: "tstatus-spectator".to_string(),
+            room_code: room.room_code.clone(),
+            spectator_name: "Watcher".to_string(),
+        },
+    )
+    .await;
+    let spectator_id = next_matching_server_message_within(
+        &mut spectator,
+        SERVER_MESSAGE_TIMEOUT,
+        "SpectatorJoined",
+        |message| match message {
+            ServerMessage::SpectatorJoined(payload) => Some(payload.spectator_id),
+            ServerMessage::SpectatorJoinFailed { reason, error_code } => {
+                panic!("spectator join failed: {reason} ({error_code:?})")
+            }
+            _ => None,
+        },
+    )
+    .await;
+    next_matching_server_message_within(
+        &mut seated,
+        SERVER_MESSAGE_TIMEOUT,
+        "NewSpectatorJoined",
+        |message| matches!(message, ServerMessage::NewSpectatorJoined { .. }).then_some(()),
+    )
+    .await;
+
+    report_transport_status(&mut spectator, Transport::WebRtc, true).await;
+    await_client_message_barrier(&mut spectator).await;
+    assert_eq!(
+        server.metrics().p2p_established.load(Ordering::Relaxed),
+        2,
+        "successful spectator entry starts a fresh accepted-status generation"
+    );
+    report_transport_status(&mut spectator, Transport::WebRtc, true).await;
+    await_client_message_barrier(&mut spectator).await;
+    assert_eq!(
+        server.metrics().p2p_established.load(Ordering::Relaxed),
+        2,
+        "same-spectator-generation duplicates remain suppressed"
+    );
+    expect_no_server_message_within(
+        &mut seated,
+        SILENCE_WINDOW,
+        "seated member after spectator TransportStatus",
+    )
+    .await;
+
+    send(&mut spectator, &ClientMessage::LeaveSpectator).await;
+    next_matching_server_message_within(
+        &mut spectator,
+        SERVER_MESSAGE_TIMEOUT,
+        "SpectatorLeft",
+        |message| matches!(message, ServerMessage::SpectatorLeft { .. }).then_some(()),
+    )
+    .await;
+    next_matching_server_message_within(
+        &mut seated,
+        SERVER_MESSAGE_TIMEOUT,
+        "SpectatorDisconnected",
+        |message| match message {
+            ServerMessage::SpectatorDisconnected {
+                spectator_id: departed,
+                ..
+            } if departed == spectator_id => Some(()),
+            _ => None,
+        },
+    )
+    .await;
+
+    report_transport_status(&mut spectator, Transport::WebRtc, true).await;
+    await_client_message_barrier(&mut spectator).await;
+    assert_eq!(
+        server.metrics().p2p_established.load(Ordering::Relaxed),
+        3,
+        "successful spectator departure starts a fresh roomless generation"
+    );
+    expect_no_server_message_within(
+        &mut seated,
+        SILENCE_WINDOW,
+        "seated member after roomless TransportStatus",
+    )
+    .await;
+
+    let seated_join = join_room(
+        &mut spectator,
+        "tstatus-spectator",
+        Some(room.room_code),
+        "FormerWatcher",
+        2,
+    )
+    .await;
+    assert_eq!(seated_join.player_id, spectator_id);
+    drain_until_player_joined(&mut seated, spectator_id, "seated observer").await;
+    report_transport_status(&mut spectator, Transport::WebRtc, true).await;
+    expect_peer_transport_status(
+        &mut seated,
+        "seated observer after former spectator joins",
+        spectator_id,
+        Transport::WebRtc,
+        true,
+    )
+    .await;
+    assert_eq!(server.metrics().p2p_established.load(Ordering::Relaxed), 4);
+
+    running_server.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// 7. A reconnect clears stored transport status -> a re-report fans out again.
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
@@ -613,9 +906,8 @@ async fn reconnect_clears_stored_transport_status() {
     // The reporter establishes {webrtc,true} (fans out), then its socket drops
     // and it reconnects as the SAME player via the wire `Reconnect` flow. A
     // re-report of the very same {webrtc,true} must fan out AGAIN, because the
-    // reconnect cleared the stored per-connection state
-    // (`connection_manager::reassign_connection` sets `transport_status: None`).
-    // If suppressed, the dedup gate is leaking pre-reconnect state -> RED.
+    // reconnect advanced the membership generation. If suppressed, the dedup
+    // gate is leaking pre-reconnect state -> RED.
     let (running_server, server) = start_server_with_session(mesh_session_config()).await;
     let addr = running_server.addr();
     let game = "tstatus-reconnect";
@@ -753,7 +1045,7 @@ async fn reconnect_clears_stored_transport_status() {
 }
 
 // ---------------------------------------------------------------------------
-// 6. PeerTransportStatus is v3-gated per recipient but NOT capability-gated:
+// 8. PeerTransportStatus is v3-gated per recipient but NOT capability-gated:
 //    a relay-only v3 member still receives it; a v2 member never does.
 // ---------------------------------------------------------------------------
 
@@ -821,7 +1113,7 @@ async fn peer_transport_status_v3_gated_not_capability_gated() {
 }
 
 // ---------------------------------------------------------------------------
-// 7. The reporter is excluded from its own fan-out; a room-less report is a
+// 9. The reporter is excluded from its own fan-out; a room-less report is a
 //    recorded no-op (fans out nothing, no panic).
 // ---------------------------------------------------------------------------
 
@@ -888,7 +1180,7 @@ async fn reporter_excluded_and_roomless_report_is_noop() {
 }
 
 // ---------------------------------------------------------------------------
-// 8. Finalization race: both members ready concurrently -> finalize exactly
+// 10. Finalization race: both members ready concurrently -> finalize exactly
 //    once, identical (mirrored) plans.
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- scope protocol-v3 `TransportStatus` deduplication to collision-resistant room/spectator membership tokens
- restore the exact prior token when prepared room, spectator, or reconnect publication rolls back
- preserve same-generation duplicate suppression, seated-room fan-out, spectator roomless semantics, and frozen protocol-v2 bytes
- document the lifecycle contract and record session validation evidence

## Root cause

The server stored one transport-status baseline for the entire physical WebSocket. A player could report `{ webrtc, true }` in room A, leave, join room B on the same socket, and have room B's identical first report suppressed as a duplicate.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- focused real-WebSocket same-room, cross-room, spectator entry/leave, and reconnect tests
- injected spectator-publication rollback and deterministic lifecycle-ordering tests
- all 46 protocol-v2 wire goldens
- documentation, Markdown, CI-config, workflow-hygiene, LLM-policy, and hook checks
- two adversarial review loops, both ending with zero actionable findings

## Impact

Each seated membership can publish its own initial peer transport health even when it matches prior room or spectator state. Spectator and roomless reports remain accepted for state and metrics but do not fan out until a later seated membership reports.

Closes #260

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes v3 transport-status dedup and `PeerTransportStatus` fan-out across room/spectator/reconnect boundaries; impact is bounded by extensive e2e and unit tests and unchanged v2 wire behavior.
> 
> **Overview**
> Fixes **#260**: when a player changed rooms on one WebSocket, the first identical `TransportStatus` in the new room could be treated as a duplicate and **never** fan out as `PeerTransportStatus`.
> 
> **`ClientConnection`** now tracks a **`membership_generation`** token that advances on seated join/leave, spectator enter/leave, and reconnect, with rollback on failed prepared room or spectator transitions. Stored transport state is tagged with that generation, so same-generation duplicates stay suppressed while cross-room, same-room rejoin, spectator, and reconnect reports count as fresh.
> 
> **Spectator** entry/leave still reset dedup and accept metrics updates, but reports while spectating remain **roomless** (no peer fan-out). **Protocol v2** wire bytes and duplicate suppression within one generation are unchanged.
> 
> Docs (`protocol.md`, `transport-fallback.md`, CHANGELOG) and real-WebSocket plus unit tests cover cross-room, same-room rejoin, spectator rollback, lifecycle ordering, and reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d471d82ecf7bdd00d2257a32c574632e86c19853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->