### PR TITLE
Fix AsyncAPI accountability envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix the codegen-facing AsyncAPI accountability envelopes (issue #261).
+  Room snapshots, relayed game data, lifecycle watermarks, and reconnect replay
+  now expose closed protocol-v2/protocol-v3 wire unions that reject impossible
+  mixed or partial shapes while preserving the frozen protocol-v2 wire.
 - Fix protocol-v3 peer transport health after room changes (issue #260). The
   first `TransportStatus` report in each seated membership now fans out even
   when it matches prior room or spectator state. Spectator entry and leave also

--- a/docs/guides/building-a-client.md
+++ b/docs/guides/building-a-client.md
@@ -314,6 +314,15 @@ and error codes. A Rust test
 ([`tests/protocol_spec_consistency.rs`](https://github.com/Ambiguous-Interactive/signal-fish-server/blob/main/tests/protocol_spec_consistency.rs))
 fails the build if it drifts from the Rust source, so you can trust it.
 
+Accountability-bearing server messages use closed wire-shape unions. Generated
+models therefore distinguish the v2 forms from v3 snapshots, sequence/epoch
+pairs, terminal watermarks, and reconnect replay state instead of accepting a
+single bag of optional fields. `SpectatorJoined` also has a shared branch for an
+empty `current_players` snapshot: in a spectator-only room that payload has no
+wire-visible version field and is valid for either negotiated version.
+`Reconnected.missed_events` is limited to the exact replayable control-message
+subset and uses the matching v2 or v3 lifecycle shapes.
+
 Generate models or a client scaffold with the AsyncAPI generator:
 
 ```bash

--- a/spec/signal-fish-protocol.asyncapi.yaml
+++ b/spec/signal-fish-protocol.asyncapi.yaml
@@ -526,6 +526,7 @@ components:
 
     ReliableDeliveryCounters:
       type: object
+      additionalProperties: false
       required: [delivered, abandoned, unsupported_format]
       properties:
         delivered: { type: integer, minimum: 0 }
@@ -536,6 +537,7 @@ components:
         unsupported_format: { type: integer, minimum: 0 }
     LatestDeliveryCounters:
       type: object
+      additionalProperties: false
       required: [delivered, superseded, dropped_full, abandoned, unsupported_format]
       properties:
         delivered: { type: integer, minimum: 0 }
@@ -548,6 +550,7 @@ components:
         unsupported_format: { type: integer, minimum: 0 }
     VolatileDeliveryCounters:
       type: object
+      additionalProperties: false
       required: [delivered, dropped, abandoned, unsupported_format]
       properties:
         delivered: { type: integer, minimum: 0 }
@@ -559,6 +562,7 @@ components:
         unsupported_format: { type: integer, minimum: 0 }
     DeliveryCountersByClass:
       type: object
+      additionalProperties: false
       required: [reliable, latest, volatile]
       properties:
         reliable: { $ref: '#/components/schemas/ReliableDeliveryCounters' }
@@ -566,6 +570,7 @@ components:
         volatile: { $ref: '#/components/schemas/VolatileDeliveryCounters' }
     DeliveryGap:
       type: object
+      additionalProperties: false
       description: >-
         Exact inclusive server-stamped sequence range omitted for one recipient.
         from_seq must not exceed to_seq.
@@ -647,6 +652,7 @@ components:
             epoch for pre-v3 recipients (byte-identical wire).
     SenderWatermark:
       type: object
+      additionalProperties: false
       required: [player_id, epoch, seq]
       description: >-
         v3 only: authoritative reconnect baseline for one current room
@@ -666,6 +672,7 @@ components:
           minimum: 0
     SpectatorInfo:
       type: object
+      additionalProperties: false
       required: [id, name, connected_at]
       properties:
         id: { $ref: '#/components/schemas/PlayerId' }
@@ -1021,12 +1028,22 @@ components:
             error_code: { $ref: '#/components/schemas/ErrorCode' }
       required: [type, data]
     RoomJoined:
+      oneOf:
+        - { $ref: '#/components/schemas/V2RoomJoined' }
+        - { $ref: '#/components/schemas/V3RoomJoined' }
+      description: >-
+        Exact recipient-version projection of the flattened RoomJoinedPayload.
+        The v2 branch forbids every v3-only field; the v3 branch requires
+        version-uniform player snapshots.
+    V2RoomJoined:
       type: object
-      description: Payload is a flattened RoomJoinedPayload (boxed newtype variant).
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: RoomJoined }
         data:
           type: object
+          additionalProperties: false
           required:
             - room_id
             - room_code
@@ -1039,6 +1056,7 @@ components:
             - lobby_state
             - ready_players
             - relay_type
+            - current_spectators
           properties:
             room_id: { $ref: '#/components/schemas/RoomId' }
             room_code: { type: string }
@@ -1048,7 +1066,51 @@ components:
             supports_authority: { type: boolean }
             current_players:
               type: array
-              items: { $ref: '#/components/schemas/PlayerInfo' }
+              minItems: 1
+              items: { $ref: '#/components/schemas/V2PlayerInfo' }
+            is_authority: { type: boolean }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            ready_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerId' }
+            relay_type: { type: string }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+      required: [type, data]
+    V3RoomJoined:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      properties:
+        type: { const: RoomJoined }
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - room_id
+            - room_code
+            - player_id
+            - game_name
+            - max_players
+            - supports_authority
+            - current_players
+            - is_authority
+            - lobby_state
+            - ready_players
+            - relay_type
+            - current_spectators
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            max_players: { type: integer }
+            supports_authority: { type: boolean }
+            current_players:
+              type: array
+              minItems: 1
+              items: { $ref: '#/components/schemas/V3PlayerInfo' }
             is_authority: { type: boolean }
             lobby_state: { $ref: '#/components/schemas/LobbyState' }
             ready_players:
@@ -1060,18 +1122,16 @@ components:
               items: { $ref: '#/components/schemas/SpectatorInfo' }
             ice_servers:
               type: array
+              minItems: 1
               description: 'v3 pre-gather only; superseded by SessionPlan.ice_servers.'
               items: { $ref: '#/components/schemas/IceServer' }
             reconnection_token:
               type: string
               description: >-
-                Reconnection token for this room, minted at join (v3+
-                recipients only; absent on the v2 wire). Present it in a later
-                Reconnect after an unexpected disconnect. The string is stable
-                from join through the disconnect, but it only becomes
-                claimable for server.reconnection_window seconds counted from
-                the DISCONNECT. Rotated on every join and every successful
-                reconnect.
+                Reconnection token for this room, minted at join when
+                reconnection is enabled. Present it in a later Reconnect after
+                an unexpected disconnect. The token is absent when the
+                deployment disables reconnection.
       required: [type, data]
     RoomJoinFailed:
       type: object
@@ -1091,26 +1151,67 @@ components:
         type: { const: RoomLeft }
       required: [type]
     PlayerJoined:
+      oneOf:
+        - { $ref: '#/components/schemas/V2PlayerJoined' }
+        - { $ref: '#/components/schemas/V3PlayerJoined' }
+    V2PlayerJoined:
       type: object
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: PlayerJoined }
         data:
           type: object
+          additionalProperties: false
           required: [player]
           properties:
-            player: { $ref: '#/components/schemas/PlayerInfo' }
+            player: { $ref: '#/components/schemas/V2PlayerInfo' }
+      required: [type, data]
+    V3PlayerJoined:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      properties:
+        type: { const: PlayerJoined }
+        data:
+          type: object
+          additionalProperties: false
+          required: [player]
+          properties:
+            player: { $ref: '#/components/schemas/V3PlayerInfo' }
       required: [type, data]
     PlayerLeft:
-      type: object
+      oneOf:
+        - { $ref: '#/components/schemas/V2PlayerLeft' }
+        - { $ref: '#/components/schemas/V3PlayerLeft' }
       description: >-
-        v3 adds a terminal sender watermark so the recipient can retain any
-        priority-overtaken data tail until delivered frames plus exact prior
-        gaps cover final_seq, then retire that sender's accounting state. The
-        frozen v2 form contains player_id only.
+        Protocol v3 adds a terminal sender watermark so the recipient can
+        retain any priority-overtaken data tail until delivered frames plus
+        exact prior gaps cover final_seq. The frozen v2 form contains only
+        player_id.
+    V2PlayerLeft:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: PlayerLeft }
         data:
           type: object
+          additionalProperties: false
+          required: [player_id]
+          properties:
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+      required: [type, data]
+    V3PlayerLeft:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      properties:
+        type: { const: PlayerLeft }
+        data:
+          type: object
+          additionalProperties: false
+          required: [player_id, epoch, final_seq]
           properties:
             player_id: { $ref: '#/components/schemas/PlayerId' }
             epoch:
@@ -1120,29 +1221,45 @@ components:
             final_seq:
               type: integer
               minimum: 0
-          oneOf:
-            - required: [player_id]
-              not:
-                anyOf:
-                  - required: [epoch]
-                  - required: [final_seq]
-            - required: [player_id, epoch, final_seq]
       required: [type, data]
     ServerGameData:
-      type: object
+      oneOf:
+        - { $ref: '#/components/schemas/V2ServerGameData' }
+        - { $ref: '#/components/schemas/V3ServerGameData' }
       description: >-
-        DELIVERY CONTRACT: pre-v3 traffic and v3 reliable traffic preserve every
-        message or disconnect the recipient loudly. Protocol-v3 latest and
-        volatile traffic may omit data only under their documented queue policy;
-        every omission is counted and named by an exact, causally-prioritized
-        DeliveryReport gap range before later data exposes the discontinuity.
-        class omission means reliable. A recipient closed with SLOW_CONSUMER must
-        resynchronize after reconnecting.
+        Exact recipient projection of relayed JSON GameData. Protocol v2
+        forbids accountability metadata. Protocol v3 requires the paired
+        epoch/seq stamp and enforces the delivery class/key combinations.
+    V2ServerGameData:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: GameData }
         data:
           type: object
+          additionalProperties: false
           required: [from_player, data]
+          properties:
+            from_player: { $ref: '#/components/schemas/PlayerId' }
+            data:
+              description: Opaque application game data (any JSON value).
+      required: [type, data]
+    V3ServerGameData:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      description: >-
+        DELIVERY CONTRACT: reliable traffic preserves every message or closes
+        the recipient loudly. Latest and volatile traffic may omit data only
+        under their queue policy, with every omission covered by a causally
+        prior exact DeliveryReport gap range.
+      properties:
+        type: { const: GameData }
+        data:
+          type: object
+          additionalProperties: false
+          required: [from_player, data, seq, epoch]
           properties:
             from_player: { $ref: '#/components/schemas/PlayerId' }
             data:
@@ -1151,57 +1268,46 @@ components:
               type: integer
               minimum: 1
               description: >-
-                v3 only: server-stamped relay sequence number, per (sender,
-                room). Starts at 1 and advances once for every accepted send.
-                Within an epoch, surviving frames are strictly increasing; a
-                discontinuity is legal only when every missing sequence is
-                covered by the union of earlier exact DeliveryReport gaps, the
-                recipient disconnected loudly, or the receiver re-baselined
-                from Reconnected.sender_watermarks. Priority lifecycle control
-                may overtake queued old-epoch data: validate that tail but do not
-                apply it after the lifecycle change. A future epoch must be
-                announced; after data advances, older epochs are invalid. A new
-                sender incarnation bumps epoch and restarts seq at 1.
-                Absent for pre-v3 recipients (their bytes are byte-identical).
-                Client-to-server GameData carries no seq or epoch; stamping is
-                purely server-side.
+                Server-stamped relay sequence number paired with epoch. It
+                starts at 1 and advances for every accepted send in the
+                sender's current room incarnation.
             epoch:
               type: integer
               minimum: 1
               maximum: 4294967295
               description: >-
-                v3 only: server-tracked incarnation epoch. A single monotonic
-                per-connection counter that increments once per incarnation (the
-                first join is 1; each join-after-leave or reconnect increments
-                it; NOT reset when the same connection switches rooms), while seq
-                restarts at 1 within each epoch. Data-lane stamps increase
-                lexicographically per (sender, room), but priority lifecycle
-                control may be observed before a queued old-epoch tail. The
-                absolute value is not meaningful: baseline each sender from the
-                epoch first observed in a snapshot, require lifecycle announcement
-                of future epochs, and compare relatively. Stamped together with
-                seq; absent for pre-v3 recipients (byte-identical wire). Also
-                carried on room snapshots (see PlayerInfo.epoch,
-                PlayerReconnected.epoch).
+                Server-tracked sender incarnation, always stamped together
+                with seq and announced by snapshot/lifecycle control.
             class:
               allOf: [{ $ref: '#/components/schemas/DeliveryClass' }]
               description: >-
-                v3 only: the sender-requested delivery class, echoed when the
-                client supplied it. Absence means reliable.
+                Echoed only when the sender supplied a v3 delivery class.
+                Omission means reliable.
             key:
               type: integer
               minimum: 0
               maximum: 4294967295
-              description: 'v3 only: sender-defined coalescing key for class latest.'
-          allOf:
-            - if:
-                required: [class]
-                properties:
-                  class: { const: latest }
-              then:
-                required: [key]
-              else:
-                not: { required: [key] }
+              description: Sender-defined coalescing key, legal only with latest.
+          oneOf:
+            - type: object
+              not:
+                anyOf:
+                  - required: [class]
+                  - required: [key]
+            - type: object
+              required: [class]
+              properties:
+                class: { const: reliable }
+              not: { required: [key] }
+            - type: object
+              required: [class]
+              properties:
+                class: { const: volatile }
+              not: { required: [key] }
+            - type: object
+              required: [class, key]
+              properties:
+                class: { const: latest }
       required: [type, data]
     V2BinaryGameDataEnvelope:
       type: object
@@ -1246,10 +1352,12 @@ components:
           maximum: 4294967295
     AuthorityChanged:
       type: object
+      additionalProperties: false
       properties:
         type: { const: AuthorityChanged }
         data:
           type: object
+          additionalProperties: false
           required: [authority_player, you_are_authority]
           properties:
             authority_player:
@@ -1271,10 +1379,12 @@ components:
       required: [type, data]
     LobbyStateChanged:
       type: object
+      additionalProperties: false
       properties:
         type: { const: LobbyStateChanged }
         data:
           type: object
+          additionalProperties: false
           required: [lobby_state, ready_players, all_ready]
           properties:
             lobby_state: { $ref: '#/components/schemas/LobbyState' }
@@ -1408,12 +1518,41 @@ components:
         type: { const: Pong }
       required: [type]
     Reconnected:
+      oneOf:
+        - { $ref: '#/components/schemas/V2Reconnected' }
+        - { $ref: '#/components/schemas/V3Reconnected' }
+      description: >-
+        Exact recipient-version projection of the flattened ReconnectedPayload.
+        Missed controls are version-uniform and GameData is never replayed.
+    V2ReplayableServerMessageEnvelope:
+      oneOf:
+        - { $ref: '#/components/schemas/V2PlayerJoined' }
+        - { $ref: '#/components/schemas/V2PlayerLeft' }
+        - { $ref: '#/components/schemas/V2PlayerReconnected' }
+        - { $ref: '#/components/schemas/NewSpectatorJoined' }
+        - { $ref: '#/components/schemas/SpectatorDisconnected' }
+        - { $ref: '#/components/schemas/LobbyStateChanged' }
+        - { $ref: '#/components/schemas/AuthorityChanged' }
+      description: Exact room-uniform control subset replayable to a v2 reconnector.
+    V3ReplayableServerMessageEnvelope:
+      oneOf:
+        - { $ref: '#/components/schemas/V3PlayerJoined' }
+        - { $ref: '#/components/schemas/V3PlayerLeft' }
+        - { $ref: '#/components/schemas/V3PlayerReconnected' }
+        - { $ref: '#/components/schemas/NewSpectatorJoined' }
+        - { $ref: '#/components/schemas/SpectatorDisconnected' }
+        - { $ref: '#/components/schemas/LobbyStateChanged' }
+        - { $ref: '#/components/schemas/AuthorityChanged' }
+      description: Exact room-uniform control subset replayable to a v3 reconnector.
+    V2Reconnected:
       type: object
-      description: Payload is a flattened ReconnectedPayload (boxed newtype variant).
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: Reconnected }
         data:
           type: object
+          additionalProperties: false
           required:
             - room_id
             - room_code
@@ -1426,6 +1565,7 @@ components:
             - lobby_state
             - ready_players
             - relay_type
+            - current_spectators
             - missed_events
           properties:
             room_id: { $ref: '#/components/schemas/RoomId' }
@@ -1436,7 +1576,58 @@ components:
             supports_authority: { type: boolean }
             current_players:
               type: array
-              items: { $ref: '#/components/schemas/PlayerInfo' }
+              minItems: 1
+              items: { $ref: '#/components/schemas/V2PlayerInfo' }
+            is_authority: { type: boolean }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            ready_players:
+              type: array
+              items: { $ref: '#/components/schemas/PlayerId' }
+            relay_type: { type: string }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            missed_events:
+              type: array
+              items: { $ref: '#/components/schemas/V2ReplayableServerMessageEnvelope' }
+      required: [type, data]
+    V3Reconnected:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      properties:
+        type: { const: Reconnected }
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - room_id
+            - room_code
+            - player_id
+            - game_name
+            - max_players
+            - supports_authority
+            - current_players
+            - is_authority
+            - lobby_state
+            - ready_players
+            - relay_type
+            - current_spectators
+            - missed_events
+            - replay
+            - sender_watermarks
+            - reconnection_token
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            max_players: { type: integer }
+            supports_authority: { type: boolean }
+            current_players:
+              type: array
+              minItems: 1
+              items: { $ref: '#/components/schemas/V3PlayerInfo' }
             is_authority: { type: boolean }
             lobby_state: { $ref: '#/components/schemas/LobbyState' }
             ready_players:
@@ -1448,37 +1639,29 @@ components:
               items: { $ref: '#/components/schemas/SpectatorInfo' }
             ice_servers:
               type: array
+              minItems: 1
+              description: Optional v3 pre-gather list; a later SessionPlan supersedes it.
               items: { $ref: '#/components/schemas/IceServer' }
             missed_events:
               type: array
               description: >-
-                Room-uniform control events broadcast while disconnected
-                (ServerMessage values: PlayerJoined, PlayerLeft,
-                PlayerReconnected, NewSpectatorJoined, SpectatorDisconnected,
-                LobbyStateChanged, AuthorityChanged), oldest first. GameData,
-                Signal, and the per-recipient GameStarting are never replayed —
-                resync from this payload's snapshot fields and, for started
-                sessions, the late-join SessionPlan.
-              items: { type: object }
-            replay:
-              # Completeness of missed_events; v3+ recipients only (absent on
-              # the v2 wire). See the ReplayStatus schema for the contract.
-              $ref: '#/components/schemas/ReplayStatus'
+                Exact room-uniform control subset broadcast while disconnected,
+                oldest first. GameData, Signal, and per-recipient GameStarting
+                are never replayed.
+              items: { $ref: '#/components/schemas/V3ReplayableServerMessageEnvelope' }
+            replay: { $ref: '#/components/schemas/ReplayStatus' }
             sender_watermarks:
               type: array
+              minItems: 1
               description: >-
-                v3+ recipients only (absent on the v2 wire). Authoritative
-                per-sender `(epoch, seq)` baselines for current room members;
-                required to classify gaps after GameData skipped during the
-                reconnecting client's absence.
+                Authoritative per-sender epoch/seq baselines for every current
+                room member, including the reconnector.
               items: { $ref: '#/components/schemas/SenderWatermark' }
             reconnection_token:
               type: string
               description: >-
-                Fresh (rotated) reconnection token replacing the one just
-                used (v3+ recipients only; absent on the v2 wire). Store it
-                for the next unexpected disconnect; the previous token is no
-                longer claimable.
+                Fresh rotated token for the next unexpected disconnect. A
+                successful v3 reconnect necessarily has reconnection enabled.
       required: [type, data]
     ReconnectionFailed:
       type: object
@@ -1492,12 +1675,32 @@ components:
             error_code: { $ref: '#/components/schemas/ErrorCode' }
       required: [type, data]
     PlayerReconnected:
+      oneOf:
+        - { $ref: '#/components/schemas/V2PlayerReconnected' }
+        - { $ref: '#/components/schemas/V3PlayerReconnected' }
+    V2PlayerReconnected:
       type: object
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: PlayerReconnected }
         data:
           type: object
+          additionalProperties: false
           required: [player_id]
+          properties:
+            player_id: { $ref: '#/components/schemas/PlayerId' }
+      required: [type, data]
+    V3PlayerReconnected:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      properties:
+        type: { const: PlayerReconnected }
+        data:
+          type: object
+          additionalProperties: false
+          required: [player_id, epoch]
           properties:
             player_id: { $ref: '#/components/schemas/PlayerId' }
             epoch:
@@ -1505,19 +1708,27 @@ components:
               minimum: 1
               maximum: 4294967295
               description: >-
-                v3 only: the reconnector's new incarnation epoch (see
-                ServerGameData.epoch) — the same value now stamped on its relayed
-                GameData — so recipients re-baseline the per-sender (epoch, seq)
-                stream immediately. Absent for pre-v3 recipients (byte-identical
-                wire).
+                The reconnector's new incarnation epoch, announced before its
+                first post-reconnect GameData frame.
       required: [type, data]
     SpectatorJoined:
+      oneOf:
+        - { $ref: '#/components/schemas/V2SpectatorJoined' }
+        - { $ref: '#/components/schemas/V3SpectatorJoined' }
+        - { $ref: '#/components/schemas/EmptySpectatorJoined' }
+      description: >-
+        Versioned player snapshots when a room has players. A spectator-only
+        room has an empty snapshot whose bytes do not identify the recipient
+        protocol, so that shared shape is a third disjoint branch.
+    V2SpectatorJoined:
       type: object
-      description: Payload is a flattened SpectatorJoinedPayload (boxed newtype variant).
+      additionalProperties: false
+      x-protocol-version: 2
       properties:
         type: { const: SpectatorJoined }
         data:
           type: object
+          additionalProperties: false
           required:
             - room_id
             - room_code
@@ -1533,6 +1744,73 @@ components:
             game_name: { type: string }
             current_players:
               type: array
+              minItems: 1
+              items: { $ref: '#/components/schemas/V2PlayerInfo' }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
+      required: [type, data]
+    V3SpectatorJoined:
+      type: object
+      additionalProperties: false
+      x-protocol-version: 3
+      properties:
+        type: { const: SpectatorJoined }
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - room_id
+            - room_code
+            - spectator_id
+            - game_name
+            - current_players
+            - current_spectators
+            - lobby_state
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            spectator_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            current_players:
+              type: array
+              minItems: 1
+              items: { $ref: '#/components/schemas/V3PlayerInfo' }
+            current_spectators:
+              type: array
+              items: { $ref: '#/components/schemas/SpectatorInfo' }
+            lobby_state: { $ref: '#/components/schemas/LobbyState' }
+            reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
+      required: [type, data]
+    EmptySpectatorJoined:
+      type: object
+      additionalProperties: false
+      description: >-
+        Shared v2/v3 wire shape for a spectator-only room. No PlayerInfo value
+        is present from which to infer recipient protocol.
+      properties:
+        type: { const: SpectatorJoined }
+        data:
+          type: object
+          additionalProperties: false
+          required:
+            - room_id
+            - room_code
+            - spectator_id
+            - game_name
+            - current_players
+            - current_spectators
+            - lobby_state
+          properties:
+            room_id: { $ref: '#/components/schemas/RoomId' }
+            room_code: { type: string }
+            spectator_id: { $ref: '#/components/schemas/PlayerId' }
+            game_name: { type: string }
+            current_players:
+              type: array
+              maxItems: 0
               items: { $ref: '#/components/schemas/PlayerInfo' }
             current_spectators:
               type: array
@@ -1567,11 +1845,13 @@ components:
       required: [type, data]
     NewSpectatorJoined:
       type: object
+      additionalProperties: false
       properties:
         type: { const: NewSpectatorJoined }
         data:
           type: object
-          required: [spectator]
+          additionalProperties: false
+          required: [spectator, current_spectators]
           properties:
             spectator: { $ref: '#/components/schemas/SpectatorInfo' }
             current_spectators:
@@ -1581,11 +1861,13 @@ components:
       required: [type, data]
     SpectatorDisconnected:
       type: object
+      additionalProperties: false
       properties:
         type: { const: SpectatorDisconnected }
         data:
           type: object
-          required: [spectator_id]
+          additionalProperties: false
+          required: [spectator_id, current_spectators]
           properties:
             spectator_id: { $ref: '#/components/schemas/PlayerId' }
             reason: { $ref: '#/components/schemas/SpectatorStateChangeReason' }
@@ -1619,6 +1901,7 @@ components:
       required: [type, data]
     RelayStats:
       type: object
+      additionalProperties: false
       description: >-
         v3 only, config-gated (websocket.delivery_stats_interval_secs > 0;
         default 0 = disabled) and never emitted to a connection that
@@ -1635,6 +1918,7 @@ components:
         type: { const: RelayStats }
         data:
           type: object
+          additionalProperties: false
           required: [interval_ms, sent_to_you, dropped_for_you, backpressure_events]
           properties:
             interval_ms:
@@ -1683,6 +1967,7 @@ components:
       required: [type, data]
     DeliveryReport:
       type: object
+      additionalProperties: false
       description: >-
         Protocol-v3 delivery accountability for this connection. Per-class
         counters are cumulative. Each gaps entry is a newly-accounted exact
@@ -1695,6 +1980,7 @@ components:
         type: { const: DeliveryReport }
         data:
           type: object
+          additionalProperties: false
           required: [per_class]
           properties:
             per_class: { $ref: '#/components/schemas/DeliveryCountersByClass' }

--- a/tests/protocol_spec_consistency.rs
+++ b/tests/protocol_spec_consistency.rs
@@ -227,6 +227,179 @@ fn resolve_local_reference<'doc, 'input>(
     Some(node)
 }
 
+/// Validate the JSON value-shape keywords used by the protocol's versioned
+/// envelope schemas. This deliberately covers the object-union contract under
+/// test (`$ref`, `oneOf`/`anyOf`/`allOf`, `not`, `const`, `type`, `required`,
+/// `properties`, `additionalProperties`, and array `items`) rather than
+/// pretending to be a general-purpose JSON Schema implementation.
+fn schema_shape_matches(root: &Yaml, schema: &Yaml, value: &serde_json::Value) -> bool {
+    if let Some(reference) = schema.as_mapping_get("$ref").and_then(Yaml::as_str) {
+        return resolve_local_reference(root, reference)
+            .is_some_and(|resolved| schema_shape_matches(root, resolved, value));
+    }
+
+    if value.is_null() && schema.as_mapping_get("nullable").and_then(Yaml::as_bool) == Some(true) {
+        return true;
+    }
+
+    if let Some(branches) = schema.as_mapping_get("oneOf").and_then(Yaml::as_sequence) {
+        if branches
+            .iter()
+            .filter(|branch| schema_shape_matches(root, branch, value))
+            .count()
+            != 1
+        {
+            return false;
+        }
+    }
+    if let Some(branches) = schema.as_mapping_get("anyOf").and_then(Yaml::as_sequence) {
+        if !branches
+            .iter()
+            .any(|branch| schema_shape_matches(root, branch, value))
+        {
+            return false;
+        }
+    }
+    if let Some(branches) = schema.as_mapping_get("allOf").and_then(Yaml::as_sequence) {
+        if !branches
+            .iter()
+            .all(|branch| schema_shape_matches(root, branch, value))
+        {
+            return false;
+        }
+    }
+    if let Some(forbidden) = schema.as_mapping_get("not") {
+        if schema_shape_matches(root, forbidden, value) {
+            return false;
+        }
+    }
+    if let Some(condition) = schema.as_mapping_get("if") {
+        let consequence = if schema_shape_matches(root, condition, value) {
+            schema.as_mapping_get("then")
+        } else {
+            schema.as_mapping_get("else")
+        };
+        if consequence.is_some_and(|branch| !schema_shape_matches(root, branch, value)) {
+            return false;
+        }
+    }
+
+    if let Some(expected) = schema.as_mapping_get("const") {
+        let matches = expected
+            .as_str()
+            .is_some_and(|expected| value.as_str() == Some(expected))
+            || expected
+                .as_integer()
+                .is_some_and(|expected| value.as_i64() == Some(expected))
+            || expected
+                .as_bool()
+                .is_some_and(|expected| value.as_bool() == Some(expected));
+        if !matches {
+            return false;
+        }
+    }
+    if let Some(allowed) = schema.as_mapping_get("enum").and_then(Yaml::as_sequence) {
+        let matches = allowed.iter().any(|expected| {
+            expected
+                .as_str()
+                .is_some_and(|expected| value.as_str() == Some(expected))
+                || expected
+                    .as_integer()
+                    .is_some_and(|expected| value.as_i64() == Some(expected))
+                || expected
+                    .as_bool()
+                    .is_some_and(|expected| value.as_bool() == Some(expected))
+        });
+        if !matches {
+            return false;
+        }
+    }
+
+    let schema_type = schema.as_mapping_get("type").and_then(Yaml::as_str);
+    let has_object_keywords = schema.as_mapping_get("required").is_some()
+        || schema.as_mapping_get("properties").is_some()
+        || schema.as_mapping_get("additionalProperties").is_some();
+    if schema_type == Some("object") || has_object_keywords {
+        let Some(object) = value.as_object() else {
+            return false;
+        };
+        let required: BTreeSet<_> = schema
+            .as_mapping_get("required")
+            .and_then(Yaml::as_sequence)
+            .into_iter()
+            .flatten()
+            .filter_map(Yaml::as_str)
+            .collect();
+        if required.iter().any(|field| !object.contains_key(*field)) {
+            return false;
+        }
+
+        let properties = schema
+            .as_mapping_get("properties")
+            .and_then(Yaml::as_mapping);
+        if schema
+            .as_mapping_get("additionalProperties")
+            .and_then(Yaml::as_bool)
+            == Some(false)
+            && object.keys().any(|field| {
+                properties.is_none_or(|properties| {
+                    !properties
+                        .keys()
+                        .filter_map(Yaml::as_str)
+                        .any(|property| property == field)
+                })
+            })
+        {
+            return false;
+        }
+
+        if let Some(properties) = properties {
+            for (key, property_schema) in properties.iter() {
+                if let Some((_, field_value)) =
+                    key.as_str().and_then(|key| object.get_key_value(key))
+                {
+                    if !schema_shape_matches(root, property_schema, field_value) {
+                        return false;
+                    }
+                }
+            }
+        }
+    } else if schema_type == Some("array") || schema.as_mapping_get("items").is_some() {
+        let Some(items) = value.as_array() else {
+            return false;
+        };
+        if schema
+            .as_mapping_get("minItems")
+            .and_then(Yaml::as_integer)
+            .is_some_and(|minimum| items.len() < minimum as usize)
+            || schema
+                .as_mapping_get("maxItems")
+                .and_then(Yaml::as_integer)
+                .is_some_and(|maximum| items.len() > maximum as usize)
+        {
+            return false;
+        }
+        if let Some(item_schema) = schema.as_mapping_get("items") {
+            if !items
+                .iter()
+                .all(|item| schema_shape_matches(root, item_schema, item))
+            {
+                return false;
+            }
+        }
+    } else {
+        match schema_type {
+            Some("string") if !value.is_string() => return false,
+            Some("integer") if !value.is_i64() && !value.is_u64() => return false,
+            Some("boolean") if !value.is_boolean() => return false,
+            Some("number") if !value.is_number() => return false,
+            _ => {}
+        }
+    }
+
+    true
+}
+
 #[test]
 fn spec_has_no_dangling_local_references() {
     let text = spec_text();
@@ -567,6 +740,46 @@ fn spec_delivery_report_gap_bound_matches_protocol_constant() {
 }
 
 #[test]
+fn accountability_component_objects_reject_unknown_fields() {
+    let text = spec_text();
+    let docs = Yaml::load_from_str(&text)
+        .unwrap_or_else(|error| panic!("protocol spec is not valid YAML: {error}"));
+    let root = docs
+        .first()
+        .expect("protocol spec must contain one document");
+
+    for path in [
+        &["components", "schemas", "ReliableDeliveryCounters"][..],
+        &["components", "schemas", "LatestDeliveryCounters"],
+        &["components", "schemas", "VolatileDeliveryCounters"],
+        &["components", "schemas", "DeliveryCountersByClass"],
+        &["components", "schemas", "DeliveryGap"],
+        &["components", "schemas", "SenderWatermark"],
+        &["components", "schemas", "RelayStats"],
+        &["components", "schemas", "RelayStats", "properties", "data"],
+        &["components", "schemas", "DeliveryReport"],
+        &[
+            "components",
+            "schemas",
+            "DeliveryReport",
+            "properties",
+            "data",
+        ],
+    ] {
+        let schema = mapping_path(root, path)
+            .unwrap_or_else(|| panic!("missing accountability schema at {}", path.join(".")));
+        assert_eq!(
+            schema
+                .as_mapping_get("additionalProperties")
+                .and_then(Yaml::as_bool),
+            Some(false),
+            "{} must reject unknown fields",
+            path.join(".")
+        );
+    }
+}
+
+#[test]
 fn spec_models_disjoint_v2_and_v3_physical_binary_envelopes() {
     let text = spec_text();
     let docs = Yaml::load_from_str(&text)
@@ -788,6 +1001,437 @@ fn spec_player_snapshots_have_disjoint_versioned_relay_baselines() {
         mapping_path(v3, &["properties", "seq", "minimum"]).and_then(Yaml::as_integer),
         Some(0)
     );
+}
+
+#[test]
+fn accountability_message_envelopes_use_closed_versioned_branches() {
+    let text = spec_text();
+    let docs = Yaml::load_from_str(&text)
+        .unwrap_or_else(|error| panic!("protocol spec is not valid YAML: {error}"));
+    let root = docs
+        .first()
+        .expect("protocol spec must contain one document");
+
+    let envelopes = [
+        ("RoomJoined", &["V2RoomJoined", "V3RoomJoined"][..]),
+        ("PlayerJoined", &["V2PlayerJoined", "V3PlayerJoined"][..]),
+        ("PlayerLeft", &["V2PlayerLeft", "V3PlayerLeft"][..]),
+        (
+            "ServerGameData",
+            &["V2ServerGameData", "V3ServerGameData"][..],
+        ),
+        ("Reconnected", &["V2Reconnected", "V3Reconnected"][..]),
+        (
+            "PlayerReconnected",
+            &["V2PlayerReconnected", "V3PlayerReconnected"][..],
+        ),
+        (
+            "SpectatorJoined",
+            &[
+                "V2SpectatorJoined",
+                "V3SpectatorJoined",
+                "EmptySpectatorJoined",
+            ][..],
+        ),
+    ];
+
+    for (public_name, branch_names) in envelopes {
+        let public_schema = mapping_path(root, &["components", "schemas", public_name])
+            .unwrap_or_else(|| panic!("spec must define {public_name}"));
+        let references: Vec<_> = public_schema
+            .as_mapping_get("oneOf")
+            .and_then(Yaml::as_sequence)
+            .unwrap_or_else(|| panic!("{public_name} must be an exact versioned oneOf"))
+            .iter()
+            .map(|branch| {
+                branch
+                    .as_mapping_get("$ref")
+                    .and_then(Yaml::as_str)
+                    .unwrap_or_else(|| panic!("{public_name} branches must be local references"))
+            })
+            .collect();
+        assert_eq!(
+            references,
+            branch_names
+                .iter()
+                .map(|name| format!("#/components/schemas/{name}"))
+                .collect::<Vec<_>>(),
+            "{public_name} branch order or version coverage drifted"
+        );
+
+        for branch_name in branch_names {
+            let branch = mapping_path(root, &["components", "schemas", branch_name])
+                .unwrap_or_else(|| panic!("spec must define {branch_name}"));
+            assert_eq!(
+                branch
+                    .as_mapping_get("additionalProperties")
+                    .and_then(Yaml::as_bool),
+                Some(false),
+                "{branch_name} must reject unknown outer-envelope fields"
+            );
+            let required: BTreeSet<_> = branch
+                .as_mapping_get("required")
+                .and_then(Yaml::as_sequence)
+                .unwrap_or_else(|| panic!("{branch_name} must list required envelope fields"))
+                .iter()
+                .map(|field| field.as_str().expect("required field must be a string"))
+                .collect();
+            assert_eq!(required, BTreeSet::from(["type", "data"]));
+
+            let data = mapping_path(branch, &["properties", "data"])
+                .unwrap_or_else(|| panic!("{branch_name} must define data"));
+            assert_eq!(
+                data.as_mapping_get("additionalProperties")
+                    .and_then(Yaml::as_bool),
+                Some(false),
+                "{branch_name}.data must reject unknown and cross-version fields"
+            );
+        }
+    }
+}
+
+#[test]
+fn reconnect_replay_uses_exact_versioned_control_message_unions() {
+    let text = spec_text();
+    let docs = Yaml::load_from_str(&text)
+        .unwrap_or_else(|error| panic!("protocol spec is not valid YAML: {error}"));
+    let root = docs
+        .first()
+        .expect("protocol spec must contain one document");
+
+    for (version, versioned) in [
+        (
+            "V2",
+            ["V2PlayerJoined", "V2PlayerLeft", "V2PlayerReconnected"],
+        ),
+        (
+            "V3",
+            ["V3PlayerJoined", "V3PlayerLeft", "V3PlayerReconnected"],
+        ),
+    ] {
+        let union_name = format!("{version}ReplayableServerMessageEnvelope");
+        let union = mapping_path(root, &["components", "schemas", &union_name])
+            .unwrap_or_else(|| panic!("spec must define {union_name}"));
+        let references: Vec<_> = union
+            .as_mapping_get("oneOf")
+            .and_then(Yaml::as_sequence)
+            .unwrap_or_else(|| panic!("{union_name} must be an exact oneOf"))
+            .iter()
+            .map(|branch| {
+                branch
+                    .as_mapping_get("$ref")
+                    .and_then(Yaml::as_str)
+                    .unwrap_or_else(|| panic!("{union_name} branches must be references"))
+            })
+            .collect();
+        let expected: Vec<_> = versioned
+            .iter()
+            .chain(
+                [
+                    "NewSpectatorJoined",
+                    "SpectatorDisconnected",
+                    "LobbyStateChanged",
+                    "AuthorityChanged",
+                ]
+                .iter(),
+            )
+            .map(|name| format!("#/components/schemas/{name}"))
+            .collect();
+        assert_eq!(references, expected, "{union_name} replay coverage drifted");
+    }
+
+    for shared in [
+        "NewSpectatorJoined",
+        "SpectatorDisconnected",
+        "LobbyStateChanged",
+        "AuthorityChanged",
+    ] {
+        let envelope = mapping_path(root, &["components", "schemas", shared])
+            .unwrap_or_else(|| panic!("spec must define {shared}"));
+        assert_eq!(
+            envelope
+                .as_mapping_get("additionalProperties")
+                .and_then(Yaml::as_bool),
+            Some(false),
+            "{shared} must be closed before it enters the replay union"
+        );
+        assert_eq!(
+            mapping_path(envelope, &["properties", "data", "additionalProperties"])
+                .and_then(Yaml::as_bool),
+            Some(false),
+            "{shared}.data must be closed before it enters the replay union"
+        );
+    }
+}
+
+#[test]
+fn accountability_message_schemas_accept_rust_wire_shapes_and_reject_hybrids() {
+    use signal_fish_server::protocol::{
+        LobbyState, PlayerInfo, ReconnectedPayload, ReplayStatus, RoomJoinedPayload,
+        SenderWatermark, ServerMessage, SpectatorJoinedPayload,
+    };
+    use uuid::Uuid;
+
+    let text = spec_text();
+    let docs = Yaml::load_from_str(&text)
+        .unwrap_or_else(|error| panic!("protocol spec is not valid YAML: {error}"));
+    let root = docs
+        .first()
+        .expect("protocol spec must contain one document");
+    let player_id = Uuid::from_u128(1);
+    let room_id = Uuid::from_u128(2);
+    let connected_at = chrono::DateTime::parse_from_rfc3339("2024-01-02T03:04:05Z")
+        .expect("valid timestamp fixture")
+        .with_timezone(&chrono::Utc);
+    let player = |accountable: bool| PlayerInfo {
+        id: player_id,
+        name: "Alice".to_string(),
+        is_authority: true,
+        is_ready: false,
+        connected_at,
+        connection_info: None,
+        epoch: accountable.then_some(3),
+        seq: accountable.then_some(7),
+        region_id: String::new(),
+    };
+    let room_joined = |accountable: bool| {
+        ServerMessage::RoomJoined(Box::new(RoomJoinedPayload {
+            room_id,
+            room_code: "ABC123".to_string(),
+            player_id,
+            game_name: "game".to_string(),
+            max_players: 4,
+            supports_authority: true,
+            current_players: vec![player(accountable)],
+            is_authority: true,
+            lobby_state: LobbyState::Waiting,
+            ready_players: Vec::new(),
+            relay_type: "WebSocket".to_string(),
+            current_spectators: Vec::new(),
+            ice_servers: Vec::new(),
+            reconnection_token: accountable.then(|| "join-token".to_string()),
+        }))
+    };
+    let reconnected = |accountable: bool| {
+        ServerMessage::Reconnected(Box::new(ReconnectedPayload {
+            room_id,
+            room_code: "ABC123".to_string(),
+            player_id,
+            game_name: "game".to_string(),
+            max_players: 4,
+            supports_authority: true,
+            current_players: vec![player(accountable)],
+            is_authority: true,
+            lobby_state: LobbyState::Waiting,
+            ready_players: Vec::new(),
+            relay_type: "WebSocket".to_string(),
+            current_spectators: Vec::new(),
+            ice_servers: Vec::new(),
+            missed_events: vec![ServerMessage::PlayerLeft {
+                player_id: Uuid::from_u128(4),
+                epoch: accountable.then_some(2),
+                final_seq: accountable.then_some(5),
+            }],
+            replay: accountable.then_some(ReplayStatus::Complete),
+            sender_watermarks: accountable
+                .then_some(vec![SenderWatermark {
+                    player_id,
+                    epoch: 3,
+                    seq: 7,
+                }])
+                .unwrap_or_default(),
+            reconnection_token: accountable.then(|| "next-token".to_string()),
+        }))
+    };
+    let spectator_joined = |accountable: bool| {
+        ServerMessage::SpectatorJoined(Box::new(SpectatorJoinedPayload {
+            room_id,
+            room_code: "ABC123".to_string(),
+            spectator_id: Uuid::from_u128(3),
+            game_name: "game".to_string(),
+            current_players: vec![player(accountable)],
+            current_spectators: Vec::new(),
+            lobby_state: LobbyState::Waiting,
+            reason: None,
+        }))
+    };
+
+    let mut empty_spectator =
+        serde_json::to_value(spectator_joined(false)).expect("serialize SpectatorJoined");
+    empty_spectator["data"]["current_players"] = serde_json::json!([]);
+
+    let valid_cases = [
+        ("RoomJoined", serde_json::to_value(room_joined(false))),
+        ("RoomJoined", serde_json::to_value(room_joined(true))),
+        (
+            "PlayerJoined",
+            serde_json::to_value(ServerMessage::PlayerJoined {
+                player: player(false),
+            }),
+        ),
+        (
+            "PlayerJoined",
+            serde_json::to_value(ServerMessage::PlayerJoined {
+                player: player(true),
+            }),
+        ),
+        (
+            "PlayerLeft",
+            serde_json::to_value(ServerMessage::PlayerLeft {
+                player_id,
+                epoch: None,
+                final_seq: None,
+            }),
+        ),
+        (
+            "PlayerLeft",
+            serde_json::to_value(ServerMessage::PlayerLeft {
+                player_id,
+                epoch: Some(3),
+                final_seq: Some(7),
+            }),
+        ),
+        (
+            "ServerGameData",
+            serde_json::to_value(ServerMessage::GameData {
+                from_player: player_id,
+                data: serde_json::json!({"move": "up"}),
+                seq: None,
+                epoch: None,
+                class: None,
+                key: None,
+            }),
+        ),
+        (
+            "ServerGameData",
+            serde_json::to_value(ServerMessage::GameData {
+                from_player: player_id,
+                data: serde_json::json!({"state": "fresh"}),
+                seq: Some(8),
+                epoch: Some(3),
+                class: Some(signal_fish_server::protocol::DeliveryClass::Latest),
+                key: Some(9),
+            }),
+        ),
+        ("Reconnected", serde_json::to_value(reconnected(false))),
+        ("Reconnected", serde_json::to_value(reconnected(true))),
+        (
+            "PlayerReconnected",
+            serde_json::to_value(ServerMessage::PlayerReconnected {
+                player_id,
+                epoch: None,
+            }),
+        ),
+        (
+            "PlayerReconnected",
+            serde_json::to_value(ServerMessage::PlayerReconnected {
+                player_id,
+                epoch: Some(3),
+            }),
+        ),
+        (
+            "SpectatorJoined",
+            serde_json::to_value(spectator_joined(false)),
+        ),
+        (
+            "SpectatorJoined",
+            serde_json::to_value(spectator_joined(true)),
+        ),
+        ("SpectatorJoined", Ok(empty_spectator)),
+    ];
+
+    for (schema_name, serialized) in valid_cases {
+        let value = serialized.unwrap_or_else(|error| {
+            panic!("failed to serialize representative {schema_name}: {error}")
+        });
+        let schema = mapping_path(root, &["components", "schemas", schema_name])
+            .unwrap_or_else(|| panic!("spec must define {schema_name}"));
+        assert!(
+            schema_shape_matches(root, schema, &value),
+            "{schema_name} rejected an actual Rust wire shape: {value}"
+        );
+    }
+
+    let mut invalid_cases = Vec::new();
+
+    let mut extra_outer = serde_json::to_value(room_joined(false)).expect("serialize RoomJoined");
+    extra_outer["unexpected"] = serde_json::json!(true);
+    invalid_cases.push(("RoomJoined", "unknown outer field", extra_outer));
+
+    let mut mixed_room = serde_json::to_value(room_joined(false)).expect("serialize RoomJoined");
+    mixed_room["data"]["current_players"] = serde_json::json!([player(false), player(true)]);
+    invalid_cases.push(("RoomJoined", "mixed snapshot versions", mixed_room));
+
+    let mut mixed_player = serde_json::to_value(ServerMessage::PlayerJoined {
+        player: player(false),
+    })
+    .expect("serialize PlayerJoined");
+    mixed_player["data"]["player"]["epoch"] = serde_json::json!(3);
+    invalid_cases.push(("PlayerJoined", "unpaired player epoch", mixed_player));
+
+    let mut partial_left = serde_json::to_value(ServerMessage::PlayerLeft {
+        player_id,
+        epoch: None,
+        final_seq: None,
+    })
+    .expect("serialize PlayerLeft");
+    partial_left["data"]["epoch"] = serde_json::json!(3);
+    invalid_cases.push(("PlayerLeft", "unpaired terminal epoch", partial_left));
+
+    let mut partial_data = serde_json::to_value(ServerMessage::GameData {
+        from_player: player_id,
+        data: serde_json::json!(null),
+        seq: None,
+        epoch: None,
+        class: None,
+        key: None,
+    })
+    .expect("serialize GameData");
+    partial_data["data"]["seq"] = serde_json::json!(1);
+    invalid_cases.push(("ServerGameData", "unpaired sequence", partial_data));
+
+    let mut class_without_stamp = serde_json::to_value(ServerMessage::GameData {
+        from_player: player_id,
+        data: serde_json::json!(null),
+        seq: None,
+        epoch: None,
+        class: None,
+        key: None,
+    })
+    .expect("serialize GameData");
+    class_without_stamp["data"]["class"] = serde_json::json!("volatile");
+    invalid_cases.push((
+        "ServerGameData",
+        "v3 class on a v2 envelope",
+        class_without_stamp,
+    ));
+
+    let mut reconnect_hybrid =
+        serde_json::to_value(reconnected(false)).expect("serialize Reconnected");
+    reconnect_hybrid["data"]["replay"] = serde_json::json!("complete");
+    invalid_cases.push((
+        "Reconnected",
+        "partial v3 reconnect state",
+        reconnect_hybrid,
+    ));
+
+    let mut mixed_spectator =
+        serde_json::to_value(spectator_joined(false)).expect("serialize SpectatorJoined");
+    mixed_spectator["data"]["current_players"] = serde_json::json!([player(false), player(true)]);
+    invalid_cases.push((
+        "SpectatorJoined",
+        "mixed snapshot versions",
+        mixed_spectator,
+    ));
+
+    for (schema_name, case, value) in invalid_cases {
+        let schema = mapping_path(root, &["components", "schemas", schema_name])
+            .unwrap_or_else(|| panic!("spec must define {schema_name}"));
+        assert!(
+            !schema_shape_matches(root, schema, &value),
+            "{schema_name} accepted {case}: {value}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace broad accountability-bearing AsyncAPI message schemas with named, closed protocol-v2/protocol-v3 wire unions
- preserve the byte-identical empty `SpectatorJoined` snapshot as a shared disjoint branch
- constrain `Reconnected.missed_events` to the exact version-specific production replay subset
- add executable Rust-serialization shape checks for valid branches and impossible hybrids
- document the generated-client contract and changelog entry

## Why

The inner player and binary relay schemas were exact, but several enclosing text-message schemas still accepted impossible combinations of v2 and v3 fields. Generated SDKs could therefore model or emit payloads the server never produces.

## Compatibility

This is a specification and test hardening change only. Runtime serialization is unchanged, and all 46 frozen protocol-v2 wire goldens pass without fixture changes.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- protocol specification consistency: 16/16
- v2 wire goldens: 46/46
- v3 reliability wire goldens: 16/16
- v3 canonical samples: 3/3
- documentation, Markdown, workflow, tooling, hook-readiness, and source-hygiene gates
- independent adversarial implementation review: zero findings

Closes #261

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Specification, documentation, and consistency tests only; PR states runtime serialization and v2 wire goldens are unchanged, so risk is limited to downstream codegen consumers adapting to stricter generated types.
> 
> **Overview**
> Hardens the **AsyncAPI / JSON Schema** surface for accountability-bearing server messages so generated SDKs cannot model impossible v2/v3 hybrids. Runtime wire serialization is unchanged; this is spec, tests, and docs only.
> 
> **Room snapshots and relayed data** (`RoomJoined`, `PlayerJoined`, `ServerGameData`, `SpectatorJoined`, etc.) are no longer one loose object with optional v3 fields. Each public envelope is a **`oneOf`** of closed **`V2*`** and **`V3*`** branches (`additionalProperties: false`), with **`V2PlayerInfo`** / **`V3PlayerInfo`** enforcing version-uniform `current_players` snapshots (v3 requires paired **`epoch`** / **`seq`**).
> 
> **Lifecycle watermarks** follow the same pattern: **`PlayerLeft`** and **`PlayerReconnected`** split into v2-only vs v3-required terminal/incarnation fields; v3 **`ServerGameData`** requires **`seq`** / **`epoch`** and constrains **`class`** / **`key`** combinations.
> 
> **Reconnect replay** is tightened: **`Reconnected`** is versioned like other envelopes; **`missed_events`** references **`V2ReplayableServerMessageEnvelope`** or **`V3ReplayableServerMessageEnvelope`** (exact control subset, not arbitrary objects). **`EmptySpectatorJoined`** is a third disjoint branch when **`current_players`** is empty (wire shape shared across negotiated versions).
> 
> Delivery accountability component schemas and several other payloads also reject unknown fields. **`tests/protocol_spec_consistency.rs`** adds a partial JSON Schema matcher and tests that Rust-serialized wire shapes match valid branches and reject hybrids; **`building-a-client.md`** and **`CHANGELOG.md`** document the codegen contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f95ac2f7ee52bd493681cf5a80ec90765c05b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->