### PR TITLE
Bind a routable ICE source for every configured server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Report every advertised local ICE candidate on the client's JSONL event
+  stream as `local_candidate` (`peer`, `candidate_type`, `address`, `port`,
+  `protocol`), emitted after the relay so the set describes what the remote
+  side can actually see (issues #275, #276). The relay-only TURN cells now
+  require the positive control to advertise relay candidates and only relay
+  candidates, and the mismatched-secret control to advertise none; the IPv6
+  cell requires no IPv4 entry in the advertised set, closing the gap where a
+  `--ip-family` regressed to a no-op could still pass on a dual-stack host.
 - Prove the native reference client on every supported desktop platform and over
   IPv6 (issue #271). A locked Windows/macOS matrix now builds, lints, and
   unit-tests `clients/native` on the exact repository MSRV, alongside the
@@ -95,6 +103,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bind the kernel's own source address for every configured STUN/TURN server in
+  the native reference client, alongside the enumerated interface addresses
+  (issue #276). Interface enumeration reports only interfaces whose operational
+  status is _up_, while reachability is a property of the routing table: a
+  Docker bridge that is momentarily carrier-down — reproduced here as
+  `NO-CARRIER ... state DOWN` on an `--internal` network — is invisible to
+  enumeration while remaining the only address that network accepts. webrtc
+  0.20 starts a binding request or allocation from _every_ bound socket, so
+  when none of them routes to the server the session gathers no relay candidate
+  at all, and under `--ice-transport-policy relay` no candidate whatsoever,
+  which is how the TURN interoperability lane failed intermittently with only
+  "no candidate pairs" as evidence. The source address is obtained by
+  `connect()`ing an unbound UDP socket, which performs the route lookup without
+  sending a packet; the two sets are unioned and filtered by the same rule, so
+  a routing answer can never widen `--ip-family`, and `--cripple-ice` is
+  exempt.
 - Preserve deterministic `--cripple-ice` fallback on webrtc-rs 0.20 by keeping
   offer/answer and gathering lifecycles live while preventing both local and
   SDP-embedded remote candidates from forming an ICE pair.

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -262,6 +262,11 @@ anyway.
 The two sets are unioned and then filtered by the same rule, so a routing answer can never widen `--ip-family`.
 `--cripple-ice` is exempt from (2): that transport exists to be unreachable.
 
+Rule (2) runs on the task that also pumps the WebSocket, so it is bounded twice: the whole probe shares a
+two-second budget, and its answers are resolved once per endpoint set rather than once per pair. A resolver that
+hangs therefore costs the union and nothing else — never the pairing, and never the server's activity deadlines.
+A replan that changes servers re-probes; a credential rotation, which keeps the same URLs, does not.
+
 CI runs the native suite via [`scripts/run-webrtc-interop.sh`](../../scripts/run-webrtc-interop.sh) in
 `.github/workflows/webrtc-interop.yml`, and the browser cells via
 [`scripts/run-browser-interop.sh`](../../scripts/run-browser-interop.sh) in

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -131,6 +131,7 @@ process continues to its normal bounded exit.
 | `signal_sent` | `to`, `kind` | Outbound `Signal` relayed (`kind` ∈ `offer`/`answer`/`ice_candidate`/`pair_retry`/`other`) |
 | `signal_received` | `from`, `kind` | Inbound `Signal` arrived (emitted even when `--cripple-ice` then drops it) |
 | `ice_candidate_dropped` | `from` | Native-only `--drop-ice-from` discarded this peer's inbound candidate after `signal_received` made the signaling hop observable. The older shared `--cripple-ice` contract remains unchanged and does not emit this event |
+| `local_candidate` | `peer`, `candidate_type`, `address`, `port`, `protocol` | Native-only: a gathered local ICE candidate was advertised to `peer`, reported after the relay so the set describes what the remote side can see. `candidate_type` ∈ `host`/`srflx`/`prflx`/`relay`. The relay-only TURN cell requires every entry to be `relay`, and the IPv6 cell requires no entry of the other family; without it, a session that gathers nothing reports only "no candidate pairs" |
 | `pc_state` | `peer`, `state` | RTCPeerConnection state transition (informational) |
 | `channel_open` | `peer`, `label` | One data channel reached open (`label` ∈ `reliable`/`unreliable`) |
 | `channel_closed` | `peer`, `label` | A required data channel closed or became unreadable; the unusable pair is removed and relay fallback remains live |
@@ -239,7 +240,27 @@ exchange on both channel labels. It shares the file's scenario-serialization gua
 multi-process cell. Signaling still runs over the harness server's IPv4 loopback listener, so the IPv6 claim is
 about the WebRTC data path (ICE, DTLS, SCTP), not the WebSocket. Its precondition applies the client's own
 interface-selection rule, so a runner that cannot serve IPv6 fails the cell with an actionable message; it is
-never skipped.
+never skipped. The cell also asserts the **advertised** candidate set carries no IPv4 entry, so a
+`--ip-family` that silently became a no-op cannot pass on a dual-stack host that happens to select IPv6
+anyway.
+
+## ICE socket selection
+
+`--ip-family` decides which families this client binds; two rules decide _which addresses_:
+
+1. **Every usable interface address.** webrtc 0.20 turns each supplied bind directly into a host candidate, so
+   a wildcard bind would advertise `0.0.0.0`. Unspecified, multicast, and IPv6 link-local addresses are dropped
+   (the candidate grammar cannot carry a scope ID).
+2. **The kernel's own source address for each configured STUN/TURN server.** Interface enumeration reports only
+   interfaces whose operational status is _up_, while reachability is a property of the routing table. A Docker
+   bridge, a VPN adapter, or any interface that is momentarily carrier-down is therefore invisible to (1) while
+   still being the only address that can reach the server. webrtc starts a binding request or allocation from
+   _every_ bound socket, so when none of them routes to the server the session gathers no relay candidate at
+   all — and under `--ice-transport-policy relay`, no candidate whatsoever. The source address is obtained by
+   `connect()`ing an unbound UDP socket, which performs the route lookup without sending a packet.
+
+The two sets are unioned and then filtered by the same rule, so a routing answer can never widen `--ip-family`.
+`--cripple-ice` is exempt from (2): that transport exists to be unreachable.
 
 CI runs the native suite via [`scripts/run-webrtc-interop.sh`](../../scripts/run-webrtc-interop.sh) in
 `.github/workflows/webrtc-interop.yml`, and the browser cells via

--- a/clients/native/src/client.rs
+++ b/clients/native/src/client.rs
@@ -1731,6 +1731,7 @@ impl Orchestrator<'_> {
             EngineEvent::LocalCandidate {
                 peer,
                 candidate_json,
+                gathered,
                 ..
             } => {
                 // Crippled mode never reaches here (the engine drops gathered
@@ -1741,6 +1742,15 @@ impl Orchestrator<'_> {
                     json!({ "IceCandidate": candidate_json }),
                 )
                 .await?;
+                // After the relay, never before: the event means "the peer can
+                // see this candidate", which is what a harness asserts on.
+                emit(&Event::LocalCandidate {
+                    peer,
+                    candidate_type: gathered.candidate_type,
+                    address: gathered.address,
+                    port: gathered.port,
+                    protocol: gathered.protocol,
+                });
             }
             EngineEvent::IceGatheringComplete { peer, .. } => {
                 self.ice_gathering_complete.insert(peer);

--- a/clients/native/src/engine.rs
+++ b/clients/native/src/engine.rs
@@ -25,13 +25,13 @@
 //! they forward through an unbounded [`EngineEvent`] channel back to the orchestrator.
 
 use std::collections::{BTreeSet, HashMap};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use clap::ValueEnum;
-use rtc::ice::{mdns::MulticastDnsMode, network_type::NetworkType};
+use rtc::ice::{mdns::MulticastDnsMode, network_type::NetworkType, url::SchemeType, url::Url};
 use signal_fish_server::protocol::{IceServer, PlayerId};
 use tokio::sync::mpsc;
 use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
@@ -52,11 +52,13 @@ pub const UNRELIABLE_LABEL: &str = "unreliable";
 /// (No `Debug` derive: `RTCDataChannel` is not `Debug`.)
 pub enum EngineEvent {
     /// A local ICE candidate was gathered; `candidate_json` is the serialized
-    /// `RTCIceCandidateInit` to relay as `{"IceCandidate": candidate_json}`.
+    /// `RTCIceCandidateInit` to relay as `{"IceCandidate": candidate_json}`,
+    /// and `gathered` its typed projection for the JSONL event stream.
     LocalCandidate {
         peer: PlayerId,
         generation: u64,
         candidate_json: String,
+        gathered: GatheredCandidate,
     },
     /// This peer connection emitted the end-of-gathering marker after all
     /// local candidates for its generation.
@@ -301,7 +303,11 @@ impl Engine {
             events: self.events.clone(),
             runtime: self.runtime.clone(),
         });
-        let udp_addrs = local_udp_addrs(self.settings)?;
+        let udp_addrs = session_udp_addrs(
+            self.settings,
+            local_udp_addrs,
+            ice_server_source_addrs(ice_servers).await,
+        )?;
         let pc: Arc<dyn PeerConnection> = Arc::new(
             PeerConnectionBuilder::new()
                 .with_configuration(config)
@@ -544,6 +550,25 @@ impl Engine {
     }
 }
 
+/// A local ICE candidate this client gathered and advertised to a peer.
+///
+/// Taken from the stack's typed candidate rather than re-parsed out of the SDP
+/// attribute line, so the fields cannot drift from what was actually
+/// advertised. A harness asserts on the advertised *set*: that a relay-only
+/// session gathered a relay candidate at all (issue #276 had none, and the
+/// only evidence was "no candidate pairs"), and that an `--ip-family` run
+/// advertised nothing of the other family (issue #275).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GatheredCandidate {
+    /// `host`, `srflx`, `prflx` or `relay`.
+    pub candidate_type: String,
+    /// The candidate's own address, as the stack renders it.
+    pub address: String,
+    pub port: u16,
+    /// `udp` or `tcp`.
+    pub protocol: String,
+}
+
 /// The ICE candidate pair that carries a connected peer's data channels.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedCandidatePair {
@@ -571,6 +596,12 @@ impl PeerConnectionEventHandler for PeerHandler {
         if self.crippled {
             return;
         }
+        let gathered = GatheredCandidate {
+            candidate_type: event.candidate.typ.to_string(),
+            address: event.candidate.address.clone(),
+            port: event.candidate.port,
+            protocol: event.candidate.protocol.to_string(),
+        };
         match event
             .candidate
             .to_json()
@@ -582,6 +613,7 @@ impl PeerConnectionEventHandler for PeerHandler {
                     peer: self.peer,
                     generation: self.generation,
                     candidate_json,
+                    gathered,
                 });
             }
             Err(error) => {
@@ -736,6 +768,132 @@ fn select_udp_addrs(
     Ok(addrs.into_iter().collect())
 }
 
+/// The complete bind set for one peer connection: every address the interface
+/// table offers, plus the local address the host's own routing table selects
+/// for each configured ICE server.
+///
+/// Interface enumeration alone is not sufficient. webrtc 0.20 starts a STUN
+/// binding and a TURN allocation from *every* socket the application supplies,
+/// and a socket that cannot route to the server either fails outright at
+/// `sendto` (`EINVAL` from a loopback source toward a routed destination) or is
+/// dropped in transit. When no bound address routes to the server, the run
+/// gathers no relay candidate — and under `--ice-transport-policy relay`, no
+/// candidate at all, which is issue #276. The kernel's own source address for
+/// a server is routable by construction, so it belongs in the bind set whether
+/// or not interface enumeration happened to report it.
+///
+/// `enumerate` is the interface rule (production passes [`local_udp_addrs`])
+/// and `sources` the routing-table answers (production passes
+/// [`ice_server_source_addrs`]). Both halves of the union are arguments of the
+/// production entry point, so the unit-tested function *is* the shipped one.
+pub fn session_udp_addrs(
+    settings: EngineSettings,
+    enumerate: impl Fn(EngineSettings) -> Result<Vec<SocketAddr>>,
+    sources: impl IntoIterator<Item = IpAddr>,
+) -> Result<Vec<SocketAddr>> {
+    let enumerated = enumerate(settings)?;
+    if settings.crippled {
+        // The crippled transport exists to be unusable. A routable source
+        // address would hand it exactly the reachability it must never have.
+        return Ok(enumerated);
+    }
+    // One rule governs both halves: `select_udp_addrs` drops what cannot serve
+    // as a host candidate and enforces `--ip-family`, so a routing answer can
+    // never smuggle in an address the family pin excludes.
+    let merged = select_udp_addrs(
+        enumerated.iter().map(SocketAddr::ip).chain(sources),
+        settings.ip_family,
+    )?;
+    if merged.len() > enumerated.len() {
+        // The exact condition behind issue #276. Without this line a failed run
+        // shows only "no candidate pairs", with nothing naming the cause.
+        tracing::info!(
+            enumerated = enumerated.len(),
+            bound = merged.len(),
+            "interface enumeration missed a route to a configured ICE server; \
+             binding the kernel's source address for it as well"
+        );
+    }
+    Ok(merged)
+}
+
+/// Kernel-selected source addresses for every configured STUN/TURN server.
+///
+/// A server this host cannot resolve or route to contributes nothing and is
+/// reported as a diagnostic rather than an error: the enumerated interface
+/// addresses still stand, and webrtc applies its own URL validation to the
+/// same list.
+pub async fn ice_server_source_addrs(ice_servers: &[IceServer]) -> Vec<IpAddr> {
+    let mut sources = BTreeSet::new();
+    for (host, port) in ice_server_endpoints(ice_servers) {
+        let resolved = match tokio::net::lookup_host((host.as_str(), port)).await {
+            Ok(resolved) => resolved,
+            Err(error) => {
+                tracing::debug!(%host, port, %error, "ICE server did not resolve; no route probe");
+                continue;
+            }
+        };
+        for server in resolved {
+            match route_source_addr(server) {
+                Ok(source) => {
+                    sources.insert(source);
+                }
+                Err(error) => {
+                    tracing::debug!(%server, %error, "no local route to this ICE server");
+                }
+            }
+        }
+    }
+    sources.into_iter().collect()
+}
+
+/// Host and port of every STUN or TURN URL a session plan carried.
+///
+/// Unparsable or non-STUN/TURN URLs are skipped rather than rejected: this
+/// client is not the authority on the URL grammar, and an entry it cannot read
+/// must not cost the session the servers it can.
+fn ice_server_endpoints(ice_servers: &[IceServer]) -> Vec<(String, u16)> {
+    let mut endpoints = BTreeSet::new();
+    for server in ice_servers {
+        for raw in &server.urls {
+            match Url::parse_url(raw) {
+                Ok(url)
+                    if matches!(
+                        url.scheme,
+                        SchemeType::Stun | SchemeType::Stuns | SchemeType::Turn | SchemeType::Turns
+                    ) =>
+                {
+                    endpoints.insert((url.host.clone(), url.port));
+                }
+                Ok(url) => {
+                    tracing::debug!(%raw, scheme = %url.scheme, "ignoring non-STUN/TURN ICE URL");
+                }
+                Err(error) => {
+                    tracing::debug!(%raw, %error, "ignoring unparsable ICE URL");
+                }
+            }
+        }
+    }
+    endpoints.into_iter().collect()
+}
+
+/// The local address this host would send from to reach `server`, as chosen by
+/// its routing table.
+///
+/// Connecting an unbound UDP socket performs the route lookup and assigns the
+/// source address without sending a packet, which is the portable way to ask
+/// "which of my addresses reaches this peer?" on Linux, macOS and Windows.
+fn route_source_addr(server: SocketAddr) -> std::io::Result<IpAddr> {
+    let wildcard = if server.is_ipv4() {
+        SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))
+    } else {
+        SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))
+    };
+    let probe = UdpSocket::bind(wildcard)?;
+    probe.connect(server)?;
+    Ok(probe.local_addr()?.ip())
+}
+
 fn spawn_channel_event_loop(
     runtime: &Arc<dyn Runtime>,
     events: &mpsc::UnboundedSender<EngineEvent>,
@@ -807,9 +965,38 @@ fn convert_ice_servers(ice_servers: &[IceServer]) -> Vec<RTCIceServer> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Only the fixtures need the IPv6 constructors; production selection is
-    // family-agnostic.
-    use std::net::Ipv6Addr;
+    use std::time::Duration;
+
+    /// Payload of the routing probes below. Its exact bytes are compared on
+    /// arrival, so a datagram from anything else cannot be mistaken for it.
+    const ROUTE_PROBE: &[u8] = b"signal-fish-route-probe";
+
+    /// Bind each candidate address and try to send [`ROUTE_PROBE`] to `server`,
+    /// reporting what the kernel did for every one of them.
+    ///
+    /// This is the operation issue #276 observed failing in production: webrtc
+    /// starts its TURN allocation from each bound socket, and a socket that
+    /// cannot route to the server fails here (`EINVAL` for a loopback source
+    /// toward a routed destination) rather than at any protocol layer.
+    fn probe_route(binds: &[SocketAddr], server: SocketAddr) -> Vec<(SocketAddr, String)> {
+        binds
+            .iter()
+            .map(|bind| {
+                let outcome = UdpSocket::bind(*bind)
+                    .and_then(|socket| socket.send_to(ROUTE_PROBE, server))
+                    .map_or_else(|error| format!("{error}"), |_sent| "sent".to_string());
+                (*bind, outcome)
+            })
+            .collect()
+    }
+
+    /// The first bind address whose socket reached `server`, if any.
+    fn source_that_reaches(binds: &[SocketAddr], server: SocketAddr) -> Option<SocketAddr> {
+        probe_route(binds, server)
+            .into_iter()
+            .find(|(_bind, outcome)| outcome == "sent")
+            .map(|(bind, _outcome)| bind)
+    }
 
     /// Deterministic ICE failure in the given family.
     fn crippled_settings(ip_family: IpFamily) -> EngineSettings {
@@ -1104,6 +1291,233 @@ mod tests {
         // `tests/ci_config_tests.rs`.
     }
 
+    #[test]
+    fn the_bind_set_reaches_a_configured_server_the_interface_table_misses() {
+        // Stand-in for the configured TURN server: a socket this test owns, on
+        // the IPv6 loopback every supported platform provides. Using a real
+        // socket means "reachable" is decided by the kernel, not by the test.
+        let server = UdpSocket::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, 0)))
+            .expect("the IPv6 loopback must be bindable");
+        let server_addr = server.local_addr().expect("a bound socket has an address");
+        server
+            .set_read_timeout(Some(Duration::from_secs(10)))
+            .expect("probe reads must not block a failing run forever");
+
+        // Run 30962028644's condition reduced to its essence: interface
+        // enumeration produced no address that can reach the configured
+        // server. There, every Allocate either failed with `EINVAL` from the
+        // loopback source or was dropped before coturn, and the relay-only
+        // session gathered no candidate at all.
+        let missing_the_route = vec![SocketAddr::from((Ipv4Addr::LOCALHOST, 0))];
+        assert!(
+            source_that_reaches(&missing_the_route, server_addr).is_none(),
+            "precondition: the enumerated set must not already reach {server_addr}, \
+             otherwise this proves nothing: {:?}",
+            probe_route(&missing_the_route, server_addr)
+        );
+
+        let source = route_source_addr(server_addr)
+            .expect("every host routes to its own loopback by definition");
+        let bound = session_udp_addrs(
+            EngineSettings::default(),
+            |_settings| Ok(missing_the_route.clone()),
+            [source],
+        )
+        .expect("merging one routing answer into a non-empty set resolves");
+
+        // Every address the interface rule offered is still bound: host
+        // candidates are not sacrificed to reach a TURN server.
+        for addr in &missing_the_route {
+            assert!(bound.contains(addr), "{addr} must stay in {bound:?}");
+        }
+        let reaching = source_that_reaches(&bound, server_addr).unwrap_or_else(|| {
+            panic!(
+                "the merged bind set still cannot reach {server_addr}: {:?}",
+                probe_route(&bound, server_addr)
+            )
+        });
+
+        // A successful `send_to` is not delivery. Read the datagram back, so a
+        // kernel that accepted the write but dropped the packet still fails.
+        let mut buffer = [0_u8; 64];
+        let (read, from) = server
+            .recv_from(&mut buffer)
+            .expect("the probe datagram must arrive");
+        assert_eq!(&buffer[..read], ROUTE_PROBE);
+        assert_eq!(
+            from.ip(),
+            reaching.ip(),
+            "the datagram must come from the address the merge added"
+        );
+    }
+
+    #[tokio::test]
+    async fn ice_server_source_addrs_routes_the_production_turn_url_shape() {
+        let server = UdpSocket::bind(SocketAddr::from((Ipv6Addr::LOCALHOST, 0)))
+            .expect("the IPv6 loopback must be bindable");
+        let port = server.local_addr().expect("bound socket").port();
+        // Exactly the shape scripts/run-turn-interop.sh mints, so URL parsing,
+        // resolution and the route probe are proven on the production string.
+        let ice_servers = vec![IceServer {
+            urls: vec![format!("turn:[::1]:{port}?transport=udp")],
+            username: Some("interop".to_string()),
+            credential: Some("interop".to_string()),
+        }];
+        assert_eq!(
+            ice_server_source_addrs(&ice_servers).await,
+            vec![IpAddr::from(Ipv6Addr::LOCALHOST)],
+            "the routing answer for a reachable TURN URL is its own loopback"
+        );
+
+        // A server this host cannot resolve costs the session nothing.
+        let unresolvable = vec![IceServer {
+            urls: vec!["turn:invalid.invalid:3478?transport=udp".to_string()],
+            username: None,
+            credential: None,
+        }];
+        assert!(ice_server_source_addrs(&unresolvable).await.is_empty());
+    }
+
+    #[test]
+    fn ice_server_endpoints_reads_every_stun_and_turn_shape() {
+        let cases: [(&str, Option<(&str, u16)>); 8] = [
+            // The production TURN interop URL, and its IPv6 literal form.
+            (
+                "turn:10.254.124.2:3478?transport=udp",
+                Some(("10.254.124.2", 3478)),
+            ),
+            (
+                "turn:[2001:db8::1]:3478?transport=udp",
+                Some(("2001:db8::1", 3478)),
+            ),
+            (
+                "turns:turn.example.com:5349?transport=tcp",
+                Some(("turn.example.com", 5349)),
+            ),
+            // Default ports differ by scheme and must not be invented here.
+            ("stun:stun.example.com", Some(("stun.example.com", 3478))),
+            ("stuns:stun.example.com", Some(("stun.example.com", 5349))),
+            // Neither a scheme this client probes...
+            ("http:example.com", None),
+            // ...nor an unparsable entry may cost the session its real servers.
+            ("nonsense", None),
+            ("", None),
+        ];
+        for (raw, expected) in cases {
+            let servers = [IceServer {
+                urls: vec![raw.to_string()],
+                username: None,
+                credential: None,
+            }];
+            let endpoints = ice_server_endpoints(&servers);
+            match expected {
+                Some((host, port)) => assert_eq!(
+                    endpoints,
+                    vec![(host.to_string(), port)],
+                    "endpoint for {raw:?}"
+                ),
+                None => assert!(
+                    endpoints.is_empty(),
+                    "{raw:?} must contribute no endpoint, got {endpoints:?}"
+                ),
+            }
+        }
+
+        // Every URL of every server is probed, deduplicated across entries.
+        let repeated = [
+            IceServer {
+                urls: vec![
+                    "stun:stun.example.com:3478".to_string(),
+                    "turn:turn.example.com:3478?transport=udp".to_string(),
+                ],
+                username: None,
+                credential: None,
+            },
+            IceServer {
+                urls: vec!["stun:stun.example.com:3478".to_string()],
+                username: None,
+                credential: None,
+            },
+        ];
+        assert_eq!(
+            ice_server_endpoints(&repeated),
+            vec![
+                ("stun.example.com".to_string(), 3478),
+                ("turn.example.com".to_string(), 3478),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_routing_answer_can_never_defeat_the_requested_ip_family() {
+        let loopback_v4 = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+        let loopback_v6 = SocketAddr::from((Ipv6Addr::LOCALHOST, 0));
+        for (family, enumerated, rejected_source) in [
+            (
+                IpFamily::Ipv4,
+                loopback_v4,
+                IpAddr::from(Ipv6Addr::LOCALHOST),
+            ),
+            (
+                IpFamily::Ipv6,
+                loopback_v6,
+                IpAddr::from(Ipv4Addr::LOCALHOST),
+            ),
+        ] {
+            let settings = EngineSettings {
+                ip_family: family,
+                ..EngineSettings::default()
+            };
+            assert_eq!(
+                session_udp_addrs(
+                    settings,
+                    |_settings| Ok(vec![enumerated]),
+                    [rejected_source]
+                )
+                .expect("the pinned family still resolves"),
+                vec![enumerated],
+                "--ip-family {} must reject the {rejected_source} routing answer",
+                family.as_str()
+            );
+        }
+
+        // Addresses no peer could dial are dropped from a routing answer for
+        // the same reasons they are dropped from the interface table.
+        let undialable = [
+            IpAddr::from(Ipv4Addr::UNSPECIFIED),
+            IpAddr::from(Ipv6Addr::UNSPECIFIED),
+            IpAddr::from([224, 0, 0, 1]),
+            IpAddr::from([0xfe80, 0, 0, 0, 0, 0, 0, 1]),
+        ];
+        assert_eq!(
+            session_udp_addrs(
+                EngineSettings::default(),
+                |_settings| Ok(vec![loopback_v4]),
+                undialable,
+            )
+            .expect("undialable answers are filtered, not fatal"),
+            vec![loopback_v4]
+        );
+    }
+
+    #[test]
+    fn the_crippled_transport_never_gains_a_routable_source() {
+        // `--cripple-ice` exists to be unreachable. Applying the real interface
+        // rule proves the guard is the crippled flag, not a fixture.
+        assert_eq!(
+            session_udp_addrs(
+                crippled_settings(IpFamily::Any),
+                local_udp_addrs,
+                [
+                    IpAddr::from(Ipv6Addr::LOCALHOST),
+                    IpAddr::from([203, 0, 113, 1])
+                ],
+            )
+            .expect("the crippled transport resolves"),
+            vec![SocketAddr::from((Ipv4Addr::LOCALHOST, 0))]
+        );
+    }
+
     #[tokio::test]
     async fn gathered_host_candidates_never_advertise_wildcard_addresses() {
         let udp_addrs =
@@ -1243,6 +1657,12 @@ mod tests {
                 peer,
                 generation: stale_generation,
                 candidate_json: "{}".to_string(),
+                gathered: GatheredCandidate {
+                    candidate_type: "host".to_string(),
+                    address: Ipv4Addr::LOCALHOST.to_string(),
+                    port: 1,
+                    protocol: "udp".to_string(),
+                },
             },
             EngineEvent::IceGatheringComplete {
                 peer,

--- a/clients/native/src/engine.rs
+++ b/clients/native/src/engine.rs
@@ -27,6 +27,7 @@
 use std::collections::{BTreeSet, HashMap};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -200,6 +201,16 @@ pub struct Engine {
     events: mpsc::UnboundedSender<EngineEvent>,
     peers: HashMap<PlayerId, PeerLink>,
     next_generation: u64,
+    /// Routing answers for the current ICE endpoints, resolved once per set
+    /// rather than once per pair.
+    ///
+    /// Pairing runs on the orchestrator task, which also pumps the WebSocket.
+    /// Resolving every server for every peer would multiply any resolver
+    /// latency by the mesh size on that task, and a long enough stall there is
+    /// indistinguishable from an idle client to the server. The key is the
+    /// endpoint list itself, so a replan that changes servers re-probes while a
+    /// credential rotation — same URLs, new username and password — does not.
+    ice_route_sources: Option<(Vec<(String, u16)>, Vec<IpAddr>)>,
 }
 
 impl Engine {
@@ -217,7 +228,22 @@ impl Engine {
             events,
             peers: HashMap::new(),
             next_generation: 0,
+            ice_route_sources: None,
         })
+    }
+
+    /// Routing answers for `ice_servers`, resolved on first use and reused
+    /// while the endpoint set is unchanged (see [`Engine::ice_route_sources`]).
+    async fn ice_route_sources(&mut self, ice_servers: &[IceServer]) -> Vec<IpAddr> {
+        let endpoints = ice_server_endpoints(ice_servers);
+        if let Some((probed, sources)) = &self.ice_route_sources {
+            if *probed == endpoints {
+                return sources.clone();
+            }
+        }
+        let sources = ice_server_source_addrs(&endpoints).await;
+        self.ice_route_sources = Some((endpoints, sources.clone()));
+        sources
     }
 
     /// Whether a peer connection toward `peer` already exists.
@@ -306,7 +332,7 @@ impl Engine {
         let udp_addrs = session_udp_addrs(
             self.settings,
             local_udp_addrs,
-            ice_server_source_addrs(ice_servers).await,
+            self.ice_route_sources(ice_servers).await,
         )?;
         let pc: Arc<dyn PeerConnection> = Arc::new(
             PeerConnectionBuilder::new()
@@ -804,12 +830,20 @@ pub fn session_udp_addrs(
         enumerated.iter().map(SocketAddr::ip).chain(sources),
         settings.ip_family,
     )?;
-    if merged.len() > enumerated.len() {
-        // The exact condition behind issue #276. Without this line a failed run
-        // shows only "no candidate pairs", with nothing naming the cause.
+    // Name the exact condition behind issue #276. Comparing lengths would not:
+    // the interface rule drops link-local and duplicate addresses, so a set
+    // that gained a routing answer can still be no larger. Without this line a
+    // failed run shows only "no candidate pairs", with nothing naming the
+    // cause.
+    let enumerated_ips: BTreeSet<IpAddr> = enumerated.iter().map(SocketAddr::ip).collect();
+    let added: Vec<IpAddr> = merged
+        .iter()
+        .map(SocketAddr::ip)
+        .filter(|ip| !enumerated_ips.contains(ip))
+        .collect();
+    if !added.is_empty() {
         tracing::info!(
-            enumerated = enumerated.len(),
-            bound = merged.len(),
+            ?added,
             "interface enumeration missed a route to a configured ICE server; \
              binding the kernel's source address for it as well"
         );
@@ -817,34 +851,73 @@ pub fn session_udp_addrs(
     Ok(merged)
 }
 
-/// Kernel-selected source addresses for every configured STUN/TURN server.
+/// Total budget for the routing probe.
+///
+/// The probe runs on the orchestrator task, which also pumps the WebSocket, so
+/// a resolver that hangs must cost the session a bounded delay and the union —
+/// never the pairing, and never the server's activity deadlines. Every
+/// configured URL shares one budget; on expiry the enumerated interface
+/// addresses stand alone, exactly as before this rule existed.
+const ICE_ROUTE_PROBE_BUDGET: Duration = Duration::from_secs(2);
+
+/// Kernel-selected source addresses for the given STUN/TURN endpoints.
 ///
 /// A server this host cannot resolve or route to contributes nothing and is
 /// reported as a diagnostic rather than an error: the enumerated interface
 /// addresses still stand, and webrtc applies its own URL validation to the
 /// same list.
-pub async fn ice_server_source_addrs(ice_servers: &[IceServer]) -> Vec<IpAddr> {
-    let mut sources = BTreeSet::new();
-    for (host, port) in ice_server_endpoints(ice_servers) {
-        let resolved = match tokio::net::lookup_host((host.as_str(), port)).await {
-            Ok(resolved) => resolved,
-            Err(error) => {
-                tracing::debug!(%host, port, %error, "ICE server did not resolve; no route probe");
-                continue;
-            }
-        };
-        for server in resolved {
-            match route_source_addr(server) {
-                Ok(source) => {
-                    sources.insert(source);
-                }
+pub async fn ice_server_source_addrs(endpoints: &[(String, u16)]) -> Vec<IpAddr> {
+    if endpoints.is_empty() {
+        return Vec::new();
+    }
+    let probe = async {
+        let mut sources = BTreeSet::new();
+        for (host, port) in endpoints {
+            let resolved = match tokio::net::lookup_host((host.as_str(), *port)).await {
+                Ok(resolved) => resolved,
                 Err(error) => {
-                    tracing::debug!(%server, %error, "no local route to this ICE server");
+                    tracing::debug!(%host, port, %error, "ICE server did not resolve");
+                    continue;
+                }
+            };
+            for server in resolved {
+                match route_source_addr(server) {
+                    Ok(source) => {
+                        sources.insert(source);
+                    }
+                    Err(error) => {
+                        tracing::debug!(%server, %error, "no local route to this ICE server");
+                    }
                 }
             }
         }
+        sources.into_iter().collect()
+    };
+    route_sources_within(ICE_ROUTE_PROBE_BUDGET, probe).await
+}
+
+/// Run `probe` under `budget`, yielding no routing answers when it expires.
+///
+/// Separated from the probe body so the expiry path is reachable from a test
+/// without a hung resolver. A `timeout` wrapped around real resolution races
+/// Tokio's poll order — the inner future is polled before the timer, so a
+/// lookup that already finished on the blocking pool wins — which is a flaky
+/// oracle, not a proof.
+async fn route_sources_within(
+    budget: Duration,
+    probe: impl std::future::Future<Output = Vec<IpAddr>>,
+) -> Vec<IpAddr> {
+    match tokio::time::timeout(budget, probe).await {
+        Ok(sources) => sources,
+        Err(_elapsed) => {
+            tracing::warn!(
+                budget_ms = budget.as_millis(),
+                "ICE server route probe exceeded its budget; pairing continues on the \
+                 enumerated interface addresses alone"
+            );
+            Vec::new()
+        }
     }
-    sources.into_iter().collect()
 }
 
 /// Host and port of every STUN or TURN URL a session plan carried.
@@ -852,7 +925,7 @@ pub async fn ice_server_source_addrs(ice_servers: &[IceServer]) -> Vec<IpAddr> {
 /// Unparsable or non-STUN/TURN URLs are skipped rather than rejected: this
 /// client is not the authority on the URL grammar, and an entry it cannot read
 /// must not cost the session the servers it can.
-fn ice_server_endpoints(ice_servers: &[IceServer]) -> Vec<(String, u16)> {
+pub fn ice_server_endpoints(ice_servers: &[IceServer]) -> Vec<(String, u16)> {
     let mut endpoints = BTreeSet::new();
     for server in ice_servers {
         for raw in &server.urls {
@@ -1364,18 +1437,98 @@ mod tests {
             credential: Some("interop".to_string()),
         }];
         assert_eq!(
-            ice_server_source_addrs(&ice_servers).await,
+            ice_server_source_addrs(&ice_server_endpoints(&ice_servers)).await,
             vec![IpAddr::from(Ipv6Addr::LOCALHOST)],
             "the routing answer for a reachable TURN URL is its own loopback"
         );
 
         // A server this host cannot resolve costs the session nothing.
-        let unresolvable = vec![IceServer {
+        let unresolvable = [IceServer {
             urls: vec!["turn:invalid.invalid:3478?transport=udp".to_string()],
             username: None,
             credential: None,
         }];
-        assert!(ice_server_source_addrs(&unresolvable).await.is_empty());
+        assert!(
+            ice_server_source_addrs(&ice_server_endpoints(&unresolvable))
+                .await
+                .is_empty()
+        );
+        // No endpoints means no probe at all, not an empty resolution.
+        assert!(ice_server_source_addrs(&[]).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn the_route_probe_gives_up_within_its_budget() {
+        // The probe runs on the task that also pumps the WebSocket, so a
+        // resolver that never answers must cost the union, not the session: a
+        // stalled read would let the server's own activity deadline close a
+        // healthy connection. `pending()` IS that resolver, exactly, with no
+        // dependence on when a blocking lookup happens to finish.
+        assert_eq!(
+            route_sources_within(Duration::from_millis(50), std::future::pending()).await,
+            Vec::<IpAddr>::new(),
+            "an expired budget yields no routing answers, never a stall"
+        );
+        // A probe that answers inside its budget is returned untouched, so the
+        // assertion above cannot be passing because the wrapper drops answers.
+        let answer = vec![IpAddr::from(Ipv4Addr::LOCALHOST)];
+        assert_eq!(
+            route_sources_within(Duration::from_secs(30), async { answer.clone() }).await,
+            answer
+        );
+        // The shipped budget is the only thing between a hung resolver and a
+        // stalled pairing; a zero or near-zero value would disable the union on
+        // every host, silently, with no failing cell anywhere.
+        assert!(
+            ICE_ROUTE_PROBE_BUDGET >= Duration::from_secs(1),
+            "the route probe budget must leave a real resolver time to answer"
+        );
+    }
+
+    #[tokio::test]
+    async fn routing_answers_are_probed_once_per_endpoint_set() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut engine = Engine::new(EngineSettings::default(), tx).expect("engine builds");
+        let loopback = [IceServer {
+            urls: vec!["turn:127.0.0.1:3478?transport=udp".to_string()],
+            username: Some("a".to_string()),
+            credential: Some("b".to_string()),
+        }];
+        let expected = vec![IpAddr::from(Ipv4Addr::LOCALHOST)];
+        assert_eq!(engine.ice_route_sources(&loopback).await, expected);
+
+        // A credential rotation keeps the same URLs, so it must not re-probe.
+        let rotated = [IceServer {
+            urls: loopback[0].urls.clone(),
+            username: Some("rotated".to_string()),
+            credential: Some("rotated".to_string()),
+        }];
+        assert_eq!(engine.ice_route_sources(&rotated).await, expected);
+        assert_eq!(
+            engine.ice_route_sources.as_ref().map(|(probed, _)| probed),
+            Some(&ice_server_endpoints(&loopback)),
+            "the memo is keyed by the endpoint set, not by the credentials"
+        );
+
+        // A replan that changes the servers must, so a stale answer cannot
+        // outlive the endpoints it was measured for.
+        let replanned = [IceServer {
+            urls: vec!["turn:[::1]:3478?transport=udp".to_string()],
+            username: None,
+            credential: None,
+        }];
+        assert_eq!(
+            engine.ice_route_sources(&replanned).await,
+            vec![IpAddr::from(Ipv6Addr::LOCALHOST)]
+        );
+
+        // A plan with no ICE servers probes nothing and caches that.
+        assert!(engine.ice_route_sources(&[]).await.is_empty());
+        assert_eq!(
+            engine.ice_route_sources,
+            Some((Vec::new(), Vec::new())),
+            "an empty endpoint set is a cached answer, not a repeated no-op probe"
+        );
     }
 
     #[test]

--- a/clients/native/src/events.rs
+++ b/clients/native/src/events.rs
@@ -67,6 +67,23 @@ pub enum Event {
     /// A configured ICE fault discarded this peer's inbound candidate after
     /// the signaling envelope was observed.
     IceCandidateDropped { from: PlayerId },
+    /// A gathered local ICE candidate was advertised to `peer`, reported after
+    /// the relay succeeded so the stream describes what the remote side can
+    /// actually see. `candidate_type` is `host`/`srflx`/`prflx`/`relay` and
+    /// `protocol` is `udp`/`tcp`.
+    ///
+    /// Harnesses assert on the advertised *set*: that a relay-only session
+    /// gathered a relay candidate at all, and that an `--ip-family` run
+    /// advertised no address of the other family. Without it, a session that
+    /// gathers nothing reports only "no candidate pairs", with nothing naming
+    /// the cause (issues #275, #276).
+    LocalCandidate {
+        peer: PlayerId,
+        candidate_type: String,
+        address: String,
+        port: u16,
+        protocol: String,
+    },
     /// RTCPeerConnection state transition (`new`/`connecting`/`connected`/...).
     PcState { peer: PlayerId, state: String },
     /// One data channel reached the open state.
@@ -278,6 +295,16 @@ mod tests {
                 },
                 "transport_status_sent",
             ),
+            (
+                Event::LocalCandidate {
+                    peer: PlayerId::nil(),
+                    candidate_type: "relay".to_string(),
+                    address: "10.254.124.2".to_string(),
+                    port: 49160,
+                    protocol: "udp".to_string(),
+                },
+                "local_candidate",
+            ),
             (Event::GameDataSent, "game_data_sent"),
             (Event::FallbackEngaged, "fallback_engaged"),
             (Event::ExchangeReady, "exchange_ready"),
@@ -382,6 +409,28 @@ mod tests {
             redacted["remote_candidate_address"],
             serde_json::Value::Null
         );
+    }
+
+    #[test]
+    fn local_candidate_event_carries_the_advertised_type_and_address() {
+        let peer = PlayerId::new_v4();
+        let value = serde_json::to_value(Event::LocalCandidate {
+            peer,
+            candidate_type: "relay".to_string(),
+            address: "10.254.124.2".to_string(),
+            port: 49160,
+            protocol: "udp".to_string(),
+        })
+        .expect("event serializes");
+        assert_eq!(value["event"], "local_candidate");
+        assert_eq!(value["peer"], peer.to_string());
+        // The harness reads exactly these keys to decide whether a relay-only
+        // session gathered a relay candidate, and whether an --ip-family run
+        // advertised anything of the other family.
+        assert_eq!(value["candidate_type"], "relay");
+        assert_eq!(value["address"], "10.254.124.2");
+        assert_eq!(value["port"], 49160);
+        assert_eq!(value["protocol"], "udp");
     }
 
     #[test]

--- a/clients/native/tests/harness/mod.rs
+++ b/clients/native/tests/harness/mod.rs
@@ -744,6 +744,46 @@ pub fn str_field<'a>(event: &'a Value, field: &str) -> &'a str {
         .unwrap_or_else(|| panic!("event missing string field `{field}`: {event}"))
 }
 
+/// The local ICE candidates this client advertised, as `type address:port`
+/// strings in emission order.
+///
+/// The advertised set is the only record of *why* ICE had nothing to pair: a
+/// session that gathers no candidate otherwise reports just "no candidate
+/// pairs", which is exactly how issue #276 presented. Rendered as strings so a
+/// failing assertion prints the whole set (issues #275, #276).
+pub fn advertised_candidates(events: &[Value]) -> Vec<String> {
+    events_named(events, "local_candidate")
+        .into_iter()
+        .map(|event| {
+            format!(
+                "{} {}:{}",
+                str_field(event, "candidate_type"),
+                str_field(event, "address"),
+                event
+                    .get("port")
+                    .and_then(Value::as_u64)
+                    .unwrap_or_else(|| panic!("local_candidate has no `port`: {event}")),
+            )
+        })
+        .collect()
+}
+
+/// The address of each advertised local ICE candidate, parsed.
+///
+/// A candidate whose address is not an IP fails loudly: it would otherwise let
+/// a family assertion pass over something it never checked.
+pub fn advertised_candidate_addresses(events: &[Value], who: &str) -> Vec<std::net::IpAddr> {
+    events_named(events, "local_candidate")
+        .into_iter()
+        .map(|event| {
+            let raw = str_field(event, "address");
+            raw.parse().unwrap_or_else(|error| {
+                panic!("{who}: advertised candidate address `{raw}` is not an IP ({error})")
+            })
+        })
+        .collect()
+}
+
 /// This client's own player id (from its `room_joined` event).
 pub fn player_id_of(events: &[Value], who: &str) -> String {
     str_field(single_event(events, "room_joined", who), "player_id").to_string()

--- a/clients/native/tests/interop_e2e.rs
+++ b/clients/native/tests/interop_e2e.rs
@@ -74,8 +74,9 @@ use std::net::{IpAddr, Ipv6Addr, UdpSocket};
 use std::time::Duration;
 
 use harness::{
-    events_named, player_id_of, scenario_window, single_event, spawn_client, spawn_server,
-    str_field, ClientProcess, ClientSpec, CLIENT_EXIT_TIMEOUT, EVENT_TIMEOUT,
+    advertised_candidate_addresses, events_named, player_id_of, scenario_window, single_event,
+    spawn_client, spawn_server, str_field, ClientProcess, ClientSpec, CLIENT_EXIT_TIMEOUT,
+    EVENT_TIMEOUT,
 };
 use serde_json::Value;
 use signal_fish_reference_native::engine::{local_udp_addrs, EngineSettings, IpFamily};
@@ -1558,6 +1559,32 @@ fn assert_ipv6_host_path(events: &[Value], who: &str, peer_id: &str) {
     }
 }
 
+/// Assert the *advertised* candidate set carries no IPv4 entry.
+///
+/// The selected pair alone cannot prove `--ip-family`: on a dual-stack host a
+/// regression that made the flag a no-op would still let ICE choose IPv6, and
+/// the cell would pass while proving nothing (issue #275, gap 2). What the
+/// flag actually controls is the *bind set*, and the advertised candidates are
+/// its observable image — one candidate per bound socket under the zero-STUN,
+/// zero-TURN configuration this scenario runs.
+fn assert_no_ipv4_candidate_advertised(events: &[Value], who: &str) {
+    let advertised = advertised_candidate_addresses(events, who);
+    assert!(
+        !advertised.is_empty(),
+        "{who}: the run advertised no local candidate, so there is nothing to \
+         prove the family of"
+    );
+    let ipv4: Vec<&IpAddr> = advertised
+        .iter()
+        .filter(|address| address.is_ipv4())
+        .collect();
+    assert!(
+        ipv4.is_empty(),
+        "{who}: --ip-family ipv6 must bind no IPv4 socket, but the run advertised \
+         {ipv4:?} among {advertised:?}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path() {
     let _serial = acquire_serial().await;
@@ -1656,6 +1683,7 @@ async fn ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path() {
 
         // ...over IPv6, with the exact exchange on both channel labels.
         assert_ipv6_host_path(window, who, peer_id);
+        assert_no_ipv4_candidate_advertised(window, who);
         assert_exchange_sent_to(window, who, &peers);
         assert_exchange_received_from(window, who, &peers);
     }

--- a/clients/native/tests/turn_interop_e2e.rs
+++ b/clients/native/tests/turn_interop_e2e.rs
@@ -10,7 +10,7 @@ mod harness;
 use std::collections::BTreeMap;
 
 use harness::{
-    events_named, player_id_of, scenario_window, single_event, spawn_client,
+    advertised_candidates, events_named, player_id_of, scenario_window, single_event, spawn_client,
     spawn_server_with_turn, str_field, ClientProcess, ClientSpec, ServerProcess,
     CLIENT_EXIT_TIMEOUT, EVENT_TIMEOUT,
 };
@@ -141,6 +141,31 @@ fn assert_turn_plan(events: &[Value], who: &str) {
     );
 }
 
+/// Under `--ice-transport-policy relay` the only candidate a client may
+/// advertise is one a TURN allocation produced.
+///
+/// This is the oracle issue #276 lacked. Run 30962028644 gathered nothing —
+/// every Allocate left from a socket that could not route to the coturn
+/// container — and the only symptom the cell could report was
+/// "expected exactly one `p2p_pair_connected` event, got 0: []", with no
+/// evidence naming the cause. Asserting the advertised set makes a failed
+/// allocation self-describing, and forbids a host or reflexive candidate from
+/// silently carrying a run this lane exists to prove relayed.
+fn assert_only_relay_candidates_advertised(events: &[Value], who: &str) {
+    let advertised = advertised_candidates(events);
+    assert!(
+        !advertised.is_empty(),
+        "{who}: the relay-only session advertised no ICE candidate at all, so the \
+         TURN allocation produced none (issue #276); the client's stderr carries \
+         the allocation errors"
+    );
+    assert!(
+        advertised.iter().all(|entry| entry.starts_with("relay ")),
+        "{who}: --ice-transport-policy relay must advertise relay candidates only, \
+         got {advertised:?}"
+    );
+}
+
 fn assert_relay_floor(run: &TurnRun, index: usize) {
     let events = scenario_window(&run.logs[index]);
     single_event(events, "game_data_sent", CLIENT_NAMES[index]);
@@ -239,6 +264,7 @@ async fn turn_only_pair_selects_relay_candidates_and_keeps_websocket_floor_live(
     for (index, who) in CLIENT_NAMES.iter().copied().enumerate() {
         let events = scenario_window(&run.logs[index]);
         assert_turn_plan(events, who);
+        assert_only_relay_candidates_advertised(events, who);
         single_event(events, "p2p_pair_connected", who);
         let selected = single_event(events, "selected_candidate_pair", who);
         assert_eq!(str_field(selected, "peer"), run.ids[1 - index]);
@@ -269,6 +295,15 @@ async fn mismatched_turn_secret_fails_p2p_and_uses_websocket_fallback() {
         assert_turn_plan(events, who);
         assert!(events_named(events, "p2p_pair_connected").is_empty());
         assert!(events_named(events, "selected_candidate_pair").is_empty());
+        // The complement of the positive control: a rejected allocation yields
+        // no relay candidate, and the relay policy admits no other kind. An
+        // advertised candidate here would mean the fallback was reached with a
+        // usable path still in hand.
+        assert!(
+            advertised_candidates(events).is_empty(),
+            "{who}: a rejected TURN allocation must advertise no candidate, got {:?}",
+            advertised_candidates(events)
+        );
         let status = single_event(events, "transport_status_sent", who);
         assert_eq!(str_field(status, "transport"), "webrtc");
         assert_eq!(

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -23839,6 +23839,192 @@ fn test_native_client_platform_matrix_and_ipv6_proof_are_pinned() {
     );
 }
 
+/// The engine's per-pair bind set must be the routing-aware union, applied to
+/// this session's real ICE servers (issue #276).
+///
+/// Every part of this is defeatable by an edit that keeps the call in place.
+/// `session_udp_addrs(self.settings, local_udp_addrs, Vec::new())` compiles,
+/// passes `clippy -D warnings`, and passes every live cell on a host whose
+/// interface table already contains the route — which is most of them, and
+/// exactly why the original defect was intermittent. So the arguments, not the
+/// call, are what this pins.
+fn assert_ice_bind_set_is_routing_aware(root: &Path) {
+    let source = read_file(&root.join("clients/native/src/engine.rs"));
+    let file = syn::parse_file(&source).expect("engine.rs must parse as Rust");
+
+    // Exactly one production call site. A second one cannot satisfy this while
+    // the effective path skips it, and the unit tests below `mod tests` call
+    // the same function with fixtures, so counting the raw text would not see
+    // the difference.
+    let mut call_sites = production_call_arguments(&file, "session_udp_addrs");
+    assert_eq!(
+        call_sites.len(),
+        1,
+        "exactly one production call site must build the bind set through \
+         engine::session_udp_addrs; found {}",
+        call_sites.len()
+    );
+    let arguments = call_sites.remove(0);
+    assert_eq!(
+        arguments.len(),
+        3,
+        "the bind set takes the settings, the interface rule and the routing answers"
+    );
+
+    // The settings must be this engine's own, not a constant: `--cripple-ice`
+    // and `--ip-family` both read from them, and `EngineSettings::default()`
+    // would quietly re-enable both.
+    let syn::Expr::Field(settings) = arguments[0] else {
+        panic!("the bind set must be built from `self.settings`, not a constant")
+    };
+    let syn::Member::Named(field) = &settings.member else {
+        panic!("the bind set must be built from `self.settings`")
+    };
+    assert_eq!(
+        field, "settings",
+        "the bind set reads this engine's settings"
+    );
+
+    // The interface rule must be the engine's own function, passed by path. A
+    // closure could swallow its failure or substitute a fixture.
+    let syn::Expr::Path(enumerate) = arguments[1] else {
+        panic!(
+            "the interface rule must be the path `local_udp_addrs`, not a \
+             closure or adapter that can swallow its failure"
+        )
+    };
+    assert!(
+        enumerate.path.is_ident("local_udp_addrs"),
+        "the interface rule must be `local_udp_addrs`, got {:?}",
+        enumerate.path.segments.last().map(|s| s.ident.to_string())
+    );
+
+    // The routing answers must come from THIS session's servers. An empty
+    // literal, or `ice_server_source_addrs(&[])`, restores the pre-#276
+    // behaviour with the call still in place.
+    let syn::Expr::Await(awaited) = arguments[2] else {
+        panic!(
+            "the routing answers must be `ice_server_source_addrs(..).await`; a \
+             literal or a constant makes the union a permanent no-op"
+        )
+    };
+    let syn::Expr::Call(probe) = awaited.base.as_ref() else {
+        panic!("the routing answers must come from a call to ice_server_source_addrs")
+    };
+    let syn::Expr::Path(probe_path) = probe.func.as_ref() else {
+        panic!("the routing answers must come from a call to ice_server_source_addrs")
+    };
+    assert!(
+        probe_path.path.is_ident("ice_server_source_addrs"),
+        "the routing answers must come from `ice_server_source_addrs`"
+    );
+    let probe_argument = probe
+        .args
+        .first()
+        .expect("the probe takes the session's ICE servers");
+    let syn::Expr::Path(servers) = probe_argument else {
+        panic!(
+            "the probe must be handed `ice_servers` — this pairing's real \
+             servers — not a literal or a constructed list"
+        )
+    };
+    assert!(
+        servers.path.is_ident("ice_servers"),
+        "the probe must be handed this pairing's `ice_servers`"
+    );
+}
+
+/// Arguments of every call to `name` in `file`'s production items — that is,
+/// excluding the `mod tests` unit-test module, whose fixture calls would
+/// otherwise be indistinguishable from the shipped one.
+fn production_call_arguments<'ast>(file: &'ast syn::File, name: &str) -> Vec<Vec<&'ast syn::Expr>> {
+    struct Finder<'ast, 'a> {
+        name: &'a str,
+        calls: Vec<Vec<&'ast syn::Expr>>,
+    }
+
+    impl<'ast> Visit<'ast> for Finder<'ast, '_> {
+        fn visit_expr_call(&mut self, call: &'ast syn::ExprCall) {
+            if let syn::Expr::Path(path) = call.func.as_ref() {
+                if path
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == self.name)
+                {
+                    self.calls.push(call.args.iter().collect());
+                }
+            }
+            syn::visit::visit_expr_call(self, call);
+        }
+    }
+
+    let mut finder = Finder {
+        name,
+        calls: Vec::new(),
+    };
+    for item in &file.items {
+        let is_test_module = matches!(item, syn::Item::Mod(module) if module.ident == "tests");
+        if !is_test_module {
+            finder.visit_item(item);
+        }
+    }
+    finder.calls
+}
+
+/// The routing-aware ICE bind set and the advertised-candidate oracles that
+/// make a failed gathering self-describing (issues #275, #276).
+#[test]
+fn test_ice_bind_set_and_advertised_candidate_oracles_are_pinned() {
+    let root = repo_root();
+    assert_ice_bind_set_is_routing_aware(&root);
+
+    // Each of these is a line the proof cannot lose while still proving
+    // anything.
+    let turn = read_live_file(&root.join("clients/native/tests/turn_interop_e2e.rs"));
+    for required in [
+        "fn assert_only_relay_candidates_advertised(events: &[Value], who: &str) {",
+        "assert_only_relay_candidates_advertised(events, who);",
+        r#"advertised.iter().all(|entry| entry.starts_with("relay ")),"#,
+        // The negative control's complement: a rejected allocation advertises
+        // nothing, so "no pair" cannot be reported while a path existed.
+        "advertised_candidates(events).is_empty(),",
+    ] {
+        assert!(
+            turn.contains(required),
+            "the TURN relay-candidate oracle lost marker `{required}` (issue #276)"
+        );
+    }
+
+    let interop = read_live_file(&root.join("clients/native/tests/interop_e2e.rs"));
+    for required in [
+        "fn assert_no_ipv4_candidate_advertised(events: &[Value], who: &str) {",
+        "assert_no_ipv4_candidate_advertised(window, who);",
+        "advertised_candidate_addresses(events, who);",
+    ] {
+        assert!(
+            interop.contains(required),
+            "the IPv6 advertised-candidate oracle lost marker `{required}` (issue #275)"
+        );
+    }
+
+    // The event those oracles read must still be emitted, and emitted only
+    // after the candidate was actually relayed to the peer.
+    let client = read_live_file(&root.join("clients/native/src/client.rs"));
+    let relay = client
+        .find("json!({ \"IceCandidate\": candidate_json }),")
+        .expect("client.rs must relay gathered candidates as IceCandidate signals");
+    let emit = client
+        .find("emit(&Event::LocalCandidate {")
+        .expect("client.rs must report every advertised candidate on the event stream");
+    assert!(
+        relay < emit,
+        "`local_candidate` must be emitted after the relay succeeds; reporting a \
+         candidate the peer never received would make the oracles read a set \
+         that does not exist"
+    );
+}
+
 #[test]
 fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     let root = repo_root();

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -23899,24 +23899,20 @@ fn assert_ice_bind_set_is_routing_aware(root: &Path) {
         enumerate.path.segments.last().map(|s| s.ident.to_string())
     );
 
-    // The routing answers must come from THIS session's servers. An empty
-    // literal, or `ice_server_source_addrs(&[])`, restores the pre-#276
-    // behaviour with the call still in place.
+    // The routing answers must come from THIS pairing's servers. An empty
+    // literal restores the pre-#276 behaviour with the call still in place.
     let syn::Expr::Await(awaited) = arguments[2] else {
         panic!(
-            "the routing answers must be `ice_server_source_addrs(..).await`; a \
+            "the routing answers must be `self.ice_route_sources(..).await`; a \
              literal or a constant makes the union a permanent no-op"
         )
     };
-    let syn::Expr::Call(probe) = awaited.base.as_ref() else {
-        panic!("the routing answers must come from a call to ice_server_source_addrs")
+    let syn::Expr::MethodCall(probe) = awaited.base.as_ref() else {
+        panic!("the routing answers must come from `self.ice_route_sources(..)`")
     };
-    let syn::Expr::Path(probe_path) = probe.func.as_ref() else {
-        panic!("the routing answers must come from a call to ice_server_source_addrs")
-    };
-    assert!(
-        probe_path.path.is_ident("ice_server_source_addrs"),
-        "the routing answers must come from `ice_server_source_addrs`"
+    assert_eq!(
+        probe.method, "ice_route_sources",
+        "the routing answers must come from `self.ice_route_sources(..)`"
     );
     let probe_argument = probe
         .args
@@ -23931,6 +23927,23 @@ fn assert_ice_bind_set_is_routing_aware(root: &Path) {
     assert!(
         servers.path.is_ident("ice_servers"),
         "the probe must be handed this pairing's `ice_servers`"
+    );
+
+    // ...and that memo must be a memo of the real probe. Returning a cached
+    // constant, or dropping the probe entirely, is invisible to every live cell
+    // on a host whose interface table already contains the route.
+    let memo = production_call_arguments(&file, "ice_server_source_addrs");
+    assert_eq!(
+        memo.len(),
+        1,
+        "`ice_route_sources` must resolve through exactly one call to \
+         `ice_server_source_addrs`; found {}",
+        memo.len()
+    );
+    assert!(
+        source.contains("let endpoints = ice_server_endpoints(ice_servers);"),
+        "the memo must key on the endpoints of THIS pairing's servers, so a \
+         replan that changes servers re-probes"
     );
 }
 


### PR DESCRIPTION
## Summary

The `TURN-only WebRTC Interop` lane failed intermittently with only
`expected exactly one p2p_pair_connected event, got 0: []` as evidence (issue #276).
The native client chose its ICE bind set from the interface table alone, and webrtc 0.20 starts a
STUN binding and a TURN allocation from **every** socket the application supplies. When none of
them routes to the configured server, a relay-only session gathers no candidate at all.

## Root cause

Reading webrtc 0.20 falsified the issue's recorded hypothesis (it does not "select one socket" —
`gather()` creates a client per bound address). The run's own artifacts show one `sendto` rejected
with `EINVAL` from `127.0.0.1` and **two** further allocations timing out, with coturn logging no
Allocate at all: three bound sockets, none of which the network accepted.

The mechanism was then reproduced directly against the lane's real topology:

| Probe (host namespace to an `--internal` Docker network) | Result |
| --- | --- |
| `sendto` from the network's own bridge address `10.254.226.1` | **arrives** |
| `sendto` from another host address `192.168.65.3` | `sendto` succeeds, packet **never arrives** |
| `ip link` for that bridge, no container attached | `<NO-CARRIER,BROADCAST,MULTICAST,UP> ... state DOWN` |
| `ip link` for that bridge, container attached | `<BROADCAST,MULTICAST,UP,LOWER_UP> ... state UP` |
| `ip route get`, bridge carrier **down** | `dev br-... src 10.254.227.1` |
| `connect()` on an unbound UDP socket, same condition | `kernel source = 10.254.227.1` |

`if_addrs::Interface::is_oper_up()` is `oper_status == IfOperStatus::Up`, so enumeration drops that
bridge exactly when its carrier is down, while the routing table keeps naming the one address the
network accepts. **Reachability is a routing fact; interface enumeration is a carrier-state
snapshot.** This is not Docker-specific: a VPN adapter or virtual switch that flaps has the same
shape.

## Change

- `engine::session_udp_addrs` unions the interface rule with the kernel's source address for each
  configured STUN/TURN server, then passes **both** halves through the single existing
  `select_udp_addrs` filter, so a routing answer can never widen `--ip-family` or admit an address
  no peer could dial. `--cripple-ice` short-circuits: that transport exists to be unreachable.
- `engine::ice_server_source_addrs` parses each URL with the stack's own `rtc::ice::url::Url`,
  resolves it, and asks the kernel by `connect()`ing an unbound UDP socket - a route lookup, no
  packet. A server that does not resolve or route is a debug diagnostic, never an error.
- STUN is covered alongside TURN; `stun_gatherer` has the identical per-local-address structure, so
  fixing only the TURN half would leave the same failure mode one transport over.
- One `info` line fires only when the union actually adds an address. That single line is what the
  failing run lacked.
- New `local_candidate` JSONL event (`peer`, `candidate_type`, `address`, `port`, `protocol`),
  projected from the stack's typed candidate and emitted **after** the relay, so the event means
  "the peer can see this".

## Oracles

- TURN positive control: must advertise relay candidates and **only** relay candidates.
- Mismatched-secret control: must advertise **none** (its complement).
- IPv6 cell: the advertised set must carry no IPv4 entry - this closes gap 2 of #275, since the
  selected pair alone cannot catch an `--ip-family` that regressed to a no-op on a dual-stack host.

## Red-green and falsification evidence

- **The defect, behaviorally.** `the_bind_set_reaches_a_configured_server_the_interface_table_misses`
  owns a real UDP socket, hands the engine an enumeration that cannot reach it, and requires the
  merged set to deliver a datagram read back from the address the merge added. Against the
  pre-change rule it fails with
  `the merged bind set still cannot reach [::1]:54243: [(127.0.0.1:0, "Address family not supported by protocol (os error 97)")]`.
  Portable and deterministic - both loopbacks exist everywhere, no external network is touched.
- **The IPv6 oracle is not vacuous.** Making `--ip-family` a no-op fails the cell with
  `c0: --ip-family ipv6 must bind no IPv4 socket, but the run advertised [127.0.0.1, 172.17.0.2] among [127.0.0.1, 172.17.0.2, ::1]`.
- **The call-site pin is real.** `session_udp_addrs(self.settings, local_udp_addrs, Vec::new())`
  compiles, passes `clippy -D warnings`, and passes every live cell on a host whose interface table
  already contains the route - which is most of them, and precisely why the original defect was
  intermittent. Four hollow-guard shapes were attacked and each is rejected at its own assertion
  (empty server list, no routing answers, constant settings, closure interface rule); the unmodified
  call site passes as the control.

## Validation

- Native unit suite 87 green (80 before); root `cargo test --all-features` green.
- Live TURN interoperability run locally against the pinned coturn image: both controls pass with
  the new oracles active, and the positive control's stream carries
  `{"address":"10.254.52.2","candidate_type":"relay","event":"local_candidate",...}`.
- Live IPv6 cell green with the advertised-set assertion added.
- Root and native `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean; zero-panic,
  markdown, link and doc-consistency gates green.

Closes #276. Closes the advertised-candidate half of #275 (its live-transport-off-Linux gap stays
open, as does #274).

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WebRTC ICE socket binding and TURN/STUN reachability on the orchestrator task; mistakes could affect pairing, relay-only sessions, or `--ip-family` behavior, though bounded probes, crippled-mode guards, and new interop oracles limit blast radius.
> 
> **Overview**
> Fixes intermittent **relay-only** TURN failures (#276) where ICE bound only **up** interface addresses, so webrtc 0.20 could start STUN/TURN from sockets that **do not route** to the configured server and gather **no** relay candidates.
> 
> The engine now builds each peer’s UDP bind set via **`session_udp_addrs`**: union interface enumeration with the kernel **source address** per configured STUN/TURN URL (`connect()` on an unbound UDP socket), then the same **`select_udp_addrs`** filter so routing cannot widen **`--ip-family`**. Route probes are **memoized per endpoint set**, capped at **2s**, and skipped for **`--cripple-ice`**.
> 
> Harnesses get a new **`local_candidate`** JSONL event (emitted **after** the ICE signal relay) plus stricter oracles: TURN cells require **relay-only** advertised candidates (and **none** on bad secret); the IPv6 cell rejects any advertised **IPv4** address (#275). CI pins the production **`session_udp_addrs`** wiring so an empty routing union cannot slip through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e0cf552cd1fe55e7cbb643fc2cc36bc2d8d1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->