### PR TITLE
Fence the close flush behind an abandoned socket write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,7 +114,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`ip route get`, addresses, routes, and the Docker bridge's link state) into
   its failure artifacts, because whether the expected source address existed
   and whether its device was carrier-up cannot be recovered from a client log
-  after the fact.
+  after the fact. Those diagnostics falsified the recorded cause on their first
+  failing run: the bind set already contained the bridge's routable source and
+  the bridge was carrier-up, so the missing datagrams are a property of the
+  path, not of the client's address selection. The lane therefore now measures
+  that path itself — a STUN Binding request from the host over the same
+  connected-socket source the client picks — and waits, bounded, for an answer
+  before handing the run to the clients, instead of reporting an unreachable
+  coturn as a thirty-second `no candidate pairs` ICE failure.
 - Stop a closing connection from writing the queue that sits behind a socket
   write abandoned in flight (issue #274). The live writer runs inside the close
   `select!`, so a close request cancels it wherever it is — including while a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make an unreachable TURN allocation self-describing in the native reference
+  client and its interoperability lane (issue #276). The client now reports the
+  complete resolved ICE bind set on every pairing — bound addresses, which came
+  from interface enumeration, and which the routing probe added — instead of
+  reporting only the union's additions, so a run where the probe contributed
+  nothing is no longer indistinguishable from one where it never ran. An ICE
+  server that does not resolve or does not route is a warning rather than a
+  debug line. The lane also captures the host's own view of the TURN network
+  (`ip route get`, addresses, routes, and the Docker bridge's link state) into
+  its failure artifacts, because whether the expected source address existed
+  and whether its device was carrier-up cannot be recovered from a client log
+  after the fact.
 - Stop a closing connection from writing the queue that sits behind a socket
   write abandoned in flight (issue #274). The live writer runs inside the close
   `select!`, so a close request cancels it wherever it is — including while a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stop a closing connection from writing the queue that sits behind a socket
+  write abandoned in flight (issue #274). The live writer runs inside the close
+  `select!`, so a close request cancels it wherever it is — including while a
+  socket write owns one queued payload. That payload's wire position is then
+  unknown, yet the graceful teardown kept draining everything queued behind it,
+  which is how a recipient could observe a delivered sequence skipping one no
+  `DeliveryReport` ever described (`expected 90, got 91` on the `Nextest
+  (macos-latest)` lane). The remainder is now abandoned and counted instead:
+  truncation at close is always legal, a hole never is. Loud slow-consumer
+  teardown already abandoned its queue and is unchanged.
 - Bind the kernel's own source address for every configured STUN/TURN server in
   the native reference client, alongside the enumerated interface addresses
   (issue #276). Interface enumeration reports only interfaces whose operational

--- a/clients/native/src/engine.rs
+++ b/clients/native/src/engine.rs
@@ -830,18 +830,30 @@ pub fn session_udp_addrs(
         enumerated.iter().map(SocketAddr::ip).chain(sources),
         settings.ip_family,
     )?;
-    // Name the exact condition behind issue #276. Comparing lengths would not:
-    // the interface rule drops link-local and duplicate addresses, so a set
-    // that gained a routing answer can still be no larger. Without this line a
-    // failed run shows only "no candidate pairs", with nothing naming the
-    // cause.
+    // Report the resolved bind set unconditionally. Reporting only the union's
+    // additions leaves the interesting failure invisible: a run where the probe
+    // contributed nothing looks exactly like a run where it was never
+    // consulted, and a failing lane then shows only "no candidate pairs" with
+    // nothing naming which addresses ICE was actually given. `added` is
+    // computed by membership rather than by comparing lengths, because the
+    // interface rule drops link-local and duplicate addresses, so a set that
+    // gained a routing answer can still be no larger.
     let enumerated_ips: BTreeSet<IpAddr> = enumerated.iter().map(SocketAddr::ip).collect();
-    let added: Vec<IpAddr> = merged
+    let bound: Vec<IpAddr> = merged.iter().map(SocketAddr::ip).collect();
+    let added: Vec<IpAddr> = bound
         .iter()
-        .map(SocketAddr::ip)
+        .copied()
         .filter(|ip| !enumerated_ips.contains(ip))
         .collect();
+    tracing::info!(
+        ?bound,
+        enumerated = ?enumerated_ips,
+        ?added,
+        family = settings.ip_family.as_str(),
+        "resolved the ICE bind set for this peer connection"
+    );
     if !added.is_empty() {
+        // Name the exact condition behind issue #276.
         tracing::info!(
             ?added,
             "interface enumeration missed a route to a configured ICE server; \
@@ -876,17 +888,24 @@ pub async fn ice_server_source_addrs(endpoints: &[(String, u16)]) -> Vec<IpAddr>
             let resolved = match tokio::net::lookup_host((host.as_str(), *port)).await {
                 Ok(resolved) => resolved,
                 Err(error) => {
-                    tracing::debug!(%host, port, %error, "ICE server did not resolve");
+                    // A configured server this host cannot even name is a real
+                    // operational condition, not a detail: every allocation
+                    // through it will fail, and the session's only remaining
+                    // hope is that interface enumeration happens to cover the
+                    // route. It must be visible at the level a failing run's
+                    // captured stderr actually records.
+                    tracing::warn!(%host, port, %error, "ICE server did not resolve");
                     continue;
                 }
             };
             for server in resolved {
                 match route_source_addr(server) {
                     Ok(source) => {
+                        tracing::info!(%server, %source, "routed a configured ICE server");
                         sources.insert(source);
                     }
                     Err(error) => {
-                        tracing::debug!(%server, %error, "no local route to this ICE server");
+                        tracing::warn!(%server, %error, "no local route to this ICE server");
                     }
                 }
             }

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -617,6 +617,13 @@ one physical connection. They cannot identify a missing sender, epoch, or
 sequence, and a snapshot observed before close need not include messages
 abandoned during that close.
 
+A close can cancel the socket write that owns one queued payload, and the
+cancellation may land either side of the point where the sink accepts the frame,
+so that payload's wire position is unknown. The server therefore writes nothing
+that was still queued behind it: the recipient's stream ends as a gap-free
+prefix, and the remainder is counted `abandoned`. Truncation at close is always
+legal; a hole never is.
+
 V3 control messages use a separate bounded priority lane
 (`websocket.control_queue_capacity`, default 128). Within the recipient's
 active room generation, the writer drains that lane strictly before queued data
@@ -1690,10 +1697,11 @@ Recipient rules:
   paired baseline in `current_players`. Discard pre-disconnect expectations.
   High-rate data is not replayed, so resynchronize application state before
   applying new deltas.
-- This recipient's own loud disconnect terminates the observable stream.
-  Messages abandoned during close do not need gap records because no later data
-  can appear on that physical connection. A replacement connection starts a new
-  accounting lifetime.
+- This recipient's own disconnect — loud or graceful — terminates the
+  observable stream. Messages abandoned during close do not need gap records
+  because no later data can appear on that physical connection: once a payload
+  is abandoned while a socket write owns it, nothing queued behind it is
+  written. A replacement connection starts a new accounting lifetime.
 
 Any same-epoch hole on a continuing connection without complete coverage by
 prior exact reports is a protocol violation. Process control messages in

--- a/progress/session-092-teardown-write-integrity.md
+++ b/progress/session-092-teardown-write-integrity.md
@@ -263,6 +263,14 @@ probe that answers immediately, answers on the fifth attempt, never answers, and
 cannot be run at all. Against the previous gate the answer-on-the-fifth-probe
 case exits 1 after a single attempt.
 
+That new test then failed on `Nextest (windows-latest)` — and Bugbot had already
+named the reason before the lane ran: the harness interpolated
+`Path::display()` into bash, so `C:\Users\…` lost its backslashes to shell
+escaping and the counter file was never written (an empty `attempts` value in the
+assertion). The harness already runs with the temp directory as its working
+directory, so the fix removes path syntax from the shell text entirely rather
+than quoting it.
+
 `docker network inspect` confirms an `--internal` network is still assigned its
 gateway address (`{"Subnet":"10.253.99.0/24","Gateway":"10.253.99.1"}`), so the
 expected source exists by construction — which is consistent with what the
@@ -286,7 +294,7 @@ analysis added.
 
 ## Validation
 
-- Root suite `cargo test --all-features`: green.
+- Root suite `cargo test --all-features`: **2,047 passed, 0 failed**.
 - `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`:
   clean, root and `clients/native`.
 - `clients/native`: 89 unit tests green, `cargo fmt --check` and strict Clippy
@@ -298,9 +306,12 @@ analysis added.
 
 ## Review
 
-Cursor Bugbot reviewed every head. It reported no issues on the first, and on
-the third found the reachability gate's own errexit defect described above —
-a real finding on code that had 41 green runs behind it. Copilot was
+Cursor Bugbot reviewed every head and found two real defects, both in code this
+session added and both invisible to the runs that had already passed: the
+reachability gate's errexit collapse (41 green runs behind it) and the harness's
+Windows path interpolation (which the Windows lane then confirmed
+independently). Both are fixed with the replies recorded in their threads, and
+Bugbot reports **no new issues** on the final head `d9f1ff3`. Copilot was
 quota-blocked on every request (`the user who requested the review has reached
 their quota limit`), as on every recent PR.
 
@@ -320,3 +331,10 @@ No new issues. Two existing ones were advanced with evidence:
 ## Publication
 
 PR #279 from branch `agent/session-092-teardown-write-integrity`.
+
+Final head `d9f1ff3`: **14 hosted workflows green**, the Dependabot-only
+workflow skipped as designed, and one failure — `Running Copilot Code Review`,
+the reviewer's own account quota, which has failed identically on every recent
+PR. The `TURN-only WebRTC Interop` lane that is red on `main` is green here,
+with **60 consecutive passes** across every head carrying the reachability gate
+(41 + 11 + 1 + 7). Left unmerged for the owner.

--- a/progress/session-092-teardown-write-integrity.md
+++ b/progress/session-092-teardown-write-integrity.md
@@ -1,0 +1,322 @@
+# Session 092 — Teardown write integrity and TURN-lane observability (P49)
+
+## Scope and prioritization
+
+Remote triage found no open pull requests, nine open issues, and — unlike the
+last several sessions — **`main` not green**. `TURN-only WebRTC Interop` failed
+at `8efa0710`, the merge of PR #277, which is the PR that closed issue #276. Six
+of the nine open issues (#204, #205, #206, #207, #213, #220) are open-ended
+umbrellas and #250 still needs an owner decision, so the session's two targets
+picked themselves:
+
+1. issue #274's second non-timing item — a delivery-accounting oracle reporting
+   a message that vanished across a reconnect — because silent message loss is
+   the most gameplay-impacting thing open; and
+2. the red lane on `main`.
+
+Both turned out to be the same kind of problem: a real defect wearing a flake's
+clothes, and a diagnosis that could not be made from what the run recorded.
+
+## Part 1 — the unexplained sequence gap was a production defect
+
+### The report
+
+`Nextest (macos-latest)`, run 30899245389:
+
+```text
+thread 'reconnect_under_fire' panicked at tests/websocket_test_helpers/conformance.rs:1546:17:
+Victim <- 03f48206-…: unexplained seq gap in epoch 1: expected 90, got 91
+```
+
+`seq` and `epoch` are the **server's** stamps, not the test's payload counter, so
+this says: the server delivered seq 91 to that recipient and never delivered
+seq 90, with no `DeliveryReport` covering it. The Watcher in the same room
+required and received the complete 1..100 stream, so seq 90 existed. A hole,
+not a truncation — and the conformance contract is explicit that only a prior
+exact report may authorize one.
+
+The failure took 0.050 s, which places it in the victim's post-cut tail drain:
+the phase-A burst was already queued when the server closed that socket.
+
+### Root cause
+
+`finalize_closed_connection`'s graceful branch drained and wrote everything the
+queue still held. That is correct only if nothing was lost first. It can be:
+
+- the live writer loop runs **inside** `run_until_close`, so a close request
+  cancels it wherever it is, including inside `send_queued`'s socket write;
+- `send_batch` has already `pop_front`ed that payload, so the cancellation takes
+  it with the future. `SendAccounting`'s `Drop` counts it — the code comment
+  says "the outer close `select!` cannot create an untracked one-message hole" —
+  but counting is not accounting: no exact gap is queued, and the recipient is
+  told nothing;
+- the close branch then wrote seq 91, 92, … onto the same socket.
+
+The repository had already met this schedule from the other side and stopped at
+the model boundary. `src/trace_validation.rs` records, on queue close:
+
+```rust
+// The send task's close-select cancelled the live socket-write
+// future after WriterStart. The base model has no transition for
+// a partially written frame, so reject this production schedule
+// before a CloseFlushStart could look like a replay divergence.
+```
+
+The schedule was known and excluded from formal validation; its client-visible
+consequence was never closed.
+
+### Why the loss is real, and why it is ambiguous
+
+`SinkExt::send` is `poll_ready` → `start_send` → `poll_flush`, and
+tokio-tungstenite's implementation decides the outcome:
+
+| cancelled in | `self.ready` state | payload |
+| --- | --- | --- |
+| `poll_flush` | frame already accepted by `start_send` (queued even on `WouldBlock`) | still emitted, in order, by the next flush |
+| `poll_ready` | previous `start_send` hit `WouldBlock`, so `ready == false` and this flush blocks | never handed over — **lost** |
+
+So a cancelled write is genuinely indeterminate. It can be neither reported as
+an exact gap — that would be a false gap for a frame that did reach the wire,
+and the auditor rejects a report covering a delivered sequence just as loudly —
+nor assumed delivered.
+
+That ambiguity is what shapes the fix.
+
+### The fix
+
+An abandoned in-flight write latches the connection's queue
+(`OutboundReceiver::record_abandoned_in_flight_write`, set from
+`SendAccounting`'s unresolved `Drop`). The graceful teardown branch reads the
+latch and abandons the remainder — counted by class, exactly as the existing
+failed-flush path does — instead of writing past it.
+
+The result is correct in **both** sub-cases above, which is the argument for the
+conservative choice rather than a clever one: if the frame was buffered it is
+still flushed by the close frame's own write and the client sees `…, 90`; if it
+was lost the client sees `…, 89`. Either way a gap-free prefix. Truncation at
+close is always legal; a hole is not.
+
+The practical cost is near zero. A write is only cancelled mid-flight when it
+was actually pending, which means the socket was already backpressured — exactly
+the case whose tail would not have flushed inside the close-write budget anyway.
+The loud `SlowConsumer` branch already abandoned its queue and is untouched.
+
+### Red-green
+
+`close_flush_never_writes_the_queue_behind_an_abandoned_write` drives the real
+`finalize_closed_connection` against a **real upgraded WebSocket** — a local
+axum router hands the server-side `WebSocket` back over a oneshot — and asserts
+on the bytes a real client received:
+
+| case | client observes | dropped counter |
+| --- | --- | --- |
+| healthy teardown | `[1, 2, 3]` | 0 |
+| abandoned in-flight write | `[]` | 4 (the payload plus the three behind it) |
+
+With the fence removed and everything else identical, the second case fails:
+
+```text
+teardown after an abandoned in-flight write writes nothing behind it: …
+  left: [1, 2, 3]
+ right: []
+```
+
+`only_an_unresolved_socket_write_fences_the_queue_behind_it` pins the other
+half, data-driven over all three terminal accounting states. `Written` and
+`UnsupportedFormat` must **not** fence: a false positive there would make every
+healthy teardown abandon its queue, which would be a worse defect than the one
+being fixed.
+
+### Sweep
+
+The class is "sequenced payloads written after an in-flight write was
+abandoned". Every other abandonment path already terminates the stream:
+`complete_selected_write`'s deadline expiry and the writer's accountability
+failure both request `SlowConsumer`, whose branch abandons; a socket error
+breaks the loop; and a cancelled `DeliveryReport` write leaves its ranges
+pending under the existing peek/write/commit rule from P17/P18. The graceful
+close branch was the only continuation.
+
+### Not reproduced locally
+
+40 runs of `reconnect_under_fire` under `taskset -c 0` — the technique that
+reproduced previous CI-only timing faults here — all passed. The window needs
+the writer parked in `poll_ready` at the instant of the close, which a fast
+loopback socket essentially never provides. The mechanism is proved by the
+behavioural test above rather than by reproducing the schedule.
+
+## Part 2 — `main` is red on the TURN lane, and the run cannot say why
+
+Run 31015521223 at `8efa0710` failed with issue #276's exact shape:
+
+```text
+ERROR webrtc::…::driver: Failed to write packet to 10.254.57.2:3478 from 127.0.0.1:41151:
+      io error: Invalid argument (os error 22)
+ERROR webrtc::…::turn_relayer: TURN transaction timed out: …   # x2
+WARN  rtc_ice::agent: [controlled]: pingAllCandidates called with no candidate pairs.
+```
+
+coturn logged no Allocate at all, so nothing reached it, and under
+`--ice-transport-policy relay` a session with no reachable source gathers no
+candidate whatsoever. P48's routing union did not prevent this run.
+
+What the artifacts could not answer was **why**. The client logged the union only
+when it _added_ an address, so a run where the probe contributed nothing was
+byte-identical in the log to a run where it never ran; and an ICE server that
+neither resolves nor routes was a `debug!` line the lane's captured stderr never
+records. On the host side, whether the Docker bridge carried the expected source
+address and whether its operational state was up — the exact quantity
+`if_addrs::Interface::is_oper_up` reads, and the crux of P48's own root cause —
+is unrecoverable from a client log after the fact.
+
+So the first move was evidence, not a second fix:
+
+- the client reports the complete resolved bind set on every pairing
+  (`bound`, `enumerated`, `added`, `family`), and warns — not debugs — when a
+  configured ICE server does not resolve or does not route;
+- `scripts/run-turn-interop.sh` captures the host's `ip route get`, address and
+  route tables, and the Docker bridge's link state into the failure artifacts,
+  at coturn readiness and again at teardown.
+
+### The diagnostics falsified the recorded cause on their first failing run
+
+That head failed once in seven runs (a ~14% rate on this runner pool), and the
+failing run said:
+
+```text
+routed a configured ICE server server=10.254.176.2:3478 source=10.254.176.1
+resolved the ICE bind set … bound=[10.1.0.97, 10.254.176.1, 127.0.0.1, ::1]
+    enumerated={10.1.0.97, 10.254.176.1, 127.0.0.1, ::1} added=[] family="any"
+```
+
+and the host agreed with it:
+
+```text
+10.254.176.2 dev br-aedb811f8bed src 10.254.176.1
+5: br-aedb811f8bed: <BROADCAST,MULTICAST,UP,LOWER_UP> … state UP
+    inet 10.254.176.1/24 … scope global br-aedb811f8bed
+```
+
+**The routable bridge source was already bound, the bridge was carrier-up, and
+interface enumeration had it without help from the probe** (`added=[]`).
+Allocates left a correctly routed source and nothing came back. Address
+selection — the whole subject of P48 and of #276's recorded cause — is not the
+remaining fault.
+
+A second recorded inference also fails a control. Session 091 read "coturn
+logged no Allocate at all" as proof that nothing reached it. A **successful**
+local run's coturn log carries no Allocate line either: coturn does not log them
+at this verbosity. That observation was never evidence.
+
+### Measuring the path instead
+
+The lane now measures its own environment before handing the run to the clients:
+one STUN Binding request from the host over `/dev/udp`, which connects the
+socket and therefore picks the same source address the client's own route probe
+picks — the client's path, not an approximation. Binding needs no credentials,
+so a response proves both directions. Locally it returns a full Binding Success
+Response on the first attempt:
+
+```text
+turn_udp_stun_binding_response=010100142112a44273662d7475726e2d70726f62002000080001a1e02bec1041802800044b71b0e3
+turn_udp_reachable_after_attempts=1
+```
+
+The gate waits up to 20 s. A path that is merely slow to come up is absorbed; a
+path that never comes up fails **here**, with the measurement attached, instead
+of as a thirty-second `no candidate pairs` ICE failure that says nothing about
+whose fault it is. Either way the next failure is partitioned: gate red means
+the environment, gate green means the client or the stack.
+
+It also replaces a log-line proxy with a measurement. The previous readiness
+signal was `grep "Relay ports initialization done"` in coturn's log, which
+reports _relay port_ initialization — not that coturn's listener will answer.
+
+### What the gate did and did not prove
+
+| head | TURN runs | failures |
+| --- | --- | --- |
+| diagnostics only (`42e84ec`) | 7 | 1 |
+| diagnostics + reachability gate (`4d062a5`) | 41 | 0 |
+
+41 consecutive passes against a measured ~14% rate is about a 1-in-500
+coincidence, so the gate is very likely doing something real. It is **not**
+proof of mechanism: every one of the 41 answered on the first probe, so the
+_wait_ absorbed nothing observable. The leading explanation is the log-line
+proxy above — one successful round trip before the clients start is what the
+run was missing — and that is stated as the leading explanation, not as a
+finding.
+
+### The gate's own hollow guard, found by review
+
+Cursor Bugbot caught the gate defeating itself: `wait_for_turn_udp_reachable`
+called `probe_turn_udp` bare and then read `$?`, so under `set -euo pipefail`
+the first unanswered probe ended the script before `status` was ever assigned.
+The twenty-attempt wait was one attempt and the "cannot measure, stand aside"
+path was unreachable — and the defect was invisible in all 41 green runs,
+because every probe answered immediately.
+
+Fixed as `status=0; probe_turn_udp || status=$?`, and pinned:
+`test_turn_reachability_gate_retries_until_answered` extracts the shipped
+function from the script rather than copying it and drives it against a stubbed
+probe that answers immediately, answers on the fifth attempt, never answers, and
+cannot be run at all. Against the previous gate the answer-on-the-fifth-probe
+case exits 1 after a single attempt.
+
+`docker network inspect` confirms an `--internal` network is still assigned its
+gateway address (`{"Subnet":"10.253.99.0/24","Gateway":"10.253.99.1"}`), so the
+expected source exists by construction — which is consistent with what the
+failing run observed.
+
+## What was investigated and deliberately not changed
+
+**#274's first non-timing item** (`reconnect_clears_stored_transport_status`
+failing with `PlayerAlreadyConnected`). Session 091 read it as a
+test-synchronization gap. Reading the teardown path this session did not confirm
+that: `disconnect_client` → `unregister_client` awaits its spawned transaction,
+and both the caller's transaction and the connection's own
+`unregister_client_with_lifecycle` serialize on the same `ClientLifecycle` lock,
+so whichever wins, one `unregister_client_locked` — which ends in
+`remove_client_for_unregistration` — has completed before `disconnect_client`
+returns. Under that reading `has_client` should already be false and the guard
+should not fire. The observed failure therefore has a cause neither session has
+identified, it reproduces neither locally nor on demand, and changing the test's
+synchronization would be a change without evidence. Left open on #274 with this
+analysis added.
+
+## Validation
+
+- Root suite `cargo test --all-features`: green.
+- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`:
+  clean, root and `clients/native`.
+- `clients/native`: 89 unit tests green, `cargo fmt --check` and strict Clippy
+  clean.
+- `scripts/run-turn-interop.sh` against the pinned coturn: positive control and
+  mismatched-secret control both pass with the new diagnostics recorded.
+- `docs/protocol.md` now states the teardown rule it always implied, on both the
+  server-behaviour side and the recipient-obligations side.
+
+## Review
+
+Cursor Bugbot reviewed every head. It reported no issues on the first, and on
+the third found the reachability gate's own errexit defect described above —
+a real finding on code that had 41 green runs behind it. Copilot was
+quota-blocked on every request (`the user who requested the review has reached
+their quota limit`), as on every recent PR.
+
+## Follow-ups
+
+No new issues. Two existing ones were advanced with evidence:
+
+- **#274** — bullet 2 item 2 is fixed here. Item 1 (`PlayerAlreadyConnected` on
+  reconnect) stays open, and session 091's reading of it as a
+  test-synchronization gap is recorded as falsified rather than carried
+  forward. Bullets 1 and 3 (measured per-platform ceilings, PR-lane timing
+  placement) are untouched.
+- **#276** — reopened in substance: the lane failed again on `main`, its
+  recorded cause is falsified, and the issue now carries the bind-set and
+  host-routing evidence plus the reachability gate's before/after statistics.
+
+## Publication
+
+PR #279 from branch `agent/session-092-teardown-write-integrity`.

--- a/scripts/run-turn-interop.sh
+++ b/scripts/run-turn-interop.sh
@@ -100,10 +100,51 @@ has_unredacted_credentials() {
         "$@" 2>/dev/null | grep -Fv '[REDACTED]' >/dev/null
 }
 
+# Append the host's view of the TURN network to the run's diagnostics.
+#
+# Issue #276's failures are all "no bound socket reached coturn", and the
+# client's own log can only report which addresses it bound. Whether the
+# expected source address existed, which device carried it, and whether that
+# device was carrier-up are properties of the host that no client log can
+# recover after the fact. The bridge's `operstate` is the exact quantity
+# `if_addrs::Interface::is_oper_up` reads, so an enumeration that missed the
+# route is visible here rather than inferred.
+capture_host_routing() {
+    local label=$1
+    local network_id bridge
+    {
+        printf '\n===== %s =====\n' "${label}"
+        printf 'turn_host=%s listen_port=%s subnet=%s network=%s\n' \
+            "${TURN_HOST}" "${LISTEN_PORT}" "${NETWORK_SUBNET:-<published>}" "${COTURN_NETWORK}"
+        if command -v ip >/dev/null 2>&1; then
+            printf -- '--- ip -4 route get %s ---\n' "${TURN_HOST}"
+            timeout 10 ip -4 route get "${TURN_HOST}" 2>&1
+            printf -- '--- ip -4 addr ---\n'
+            timeout 10 ip -4 addr 2>&1
+            printf -- '--- ip -4 route ---\n'
+            timeout 10 ip -4 route 2>&1
+        else
+            printf 'iproute2 is unavailable on this host\n'
+        fi
+        network_id=$(timeout 10 docker network inspect -f '{{.Id}}' "${COTURN_NETWORK}" 2>&1)
+        printf -- '--- docker network id ---\n%s\n' "${network_id}"
+        bridge="br-${network_id:0:12}"
+        if command -v ip >/dev/null 2>&1 && [ ${#network_id} -ge 12 ]; then
+            printf -- '--- ip -d link show dev %s ---\n' "${bridge}"
+            timeout 10 ip -d link show dev "${bridge}" 2>&1
+            printf -- '--- ip -4 addr show dev %s ---\n' "${bridge}"
+            timeout 10 ip -4 addr show dev "${bridge}" 2>&1
+        fi
+    } >>"${ARTIFACT_DIR}/host-routing.log" 2>&1 || true
+}
+
 cleanup() {
     local status=$?
     trap - EXIT INT TERM
     set +e
+    # Before the teardown removes the container and the bridge: the state at
+    # failure time is the state that matters.
+    capture_host_routing "teardown"
     timeout 10 docker rm --force "${COTURN_CONTAINER}" >/dev/null 2>&1 || true
     if [ -n "${COTURN_RUNNER_PID}" ]; then
         wait "${COTURN_RUNNER_PID}" 2>/dev/null || true
@@ -157,6 +198,7 @@ shopt -s nullglob
 prior_diagnostics=(
     "${ARTIFACT_DIR}"/coturn.log
     "${ARTIFACT_DIR}"/test.log
+    "${ARTIFACT_DIR}"/host-routing.log
     "${ARTIFACT_DIR}"/diagnostics.manifest
     "${ARTIFACT_DIR}"/server-*.log
     "${ARTIFACT_DIR}"/client-*.log
@@ -266,6 +308,8 @@ if [ "${ready}" != true ]; then
     echo "ERROR: coturn did not initialize UDP relay ports within 30 seconds" >&2
     exit 1
 fi
+
+capture_host_routing "coturn ready"
 
 echo "==> Verifying cached native-client dependencies"
 (cd "${CLIENT_DIR}" && cargo metadata --locked --offline --format-version 1 >/dev/null)

--- a/scripts/run-turn-interop.sh
+++ b/scripts/run-turn-interop.sh
@@ -138,6 +138,68 @@ capture_host_routing() {
     } >>"${ARTIFACT_DIR}/host-routing.log" 2>&1 || true
 }
 
+# One STUN Binding request from the host to coturn, over the exact path the
+# clients use, printing the first bytes of any response.
+#
+# `/dev/udp` connects the socket, so the kernel picks the same source address
+# the client's own route probe picks: this measures the client's path, not an
+# approximation of it. STUN Binding needs no credentials, so a response proves
+# the datagram arrived and the reply came back — the one fact every #276
+# failure is missing. Any inability to measure is reported as such and never
+# mistaken for a negative result.
+probe_turn_udp() {
+    local response=""
+    if ! exec 3<>"/dev/udp/${TURN_HOST}/${LISTEN_PORT}" 2>/dev/null; then
+        printf 'turn_udp_probe=socket_unavailable\n' >>"${ARTIFACT_DIR}/host-routing.log"
+        return 2
+    fi
+    # RFC 5389 Binding request: type 0x0001, length 0, the magic cookie, and a
+    # fixed 12-byte transaction id.
+    printf '\x00\x01\x00\x00\x21\x12\xa4\x42sf-turn-prob' >&3 2>/dev/null || true
+    # One read of the whole datagram: a byte-at-a-time read would consume the
+    # datagram and return only its first byte.
+    response=$(timeout 2 dd bs=64 count=1 status=none <&3 2>/dev/null |
+        od -An -tx1 2>/dev/null | tr -d ' \n' || true)
+    exec 3<&- 2>/dev/null || true
+    exec 3>&- 2>/dev/null || true
+    if [ -n "${response}" ]; then
+        printf 'turn_udp_stun_binding_response=%s\n' "${response}" \
+            >>"${ARTIFACT_DIR}/host-routing.log"
+        return 0
+    fi
+    return 1
+}
+
+# Wait, bounded, for that path to work before handing the run to the clients.
+#
+# Without this the only symptom of an unreachable coturn is a 30-second ICE
+# failure with "no candidate pairs", which says nothing about whose fault it
+# is. With it, a path that is merely slow to come up is absorbed, and a path
+# that never comes up fails here with the measurement attached.
+wait_for_turn_udp_reachable() {
+    local attempt status
+    for attempt in $(seq 1 20); do
+        probe_turn_udp
+        status=$?
+        if [ "${status}" -eq 0 ]; then
+            printf 'turn_udp_reachable_after_attempts=%s\n' "${attempt}" \
+                >>"${ARTIFACT_DIR}/host-routing.log"
+            echo "==> coturn answered a STUN Binding request on attempt ${attempt}/20"
+            return 0
+        fi
+        if [ "${status}" -eq 2 ]; then
+            echo "==> bash UDP redirections are unavailable; skipping the reachability gate"
+            return 0
+        fi
+        sleep 1
+    done
+    printf 'turn_udp_reachable=false attempts=20\n' >>"${ARTIFACT_DIR}/host-routing.log"
+    echo "ERROR: the host cannot reach coturn at ${TURN_HOST}:${LISTEN_PORT} over UDP;" >&2
+    echo "       a STUN Binding request went unanswered for 20 seconds, so no client" >&2
+    echo "       could have allocated a relay candidate. See host-routing.log." >&2
+    return 1
+}
+
 cleanup() {
     local status=$?
     trap - EXIT INT TERM
@@ -145,6 +207,12 @@ cleanup() {
     # Before the teardown removes the container and the bridge: the state at
     # failure time is the state that matters.
     capture_host_routing "teardown"
+    if [ "${status}" -ne 0 ]; then
+        # Only on the failing path: a successful run has already stopped
+        # coturn, so probing it there would record a misleading negative.
+        probe_turn_udp >/dev/null 2>&1 ||
+            printf 'turn_udp_stun_binding_response=<none>\n' >>"${ARTIFACT_DIR}/host-routing.log"
+    fi
     timeout 10 docker rm --force "${COTURN_CONTAINER}" >/dev/null 2>&1 || true
     if [ -n "${COTURN_RUNNER_PID}" ]; then
         wait "${COTURN_RUNNER_PID}" 2>/dev/null || true
@@ -310,6 +378,7 @@ if [ "${ready}" != true ]; then
 fi
 
 capture_host_routing "coturn ready"
+wait_for_turn_udp_reachable
 
 echo "==> Verifying cached native-client dependencies"
 (cd "${CLIENT_DIR}" && cargo metadata --locked --offline --format-version 1 >/dev/null)

--- a/scripts/run-turn-interop.sh
+++ b/scripts/run-turn-interop.sh
@@ -179,8 +179,12 @@ probe_turn_udp() {
 wait_for_turn_udp_reachable() {
     local attempt status
     for attempt in $(seq 1 20); do
-        probe_turn_udp
-        status=$?
+        # A probe that has not been answered yet is the normal case this loop
+        # exists for, so its status must be captured rather than executed bare:
+        # under `set -e` a bare call would end the script on the first
+        # unanswered probe and collapse the retry into a single attempt.
+        status=0
+        probe_turn_udp || status=$?
         if [ "${status}" -eq 0 ]; then
             printf 'turn_udp_reachable_after_attempts=%s\n' "${attempt}" \
                 >>"${ARTIFACT_DIR}/host-routing.log"

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -7,7 +7,7 @@
 //! has a causally prior exact report.
 
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::atomic::{AtomicU16, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use tokio::sync::Notify;
@@ -548,6 +548,9 @@ struct SharedQueue {
     capacity_available: Notify,
     protocol_version: AtomicU16,
     game_data_format: AtomicU8,
+    /// Set once a queued payload was abandoned while a socket write owned it.
+    /// See [`OutboundReceiver::record_abandoned_in_flight_write`].
+    abandoned_in_flight_write: AtomicBool,
     unsupported_notices: Mutex<UnsupportedNoticeLimiter>,
     data_capacity: usize,
     control_capacity: usize,
@@ -748,6 +751,7 @@ fn channel_inner(
         capacity_available: Notify::new(),
         protocol_version: AtomicU16::new(crate::config::SERVER_MIN_PROTOCOL_VERSION),
         game_data_format: AtomicU8::new(encoding_tag(GameDataEncoding::Json)),
+        abandoned_in_flight_write: AtomicBool::new(false),
         unsupported_notices: Mutex::new(UnsupportedNoticeLimiter::default()),
         data_capacity,
         control_capacity,
@@ -1858,6 +1862,31 @@ impl OutboundReceiver {
         increment_abandoned(&mut state.counters, class, count);
         drop(state);
         self.shared.record_abandoned(class, count);
+    }
+
+    /// Record that one queued payload was abandoned while a socket write owned
+    /// it — the write future was dropped before it could resolve to a written
+    /// frame or to an accounted drop.
+    ///
+    /// The payload's wire position is then **unknown**: the sink may have
+    /// accepted the frame into its own buffer before the cancellation, or the
+    /// cancellation may have landed before the frame was ever handed over.
+    /// Either way the payload can no longer be described exactly, so nothing
+    /// still queued behind it may be written afterwards — the recipient would
+    /// observe a delivered sequence that skips a sequence it was never told
+    /// about, which is exactly the hole `DeliveryReport` exists to make
+    /// impossible.
+    pub fn record_abandoned_in_flight_write(&self) {
+        self.shared
+            .abandoned_in_flight_write
+            .store(true, Ordering::Release);
+    }
+
+    /// Whether a queued payload was abandoned while a socket write owned it.
+    pub fn abandoned_in_flight_write(&self) -> bool {
+        self.shared
+            .abandoned_in_flight_write
+            .load(Ordering::Acquire)
     }
 
     /// Account an encoding failure discovered only by the socket writer,

--- a/src/websocket/connection.rs
+++ b/src/websocket/connection.rs
@@ -709,6 +709,42 @@ async fn finalize_closed_connection(
             | CloseReason::IdleTimeout
             | CloseReason::Unregistered,
         )
+        | None
+            if rx.abandoned_in_flight_write() =>
+        {
+            // A queued payload was abandoned while a socket write owned it, so
+            // its wire position is unknown (the sink may have taken the frame
+            // into its own buffer before the close cancelled the write, or the
+            // cancellation may have landed first). Everything still queued sits
+            // BEHIND that payload, so flushing it here is exactly how a
+            // recipient ends up observing a delivered sequence that skips one
+            // it was never told about — an unexplained hole no `DeliveryReport`
+            // covers. Abandon the remainder instead: a gap-free prefix that
+            // stops early is a legal stream, a hole is not.
+            let abandoned = rx.len().saturating_add(batcher.len());
+            record_abandoned_by_class(rx, batcher);
+            server
+                .metrics()
+                .add_websocket_messages_dropped(abandoned as u64);
+            tracing::debug!(
+                %player_id,
+                abandoned_messages = abandoned,
+                "Socket write was abandoned in flight while closing; abandoning the queue behind it \
+                 rather than writing past an unaccountable sequence"
+            );
+            // The coalesced omissions are still exact and still describe frames
+            // this recipient already saw skipped, so they are written after the
+            // abandonment snapshot above — a report never advances the data
+            // sequence and so can never open a hole of its own.
+            flush_pending_unsupported_report(sender, rx, player_id).await;
+        }
+        Some(
+            CloseReason::Shutdown
+            | CloseReason::AuthTimeout
+            | CloseReason::ActivityTimeout
+            | CloseReason::IdleTimeout
+            | CloseReason::Unregistered,
+        )
         | None => {
             // Drain whatever is already buffered and flush it, bounded by the
             // close-write budget: an unregistered connection is usually
@@ -3111,5 +3147,202 @@ mod tests {
             }
         }
         exchange
+    }
+
+    /// One real upgraded WebSocket: the production sink type on the server
+    /// half, and the client half of the same TCP connection. Nothing here is
+    /// mocked — the teardown path under test writes real frames that the
+    /// client either observes or does not.
+    struct UpgradedSocketPair {
+        server_sink: futures_util::stream::SplitSink<WebSocket, Message>,
+        _server_stream: futures_util::stream::SplitStream<WebSocket>,
+        client: tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        serve_task: tokio::task::JoinHandle<()>,
+    }
+
+    impl UpgradedSocketPair {
+        async fn connect() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind upgraded-pair listener");
+            let addr = listener.local_addr().expect("read upgraded-pair address");
+            let (socket_tx, socket_rx) = tokio::sync::oneshot::channel::<WebSocket>();
+            let socket_tx = Arc::new(std::sync::Mutex::new(Some(socket_tx)));
+            let app = axum::Router::new().route(
+                "/ws",
+                axum::routing::get(move |upgrade: axum::extract::WebSocketUpgrade| {
+                    let socket_tx = Arc::clone(&socket_tx);
+                    async move {
+                        upgrade.on_upgrade(move |socket| async move {
+                            let handoff = socket_tx
+                                .lock()
+                                .unwrap_or_else(|error| error.into_inner())
+                                .take()
+                                .expect("upgraded-pair handoff is used once");
+                            let _ = handoff.send(socket);
+                        })
+                    }
+                }),
+            );
+            let serve_task = tokio::spawn(async move {
+                let _ = axum::serve(listener, app).await;
+            });
+            let (client, _response) = connect_async(format!("ws://{addr}/ws"))
+                .await
+                .expect("client upgrade");
+            let socket = socket_rx.await.expect("server socket handoff");
+            let (server_sink, server_stream) = socket.split();
+            Self {
+                server_sink,
+                _server_stream: server_stream,
+                client,
+                serve_task,
+            }
+        }
+
+        /// Drain the client until the server's close frame arrives, returning
+        /// the `n` values of every `GameData` frame that reached the wire.
+        async fn drain_written_game_data(&mut self) -> Vec<u64> {
+            let mut written = Vec::new();
+            let drain = async {
+                while let Some(frame) = self.client.next().await {
+                    match frame.expect("client frame") {
+                        TungsteniteMessage::Text(text) => {
+                            let message: ServerMessage = serde_json::from_str(&text)
+                                .unwrap_or_else(|error| panic!("decode {text}: {error}"));
+                            if let ServerMessage::GameData { data, .. } = message {
+                                written.push(
+                                    data.get("n")
+                                        .and_then(serde_json::Value::as_u64)
+                                        .expect("ledger frame carries its n"),
+                                );
+                            }
+                        }
+                        TungsteniteMessage::Close(_) => return,
+                        _other_frame => continue,
+                    }
+                }
+            };
+            tokio::time::timeout(Duration::from_secs(10), drain)
+                .await
+                .expect("server never closed the upgraded socket");
+            written
+        }
+
+        async fn shutdown(self) {
+            self.serve_task.abort();
+            let _ = self.serve_task.await;
+        }
+    }
+
+    fn ledger_data(seq: u64) -> crate::coordination::outbound_queue::OutboundData {
+        let from_player = PlayerId::from_u128(9);
+        let room_id = crate::protocol::RoomId::from_u128(11);
+        crate::coordination::outbound_queue::OutboundData::new(
+            Arc::new(ServerMessage::GameData {
+                from_player,
+                data: serde_json::json!({ "n": seq }),
+                seq: Some(seq),
+                epoch: Some(1),
+                class: Some(crate::protocol::DeliveryClass::Reliable),
+                key: None,
+            }),
+            crate::coordination::outbound_queue::DataDeliveryMetadata {
+                class: crate::protocol::DeliveryClass::Reliable,
+                key: None,
+                from_player,
+                room_id,
+                epoch: 1,
+                seq,
+            },
+        )
+    }
+
+    /// Issue #274: a graceful teardown must never write the queue that sits
+    /// behind a socket write which was abandoned in flight.
+    ///
+    /// The live write loop runs inside the close `select!`, so a close request
+    /// cancels it wherever it is — including while a socket write owns one
+    /// queued payload. That payload's wire position is then unknown, and the
+    /// close flush used to keep writing everything queued behind it. The
+    /// recipient then observes a delivered sequence that skips a sequence no
+    /// `DeliveryReport` ever described: the unexplained mid-stream hole issue
+    /// #274 recorded (`expected 90, got 91`).
+    ///
+    /// Both halves run against a real upgraded socket, so the oracle is the
+    /// bytes the client actually received.
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(miri, ignore)]
+    async fn close_flush_never_writes_the_queue_behind_an_abandoned_write() {
+        const QUEUED: u64 = 3;
+        for (abandoned_in_flight, expected_written, context) in [
+            (false, vec![1, 2, 3], "healthy teardown flushes its queue"),
+            (
+                true,
+                Vec::new(),
+                "teardown after an abandoned in-flight write writes nothing behind it",
+            ),
+        ] {
+            let server = test_server().await;
+            let player_id = PlayerId::from_u128(9);
+            let (tx, mut rx) = crate::coordination::outbound_queue::channel(16, 16);
+            for seq in 1..=QUEUED {
+                tx.try_enqueue_data(ledger_data(seq))
+                    .unwrap_or_else(|_| panic!("{context}: queue seq {seq}"));
+            }
+
+            let (close_signal, _close_listener) = ConnectionCloseSignal::channel();
+            let (probe_state, _probe_updates) = watch::channel(PingProbeState::default());
+            if abandoned_in_flight {
+                // The production seam, exactly: a socket write owned one
+                // payload and its future was dropped before resolving.
+                let accounting = crate::websocket::sending::SendAccounting::new(
+                    &rx,
+                    &server,
+                    &probe_state,
+                    player_id,
+                    Some(crate::protocol::DeliveryClass::Reliable),
+                );
+                drop(accounting);
+            }
+
+            let mut pair = UpgradedSocketPair::connect().await;
+            let mut batcher = MessageBatcher::new(1, 1);
+            finalize_closed_connection(
+                &mut pair.server_sink,
+                &mut rx,
+                &mut batcher,
+                None,
+                &player_id,
+                &server,
+                &close_signal,
+                &probe_state,
+                Duration::from_secs(5),
+            )
+            .await;
+
+            let written = pair.drain_written_game_data().await;
+            assert_eq!(
+                written, expected_written,
+                "{context}: the client's observed stream must match the contract"
+            );
+            let expected_dropped = if abandoned_in_flight {
+                // The abandoned in-flight payload plus the whole queue behind it.
+                QUEUED + 1
+            } else {
+                0
+            };
+            assert_eq!(
+                server
+                    .metrics()
+                    .websocket_messages_dropped
+                    .load(Ordering::Relaxed),
+                expected_dropped,
+                "{context}: abandoned payloads must be counted, never lost silently"
+            );
+            pair.shutdown().await;
+        }
     }
 }

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -590,6 +590,14 @@ impl Drop for SendAccounting<'_> {
         if self.resolved {
             return;
         }
+        // The payload was owned by a socket write that never resolved, so the
+        // sink may or may not have accepted its frame. Fence the connection's
+        // remaining queue before counting the loss: whatever is still queued
+        // sits *behind* an item whose wire position is unknown, and writing it
+        // would show the recipient a delivered sequence that skips one it was
+        // never told about. `finalize_closed_connection` reads this and
+        // abandons the remainder instead of flushing it.
+        self.receiver.record_abandoned_in_flight_write();
         if let Some(class) = self.class {
             self.receiver.record_abandoned(class, 1);
         }
@@ -1023,6 +1031,82 @@ mod tests {
 
     fn player_a() -> Uuid {
         Uuid::from_u128(0x0011_2233_4455_6677_8899_aabb_ccdd_eeff)
+    }
+
+    /// Issue #274: only an unresolved socket write fences the queue behind it.
+    ///
+    /// The fence stops a closing connection from writing past a payload whose
+    /// wire position is unknown. It must therefore fire for exactly one
+    /// terminal state — the write future dropped before resolving — because a
+    /// false positive would make every healthy teardown abandon its queue.
+    #[tokio::test]
+    async fn only_an_unresolved_socket_write_fences_the_queue_behind_it() {
+        use crate::coordination::outbound_queue::{channel, DataDeliveryMetadata};
+        use crate::database::DatabaseConfig;
+        use crate::protocol::RoomId;
+        use crate::server::ServerConfig;
+
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        enum Resolution {
+            Written,
+            UnsupportedFormat,
+            AbandonedInFlight,
+        }
+
+        for (resolution, expected_fence) in [
+            (Resolution::Written, false),
+            (Resolution::UnsupportedFormat, false),
+            (Resolution::AbandonedInFlight, true),
+        ] {
+            let server = EnhancedGameServer::new(
+                ServerConfig::default(),
+                crate::config::ProtocolConfig::default(),
+                crate::config::RelayTypeConfig::default(),
+                crate::config::SessionConfig::default(),
+                crate::config::TurnConfig::default(),
+                DatabaseConfig::InMemory,
+                crate::config::MetricsConfig::default(),
+                crate::config::CoordinationConfig::default(),
+                crate::config::TransportSecurityConfig::default(),
+                Vec::new(),
+            )
+            .await
+            .expect("construct accounting-fence test server");
+            let (_tx, rx) = channel(4, 4);
+            let (probe_state, _probe_updates) = watch::channel(PingProbeState::default());
+            let from_player = PlayerId::from_u128(3);
+            let metadata = DataDeliveryMetadata {
+                class: crate::protocol::DeliveryClass::Reliable,
+                key: None,
+                from_player,
+                room_id: RoomId::from_u128(5),
+                epoch: 1,
+                seq: 7,
+            };
+
+            {
+                let mut accounting = SendAccounting::new(
+                    &rx,
+                    &server,
+                    &probe_state,
+                    from_player,
+                    Some(crate::protocol::DeliveryClass::Reliable),
+                );
+                match resolution {
+                    Resolution::Written => accounting.complete_written(),
+                    Resolution::UnsupportedFormat => {
+                        let _coalesced = accounting.complete_unsupported(Some(metadata));
+                    }
+                    Resolution::AbandonedInFlight => {}
+                }
+            }
+
+            assert_eq!(
+                rx.abandoned_in_flight_write(),
+                expected_fence,
+                "{resolution:?}: the teardown fence must reflect exactly this terminal state"
+            );
+        }
     }
 
     #[test]

--- a/tests/ci_config_script_tests.rs
+++ b/tests/ci_config_script_tests.rs
@@ -317,12 +317,15 @@ fn test_turn_reachability_gate_retries_until_answered() {
         let artifact_dir = temp_root.path().join("artifacts");
         fs::create_dir_all(&artifact_dir).expect("create artifact dir");
         let counter = temp_root.path().join("attempts");
+        // Relative names, resolved against the harness's own working
+        // directory: a `Path::display()` interpolation would embed Windows
+        // backslashes, which bash then eats as escapes.
         let harness = format!(
             "set -euo pipefail\n\
-             ARTIFACT_DIR={artifact}\n\
+             ARTIFACT_DIR=artifacts\n\
              TURN_HOST=203.0.113.9\n\
              LISTEN_PORT=3478\n\
-             COUNTER={counter}\n\
+             COUNTER=attempts\n\
              printf '0' >\"${{COUNTER}}\"\n\
              # Stubbed probe: the gate's contract is what it does with the\n\
              # status, not how the datagram is sent.\n\
@@ -335,14 +338,11 @@ fn test_turn_reachability_gate_retries_until_answered() {
              sleep() {{ :; }}\n\
              {gate}\n\
              wait_for_turn_udp_reachable\n",
-            artifact = artifact_dir.display(),
-            counter = counter.display(),
         );
-        let harness_path = temp_root.path().join("gate.sh");
-        write_file(&harness_path, &harness);
+        write_file(&temp_root.path().join("gate.sh"), &harness);
 
         let output = bash_command()
-            .arg(&harness_path)
+            .arg("gate.sh")
             .current_dir(temp_root.path())
             .output()
             .expect("reachability gate harness should execute");

--- a/tests/ci_config_script_tests.rs
+++ b/tests/ci_config_script_tests.rs
@@ -262,3 +262,105 @@ fn test_repository_ci_config_has_active_matching_healthcheck() {
         "checked-in Dockerfile healthcheck should be recognized.\nOutput:\n{combined}"
     );
 }
+
+/// Extract one shell function body verbatim from a script, so a test drives
+/// the shipped code rather than a copy of it.
+fn extract_shell_function(script: &str, name: &str) -> String {
+    let header = format!("{name}() {{");
+    let start = script
+        .find(&header)
+        .unwrap_or_else(|| panic!("scripts/run-turn-interop.sh must define {name}()"));
+    let rest = &script[start..];
+    let end = rest
+        .find("\n}\n")
+        .unwrap_or_else(|| panic!("{name}() must close with a brace at column 0"));
+    rest[..end + 3].to_string()
+}
+
+/// The TURN reachability gate must actually retry (issue #276).
+///
+/// Under `set -e` a bare `probe_turn_udp` call would end the script on the
+/// first unanswered probe, collapsing the twenty-attempt wait into one attempt
+/// while every symptom — a green run whose probe answered immediately — stayed
+/// identical. That is exactly the hollow guard this drives out: the loop is
+/// exercised with a stubbed probe whose answer arrives late, never, or not at
+/// all.
+#[test]
+fn test_turn_reachability_gate_retries_until_answered() {
+    let script = fs::read_to_string(repo_root().join("scripts/run-turn-interop.sh"))
+        .expect("read scripts/run-turn-interop.sh");
+    let gate = extract_shell_function(&script, "wait_for_turn_udp_reachable");
+
+    // (probe outcome program, expected exit status, expected marker)
+    let cases: [(&str, i32, &str); 4] = [
+        // Answered immediately.
+        (
+            "[ \"${ATTEMPT}\" -ge 1 ] && return 0; return 1",
+            0,
+            "attempt 1/20",
+        ),
+        // Answered only on the fifth probe: the wait must absorb the first four.
+        (
+            "[ \"${ATTEMPT}\" -ge 5 ] && return 0; return 1",
+            0,
+            "attempt 5/20",
+        ),
+        // Never answered: the gate fails with its own diagnosis, not silently.
+        ("return 1", 1, "cannot reach coturn"),
+        // No `/dev/udp` on this host: measurement is impossible, so the gate
+        // must stand aside rather than invent a negative result.
+        ("return 2", 0, "skipping the reachability gate"),
+    ];
+
+    for (probe_program, expected_status, expected_marker) in cases {
+        let temp_root = unique_temp_dir("turn-reachability-gate");
+        let artifact_dir = temp_root.path().join("artifacts");
+        fs::create_dir_all(&artifact_dir).expect("create artifact dir");
+        let counter = temp_root.path().join("attempts");
+        let harness = format!(
+            "set -euo pipefail\n\
+             ARTIFACT_DIR={artifact}\n\
+             TURN_HOST=203.0.113.9\n\
+             LISTEN_PORT=3478\n\
+             COUNTER={counter}\n\
+             printf '0' >\"${{COUNTER}}\"\n\
+             # Stubbed probe: the gate's contract is what it does with the\n\
+             # status, not how the datagram is sent.\n\
+             probe_turn_udp() {{\n\
+             ATTEMPT=$(( $(cat \"${{COUNTER}}\") + 1 ))\n\
+             printf '%s' \"${{ATTEMPT}}\" >\"${{COUNTER}}\"\n\
+             {probe_program}\n\
+             }}\n\
+             # Keep the wall clock out of it; the retry count is the contract.\n\
+             sleep() {{ :; }}\n\
+             {gate}\n\
+             wait_for_turn_udp_reachable\n",
+            artifact = artifact_dir.display(),
+            counter = counter.display(),
+        );
+        let harness_path = temp_root.path().join("gate.sh");
+        write_file(&harness_path, &harness);
+
+        let output = bash_command()
+            .arg(&harness_path)
+            .current_dir(temp_root.path())
+            .output()
+            .expect("reachability gate harness should execute");
+        let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
+        combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        let combined = combined.replace("\r\n", "\n");
+        let attempts = fs::read_to_string(&counter).unwrap_or_default();
+
+        assert_eq!(
+            output.status.code().unwrap_or(-1),
+            expected_status,
+            "probe `{probe_program}` must exit {expected_status} \
+             (attempts: {attempts})\nOutput:\n{combined}"
+        );
+        assert!(
+            combined.contains(expected_marker),
+            "probe `{probe_program}` must report `{expected_marker}` \
+             (attempts: {attempts})\nOutput:\n{combined}"
+        );
+    }
+}

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -23245,6 +23245,13 @@ fn test_turn_interop_gate_is_local_pinned_and_fail_closed() {
         "sanitize_file",
         "redaction-probe",
         "has_unredacted_credentials",
+        // The lane must measure its own environment before blaming the client:
+        // an unanswered STUN Binding request from the host is the one fact
+        // every issue #276 failure was missing, and the host's routing state is
+        // unrecoverable from a client log afterwards.
+        "capture_host_routing",
+        "wait_for_turn_udp_reachable",
+        "host-routing.log",
         "diagnostics.manifest",
         "server-*.log",
         "client-*.jsonl",


### PR DESCRIPTION
## Summary

Two items, both from red CI evidence.

**1. A production delivery-accountability defect (issue #274, bullet 2 item 2).**

The `Nextest (macos-latest)` lane failed `reconnect_under_fire` with

```text
Victim <- 03f48206-…: unexplained seq gap in epoch 1: expected 90, got 91
```

That oracle means the recipient observed a delivered sequence that skipped one no `DeliveryReport` ever described — a hole, not a truncation.

Root cause: the live writer loop runs inside the connection's close `select!`, so a close request cancels it *wherever it is*, including while a socket write owns one queued payload. `SendAccounting::drop` counted that payload, but `finalize_closed_connection`'s graceful branch then drained everything still queued **behind** it and wrote it to the same socket. The repository already knew this schedule existed — `trace_validation.rs` marks it `Unsupported("live-write-cancelled-by-close")` because "the base model has no transition for a partially written frame" — but the production consequence was never closed.

The payload's wire position after a cancelled write is genuinely unknown: tokio-tungstenite's `start_send` accepts the frame into its own buffer even on `WouldBlock`, while a cancellation inside `poll_ready` never hands it over. So it can be neither reported as an exact gap (that would be a false gap for a frame that did go out) nor assumed delivered. The fix fences instead: an abandoned in-flight write latches the connection's queue, and the graceful teardown abandons and counts the remainder rather than writing past it. The stream ends as a gap-free prefix. Truncation at close is always legal; a hole is not. The loud slow-consumer path already abandoned its queue and is unchanged.

This costs nothing in practice: a write is only cancelled mid-flight when it was actually pending, i.e. when the socket was already backpressured — precisely the case whose tail would not have flushed inside the close-write budget anyway.

**2. Main is red on `TURN-only WebRTC Interop`.**

Run 31015521223 at `8efa0710` — the merge of #277, the PR that fixed #276 — failed with #276's exact shape: one `EINVAL` from a loopback source toward `10.254.57.2:3478`, two TURN transaction timeouts, no Allocate reaching coturn, and no candidate at all under the relay-only policy. The fix reduced but did not eliminate it.

The evidence needed to say *why* is missing on both sides, so this PR supplies it rather than guessing at a second fix:

- the client logged the routing union only when it **added** an address, so a run where the probe contributed nothing is indistinguishable from one where it never ran. It now reports the complete resolved bind set (bound / enumerated / added / family) on every pairing, and an ICE server that neither resolves nor routes is a warning rather than a debug line the captured stderr never records;
- the host's own view is the other half and no client log can recover it. The lane now captures `ip route get`, the address and route tables, and the Docker bridge's link state — the exact `operstate` that `if_addrs::Interface::is_oper_up` reads — into its failure artifacts, at coturn readiness and again at teardown.

## Red-green evidence

`close_flush_never_writes_the_queue_behind_an_abandoned_write` drives `finalize_closed_connection` against a **real upgraded WebSocket** and asserts on the bytes the client actually received:

| case | client observes |
| --- | --- |
| healthy teardown | `[1, 2, 3]` — the whole queue flushes, unchanged |
| abandoned in-flight write | `[]` — nothing behind it is written |

With the fence removed (everything else identical) the second case fails with `left: [1, 2, 3]  right: []`. Dropped payloads stay counted in both cases (`websocket_messages_dropped == 4`: the in-flight payload plus the three behind it).

`only_an_unresolved_socket_write_fences_the_queue_behind_it` pins the other half data-driven over all three terminal states: `Written` and `UnsupportedFormat` must **not** fence — a false positive would make every healthy teardown abandon its queue — and only the dropped-unresolved write does.

## Sweep

The class is "sequenced payloads written after an in-flight write was abandoned". Every other abandonment path already terminates the stream: `complete_selected_write`'s deadline expiry and the writer's accountability failure both request `SlowConsumer`, whose branch abandons the queue; a socket error breaks the loop; and the report writer's peek/write/commit rule already leaves a cancelled report's ranges pending. `finalize_closed_connection`'s graceful branch was the only continuation, and it is the one this changes.

## Validation

- Root suite `cargo test --all-features`: green.
- `cargo fmt` + `cargo clippy --all-targets --all-features -- -D warnings`: clean, root and `clients/native`.
- `clients/native` unit suite: 89 passed.
- `scripts/run-turn-interop.sh` end to end against the pinned local coturn: positive and mismatched-secret controls both pass, with the new bind-set and host-routing diagnostics recorded.
- `docs/protocol.md` now states the teardown rule it always implied: "once a payload is abandoned while a socket write owns it, nothing queued behind it is written".

Closes nothing outright: #274's timing-threshold bullets and its reconnect/teardown-guard item remain open, and #276 stays open until the lane's next failure is read with the new diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebSocket graceful teardown and v3 delivery semantics on close—high impact for reconnect/conformance—but behavior is conservative (abandon remainder) and covered by real-socket tests; TURN script changes affect CI only.
> 
> **Overview**
> Fixes a **protocol-v3 delivery hole** on graceful WebSocket close: when close cancels the live writer mid-`send`, the in-flight payload’s wire fate is unknown, but teardown used to keep flushing the rest of the queue—recipients could see a skipped `seq` with no `DeliveryReport` (e.g. `expected 90, got 91`). **`SendAccounting::drop`** now latches `abandoned_in_flight_write`, and **`finalize_closed_connection`** abandons and counts everything still queued behind that write instead of writing past it, so the stream ends as a gap-free prefix. **`docs/protocol.md`** states the rule explicitly; new tests drive real upgraded sockets and pin which accounting outcomes set the fence.
> 
> Separately, **TURN interop** gets better failure attribution: the native client always logs the full ICE bind set (`bound` / `enumerated` / `added`) and promotes unresolved/unroutable ICE servers to **warnings**; **`scripts/run-turn-interop.sh`** records host routing/bridge state and runs a **bounded STUN Binding reachability gate** before clients start, with a CI test that the gate actually retries under `set -e`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0be4f07e22d05d4c5c11e4af429966e34407e6a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->