### PR TITLE
Prove native WebRTC live on Windows and macOS

### DIFF
--- a/.github/workflows/webrtc-interop.yml
+++ b/.github/workflows/webrtc-interop.yml
@@ -7,13 +7,14 @@
 # brokered by the server's protocol v3 signaling. Scenarios cover the mesh
 # and host-star topologies, the crippled-ICE relay fallback, late-join
 # NewPeer pairing, mixed v2/v3 relay-floor rooms, and an IPv6-only pair
-# (scenario 6 of clients/native/tests/interop_e2e.rs). The interop server
+# (scenario 7 of clients/native/tests/interop_e2e.rs). The interop server
 # config disables TURN and configures zero STUN URLs, so the suite performs no
 # external network access.
 #
-# Live transport is proved on Linux only; `native-platforms` adds the
-# compile + unit-test proof for Windows and macOS, because neither the interop
-# cells nor the root CI matrix ever build clients/native on those platforms.
+# The full seven-scenario matrix runs on Linux. `native-platforms` adds the
+# compile + unit-test proof and the smallest complete live WebRTC mesh on
+# Windows and macOS, so every supported desktop platform executes real ICE,
+# DTLS, SCTP, process, and socket behavior rather than stopping at linkage.
 #
 # The reference client is a standalone crate OUTSIDE the root package (its
 # own Cargo.lock and deny.toml), so this workflow also runs cargo-deny over
@@ -114,20 +115,12 @@ jobs:
         run: bash scripts/run-webrtc-interop.sh
 
   native-platforms:
-    # The interop job above proves the LIVE transport, but only on Linux: the
-    # multi-process cells and the root matrix never compile clients/native on
-    # Windows or macOS, so a platform-specific break in the client (its
-    # interface enumeration is the obvious candidate — see issue #271) would
-    # reach users undetected. This matrix is the compile-and-unit-test proof for
-    # the other two supported desktop platforms. Linux is deliberately absent:
-    # the `interop` job above already runs this exact command set there (via
-    # scripts/run-webrtc-interop.sh) plus the live suite, so it is the control
-    # and a duplicate ubuntu leg would only pay for a second cold build of the
-    # webrtc graph.
-    #
-    # Cold-cache durations on the first run of this job: windows 4m06s,
-    # macos 2m04s — the 30-minute ceiling is a runaway guard, not a budget.
-    name: Native Client Build (${{ matrix.os }})
+    # The full suite above is the Linux proof. The other supported desktop
+    # platforms run the smallest complete live mesh in addition to their build
+    # and unit checks: two real client processes and the real server negotiate a
+    # direct host/host pair, then exchange on both SCTP data channels. Linux is
+    # deliberately absent because its full suite includes this exact selector.
+    name: Native Client Build + Live WebRTC (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -156,8 +149,11 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2.9.1
         with:
-          # Only the standalone client graph: this job never builds the server.
-          workspaces: clients/native
+          # Cover both compilation graphs: the live smoke spawns the root
+          # server binary from the standalone native-client test crate.
+          workspaces: |
+            .
+            clients/native
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Show Rust tool versions
         shell: bash
@@ -187,12 +183,25 @@ jobs:
         working-directory: clients/native
         run: cargo test --locked --all-targets --no-run
       - name: Run the native unit suite
-        # Library + binary unit tests only: the integration cells spawn the
-        # real server binary, and running them is the Linux interop job's
-        # live-transport proof.
+        # Library + binary unit tests remain separate from the selected live
+        # integration cell below so a failure identifies its evidence class.
         shell: bash
         working-directory: clients/native
         run: cargo test --locked --lib --bins
+      - name: Build the signaling server for live transport
+        shell: bash
+        run: cargo build --locked --bin signal-fish-server
+      - name: Run two-peer live WebRTC transport
+        shell: bash
+        working-directory: clients/native
+        run: |
+          SERVER_SUFFIX=""
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            SERVER_SUFFIX=".exe"
+          fi
+          SIGNAL_FISH_SERVER_BIN="$GITHUB_WORKSPACE/target/debug/signal-fish-server${SERVER_SUFFIX}" \
+            cargo test --locked --test interop_e2e \
+              two_peer_mesh_exchanges_over_live_webrtc -- --exact --nocapture
 
   client-deny:
     name: Client Dependency Audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and requires a host/host pair of concrete dialable IPv6 addresses plus the
   exact reliable and unreliable exchange. The client now reports each selected candidate's address
   alongside its type, and a runner without IPv6 loopback fails the cell with an
-  actionable message instead of skipping it. Live WebRTC transport remains
-  proved on Linux only; Windows and macOS are build-verified.
+  actionable message instead of skipping it. Windows and macOS now also build
+  the real server and run the smallest complete live mesh: two client processes
+  must select a direct host/host pair and exchange exact traffic on both SCTP
+  data channels. The larger topology, fault-injection, TURN, browser, and IPv6
+  matrices remain Linux-specific evidence (issue #275).
 - Add a deterministic TURN-only WebRTC interoperability gate (issue #239).
   Two native clients must select relay candidates through a digest-pinned local
   coturn, exchange exact reliable and unreliable data, and retain a live

--- a/clients/native/README.md
+++ b/clients/native/README.md
@@ -223,6 +223,7 @@ client processes (loopback only; the interop server config disables TURN with ze
 | Pairwise ICE partition with healthy partial mesh + relay floor | ✅ nightly `pairwise_ice_partition_preserves_partial_mesh_and_relay_floor` | — |
 | Late join (authoritative full-plan seat fill) | ✅ `late_join_authoritative_replan_real_webrtc_n3` | — (native-only cell) |
 | Mixed v2/v3 relay floor | ✅ `mixed_v2_v3_n3_relay_floor_with_reference_client` | ✅ `mixed_v2_browser_v3_native_relay_floor` |
+| Cross-platform two-peer live WebRTC | ✅ `two_peer_mesh_exchanges_over_live_webrtc` | — |
 | Browser ↔ browser mesh (Chromium↔Chromium pair) | n/a | ✅ `browser_pair_mesh_n3` |
 | mDNS `.local` obfuscation trap | n/a | ✅ `mesh_n3_browser_mdns_obfuscation` |
 | Mid-handshake close → one `error` + prompt exit 3 | n/a | ✅ `browser_cli_mid_handshake_close_single_error_exit_3` |
@@ -234,7 +235,10 @@ The browser cells live in [`tests/browser_interop_e2e.rs`](tests/browser_interop
 `browser-interop` cargo feature (this crate's default suite never compiles them; they additionally need
 `SIGNAL_FISH_BROWSER_CLI` pointing at the built [browser client](../browser/README.md) bundle).
 
-Scenario 6 is the IPv6 cell: both clients run with `--ip-family ipv6`, so only IPv6 host candidates can be
+Scenario 6 is the smallest complete live WebRTC cell: two real clients negotiate a direct host/host pair and
+exchange exact messages on both SCTP channel labels. CI runs that selector on Linux, Windows, and macOS.
+
+Scenario 7 is the IPv6 cell: both clients run with `--ip-family ipv6`, so only IPv6 host candidates can be
 advertised, and the assertions require a host/host pair of concrete dialable IPv6 addresses plus the exact
 exchange on both channel labels. It shares the file's scenario-serialization guard, so it never overlaps another
 multi-process cell. Signaling still runs over the harness server's IPv4 loopback listener, so the IPv6 claim is
@@ -283,17 +287,19 @@ says:
 | Platform | Compile + unit suite | Live WebRTC transport |
 |----------|----------------------|-----------------------|
 | Linux (`ubuntu-latest`) | ✅ `Native Client Interop (Linux)` | ✅ every native, browser, TURN-only, and IPv6 cell |
-| Windows (`windows-latest`) | ✅ `Native Client Build (windows-latest)` | ❌ not proved |
-| macOS (`macos-latest`) | ✅ `Native Client Build (macos-latest)` | ❌ not proved |
+| Windows (`windows-latest`) | ✅ `Native Client Build + Live WebRTC (windows-latest)` | ✅ two-peer direct host/host pair + both SCTP channels |
+| macOS (`macos-latest`) | ✅ `Native Client Build + Live WebRTC (macos-latest)` | ✅ two-peer direct host/host pair + both SCTP channels |
 
 The `native-platforms` matrix in `.github/workflows/webrtc-interop.yml` runs, on the repository MSRV:
 `cargo metadata --locked`, `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`,
 `cargo test --locked --all-targets --no-run`, and `cargo test --locked --lib --bins`. The `--no-run` step is
 what actually builds and links the multi-process cells — clippy only type-checks them (`--emit=metadata`, no
-codegen). Those cells are built but not run off Linux: they spawn the server binary, which is the Linux lane's
-job. Linux is absent from the matrix because the `interop` job already runs that same command set there, plus
-the live suite. Interface enumeration, socket binding, and ICE behavior on Windows and macOS are therefore
-**build-verified only**.
+codegen). The matrix then builds the real server binary and runs
+`two_peer_mesh_exchanges_over_live_webrtc` on each host. That cell executes the platform's interface
+enumeration, UDP binding, ICE, DTLS, SCTP, child-process, and path semantics and requires an exact exchange on
+both data channels. Linux is absent from the matrix because the `interop` job runs the full seven-scenario suite,
+including the same two-peer cell. Windows and macOS now carry a live transport proof, while the larger topology,
+fault-injection, TURN, browser, and IPv6 matrices remain Linux-specific evidence.
 
 ## Troubleshooting
 

--- a/clients/native/tests/interop_e2e.rs
+++ b/clients/native/tests/interop_e2e.rs
@@ -47,7 +47,11 @@
 //!    member forces the relay floor, each v3 member receives an explicit
 //!    Relay/Relay empty `SessionPlan`, the v2 member receives none, no
 //!    signaling/WebRTC activity occurs, and the GameData relay matrix completes.
-//! 6. `ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path` — the only cell whose
+//! 6. `two_peer_mesh_exchanges_over_live_webrtc` — the cross-platform smoke
+//!    cell: the smallest complete session (two clients) establishes a direct
+//!    host/host pair and exchanges one message on both data channels. CI runs
+//!    this exact selector on Linux, Windows, and macOS.
+//! 7. `ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path` — the only cell whose
 //!    live path is IPv6. webrtc 0.20 turns each application-supplied UDP bind
 //!    directly into a host candidate, so the bound family decides the
 //!    negotiated family; every other cell leaves `--ip-family any`, and a
@@ -61,7 +65,7 @@
 //!    so the IPv6 claim is about the WebRTC data path (ICE, DTLS, SCTP). A
 //!    runner without IPv6 loopback fails the cell; it is never skipped.
 //!
-//! Scenarios are serialized behind a mutex (each spawns 4+ OS processes and
+//! Scenarios are serialized behind a mutex (each spawns 3+ OS processes and
 //! up to three concurrent WebRTC stacks; running them in parallel on small CI
 //! runners invites scheduling flakes for zero extra coverage). Ports are
 //! reserved per scenario, so serialization is a robustness choice, not a
@@ -70,7 +74,7 @@
 mod harness;
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::net::{IpAddr, Ipv6Addr, UdpSocket};
+use std::net::{IpAddr, UdpSocket};
 use std::time::Duration;
 
 use harness::{
@@ -86,7 +90,7 @@ use uuid::Uuid;
 static SCENARIO_SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 /// Number of scenarios queueing behind [`SCENARIO_SERIAL`] (keep in sync with
 /// the `#[tokio::test]` functions in this file).
-const SCENARIO_COUNT: u64 = 6;
+const SCENARIO_COUNT: u64 = 7;
 /// Generous ceiling for ONE scenario in a fully degraded run, sized to the
 /// worst-case shape — scenario 4's TWO client waves:
 ///  - server spawn: up to 3 attempts x 15 s health deadline each (see
@@ -101,14 +105,15 @@ const SCENARIO_COUNT: u64 = 6;
 /// deadline (<= `CLIENT_EXIT_TIMEOUT`), releasing the lock via unwind.
 const SCENARIO_CEILING: Duration = Duration::from_secs(240);
 /// Worst case for the LAST test in the queue: every other scenario runs to
-/// its completion (or its panic deadline) first (5 x 240 s = 1,200 s).
+/// its completion (or its panic deadline) first (6 x 240 s = 1,440 s).
 const SERIAL_ACQUIRE_TIMEOUT: Duration =
     Duration::from_secs(SCENARIO_CEILING.as_secs() * (SCENARIO_COUNT - 1));
 
 const RELIABLE: &str = "reliable";
 const UNRELIABLE: &str = "unreliable";
 const CLIENT_NAMES: [&str; 3] = ["c0", "c1", "c2"];
-/// Scenario 6 only: bind IPv6 exclusively, so an IPv6 host candidate is the
+const TWO_CLIENT_NAMES: [&str; 2] = ["c0", "c1"];
+/// Scenario 7 only: bind IPv6 exclusively, so an IPv6 host candidate is the
 /// only thing this client can advertise. (No `--disable-mdns`: rtc 0.20's
 /// default multicast-DNS mode is query-only, so native host candidates are
 /// raw addresses either way.)
@@ -120,13 +125,14 @@ async fn acquire_serial() -> tokio::sync::MutexGuard<'static, ()> {
         .expect("acquire the scenario serialization lock in time")
 }
 
-/// One fully drained scenario: 3 clients (creator + 2 joiners by room code),
-/// all `--exchange --relay-payload relay-from-<name>`, run to process exit.
+/// One fully drained multi-client scenario, indexed in spawn order.
 struct ScenarioRun {
-    /// Player id strings, indexed like [`CLIENT_NAMES`] (creator first).
+    /// Player id strings (creator first).
     ids: Vec<String>,
     /// Complete stdout event logs, same indexing.
     logs: Vec<Vec<Value>>,
+    /// Recent stdout events plus captured stderr, same indexing.
+    diagnostics: Vec<String>,
 }
 
 impl ScenarioRun {
@@ -144,6 +150,10 @@ impl ScenarioRun {
     /// host-failover replans triggered by siblings exiting first.
     fn window(&self, index: usize) -> &[Value] {
         scenario_window(&self.logs[index])
+    }
+
+    fn diagnostics(&self, index: usize) -> &str {
+        &self.diagnostics[index]
     }
 }
 
@@ -280,6 +290,7 @@ async fn run_three_clients(
         .collect();
     let distinct: BTreeSet<&String> = ids.iter().collect();
     assert_eq!(distinct.len(), 3, "player ids must be distinct: {ids:?}");
+    let diagnostics = clients.iter().map(ClientProcess::diagnostics).collect();
 
     ScenarioRun {
         ids,
@@ -289,6 +300,7 @@ async fn run_three_clients(
             .into_iter()
             .map(|mut client| std::mem::take(&mut client.events))
             .collect(),
+        diagnostics,
     }
 }
 
@@ -304,6 +316,67 @@ async fn run_three_client_scenario(default_topology: &str, game_name: &str) -> S
         ],
     )
     .await
+}
+
+/// Run the smallest complete WebRTC mesh: two real client processes establish
+/// one pair and exchange on both data channels. Keeping this independent of the
+/// three-client matrix gives non-Linux CI a fast live-transport proof without
+/// weakening the full Linux suite.
+async fn run_two_peer_mesh(game_name: &str, extra_args: &'static [&'static str]) -> ScenarioRun {
+    let mut server = spawn_server("mesh").await;
+    let workdir = tempfile::tempdir().expect("create client workdir");
+    let url = server.v3_ws_url();
+
+    let mut creator = spawn_client(
+        &ClientSpec {
+            name: TWO_CLIENT_NAMES[0],
+            server_url: &url,
+            game_name,
+            join_code: None,
+            peers: 2,
+            exchange: true,
+            relay_payload: None,
+            extra_args,
+        },
+        workdir.path(),
+    );
+    let created = creator.await_event("room_created", EVENT_TIMEOUT).await;
+    let room_code = str_field(&created, "room_code").to_string();
+    let joiner = spawn_client(
+        &ClientSpec {
+            name: TWO_CLIENT_NAMES[1],
+            server_url: &url,
+            game_name,
+            join_code: Some(&room_code),
+            peers: 2,
+            exchange: true,
+            relay_payload: None,
+            extra_args,
+        },
+        workdir.path(),
+    );
+
+    let mut clients = vec![creator, joiner];
+    for client in &mut clients {
+        drain_expect_success(client).await;
+    }
+    server.shutdown().await;
+
+    let ids: Vec<String> = clients
+        .iter()
+        .map(|client| player_id_of(&client.events, &client.name))
+        .collect();
+    assert_ne!(ids[0], ids[1], "the two clients need distinct identities");
+    let diagnostics = clients.iter().map(ClientProcess::diagnostics).collect();
+
+    ScenarioRun {
+        ids,
+        logs: clients
+            .into_iter()
+            .map(|mut client| std::mem::take(&mut client.events))
+            .collect(),
+        diagnostics,
+    }
 }
 
 /// Assert the client's single `session_plan` event and return it.
@@ -1471,7 +1544,7 @@ async fn mixed_v2_v3_n3_relay_floor_with_reference_client() {
 /// The precondition applies the client's OWN selection rule rather than an
 /// approximation of it, so "the harness says yes but the client says no" is
 /// impossible; it then binds one of the resulting addresses to prove the
-/// socket layer agrees with the interface table. Scenario 6's whole claim is
+/// socket layer agrees with the interface table. Scenario 7's whole claim is
 /// that a live path ran over IPv6, so a silent skip would report a green lane
 /// that proved nothing.
 fn require_ipv6_ice_interface() {
@@ -1506,35 +1579,21 @@ fn require_ipv6_ice_interface() {
     }
 }
 
-/// The IPv6 address a `selected_candidate_pair` field carries, or a loud
-/// failure. A missing/`null` address fails: it would otherwise let a run that
-/// never proved the family pass.
-fn selected_ipv6_address(event: &Value, field: &str, who: &str) -> Ipv6Addr {
+/// The IP address a `selected_candidate_pair` field carries, or a loud failure.
+/// A missing/`null` address fails: it would otherwise let a run that never
+/// proved a concrete live path pass.
+fn selected_ip_address(event: &Value, field: &str, who: &str) -> IpAddr {
     let raw = event
         .get(field)
         .and_then(Value::as_str)
         .unwrap_or_else(|| panic!("{who}: selected pair has no `{field}`: {event}"));
-    match raw
-        .parse::<IpAddr>()
+    raw.parse::<IpAddr>()
         .unwrap_or_else(|error| panic!("{who}: `{field}` is not an IP address ({error}): {raw}"))
-    {
-        IpAddr::V6(address) => address,
-        IpAddr::V4(address) => {
-            panic!("{who}: the IPv6-only run selected an IPv4 candidate {address}: {event}")
-        }
-    }
 }
 
-/// Assert this client's single selected pair is host/host over concrete IPv6,
-/// toward the expected peer.
-///
-/// The address is not pinned to `::1`: a runner that also has a global IPv6
-/// interface binds it too, and either host candidate is a legitimate IPv6
-/// proof. What must hold is that the path is IPv6, direct (host/host, since no
-/// STUN or TURN is configured), and carried by an address a peer could actually
-/// dial — never unspecified, multicast, or link-local, whose scope ID the
-/// candidate wire cannot carry.
-fn assert_ipv6_host_path(events: &[Value], who: &str, peer_id: &str) {
+/// Assert this client's single selected pair is a direct host/host path toward
+/// the expected peer, and return its concrete local and remote addresses.
+fn assert_direct_host_path(events: &[Value], who: &str, peer_id: &str) -> [IpAddr; 2] {
     let selected = single_event(events, "selected_candidate_pair", who);
     assert_eq!(
         str_field(selected, "peer"),
@@ -1548,13 +1607,38 @@ fn assert_ipv6_host_path(events: &[Value], who: &str, peer_id: &str) {
             "{who}: {field} must be a direct host candidate (no STUN/TURN is configured)"
         );
     }
-    for field in ["local_candidate_address", "remote_candidate_address"] {
-        let address = selected_ipv6_address(selected, field, who);
+    let addresses = [
+        selected_ip_address(selected, "local_candidate_address", who),
+        selected_ip_address(selected, "remote_candidate_address", who),
+    ];
+    for address in addresses {
+        assert!(
+            !address.is_unspecified() && !address.is_multicast(),
+            "{who}: the selected pair must use concrete unicast addresses, got {address}: {selected}"
+        );
+    }
+    addresses
+}
+
+/// Assert this client's single selected pair is host/host over concrete IPv6,
+/// toward the expected peer.
+///
+/// The address is not pinned to `::1`: a runner that also has a global IPv6
+/// interface binds it too, and either host candidate is a legitimate IPv6
+/// proof. What must hold is that the path is IPv6, direct (host/host, since no
+/// STUN or TURN is configured), and carried by an address a peer could actually
+/// dial — never unspecified, multicast, or link-local, whose scope ID the
+/// candidate wire cannot carry.
+fn assert_ipv6_host_path(events: &[Value], who: &str, peer_id: &str) {
+    for address in assert_direct_host_path(events, who, peer_id) {
+        let IpAddr::V6(address) = address else {
+            panic!("{who}: the IPv6-only run selected an IPv4 candidate {address}");
+        };
         assert!(
             !address.is_unspecified()
                 && !address.is_multicast()
                 && !address.is_unicast_link_local(),
-            "{who}: {field} must be a concrete dialable IPv6 address, got {address}"
+            "{who}: the selected pair must use concrete dialable IPv6 addresses, got {address}"
         );
     }
 }
@@ -1586,75 +1670,49 @@ fn assert_no_ipv4_candidate_advertised(events: &[Value], who: &str) {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn two_peer_mesh_exchanges_over_live_webrtc() {
+    let _serial = acquire_serial().await;
+    let run = run_two_peer_mesh("interop-cross-platform-smoke", &[]).await;
+
+    for (index, who) in TWO_CLIENT_NAMES.iter().enumerate() {
+        let peer_id = run.ids[1 - index].as_str();
+        let peers = BTreeSet::from([peer_id]);
+        let window = run.window(index);
+        let plan = session_plan(window, who, "mesh", 1);
+        assert!(
+            plan.get("host").is_some_and(Value::is_null),
+            "{who}: mesh plans elect no host: {plan}"
+        );
+
+        assert_pair_connected_exactly(window, who, &peers);
+        assert_direct_host_path(window, who, peer_id);
+        assert_exchange_sent_to(window, who, &peers);
+        assert_exchange_received_from(window, who, &peers);
+        assert_transport_status_true(&run.logs[index], who);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path() {
     let _serial = acquire_serial().await;
     require_ipv6_ice_interface();
+    let run = run_two_peer_mesh("interop-ipv6", &IPV6_ARGS).await;
 
-    // Two members, not three: the claim under test is the address family of a
-    // live path, and a pair is the smallest configuration that establishes one.
-    const NAMES: [&str; 2] = ["c0", "c1"];
-    let mut server = spawn_server("mesh").await;
-    let workdir = tempfile::tempdir().expect("create client workdir");
-    let url = server.v3_ws_url();
-
-    let mut creator = spawn_client(
-        &ClientSpec {
-            name: NAMES[0],
-            server_url: &url,
-            game_name: "interop-ipv6",
-            join_code: None,
-            peers: 2,
-            exchange: true,
-            relay_payload: None,
-            extra_args: &IPV6_ARGS,
-        },
-        workdir.path(),
-    );
-    let created = creator.await_event("room_created", EVENT_TIMEOUT).await;
-    let room_code = str_field(&created, "room_code").to_string();
-    let joiner = spawn_client(
-        &ClientSpec {
-            name: NAMES[1],
-            server_url: &url,
-            game_name: "interop-ipv6",
-            join_code: Some(&room_code),
-            peers: 2,
-            exchange: true,
-            relay_payload: None,
-            extra_args: &IPV6_ARGS,
-        },
-        workdir.path(),
-    );
-
-    let mut clients = [creator, joiner];
-    for client in &mut clients {
-        drain_expect_success(client).await;
-    }
-    server.shutdown().await;
-
-    let ids = [
-        player_id_of(&clients[0].events, &clients[0].name),
-        player_id_of(&clients[1].events, &clients[1].name),
-    ];
-    assert_ne!(ids[0], ids[1], "the two clients need distinct identities");
-
-    for (index, client) in clients.iter().enumerate() {
-        let who = &client.name;
-        let peer_id = ids[1 - index].as_str();
+    for (index, who) in TWO_CLIENT_NAMES.iter().enumerate() {
+        let peer_id = run.ids[1 - index].as_str();
         let peers = BTreeSet::from([peer_id]);
-        let window = scenario_window(&client.events);
+        let window = run.window(index);
 
         // A live WebRTC pair carried the session, not the relay floor.
         assert_pair_connected_exactly(window, who, &peers);
-        assert_transport_status_true(&client.events, who);
+        assert_transport_status_true(&run.logs[index], who);
         // Bound the fallback claim to the LIVE session. A sibling that exits
         // first legitimately drives this client's status to `false` plus one
         // `fallback_engaged` — and the server emits that transition BEFORE
         // `PlayerLeft`, so `scenario_window` does not exclude it (reproduced
         // 4 times in 12 single-core runs). What must hold is that the relay
         // floor never carried the exchange.
-        let live_end = client
-            .events
+        let live_end = run.logs[index]
             .iter()
             .rposition(|event| {
                 event.get("event").and_then(Value::as_str) == Some("channel_message")
@@ -1662,23 +1720,22 @@ async fn ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path() {
             .unwrap_or_else(|| {
                 panic!(
                     "{who}: the exchange produced no channel messages;\n{}",
-                    client.diagnostics()
+                    run.diagnostics(index)
                 )
             })
             + 1;
         assert!(
-            events_named(&client.events[..live_end], "fallback_engaged").is_empty(),
+            events_named(&run.logs[index][..live_end], "fallback_engaged").is_empty(),
             "{who}: the IPv6 host path must carry the exchange, not the relay fallback;\n{}",
-            client.diagnostics()
+            run.diagnostics(index)
         );
         // Teardown produces at most one such transition, so this still catches
         // a path that collapses right after the exchange (or flaps) without
         // re-introducing the race the bound above avoids.
         assert!(
-            events_named(&client.events, "fallback_engaged").len() <= 1,
-            "{who}: at most one fallback transition (the sibling's departure) may \
-             ever occur;\n{}",
-            client.diagnostics()
+            events_named(&run.logs[index], "fallback_engaged").len() <= 1,
+            "{who}: at most one fallback transition (the sibling's departure) may ever occur;\n{}",
+            run.diagnostics(index)
         );
 
         // ...over IPv6, with the exact exchange on both channel labels.

--- a/progress/session-093-cross-platform-live-webrtc.md
+++ b/progress/session-093-cross-platform-live-webrtc.md
@@ -93,6 +93,33 @@ was inconsistent. A second agent implemented every warranted correction. The
 final independent adversarial pass reviewed the complete remediated diff and
 reported zero issues.
 
-Hosted Windows/macOS evidence and the published-PR reviewer loop remain in
-progress. P50 will not be marked complete until both platform legs and every
-triggered check are terminal green and all remote feedback is resolved.
+PR #280's implementation head `4852482` completed every substantive hosted
+workflow successfully. WebRTC Interop run 31031080742 passed the Linux full
+suite plus `Native Client Build + Live WebRTC` on both `windows-latest` and
+`macos-latest`; each non-Linux leg built the real server and client and passed
+the exact two-peer live selector. CI run 31031078683 passed all 16 jobs,
+including Windows and macOS nextest. Advanced Safety run 31031077648, TURN-only
+run 31031078869, Browser Interop run 31031077968, and the remaining policy,
+documentation, dependency, link, and spelling workflows all passed.
+
+Verification Nightly run 31031078068 initially exposed one unrelated H14
+control failure: the equally throttled compatible MessagePack recipient was
+evicted as a slow consumer, and the JSON fallback then panicked on that peer's
+`PlayerLeft`. That is the inverse of issue #212's historical amplification
+signature, which evicted only the fallback. The unchanged exact test passed
+locally under one CPU and under added contention in about 12.2 seconds with
+5,000/5,000 sequences accounted, 2,218 fallback bytes against 389,618
+compatible bytes (0.01x), and zero evictions. The failed-job retry then passed
+the H14 step on the identical SHA after the identical precursor suites, and the
+nightly run finished green. No production or workload change was justified.
+Issue #281 records the missing symmetric terminal/proxy-throughput diagnostics
+needed to classify a future recurrence without weakening the burst, throttle,
+or production deadlines.
+
+Cursor Bugbot reviewed exact implementation head `4852482` and reported zero
+issues. GitHub Copilot was explicitly requested but could not review because
+the requesting account had exhausted its quota; the PR author is the connected
+GitHub identity, so no independent human reviewer was available to request.
+The independent local adversarial loop nevertheless reviewed the complete
+remediated diff to zero findings, and a separate four-agent H14 audit converged
+on preserving the strong experiment unchanged. P50 is complete.

--- a/progress/session-093-cross-platform-live-webrtc.md
+++ b/progress/session-093-cross-platform-live-webrtc.md
@@ -1,0 +1,98 @@
+# Session 093 — Cross-platform live native WebRTC (P50)
+
+## Scope and prioritization
+
+Remote triage found no open pull requests and nine open issues. The previous
+session's PR #279 was fully green across all 16 triggered workflows. Among the
+remaining gameplay-path items, issue #274 still appeared to carry a rare
+`PlayerAlreadyConnected` reconnect failure, while issue #275 recorded that the
+native client had no live WebRTC proof outside Linux.
+
+The reconnect item was historical bookkeeping, not a current defect. GitHub
+Actions run 30804575762 checked out merge commit `0cfb7ab` (P38 over
+`2900b53`) at 10:13 UTC on 2026-08-03. Its test dropped the reporter, waited for
+`PlayerLeft`, and immediately reconnected. `PlayerLeft` commits before the old
+connection is physically removed, so the production guard correctly returned
+`PlayerAlreadyConnected`. Commit `263be4e`, merged later that day at 19:15 UTC,
+added the explicit `server.disconnect_client(...).await` teardown join now in
+the test. That exact selector then passed ten consecutive runs in session 082;
+it passes on current `main`, and lifecycle serialization proves the join cannot
+return with the old entry still registered. The later #274 comment had compared
+the old failure against post-fix source and therefore missed the chronology.
+
+With the semantic reconnect item already resolved, #275's cross-platform live
+transport gap was the highest-impact concrete work remaining.
+
+## Failure-first evidence
+
+Before this session, `.github/workflows/webrtc-interop.yml`'s
+`native-platforms` matrix ran on Windows and macOS but stopped after build,
+link, and unit tests. Its own comments and `clients/native/README.md` explicitly
+said live transport was proved on Linux only. A platform-specific fault in
+interface enumeration, UDP binding, ICE, DTLS, SCTP, child-process teardown, or
+path handling could therefore pass every non-Linux check.
+
+The existing IPv6 cell already proved that a two-member room is the smallest
+complete live transport, but its family restriction is a separate Linux-hosted
+claim. Running the full N=3/fault suite on every platform would add cost and
+timing surface beyond the missing evidence. The new cell isolates the exact
+gap: default platform networking, one planned pair, and both data channels.
+
+## Implementation
+
+- `two_peer_mesh_exchanges_over_live_webrtc` spawns the real server and two real
+  native clients, requires a mesh/WebRTC plan, one direct host/host selected
+  pair per endpoint with concrete unicast addresses, and exact sends/receives
+  on both reliable and unreliable SCTP channels.
+- The existing IPv6 cell now shares the same two-client runner and layers only
+  its family-specific candidate assertions on top. This removes duplicated
+  process orchestration while keeping the claims separate.
+- The Windows/macOS matrix now caches and builds both package graphs, builds the
+  root server binary, resolves the Windows `.exe` suffix, passes the exact
+  binary path to the standalone test crate, and runs only the new live selector.
+  Linux still runs the full seven-scenario suite, including that selector.
+- The CI policy test parses the workflow and pins both platform legs, the root
+  build, failure propagation, Windows suffix, server handoff, selector, and the
+  behavioral acceptance markers in the Rust scenario.
+- The native README and existing unreleased changelog entry now state the exact
+  evidence boundary: live native WebRTC on all desktop platforms; the larger
+  topology, fault, TURN, browser, and IPv6 matrices remain Linux-specific.
+
+## Red-green evidence
+
+The prior workflow and README are the direct red state: no non-Linux job built
+the server or executed any integration selector, and the platform table marked
+both live cells unproved. The updated policy test fails if the live step, exact
+selector, server handoff, or either platform leg is removed or made non-fatal.
+
+Locally, the focused policy test and the new real-process selector pass. The
+selector establishes and exchanges over a direct host/host pair in about two
+seconds; it does not substitute a mocked transport or a compile-only check.
+
+## Validation and review
+
+The local gauntlet is green:
+
+- root `cargo fmt --check`, strict all-target/all-feature clippy, and
+  `cargo test --locked --all-features`;
+- native-client formatting, strict all-target clippy, the complete seven-cell
+  `scripts/run-webrtc-interop.sh` suite, and focused reruns of both two-peer
+  selectors after review remediation;
+- root and standalone-client `cargo deny --all-features check`;
+- all 305 CI policy tests (304 passed, one intentionally ignored), the document
+  consistency policy/script tests, CI configuration, workflow hygiene, MSRV,
+  tooling parity, Markdown, LLM-file, hook-readiness, pre-commit worktree, and
+  pre-push worktree checks.
+
+The first independent adversarial review found five issues in the session's
+own change: the live workflow command was pinned only by substrings and could
+be hollowed out with `--ignored`; refactoring had discarded post-drain client
+stderr; several scenario labels and runner-shape comments were stale; old
+cold-cache timings no longer described the enlarged job; and P50's PLAN phase
+was inconsistent. A second agent implemented every warranted correction. The
+final independent adversarial pass reviewed the complete remediated diff and
+reported zero issues.
+
+Hosted Windows/macOS evidence and the published-PR reviewer loop remain in
+progress. P50 will not be marked complete until both platform legs and every
+triggered check are terminal green and all remote feedback is resolved.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -23573,15 +23573,15 @@ fn assert_failure_is_not_swallowed(node: &Yaml, what: &str) {
 
 /// The native reference client is a standalone crate that no other lane
 /// compiles: the root CI matrix builds only the root package, and the interop
-/// cells run on Linux. Issue #271 added two proofs that must not silently
-/// disappear — a Windows/macOS compile + unit matrix (Linux is the `interop`
-/// job's job), and one live IPv6 data-channel cell that fails loudly instead of
-/// skipping when the runner cannot serve IPv6.
+/// cells historically ran only on Linux. Issues #271 and #275 added proofs that
+/// must not silently disappear — a Windows/macOS compile + unit matrix, a live
+/// two-peer data-channel smoke on every desktop platform, and one live IPv6
+/// cell that fails loudly instead of skipping when the runner cannot serve IPv6.
 ///
 /// Both source files are read with `read_live_file`, so a marker satisfied only
 /// by a comment or a commented-out line does not count as coverage.
 #[test]
-fn test_native_client_platform_matrix_and_ipv6_proof_are_pinned() {
+fn test_native_client_platform_matrix_live_smoke_and_ipv6_proof_are_pinned() {
     let root = repo_root();
     let workflow = read_live_file(&root.join(".github/workflows/webrtc-interop.yml"));
     let interop = read_live_file(&root.join("clients/native/tests/interop_e2e.rs"));
@@ -23742,7 +23742,7 @@ fn test_native_client_platform_matrix_and_ipv6_proof_are_pinned() {
         platforms,
         vec!["windows-latest", "macos-latest"],
         "the platforms clients/native is proved on must not shrink; Linux is the \
-         separate `interop` job, which runs the same commands plus the live suite"
+         separate `interop` job, which runs the full live suite"
     );
 
     // Exact `run` values: a trailing `|| true` (or any other suffix) would keep
@@ -23790,11 +23790,80 @@ fn test_native_client_platform_matrix_and_ipv6_proof_are_pinned() {
              (issue #271)"
         );
     }
+
+    let server_build = steps
+        .iter()
+        .find(|step| {
+            step.as_mapping_get("name").and_then(Yaml::as_str)
+                == Some("Build the signaling server for live transport")
+        })
+        .expect("the non-Linux matrix must build the real signaling server");
     assert!(
-        workflow.contains("name: Native Client Build (${{ matrix.os }})"),
+        server_build.as_mapping_get("working-directory").is_none(),
+        "the signaling server must be built from the root package"
+    );
+    assert_eq!(
+        server_build.as_mapping_get("run").and_then(Yaml::as_str),
+        Some("cargo build --locked --bin signal-fish-server"),
+        "the live smoke must build the exact locked server binary"
+    );
+
+    let live_smoke = steps
+        .iter()
+        .find(|step| {
+            step.as_mapping_get("name").and_then(Yaml::as_str)
+                == Some("Run two-peer live WebRTC transport")
+        })
+        .expect("the Windows/macOS matrix must run a live WebRTC cell (issue #275)");
+    assert_eq!(
+        live_smoke
+            .as_mapping_get("working-directory")
+            .and_then(Yaml::as_str),
+        Some("clients/native"),
+        "the live smoke selector belongs to the standalone native-client crate"
+    );
+    assert_eq!(
+        live_smoke.as_mapping_get("shell").and_then(Yaml::as_str),
+        Some("bash"),
+        "the Windows/macOS live smoke uses Bash syntax and must explicitly run in Bash"
+    );
+    assert_failure_is_not_swallowed(live_smoke, "the native-platforms live smoke step");
+    let live_run = live_smoke
+        .as_mapping_get("run")
+        .and_then(Yaml::as_str)
+        .expect("the live smoke step must contain a command");
+    assert_eq!(
+        live_run.trim_end(),
+        r#"SERVER_SUFFIX=""
+if [ "$RUNNER_OS" = "Windows" ]; then
+  SERVER_SUFFIX=".exe"
+fi
+SIGNAL_FISH_SERVER_BIN="$GITHUB_WORKSPACE/target/debug/signal-fish-server${SERVER_SUFFIX}" \
+  cargo test --locked --test interop_e2e \
+    two_peer_mesh_exchanges_over_live_webrtc -- --exact --nocapture"#,
+        "the non-Linux live smoke must keep the exact Windows suffix handling, \
+         server handoff, selector, and failure-propagating command; extra flags \
+         can silently select zero tests"
+    );
+    assert!(
+        workflow.contains("name: Native Client Build + Live WebRTC (${{ matrix.os }})"),
         "the per-platform check name is what a reader (and any future branch \
          protection rule) identifies this proof by"
     );
+
+    for required in [
+        "async fn two_peer_mesh_exchanges_over_live_webrtc()",
+        r#"let run = run_two_peer_mesh("interop-cross-platform-smoke", &[]).await;"#,
+        "assert_direct_host_path(window, who, peer_id);",
+        "assert_exchange_sent_to(window, who, &peers);",
+        "assert_exchange_received_from(window, who, &peers);",
+        "assert_transport_status_true(&run.logs[index], who);",
+    ] {
+        assert!(
+            interop.contains(required),
+            "the cross-platform live WebRTC proof lost acceptance marker `{required}`"
+        );
+    }
 
     assert_ip_family_preflight_precedes_the_socket(&root);
 
@@ -23803,7 +23872,7 @@ fn test_native_client_platform_matrix_and_ipv6_proof_are_pinned() {
     for required in [
         // The clients really run IPv6-only, and the args really reach them.
         r#"const IPV6_ARGS: [&str; 2] = ["--ip-family", "ipv6"];"#,
-        "extra_args: &IPV6_ARGS,",
+        r#"run_two_peer_mesh("interop-ipv6", &IPV6_ARGS).await"#,
         // The precondition applies the client's own rule and never skips.
         "fn require_ipv6_ice_interface()",
         "require_ipv6_ice_interface();",
@@ -23812,15 +23881,15 @@ fn test_native_client_platform_matrix_and_ipv6_proof_are_pinned() {
         // The path is asserted to be direct IPv6 toward the planned peer.
         "fn assert_ipv6_host_path(",
         "assert_ipv6_host_path(window, who, peer_id);",
-        r#"fn selected_ipv6_address(event: &Value, field: &str, who: &str) -> Ipv6Addr {"#,
-        r#"IpAddr::V4(address) => {"#,
+        "fn selected_ip_address(event: &Value, field: &str, who: &str) -> IpAddr {",
+        "let IpAddr::V6(address) = address else {",
         r#"for field in ["local_candidate_type", "remote_candidate_type"] {"#,
-        r#"for field in ["local_candidate_address", "remote_candidate_address"] {"#,
+        r#"selected_ip_address(selected, "local_candidate_address", who)"#,
         // ...carrying a real session on both labels, not the relay floor.
         "assert_exchange_sent_to(window, who, &peers);",
         "assert_exchange_received_from(window, who, &peers);",
         "assert_pair_connected_exactly(window, who, &peers);",
-        r#"events_named(&client.events[..live_end], "fallback_engaged").is_empty(),"#,
+        r#"events_named(&run.logs[index][..live_end], "fallback_engaged").is_empty(),"#,
     ] {
         assert!(
             interop.contains(required),


### PR DESCRIPTION
## Summary

- add the smallest complete native WebRTC acceptance cell: two real client processes and the real signaling server negotiate a mesh pair, select a concrete direct host/host path, and exchange exact reliable and unreliable SCTP traffic
- run that exact selector on both `windows-latest` and `macos-latest`, including locked root-server builds and Windows executable-path handling
- retain the full seven-scenario Linux suite, share the two-peer harness with the IPv6 proof, preserve stderr-backed diagnostics, and pin the hosted command structurally so zero-test or swallowed-failure variants cannot pass policy
- update the native-client evidence matrix, changelog, and session record

## Why

The existing non-Linux matrix proved compilation, linking, and unit behavior only. Platform-specific failures in interface enumeration, UDP binding, ICE, DTLS, SCTP, child-process handling, or binary paths could therefore reach Windows or macOS users while every check remained green.

A two-member room is the smallest complete live transport and isolates that missing evidence without duplicating the broader topology, fault-injection, TURN, browser, and IPv6 matrices that remain Linux-specific.

## Validation

- root formatting, strict all-target/all-feature clippy, and full all-feature test suite
- native formatting, strict all-target clippy, full seven-scenario WebRTC interop suite, and focused cross-platform/IPv6 selector reruns
- root and native `cargo deny --all-features check`
- 305 CI policy tests (304 passed, one intentionally ignored) and document consistency policy/script tests
- CI config, workflow hygiene, tooling parity, MSRV consistency, Markdown, hook readiness, pre-commit, and pre-push gates
- two independent adversarial review rounds; the final pass reported zero issues

Final head `a3c583e` is ready: every substantive triggered workflow is green, including live WebRTC on Windows and macOS. Cursor Bugbot reported zero issues; Copilot was requested after each push but could not review because the requesting account had exhausted its quota.

Closes #275

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to CI, interop tests, and documentation; no production signaling or client runtime behavior is modified.
> 
> **Overview**
> Closes the gap where Windows and macOS only proved compile/link/unit checks while live ICE, DTLS, SCTP, and process behavior stayed Linux-only (#275).
> 
> Adds **`two_peer_mesh_exchanges_over_live_webrtc`**: two real native clients plus the real server negotiate a mesh plan, select a direct **host/host** pair with concrete unicast addresses, and exchange exact traffic on both SCTP data channels. The Windows/macOS **`native-platforms`** job now builds the root **`signal-fish-server`**, caches both workspace graphs, handles the Windows **`.exe`** path, and runs that selector with **`--exact`** so failures cannot be hollowed out.
> 
> Refactors the IPv6 interop cell to share **`run_two_peer_mesh`** and shared host-path helpers; IPv6-specific assertions stay on scenario 7. **`ScenarioRun`** carries stderr-backed diagnostics for clearer failures. CI policy tests pin the full live-smoke workflow command and acceptance markers so removed steps or swallowed exits fail the suite.
> 
> Docs and changelog state the evidence boundary: **live native WebRTC on all desktop platforms**; larger topology, fault, TURN, browser, and IPv6 matrices remain Linux-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c583ef668e03cd1f8fe3bcce0bc84545a2685e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->