### PR TITLE
Make generated room codes joinable and collect relay timing evidence

### DIFF
--- a/.github/workflows/relay-timing-observations.yml
+++ b/.github/workflows/relay-timing-observations.yml
@@ -1,0 +1,167 @@
+# Hosted Relay Timing Observations
+#
+# Collects the repeated, cross-platform distribution required to resolve issue
+# #274 without turning shared-runner wall clock into a guessed correctness
+# threshold. Every sample still runs the exact delivery, conformance,
+# backpressure, and eviction oracles from the ordinary clean relay matrix.
+#
+# Runs daily at 05:30 UTC, after the 03:00 delivery suite and 04:00 fuzz suite,
+# so independent hosted allocations accumulate without concentrating load.
+# Manual runs support deliberate experiments. Pull requests run this workflow
+# only when its measurement contract changes.
+#
+# all-jobs-run-on-schedule
+
+name: Relay Timing Observations
+
+on:
+  schedule:
+    - cron: "30 5 * * *"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - "tests/sixteen_player_matrix_e2e.rs"
+      - ".github/workflows/relay-timing-observations.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  REPETITIONS: 5
+  SIGNAL_FISH_RELAY_WORKLOAD_VERSION: relay-clean-v1
+
+jobs:
+  observations:
+    name: Clean Relay Samples (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Read Rust toolchain
+        id: toolchain
+        shell: bash
+        run: |
+          CHANNEL=$(bash scripts/read-toml-string.sh rust-toolchain.toml channel toolchain || true)
+          if [ -z "$CHANNEL" ]; then
+            echo "ERROR: Could not extract channel from rust-toolchain.toml"
+            exit 1
+          fi
+          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          echo "SIGNAL_FISH_RUST_TOOLCHAIN=$CHANNEL" >> "$GITHUB_ENV"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ steps.toolchain.outputs.channel }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          save-if: >-
+            ${{ github.event_name != 'pull_request' ||
+                github.event.pull_request.head.repo.full_name == github.repository }}
+
+      - name: Capture repeated clean relay observations
+        shell: bash
+        run: |
+          set -euo pipefail
+          set -o pipefail
+          : > relay-timing-observations.jsonl
+          : > relay-timing-output.log
+
+          cargo test --locked --all-features --test sixteen_player_matrix_e2e \
+            hosted_timing_profile_keeps_backpressure_gate_without_wall_clock_gate \
+            -- --exact
+
+          for sample in $(seq 1 "$REPETITIONS"); do
+            echo "=== hosted relay sample ${sample}/${REPETITIONS} on ${{ matrix.os }} ===" \
+              | tee -a relay-timing-output.log
+            SIGNAL_FISH_RELAY_OBSERVATIONS_JSONL=relay-timing-observations.jsonl \
+            SIGNAL_FISH_RELAY_OBSERVATION_SAMPLE="$sample" \
+              cargo test --locked --all-features --test sixteen_player_matrix_e2e \
+                hosted_relay_timing_observations_preserve_semantic_oracles \
+                -- --exact --ignored --nocapture --test-threads=1 \
+                2>&1 | tee -a relay-timing-output.log
+          done
+
+          expected_rows=$((REPETITIONS * 6))
+          actual_rows=$(wc -l < relay-timing-observations.jsonl | tr -d ' ')
+          if [ "$actual_rows" -ne "$expected_rows" ]; then
+            echo "ERROR: expected ${expected_rows} observation rows, found ${actual_rows}"
+            exit 1
+          fi
+
+      - name: Write attempt manifest
+        if: always()
+        shell: bash
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -u
+          expected_rows=$((REPETITIONS * 6))
+          actual_rows=0
+          if [ -f relay-timing-observations.jsonl ]; then
+            actual_rows=$(wc -l < relay-timing-observations.jsonl | tr -d ' ')
+          fi
+          complete=false
+          if [ "$JOB_STATUS" = "success" ] && [ "$actual_rows" -eq "$expected_rows" ]; then
+            complete=true
+          fi
+          eligible=false
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] && [ "$GITHUB_RUN_ATTEMPT" = "1" ]; then
+            eligible=true
+          fi
+          {
+            printf '{"schema_version":1,'
+            printf '"event_name":"%s","run_id":"%s",' \
+              "$GITHUB_EVENT_NAME" "$GITHUB_RUN_ID"
+            printf '"run_attempt":"%s","commit_sha":"%s",' \
+              "$GITHUB_RUN_ATTEMPT" "$GITHUB_SHA"
+            printf '"runner_os":"%s","runner_image_os":"%s",' \
+              "$RUNNER_OS" "${ImageOS:-unknown}"
+            printf '"runner_image_version":"%s","rust_toolchain":"%s",' \
+              "${ImageVersion:-unknown}" "${SIGNAL_FISH_RUST_TOOLCHAIN:-unknown}"
+            printf '"workload_version":"%s","job_status":"%s",' \
+              "$SIGNAL_FISH_RELAY_WORKLOAD_VERSION" "$JOB_STATUS"
+            printf '"expected_rows":%s,"actual_rows":%s,' "$expected_rows" "$actual_rows"
+            printf '"complete":%s,"eligible":%s}\n' "$complete" "$eligible"
+          } > relay-timing-attempt.json
+
+      - name: Report observation summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### Hosted relay observations — ${{ matrix.os }}"
+            echo
+            echo "Repetitions requested: ${REPETITIONS}"
+            echo
+            echo '```text'
+            grep "matrix cell" relay-timing-output.log 2>/dev/null \
+              || echo "no complete matrix-cell observations captured"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw and machine-readable observations
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: relay-timing-${{ matrix.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            relay-timing-observations.jsonl
+            relay-timing-output.log
+            relay-timing-attempt.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -469,13 +469,18 @@ jobs:
           cargo nextest run --profile ci --locked --all-features \
             --test scenario_realworld_e2e --run-ignored all \
             --success-output final 2>&1 | tee scenario-output.txt
+      # Keep the dedicated hosted-timing selector isolated in its own workflow;
+      # this broad nightly lane supplies no observation metadata and would only
+      # duplicate the clean six-cell workload under unrelated contention.
       - name: Run 16-player relay matrix and knee sweep
         shell: bash
         run: |
           set -o pipefail
           cargo nextest run --profile ci --locked --all-features \
             --test sixteen_player_matrix_e2e --run-ignored all \
-            --success-output final 2>&1 | tee relay-matrix-output.txt
+            --success-output final -- \
+            --skip hosted_relay_timing_observations_preserve_semantic_oracles \
+            2>&1 | tee relay-matrix-output.txt
       - name: Run mixed-encoding amplification experiment
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject room-code settings that can generate rooms no second player can join
+  (issue #283). `protocol.room_code_length` must now be nonzero, and
+  `server.room_code_prefix` must be a nonblank ASCII-alphanumeric string shorter
+  than the total code length. The same fail-fast invariant applies to config
+  startup and direct library construction; valid lowercase prefixes remain
+  normalized to uppercase.
 - Make an unreachable TURN allocation self-describing in the native reference
   client and its interoperability lane (issue #276). The client now reports the
   complete resolved ICE bind set on every pairing — bound addresses, which came

--- a/README.md
+++ b/README.md
@@ -261,13 +261,14 @@ complete reference.
 | `SIGNAL_FISH__SERVER__ENABLE_RECONNECTION`        | `server.enable_reconnection`       | `true`    | Enable reconnection support                         |
 | `SIGNAL_FISH__SERVER__HEARTBEAT_THROTTLE_SECS`    | `server.heartbeat_throttle_secs`   | `30`      | Min seconds between `last_seen` heartbeat writes    |
 | `SIGNAL_FISH__SERVER__REGION_ID`                  | `server.region_id`                 | `default` | Region identifier for metrics                       |
+| `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX`           | `server.room_code_prefix`          | `null`    | Optional ASCII-alphanumeric generated-code prefix   |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_ROOM_CREATIONS`     | `rate_limit.max_room_creations`    | `5`       | Max room creations per player per window            |
 | `SIGNAL_FISH__RATE_LIMIT__TIME_WINDOW`            | `rate_limit.time_window`           | `60`      | Rate limit window in seconds                        |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_JOIN_ATTEMPTS`      | `rate_limit.max_join_attempts`     | `20`      | Max join attempts per player per window             |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_SIGNALS`            | `rate_limit.max_signals`           | `600`     | Max validated WebRTC Signal dispatch attempts per player per window |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_SIGNAL_ERRORS`      | `rate_limit.max_signal_errors`     | `60`      | Detailed WebRTC rejection errors per player/window  |
 | `SIGNAL_FISH__PROTOCOL__MAX_GAME_NAME_LENGTH`     | `protocol.max_game_name_length`    | `64`      | Max characters in a game name                       |
-| `SIGNAL_FISH__PROTOCOL__ROOM_CODE_LENGTH`         | `protocol.room_code_length`        | `6`       | Length of generated room codes                      |
+| `SIGNAL_FISH__PROTOCOL__ROOM_CODE_LENGTH`         | `protocol.room_code_length`        | `6`       | Nonzero length of generated room codes              |
 | `SIGNAL_FISH__PROTOCOL__MAX_PLAYER_NAME_LENGTH`   | `protocol.max_player_name_length`  | `32`      | Max characters in a player name                     |
 | `SIGNAL_FISH__PROTOCOL__MAX_PLAYERS_LIMIT`        | `protocol.max_players_limit`       | `100`     | Hard ceiling on players per room                    |
 | `SIGNAL_FISH__PROTOCOL__ENABLE_MESSAGE_PACK_GAME_DATA` | `protocol.enable_message_pack_game_data` | `true` | Enable MessagePack game-data frames                 |

--- a/config.example.json
+++ b/config.example.json
@@ -12,7 +12,8 @@
     "event_buffer_size": 100,
     "enable_reconnection": true,
     "heartbeat_throttle_secs": 30,
-    "region_id": "default"
+    "region_id": "default",
+    "room_code_prefix": null
   },
   "rate_limit": {
     "max_room_creations": 5,

--- a/docs/concepts/rooms-and-lobbies.md
+++ b/docs/concepts/rooms-and-lobbies.md
@@ -118,7 +118,11 @@ characters that are visually confusing:
 This leaves 32 unambiguous characters: `2-9` and `A-H, J-N, P-Z`.
 
 The code length is configurable via the `room_code_length` protocol setting
-(default: 6).
+(default: 6) and must be greater than zero. An optional
+`server.room_code_prefix` is normalized to uppercase and prepended to generated
+codes. Prefixes must be nonblank ASCII alphanumeric strings shorter than the
+total code length; startup rejects any configuration that could generate a code
+the join validator would refuse.
 
 ## Room Lifecycle
 
@@ -285,7 +289,9 @@ Key room-related configuration options:
 
 - `max_players` -- Maximum players per room. Default: `8`, maximum: `100`.
   Set per room at creation time via the `JoinRoom` message.
-- `room_code_length` -- Length of generated room codes. Default: `6`.
+- `room_code_length` -- Nonzero length of generated room codes. Default: `6`.
+- `room_code_prefix` -- Optional ASCII-alphanumeric prefix, shorter than the
+  total code length.
 - `room_cleanup_interval` -- Seconds between cleanup sweeps. Default: `60`.
 - `empty_room_timeout` -- Seconds before an empty room is removed.
   Default: `300`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,14 +121,14 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__SERVER__ENABLE_RECONNECTION` | `server.enable_reconnection` | `true` | Enable reconnection support |
 | `SIGNAL_FISH__SERVER__HEARTBEAT_THROTTLE_SECS` | `server.heartbeat_throttle_secs` | `30` | Min seconds between `last_seen` heartbeat writes |
 | `SIGNAL_FISH__SERVER__REGION_ID` | `server.region_id` | `default` | Deployment region identifier; recorded in internal player and room state (not serialized to clients) |
-| `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX` | `server.room_code_prefix` | `null` | Optional prefix for generated room codes |
+| `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX` | `server.room_code_prefix` | `null` | Optional ASCII-alphanumeric generated-code prefix; must be shorter than `protocol.room_code_length` |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_ROOM_CREATIONS` | `rate_limit.max_room_creations` | `5` | Max room creations per player per window |
 | `SIGNAL_FISH__RATE_LIMIT__TIME_WINDOW` | `rate_limit.time_window` | `60` | Rate limit window in seconds (must be > 0) |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_JOIN_ATTEMPTS` | `rate_limit.max_join_attempts` | `20` | Max join attempts per player per window |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_SIGNALS` | `rate_limit.max_signals` | `600` | Max validated WebRTC Signal dispatch attempts per player per window |
 | `SIGNAL_FISH__RATE_LIMIT__MAX_SIGNAL_ERRORS` | `rate_limit.max_signal_errors` | `60` | Detailed WebRTC rejection errors per player per window before generic rate-limit errors |
 | `SIGNAL_FISH__PROTOCOL__MAX_GAME_NAME_LENGTH` | `protocol.max_game_name_length` | `64` | Max characters in a game name |
-| `SIGNAL_FISH__PROTOCOL__ROOM_CODE_LENGTH` | `protocol.room_code_length` | `6` | Length of generated room codes |
+| `SIGNAL_FISH__PROTOCOL__ROOM_CODE_LENGTH` | `protocol.room_code_length` | `6` | Nonzero length of generated room codes |
 | `SIGNAL_FISH__PROTOCOL__MAX_PLAYER_NAME_LENGTH` | `protocol.max_player_name_length` | `32` | Max characters in a player name |
 | `SIGNAL_FISH__PROTOCOL__MAX_PLAYERS_LIMIT` | `protocol.max_players_limit` | `100` | Hard ceiling on players per room |
 | `SIGNAL_FISH__PROTOCOL__ENABLE_MESSAGE_PACK_GAME_DATA` | `protocol.enable_message_pack_game_data` | `true` | Enable MessagePack game-data frames |
@@ -294,6 +294,13 @@ Complete reference of all configuration options with environment variable overri
 }
 
 ```
+
+`room_code_length` must be greater than zero. When
+`server.room_code_prefix` is configured, surrounding whitespace is trimmed,
+the prefix must contain only ASCII letters or digits, and it must be shorter
+than the total code length so at least one random character remains. Startup
+rejects settings that could generate a code the explicit join path would not
+accept.
 
 ## WebSocket Settings
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -298,6 +298,33 @@ git diff 875057d -- tests/sixteen_player_matrix_e2e.rs |
 Do not interpret a zero-test filter result from the unmodified base as a
 comparison run.
 
+Hosted-runner timing policy is measured separately by the
+`Relay Timing Observations` workflow. Its daily/manual matrix runs five complete
+all-feature clean-grid repetitions in a dedicated process on Linux, Windows,
+and macOS, keeps every delivery, conformance, zero-backpressure, and
+zero-eviction oracle, but deliberately does not gate the observed wall clock.
+Each job retains raw output, one JSONL row per completed cell, and an explicit
+attempt manifest for 90 days, including RED-run artifacts. Records identify the
+event, attempt, commit, exact Rust toolchain, workload schema, runner image, and
+completion state.
+
+Issue #274's platform decision uses the first 20 consecutive scheduled,
+first-attempt allocations per operating system after `relay-clean-v1` lands
+(100 requested observations per cell). Manual, pull-request, and rerun samples
+are diagnostic only. The GitHub workflow-run ledger is the denominator: a RED,
+cancelled, missing-artifact, incomplete, different-toolchain, or different
+workload-version attempt invalidates that enablement cohort instead of being
+dropped in favor of a later green run. A replacement cohort requires a
+documented cause and a new workload version before collection restarts.
+
+The dedicated-process observations may justify only an equivalently isolated,
+all-feature PR timing job; they cannot set a threshold for the concurrently
+loaded broad Nextest job. The current 250 ms ceiling is a candidate for that
+isolated job only if every eligible observation is below it and the largest
+retains at least 2x headroom (at most 125 ms). Otherwise the platform stays
+correctness-only. A new ceiling must not be invented from one outlier or one
+shared-runner sample.
+
 ## Code Coverage
 
 ```bash

--- a/docs/pre-deployment-checklist.md
+++ b/docs/pre-deployment-checklist.md
@@ -113,7 +113,8 @@ cargo run -- --print-config
   assigns the room home before the WebSocket upgrade and routes every initial
   connection and reconnect for that room to the same process.
 - [ ] `server.room_code_prefix` and `server.region_id`, if set, are treated as
-  routing/observability metadata rather than shared-state coordination.
+  routing/observability metadata rather than shared-state coordination; the
+  prefix is ASCII alphanumeric and shorter than `protocol.room_code_length`.
 - [ ] The load balancer stops sending new connections before `SIGTERM`, and its
   timeout allows at least `server.drain_grace_secs` for the close boundary.
 - [ ] Review the

--- a/docs/run-modes.md
+++ b/docs/run-modes.md
@@ -32,7 +32,7 @@ v2 relay floor, so enabling v3 never breaks a v2-only client.
 | TLS (built-in) | Terminates HTTPS/`wss://` in the server itself | `security.transport.tls.enabled=true`, `security.transport.tls.certificate_path`, `security.transport.tls.private_key_path` (env: `SIGNAL_FISH__SECURITY__TRANSPORT__TLS__ENABLED=true`) | `cargo run` (with the three TLS keys set) |
 | TLS (reverse proxy) | Terminates TLS at nginx/Caddy; server stays plain `ws://` on loopback | none on the server; configure the proxy (see [reverse proxy setup](deployment.md#reverse-proxy-setup)) | `cargo run` (server) + proxy in front |
 | Metrics + Prometheus | Exposes JSON + Prometheus metrics, optionally behind a bearer token | `security.require_metrics_auth=true`, `security.metrics_auth_token=<token>` (env: `SIGNAL_FISH__SECURITY__METRICS_AUTH_TOKEN`) | `SIGNAL_FISH__SECURITY__METRICS_AUTH_TOKEN="$(openssl rand -hex 32)" SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH=true cargo run` |
-| Externally routed isolated deployments | An application-owned directory chooses one independent, single-process room home before any peer opens its WebSocket; Signal Fish does not share or hand off room state | Optional observability metadata: `server.room_code_prefix="us-east-"`, `server.region_id="us-east"` (env: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east-`) | After deploying the external directory: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east- SIGNAL_FISH__SERVER__REGION_ID=us-east cargo run` |
+| Externally routed isolated deployments | An application-owned directory chooses one independent, single-process room home before any peer opens its WebSocket; Signal Fish does not share or hand off room state | Optional observability metadata: `server.room_code_prefix="USE"`, `server.region_id="us-east"` (env: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=USE`) | After deploying the external directory: `SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=USE SIGNAL_FISH__SERVER__REGION_ID=us-east cargo run` |
 
 Per-feature JSON snippets (with env equivalents and "when to use") live in the
 [configuration recipes](configuration-recipes.md).
@@ -163,10 +163,14 @@ of that external routing scheme, and `server.region_id` can label metrics, but
 both are metadata rather than coordination:
 
 ```bash
-SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=us-east- \
+SIGNAL_FISH__SERVER__ROOM_CODE_PREFIX=USE \
   SIGNAL_FISH__SERVER__REGION_ID=us-east \
   cargo run
 ```
+
+The prefix is normalized to uppercase and must contain only ASCII letters or
+digits. It must be shorter than `protocol.room_code_length`; hyphenated region
+names such as `us-east-` are invalid room-code prefixes.
 
 See the
 [single-instance deployment contract](architecture/single-instance-deployment.md)

--- a/progress/session-095-room-codes-and-relay-timing.md
+++ b/progress/session-095-room-codes-and-relay-timing.md
@@ -141,5 +141,11 @@ results. The nightly command now explicitly skips the dedicated observation
 selector while retaining its existing ordinary, fault, knee, and diagnostic
 coverage; the parsed workflow policy test pins that separation.
 
+Cursor's delayed second-head review also tightened the new H10 early-terminal
+diagnostic. It now states that termination happened during the accounting wait
+and preserves the same slow-consumer, ping, probe, activity-reaper,
+healthy-watcher, delivery, and proxy-termination evidence as the experiment's
+later terminal branches.
+
 P53 itself intentionally stays open after publication while the pre-registered
 scheduled cohort accumulates.

--- a/progress/session-095-room-codes-and-relay-timing.md
+++ b/progress/session-095-room-codes-and-relay-timing.md
@@ -101,6 +101,38 @@ The authoritative local validation completed successfully with:
   path changed in this session; the over-target warning is recorded rather than
   expanding the gameplay/workflow PR into an unrelated hook rewrite.
 
-Publication, hosted checks, and reviewer disposition remain to be recorded.
+## Publication and hosted failure analysis
+
+Pull request #285 published the two scoped commits at `ecef57f`. Eighteen
+hosted workflows completed successfully, including CI, Advanced Safety,
+Fuzzing, every interop lane, and the new three-platform Relay Timing
+Observations run; both Dependabot-only invocations skipped as designed. Cursor
+was explicitly triggered on the exact head. Copilot reached its repository/user
+review quota and returned no code review, and no independent human reviewer is
+available beyond the PR author.
+
+Verification Nightly's Real-World Scenario Profiles job was the sole failure.
+Every preceding profile passed, then H10 completed both expected reliable
+slow-consumer/reconnect cycles before its volatile terminal-accounting frontier
+missed the 60-second post-fault ceiling by less than one second. The exact
+hosted selector reproduced under `taskset -c 0`: it preserved both `4002`
+cycles, stayed connected throughout the volatile phase, conserved every offer,
+and passed in 158.399 seconds, but the healthy path's maximum interarrival gap
+reached 52.657 seconds and accounting completed almost exactly at the old
+ceiling. This classifies the failure as a loaded-runner sender-ingress backlog,
+not a production relay stall or lost terminal outcome.
+
+The accounting condition remains event-driven and unchanged. Its ceiling now
+uses H10's existing 90-second phase budget, giving the 60-second offered phase
+bounded scheduling headroom without weakening any eviction, reconnect,
+delivery, gap, liveness, or conservation oracle. A dedicated waiter also emits
+the target and complete per-class counter snapshot if the frontier genuinely
+fails again. Adversarial review found that an early victim termination could
+otherwise leave the two-recipient target unreachable for the entire wider
+ceiling; the waiter now races the observer and immediately reports its exact
+Close, transport-error, or EOF classification. The constrained exact Nextest
+selector passes at the reproduced 158-second boundary, and the follow-up head
+is subject to the same full hosted gate and reviewer loop.
+
 P53 itself intentionally stays open after publication while the pre-registered
 scheduled cohort accumulates.

--- a/progress/session-095-room-codes-and-relay-timing.md
+++ b/progress/session-095-room-codes-and-relay-timing.md
@@ -134,5 +134,12 @@ Close, transport-error, or EOF classification. The constrained exact Nextest
 selector passes at the reproduced 158-second boundary, and the follow-up head
 is subject to the same full hosted gate and reviewer loop.
 
+Cursor's delayed first-head review found that Verification Nightly's broad
+`--run-ignored all` selector also picked up the new observation-only test. That
+duplicated the six-cell clean matrix in a contended job without recording its
+results. The nightly command now explicitly skips the dedicated observation
+selector while retaining its existing ordinary, fault, knee, and diagnostic
+coverage; the parsed workflow policy test pins that separation.
+
 P53 itself intentionally stays open after publication while the pre-registered
 scheduled cohort accumulates.

--- a/progress/session-095-room-codes-and-relay-timing.md
+++ b/progress/session-095-room-codes-and-relay-timing.md
@@ -1,0 +1,106 @@
+# Session 095 — Room-code closure and relay timing observations (P52/P53)
+
+## Scope and prioritization
+
+Remote triage found no open pull requests or dependency updates. Main was at
+`ec3be74` (PR #282); the previous main revision was fully green, while the newest
+revision's CI, Advanced Safety, and Docker Publish runs were still in progress
+with no failures at session start. Issue #250 remains the highest raw
+gameplay/security concern, but changing the authentication trust boundary needs
+an explicit compatibility and credential decision. The other open safety,
+resilience, optimization, analyzer, formal-methods, and design-system issues are
+broad campaigns or off the immediate gameplay path.
+
+Two bounded gaps were actionable. Audit found that accepted room-code settings
+could create rooms no second player could join; this became #283 and the complete
+P52 fix. Issue #274's remaining timing/lane question cannot be decided from the
+two recorded macOS outliers, so P53 starts unbiased hosted evidence collection
+without claiming that the decision is complete. Generated-code collision retry
+behavior is related but separable and is tracked in #284.
+
+## Failure-first evidence
+
+Before P52, `ProtocolConfig::validate` accepted `room_code_length = 0`, and the
+server accepted prefixes such as `EU-` or values at least as long as the total
+code length. Generation could therefore return an empty or punctuated code (or
+silently ignore an oversized prefix), while the explicit join validator required
+an exact-length ASCII-alphanumeric code. A focused test first failed to compile
+because no generation/admission invariant existed.
+
+Before P53, the ordinary matrix either enforced a platform wall-clock limit or,
+on macOS, merely printed one process's timing. It did not preserve a repeated,
+machine-readable hosted distribution, and using the gated selector for evidence
+would have censored the very outliers under investigation.
+
+## Implementation
+
+- `ProtocolConfig::validate_room_code_generation` composes the protocol checks
+  with the server prefix and rejects blank, non-ASCII-alphanumeric, full-length,
+  and oversized prefixes. Both top-level config validation and direct server
+  construction call it before accepting work.
+- Table/property tests cover invalid settings and accepted generator-to-validator
+  closure. The live E2E path creates a room with a lowercase configured prefix,
+  then has a second client join using the exact normalized generated code.
+- Documentation now describes the invariant and corrects the previously invalid
+  hyphenated region-prefix example.
+- `Relay Timing Observations` runs five all-feature six-cell matrix repetitions
+  on each hosted desktop OS, writes versioned JSONL plus raw logs and an attempt
+  manifest, and uploads them even on failure. The dedicated ignored selector
+  keeps every semantic oracle but disables the wall-clock gate so the sample is
+  not selection-biased.
+- The pre-registered #274 decision uses the first 20 consecutive scheduled,
+  first-attempt allocations per OS under one workload/toolchain cohort. The
+  GitHub run ledger keeps RED, cancelled, missing, and incomplete attempts in
+  the denominator. Manual/PR/rerun observations are diagnostic only.
+- Dedicated-process evidence can justify only an equivalently isolated,
+  all-feature PR timing job. The candidate 250 ms ceiling requires every eligible
+  observation below it and a maximum at or below 125 ms; otherwise that platform
+  remains correctness-only.
+
+## Red-green evidence
+
+The focused room-code test was RED before the validation API existed, then the
+invalid-configuration table, generator/join closure property, direct-constructor
+guard, and two-client generated-code join all passed. The relay observation
+workflow's configuration test was RED while the workflow was absent, then passed
+after the workflow and exact selector were added. A local diagnostic run produced
+all six JSONL rows while preserving delivery, conformance, zero-backpressure, and
+zero-eviction assertions.
+
+## Validation and review
+
+The first independent adversarial pass found three evidence-integrity gaps in
+P53: feature-minimal isolated observations could not justify the broad
+all-feature Nextest lane, complete-only samples allowed survivorship bias, and a
+substring policy test could pass with dead or weakened workflow text. The lane
+now runs all features, scopes any future threshold to an equivalently isolated
+PR job, records explicit attempt outcomes, and pre-registers the GitHub run
+ledger as the denominator. Its structural YAML test pins the live job, matrix,
+steps, failure semantics, artifacts, and each exact Cargo invocation. A second
+pass found that the all-feature marker could still be borrowed from the unit
+guard; exact logical-command comparison closed that bypass. The third pass and
+the independent production/config review both reported zero findings.
+
+The authoritative local validation completed successfully with:
+
+- formatting plus strict all-target, all-feature Clippy with warnings denied;
+- `cargo test --locked --all-features`, including 736 library tests and all
+  integration/policy suites;
+- focused invalid-config, generator/join closure, direct-constructor, live
+  two-client join, JSONL, semantic-profile, and workflow-policy tests;
+- `cargo deny --all-features check` (only the repository's accepted duplicate
+  dependency/license-not-encountered advisories);
+- CI config, documentation, MSRV, workflow hygiene, LLM size/example, tooling
+  parity, Actionlint, and YAML lint checks; and
+- hook readiness plus worktree pre-commit and pre-push preflights. The first
+  profiled worktree pre-commit was cold at 2.8 seconds; a warm rerun reduced this
+  to 1.8 seconds, with unchanged-file discovery and the Rust panic scan accounting
+  for 1.38 seconds. The actual staged hook reduced discovery to 129 ms and passed
+  every check, but still completed in 1.6 seconds because the unchanged Rust
+  panic scan took 882 ms plus PowerShell/check overhead. No hook or hook-policy
+  path changed in this session; the over-target warning is recorded rather than
+  expanding the gameplay/workflow PR into an unrelated hook rewrite.
+
+Publication, hosted checks, and reviewer disposition remain to be recorded.
+P53 itself intentionally stays open after publication while the pre-registered
+scheduled cohort accumulates.

--- a/src/config/protocol.rs
+++ b/src/config/protocol.rs
@@ -101,6 +101,9 @@ impl ProtocolConfig {
     /// (`max >= min`), and the ceiling must not exceed what this build implements
     /// ([`SERVER_MAX_PROTOCOL_VERSION`]).
     pub fn validate(&self) -> anyhow::Result<()> {
+        if self.room_code_length == 0 {
+            anyhow::bail!("protocol.room_code_length must be greater than 0");
+        }
         if self.min_protocol_version < SERVER_MIN_PROTOCOL_VERSION {
             anyhow::bail!(
                 "protocol.min_protocol_version ({}) must be >= {SERVER_MIN_PROTOCOL_VERSION}",
@@ -121,6 +124,45 @@ impl ProtocolConfig {
                 self.max_protocol_version
             );
         }
+        Ok(())
+    }
+
+    /// Validate that automatic room-code generation can only produce codes
+    /// accepted by the client join validator.
+    ///
+    /// The optional server prefix is trimmed and uppercased by the generator.
+    /// Restricting it to ASCII alphanumeric characters keeps byte length equal
+    /// to character length and matches the exact wire validator. At least one
+    /// random character must remain so a prefix cannot collapse every room in
+    /// the deployment onto one code.
+    pub fn validate_room_code_generation(
+        &self,
+        room_code_prefix: Option<&str>,
+    ) -> anyhow::Result<()> {
+        self.validate()?;
+
+        let Some(prefix) = room_code_prefix else {
+            return Ok(());
+        };
+        let prefix = prefix.trim();
+        if prefix.is_empty() {
+            anyhow::bail!("server.room_code_prefix must not be blank when configured");
+        }
+        if !prefix
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+        {
+            anyhow::bail!(
+                "server.room_code_prefix must contain only ASCII alphanumeric characters"
+            );
+        }
+        if prefix.len() >= self.room_code_length {
+            anyhow::bail!(
+                "server.room_code_prefix must be shorter than protocol.room_code_length ({})",
+                self.room_code_length
+            );
+        }
+
         Ok(())
     }
 }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -281,8 +281,11 @@ pub fn validate_config_security(config: &Config) -> anyhow::Result<()> {
         }
     }
 
-    // Protocol version-bounds validation
-    config.protocol.validate()?;
+    // Protocol bounds plus generated-room-code closure: every automatically
+    // generated code must be admissible through the explicit join path.
+    config
+        .protocol
+        .validate_room_code_generation(config.server.room_code_prefix.as_deref())?;
 
     // Session topology/transport policy validation
     config.session.validate()?;
@@ -441,6 +444,73 @@ mod tests {
             assert!(
                 err.to_string().contains(&expected),
                 "error must point at the blank field {expected}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn room_code_generation_config_rejects_unjoinable_codes() {
+        struct Case {
+            name: &'static str,
+            length: usize,
+            prefix: Option<&'static str>,
+            expected: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "zero total length",
+                length: 0,
+                prefix: None,
+                expected: "protocol.room_code_length must be greater than 0",
+            },
+            Case {
+                name: "blank configured prefix",
+                length: 6,
+                prefix: Some(" \t"),
+                expected: "server.room_code_prefix must not be blank",
+            },
+            Case {
+                name: "punctuation in prefix",
+                length: 6,
+                prefix: Some("EU-"),
+                expected: "server.room_code_prefix must contain only ASCII alphanumeric",
+            },
+            Case {
+                name: "non-ASCII prefix",
+                length: 6,
+                prefix: Some("ÉU"),
+                expected: "server.room_code_prefix must contain only ASCII alphanumeric",
+            },
+            Case {
+                name: "prefix consumes entire code",
+                length: 6,
+                prefix: Some("ABCDEF"),
+                expected: "server.room_code_prefix must be shorter than protocol.room_code_length",
+            },
+            Case {
+                name: "prefix exceeds code",
+                length: 6,
+                prefix: Some("ABCDEFG"),
+                expected: "server.room_code_prefix must be shorter than protocol.room_code_length",
+            },
+        ];
+
+        for case in cases {
+            let mut config = Config::default();
+            config.security.require_metrics_auth = false;
+            config.protocol.room_code_length = case.length;
+            config.server.room_code_prefix = case.prefix.map(ToString::to_string);
+
+            let error = match validate_config_security(&config) {
+                Ok(()) => panic!("{} must fail startup validation", case.name),
+                Err(error) => error,
+            };
+            assert!(
+                error.to_string().contains(case.expected),
+                "{}: expected `{}`, got `{error}`",
+                case.name,
+                case.expected
             );
         }
     }

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -861,12 +861,27 @@ mod tests {
     }
 
     #[test]
-    fn region_room_code_falls_back_when_prefix_too_long() {
-        let config = ProtocolConfig {
-            room_code_length: 4,
-            ..ProtocolConfig::default()
-        };
-        let code = room_codes::generate_region_room_code(&config, Some("LONGPREFIX"));
-        assert_eq!(code.len(), 4);
+    fn accepted_room_code_generation_configs_always_produce_joinable_codes() {
+        let prefixes = [None, Some("A"), Some("na"), Some(" na "), Some("USE")];
+
+        for room_code_length in 1..=12 {
+            for prefix in prefixes {
+                let config = ProtocolConfig {
+                    room_code_length,
+                    ..ProtocolConfig::default()
+                };
+                if config.validate_room_code_generation(prefix).is_err() {
+                    continue;
+                }
+
+                for _ in 0..32 {
+                    let code = room_codes::generate_region_room_code(&config, prefix);
+                    assert!(
+                        validate_room_code_with_config(&code, &config).is_ok(),
+                        "accepted length={room_code_length}, prefix={prefix:?} generated unjoinable `{code}`"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -292,6 +292,11 @@ impl EnhancedGameServer {
         transport_security: crate::config::TransportSecurityConfig,
         authorized_apps: Vec<AppAuthEntry>,
     ) -> anyhow::Result<Arc<Self>> {
+        // Library embedders can construct `ServerConfig` directly without the
+        // top-level config loader. Enforce the same generation/join closure
+        // here before initializing storage or background tasks.
+        protocol_config.validate_room_code_generation(config.room_code_prefix.as_deref())?;
+
         let database: Arc<dyn GameDatabase> =
             Arc::from(create_database(database_config.clone()).await?);
         database.initialize().await?;
@@ -3335,5 +3340,37 @@ mod relay_projection_cache_tests {
         ] {
             assert!(!rendered.contains(removed), "stale series {removed}");
         }
+    }
+
+    #[tokio::test]
+    async fn library_constructor_rejects_unjoinable_generated_room_codes() {
+        let config = super::ServerConfig {
+            room_code_prefix: Some("EU-".to_string()),
+            ..super::ServerConfig::default()
+        };
+        let result = super::EnhancedGameServer::new(
+            config,
+            crate::config::ProtocolConfig::default(),
+            crate::config::RelayTypeConfig::default(),
+            crate::config::SessionConfig::default(),
+            crate::config::TurnConfig::default(),
+            crate::database::DatabaseConfig::InMemory,
+            crate::config::MetricsConfig::default(),
+            crate::config::CoordinationConfig::default(),
+            crate::config::TransportSecurityConfig::default(),
+            Vec::new(),
+        )
+        .await;
+
+        let error = match result {
+            Ok(_) => panic!("invalid prefix must fail before server construction"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("server.room_code_prefix must contain only ASCII alphanumeric"),
+            "constructor must report the exact invalid generation field: {error}"
+        );
     }
 }

--- a/tests/asymmetric_bandwidth_flap_e2e.rs
+++ b/tests/asymmetric_bandwidth_flap_e2e.rs
@@ -676,9 +676,29 @@ async fn asymmetric_bandwidth_preserves_lossy_delivery_and_control_progress() {
     .await
     {
         let delivery = metrics.delivery_metrics_by_class();
+        let slow_consumer_disconnects = metrics
+            .websocket_slow_consumer_disconnects
+            .load(Ordering::Relaxed);
+        let ping_timeouts = metrics.websocket_ping_timeouts.load(Ordering::Relaxed);
+        let ping_probes_skipped = metrics
+            .websocket_ping_probes_skipped_activity
+            .load(Ordering::Relaxed);
+        let ping_probes_cancelled = metrics
+            .websocket_ping_probes_cancelled_activity
+            .load(Ordering::Relaxed);
+        let expired_players = metrics.expired_players_cleaned.load(Ordering::Relaxed);
+        let proxy_terminations = proxy.terminations();
+        let watcher_delivered = watcher_state.game_data.load(Ordering::Relaxed);
         panic!(
-            "volatile victim terminated before the post-fault marker while fanouts drained: \
-             observation={observation:?} delivery={delivery:?}"
+            "volatile victim terminated before the post-fault marker after {volatile_sent} \
+             offers during the terminal fanout accounting wait: \
+             observation={observation:?}; server recorded {slow_consumer_disconnects} \
+             slow-consumer disconnects, {ping_timeouts} ping timeouts, \
+             {ping_probes_skipped} skipped and {ping_probes_cancelled} cancelled probes, and \
+             {expired_players} activity-reaper evictions; delivery={delivery:?}; healthy \
+             watcher delivered={watcher_delivered}/{} pre-marker offers; proxy terminations: \
+             {proxy_terminations:?}",
+            total_sent + volatile_sent,
         );
     }
 

--- a/tests/asymmetric_bandwidth_flap_e2e.rs
+++ b/tests/asymmetric_bandwidth_flap_e2e.rs
@@ -23,6 +23,7 @@ mod websocket_test_helpers;
 
 use futures_util::{Sink, SinkExt, StreamExt};
 use signal_fish_server::config::ProtocolConfig;
+use signal_fish_server::metrics::ServerMetrics;
 use signal_fish_server::protocol::{
     ClientMessage, DeliveryClass, DeliveryGap, DeliveryGapReason, PlayerId, ReconnectedPayload,
     ServerMessage,
@@ -49,7 +50,6 @@ const RELIABLE_CYCLES: u64 = 2;
 const VOLATILE_DURATION: Duration = Duration::from_secs(60);
 const PHASE_DEADLINE: Duration = Duration::from_secs(90);
 const EVENT_DEADLINE: Duration = Duration::from_secs(30);
-const POST_FAULT_DRAIN_DEADLINE: Duration = Duration::from_secs(60);
 const PADDING_BYTES: usize = 512;
 
 #[derive(Default)]
@@ -70,7 +70,7 @@ enum ReliableTermination {
     ResetWithoutClosingHandshake,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct VolatileObservation {
     delivered: u64,
     reported_dropped: u64,
@@ -311,6 +311,43 @@ async fn poll_until_within(context: &str, timeout: Duration, mut condition: impl
             "{context}: condition not reached before {timeout:?}"
         );
         tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn wait_for_volatile_fanouts(
+    metrics: &ServerMetrics,
+    attempted_target: u64,
+    timeout: Duration,
+    observer: &mut tokio::task::JoinHandle<VolatileObservation>,
+) -> Result<(), VolatileObservation> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    let accounting = async {
+        loop {
+            let volatile = metrics.delivery_metrics_by_class().volatile;
+            let resolved = volatile.delivered
+                + volatile.superseded
+                + volatile.dropped_full
+                + volatile.dropped
+                + volatile.abandoned
+                + volatile.unsupported_format;
+            if volatile.attempted == attempted_target && resolved == volatile.attempted {
+                return;
+            }
+            let now = tokio::time::Instant::now();
+            assert!(
+                now < deadline,
+                "volatile fanouts did not drain before {timeout:?}: \
+                 target_attempted={attempted_target} observed={volatile:?} resolved={resolved}"
+            );
+            tokio::time::sleep_until((now + Duration::from_millis(25)).min(deadline)).await;
+        }
+    };
+    tokio::select! {
+        biased;
+        observation = &mut *observer => {
+            Err(observation.expect("volatile observer panicked before the marker"))
+        }
+        () = accounting => Ok(()),
     }
 }
 
@@ -599,7 +636,7 @@ async fn asymmetric_bandwidth_preserves_lossy_delivery_and_control_progress() {
     // `victim_ws` is the live second reconnect from the loop.
     let sender_baseline = metrics.delivery_metrics_by_class().reliable.attempted;
     let volatile_attempted_baseline = metrics.delivery_metrics_by_class().volatile.attempted;
-    let volatile_observer = spawn_volatile_observer(victim_ws, sender_id, sender_watermark.seq);
+    let mut volatile_observer = spawn_volatile_observer(victim_ws, sender_id, sender_watermark.seq);
     proxy.throttle(Direction::ServerToClient, Some(DOWNSTREAM_BYTES_PER_SEC));
     let volatile_started = tokio::time::Instant::now();
     let volatile_deadline = volatile_started + VOLATILE_DURATION;
@@ -626,21 +663,24 @@ async fn asymmetric_bandwidth_preserves_lossy_delivery_and_control_progress() {
     // fanouts reached terminal accounting, then use Reliable as the post-fault
     // stream delimiter it is intended to be.
     let volatile_attempted_target = volatile_attempted_baseline + volatile_sent * 2;
-    poll_until_within(
-        "volatile fanouts drain before the reliable marker",
-        POST_FAULT_DRAIN_DEADLINE,
-        || {
-            let volatile = metrics.delivery_metrics_by_class().volatile;
-            let resolved = volatile.delivered
-                + volatile.superseded
-                + volatile.dropped_full
-                + volatile.dropped
-                + volatile.abandoned
-                + volatile.unsupported_format;
-            volatile.attempted == volatile_attempted_target && resolved == volatile.attempted
-        },
+    // This is an event-driven frontier, not a latency assertion. On a
+    // single-core runner the sender-side socket backlog can take almost the
+    // full 60-second volatile phase to reach the server after sending stops,
+    // so use the experiment's pre-registered 90-second phase ceiling.
+    if let Err(observation) = wait_for_volatile_fanouts(
+        &metrics,
+        volatile_attempted_target,
+        PHASE_DEADLINE,
+        &mut volatile_observer,
     )
-    .await;
+    .await
+    {
+        let delivery = metrics.delivery_metrics_by_class();
+        panic!(
+            "volatile victim terminated before the post-fault marker while fanouts drained: \
+             observation={observation:?} delivery={delivery:?}"
+        );
+    }
 
     send(
         &mut sender_sink,

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2356,6 +2356,43 @@ fn test_relay_timing_observations_workflow_is_bounded_complete_and_retainable() 
             .and_then(Yaml::as_str),
         Some("error")
     );
+
+    let nightly_path = root.join(".github/workflows/verification-nightly.yml");
+    let nightly = read_live_file(&nightly_path);
+    let nightly_documents =
+        Yaml::load_from_str(&nightly).expect("verification nightly workflow must parse");
+    let nightly_job = nightly_documents
+        .first()
+        .and_then(|document| document.as_mapping_get("jobs"))
+        .and_then(|jobs| jobs.as_mapping_get("scenario-profiles"))
+        .expect("verification nightly must retain the scenario-profiles job");
+    let nightly_matrix_run = nightly_job
+        .as_mapping_get("steps")
+        .and_then(Yaml::as_sequence)
+        .and_then(|steps| {
+            steps.iter().find(|step| {
+                step.as_mapping_get("name").and_then(Yaml::as_str)
+                    == Some("Run 16-player relay matrix and knee sweep")
+            })
+        })
+        .and_then(|step| step.as_mapping_get("run"))
+        .and_then(Yaml::as_str)
+        .expect("verification nightly relay-matrix command");
+    let nightly_cargo_commands: Vec<String> = shell_logical_lines(nightly_matrix_run)
+        .into_iter()
+        .filter(|line| line.contains("cargo nextest"))
+        .collect();
+    assert_eq!(
+        nightly_cargo_commands,
+        vec![
+            "cargo nextest run --profile ci --locked --all-features --test \
+             sixteen_player_matrix_e2e --run-ignored all --success-output final -- --skip \
+             hosted_relay_timing_observations_preserve_semantic_oracles 2>&1 | tee \
+             relay-matrix-output.txt"
+        ],
+        "nightly must retain its complete matrix/fault/knee selection and exclude only the \
+         dedicated hosted observation selector"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2111,6 +2111,253 @@ fn test_ci_workflow_matrix_os_values_match_constant() {
     }
 }
 
+#[test]
+fn test_relay_timing_observations_workflow_is_bounded_complete_and_retainable() {
+    let root = repo_root();
+    let workflow_path = root.join(".github/workflows/relay-timing-observations.yml");
+    assert!(
+        workflow_path.exists(),
+        "issue #274 requires .github/workflows/relay-timing-observations.yml so hosted timing \n\
+         policy is based on retained multi-run evidence instead of isolated log lines"
+    );
+    let workflow = read_live_file(&workflow_path);
+    let documents = Yaml::load_from_str(&workflow).expect("relay timing workflow must parse");
+    let document = documents.first().expect("workflow YAML document");
+    let triggers = document
+        .as_mapping_get("on")
+        .or_else(|| document.as_mapping_get("true"))
+        .expect("workflow must define triggers");
+    let schedule = triggers
+        .as_mapping_get("schedule")
+        .and_then(Yaml::as_sequence)
+        .expect("workflow must define a schedule");
+    assert_eq!(
+        schedule.len(),
+        1,
+        "timing sampling has one canonical cadence"
+    );
+    assert_eq!(
+        schedule[0].as_mapping_get("cron").and_then(Yaml::as_str),
+        Some("30 5 * * *")
+    );
+    assert!(
+        triggers.as_mapping_get("workflow_dispatch").is_some(),
+        "manual diagnostic sampling must remain available"
+    );
+    let pull_request = triggers
+        .as_mapping_get("pull_request")
+        .expect("workflow changes must validate on pull requests");
+    assert_eq!(
+        pull_request
+            .as_mapping_get("branches")
+            .and_then(Yaml::as_sequence)
+            .expect("pull request branch filter")
+            .iter()
+            .map(|value| value.as_str().expect("branch string"))
+            .collect::<Vec<_>>(),
+        vec!["main"]
+    );
+    assert_eq!(
+        pull_request
+            .as_mapping_get("paths")
+            .and_then(Yaml::as_sequence)
+            .expect("pull request path filter")
+            .iter()
+            .map(|value| value.as_str().expect("path string"))
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            "tests/sixteen_player_matrix_e2e.rs",
+            ".github/workflows/relay-timing-observations.yml",
+        ])
+    );
+
+    let concurrency = document
+        .as_mapping_get("concurrency")
+        .expect("timing attempts need explicit concurrency semantics");
+    assert_eq!(
+        concurrency
+            .as_mapping_get("cancel-in-progress")
+            .and_then(Yaml::as_bool),
+        Some(false),
+        "manual or overlapping runs must not cancel an eligible scheduled attempt"
+    );
+    assert_eq!(
+        document
+            .as_mapping_get("env")
+            .and_then(|env| env.as_mapping_get("REPETITIONS"))
+            .and_then(Yaml::as_integer),
+        Some(5)
+    );
+    assert_eq!(
+        document
+            .as_mapping_get("env")
+            .and_then(|env| env.as_mapping_get("SIGNAL_FISH_RELAY_WORKLOAD_VERSION"))
+            .and_then(Yaml::as_str),
+        Some("relay-clean-v1")
+    );
+
+    let job = document
+        .as_mapping_get("jobs")
+        .and_then(|jobs| jobs.as_mapping_get("observations"))
+        .expect("workflow must define the observations job");
+    assert!(
+        job.as_mapping_get("if").is_none(),
+        "job must be unconditional"
+    );
+    assert!(
+        job.as_mapping_get("needs").is_none(),
+        "a skipped dependency must not erase a timing attempt"
+    );
+    assert_failure_is_not_swallowed(job, "the observations job");
+    assert_eq!(
+        job.as_mapping_get("runs-on").and_then(Yaml::as_str),
+        Some("${{ matrix.os }}")
+    );
+    assert_eq!(
+        job.as_mapping_get("timeout-minutes")
+            .and_then(Yaml::as_integer),
+        Some(45)
+    );
+    let strategy = job.as_mapping_get("strategy").expect("matrix strategy");
+    assert_eq!(
+        strategy.as_mapping_get("fail-fast").and_then(Yaml::as_bool),
+        Some(false)
+    );
+    let matrix = strategy
+        .as_mapping_get("matrix")
+        .expect("observation OS matrix");
+    for narrowing in ["include", "exclude"] {
+        assert!(
+            matrix.as_mapping_get(narrowing).is_none(),
+            "matrix.{narrowing} can silently narrow the platform evidence"
+        );
+    }
+    assert_eq!(
+        matrix
+            .as_mapping_get("os")
+            .and_then(Yaml::as_sequence)
+            .expect("matrix.os")
+            .iter()
+            .map(|value| value.as_str().expect("OS string"))
+            .collect::<Vec<_>>(),
+        vec!["ubuntu-latest", "windows-latest", "macos-latest"]
+    );
+
+    let steps = job
+        .as_mapping_get("steps")
+        .and_then(Yaml::as_sequence)
+        .expect("observation steps");
+    for step in steps {
+        assert_failure_is_not_swallowed(step, "every observation step");
+    }
+    let named_step = |name: &str| {
+        steps
+            .iter()
+            .find(|step| step.as_mapping_get("name").and_then(Yaml::as_str) == Some(name))
+            .unwrap_or_else(|| panic!("missing `{name}` step"))
+    };
+    let capture = named_step("Capture repeated clean relay observations");
+    assert!(capture.as_mapping_get("if").is_none());
+    assert_eq!(
+        capture.as_mapping_get("shell").and_then(Yaml::as_str),
+        Some("bash")
+    );
+    let capture_run = capture
+        .as_mapping_get("run")
+        .and_then(Yaml::as_str)
+        .expect("capture command");
+    for required in [
+        "set -euo pipefail",
+        "SIGNAL_FISH_RELAY_OBSERVATIONS_JSONL=relay-timing-observations.jsonl",
+        "expected_rows=$((REPETITIONS * 6))",
+    ] {
+        assert!(
+            capture_run.contains(required),
+            "capture step lost `{required}`"
+        );
+    }
+    assert!(
+        !capture_run.contains("|| true"),
+        "capture must propagate every semantic test failure"
+    );
+    let cargo_commands: Vec<String> = shell_logical_lines(capture_run)
+        .into_iter()
+        .filter(|line| line.contains("cargo test"))
+        .collect();
+    assert_eq!(
+        cargo_commands,
+        vec![
+            "cargo test --locked --all-features --test sixteen_player_matrix_e2e \
+             hosted_timing_profile_keeps_backpressure_gate_without_wall_clock_gate -- --exact",
+            "SIGNAL_FISH_RELAY_OBSERVATIONS_JSONL=relay-timing-observations.jsonl \
+             SIGNAL_FISH_RELAY_OBSERVATION_SAMPLE=\"$sample\" cargo test --locked \
+             --all-features --test sixteen_player_matrix_e2e \
+             hosted_relay_timing_observations_preserve_semantic_oracles -- --exact --ignored \
+             --nocapture --test-threads=1 2>&1 | tee -a relay-timing-output.log",
+        ],
+        "the profile guard and the one repeated observation invocation must each \
+         retain their exact all-feature selector and harness flags"
+    );
+
+    let manifest = named_step("Write attempt manifest");
+    assert_eq!(
+        manifest.as_mapping_get("if").and_then(Yaml::as_str),
+        Some("always()")
+    );
+    let manifest_run = manifest
+        .as_mapping_get("run")
+        .and_then(Yaml::as_str)
+        .expect("attempt manifest command");
+    for required in [
+        "GITHUB_EVENT_NAME",
+        "GITHUB_RUN_ATTEMPT",
+        "SIGNAL_FISH_RELAY_WORKLOAD_VERSION",
+        "SIGNAL_FISH_RUST_TOOLCHAIN",
+        "ImageVersion",
+        "actual_rows",
+        "complete",
+        "eligible",
+        "relay-timing-attempt.json",
+    ] {
+        assert!(
+            manifest_run.contains(required),
+            "attempt manifest lost `{required}`"
+        );
+    }
+
+    let upload = named_step("Upload raw and machine-readable observations");
+    assert_eq!(
+        upload.as_mapping_get("if").and_then(Yaml::as_str),
+        Some("always()")
+    );
+    assert_eq!(
+        upload.as_mapping_get("uses").and_then(Yaml::as_str),
+        Some("actions/upload-artifact@v7.0.1")
+    );
+    let with = upload.as_mapping_get("with").expect("upload settings");
+    let paths = with
+        .as_mapping_get("path")
+        .and_then(Yaml::as_str)
+        .expect("artifact paths");
+    for required in [
+        "relay-timing-observations.jsonl",
+        "relay-timing-output.log",
+        "relay-timing-attempt.json",
+    ] {
+        assert!(paths.lines().any(|line| line.trim() == required));
+    }
+    assert_eq!(
+        with.as_mapping_get("retention-days")
+            .and_then(Yaml::as_integer),
+        Some(90)
+    );
+    assert_eq!(
+        with.as_mapping_get("if-no-files-found")
+            .and_then(Yaml::as_str),
+        Some("error")
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Unit tests for expand_matrix_display_name and display_name_matches_template
 // ---------------------------------------------------------------------------

--- a/tests/e2e_tests.rs
+++ b/tests/e2e_tests.rs
@@ -1467,10 +1467,14 @@ async fn test_e2e_room_code_generation_with_custom_length() {
         ..Default::default()
     };
 
+    let server_config = ServerConfig {
+        room_code_prefix: Some("eu".to_string()),
+        ..ServerConfig::default()
+    };
     let running_server =
-        start_test_server_with_config_and_protocol(ServerConfig::default(), protocol_config).await;
+        start_test_server_with_config_and_protocol(server_config, protocol_config).await;
     let addr = running_server.addr();
-    let (mut sender, mut receiver) = connect_client(addr, "/v2/ws").await;
+    let (mut creator_sender, mut creator_receiver) = connect_client(addr, "/v2/ws").await;
 
     // Create room without specifying code (should auto-generate with custom length)
     let auto_room_msg = ClientMessage::JoinRoom {
@@ -1482,10 +1486,10 @@ async fn test_e2e_room_code_generation_with_custom_length() {
         relay_transport: None,
     };
 
-    let response = send_and_receive(&mut sender, &mut receiver, auto_room_msg)
+    let response = send_and_receive(&mut creator_sender, &mut creator_receiver, auto_room_msg)
         .await
         .unwrap();
-    match response {
+    let generated_code = match response {
         ServerMessage::RoomJoined(ref payload) => {
             assert_eq!(
                 payload.room_code.len(),
@@ -1497,8 +1501,34 @@ async fn test_e2e_room_code_generation_with_custom_length() {
             assert!(!payload.room_code.contains('O'));
             assert!(!payload.room_code.contains('I'));
             assert!(!payload.room_code.contains('1'));
+            assert!(payload.room_code.starts_with("EU"));
+            payload.room_code.clone()
         }
         _ => panic!("Expected successful room creation with auto-generated code, got {response:?}"),
+    };
+
+    expect_lobby_state_changed_notification(&mut creator_receiver, "creator joined prefixed room")
+        .await;
+    let (mut joiner_sender, mut joiner_receiver) = connect_client(addr, "/v2/ws").await;
+    let join_response = send_and_receive(
+        &mut joiner_sender,
+        &mut joiner_receiver,
+        ClientMessage::JoinRoom {
+            game_name: "autogame".to_string(),
+            room_code: Some(generated_code.clone()),
+            player_name: "Joiner".to_string(),
+            max_players: None,
+            supports_authority: Some(true),
+            relay_transport: None,
+        },
+    )
+    .await
+    .unwrap();
+    match join_response {
+        ServerMessage::RoomJoined(payload) => assert_eq!(payload.room_code, generated_code),
+        other => {
+            panic!("second player could not join generated room `{generated_code}`: {other:?}")
+        }
     }
     running_server.shutdown().await;
 }

--- a/tests/sixteen_player_matrix_e2e.rs
+++ b/tests/sixteen_player_matrix_e2e.rs
@@ -18,11 +18,15 @@ mod test_helpers;
 mod websocket_test_helpers;
 
 use std::collections::BTreeSet;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
 use signal_fish_server::config::ProtocolConfig;
 use signal_fish_server::protocol::{
     ClientMessage, GameDataEncoding, ServerMessage, V3BinaryGameDataFrame,
@@ -59,18 +63,25 @@ struct TrafficProfile {
     messages_per_sender: u64,
     send_interval: Duration,
     target_sender_rate_hz: u64,
+    require_zero_backpressure: bool,
     enforce_pr_latency_limit: bool,
 }
 
 impl TrafficProfile {
-    fn one_second_at(target_sender_rate_hz: u64, enforce_pr_latency_limit: bool) -> Self {
+    fn one_second_at(target_sender_rate_hz: u64, enforce_clean_gates: bool) -> Self {
         assert!(target_sender_rate_hz > 0, "sender rate must be positive");
         Self {
             messages_per_sender: target_sender_rate_hz,
             send_interval: Duration::from_nanos(NANOS_PER_SECOND / target_sender_rate_hz),
             target_sender_rate_hz,
-            enforce_pr_latency_limit,
+            require_zero_backpressure: enforce_clean_gates,
+            enforce_pr_latency_limit: enforce_clean_gates,
         }
+    }
+
+    fn without_wall_clock_gate(mut self) -> Self {
+        self.enforce_pr_latency_limit = false;
+        self
     }
 }
 
@@ -97,7 +108,7 @@ fn wall_clock_latency_is_gated() -> bool {
     !cfg!(target_os = "macos")
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 struct CellObservation {
     target_deliveries_per_second: usize,
     completed_deliveries: usize,
@@ -111,6 +122,74 @@ struct CellObservation {
     max_micros: u64,
     backpressure_events: u64,
     rss_kib: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct RelayTimingRecord<'a> {
+    schema_version: u8,
+    event_name: Option<&'a str>,
+    run_id: Option<&'a str>,
+    run_attempt: Option<&'a str>,
+    commit_sha: Option<&'a str>,
+    runner_os: Option<&'a str>,
+    runner_image_os: Option<&'a str>,
+    runner_image_version: Option<&'a str>,
+    rust_toolchain: Option<&'a str>,
+    workload_version: Option<&'a str>,
+    target_os: &'static str,
+    target_arch: &'static str,
+    sample: u32,
+    encoding: &'static str,
+    players: usize,
+    profile: &'static str,
+    observation: &'a CellObservation,
+}
+
+fn append_relay_timing_record(path: &Path, record: &RelayTimingRecord<'_>) -> std::io::Result<()> {
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    serde_json::to_writer(&mut file, record)?;
+    file.write_all(b"\n")
+}
+
+fn record_scheduled_observation(cell: MatrixCell, observation: &CellObservation) {
+    let Ok(path) = std::env::var("SIGNAL_FISH_RELAY_OBSERVATIONS_JSONL") else {
+        return;
+    };
+    let sample = std::env::var("SIGNAL_FISH_RELAY_OBSERVATION_SAMPLE")
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or_default();
+    let event_name = std::env::var("GITHUB_EVENT_NAME").ok();
+    let run_id = std::env::var("GITHUB_RUN_ID").ok();
+    let run_attempt = std::env::var("GITHUB_RUN_ATTEMPT").ok();
+    let commit_sha = std::env::var("GITHUB_SHA").ok();
+    let runner_os = std::env::var("RUNNER_OS").ok();
+    let runner_image_os = std::env::var("ImageOS").ok();
+    let runner_image_version = std::env::var("ImageVersion").ok();
+    let rust_toolchain = std::env::var("SIGNAL_FISH_RUST_TOOLCHAIN").ok();
+    let workload_version = std::env::var("SIGNAL_FISH_RELAY_WORKLOAD_VERSION").ok();
+    let record = RelayTimingRecord {
+        schema_version: 1,
+        event_name: event_name.as_deref(),
+        run_id: run_id.as_deref(),
+        run_attempt: run_attempt.as_deref(),
+        commit_sha: commit_sha.as_deref(),
+        runner_os: runner_os.as_deref(),
+        runner_image_os: runner_image_os.as_deref(),
+        runner_image_version: runner_image_version.as_deref(),
+        rust_toolchain: rust_toolchain.as_deref(),
+        workload_version: workload_version.as_deref(),
+        target_os: std::env::consts::OS,
+        target_arch: std::env::consts::ARCH,
+        sample,
+        encoding: cell.encoding.as_wire_str(),
+        players: cell.players,
+        profile: NetworkProfile::Clean.label(),
+        observation,
+    };
+    append_relay_timing_record(Path::new(&path), &record).unwrap_or_else(|error| {
+        panic!("failed to append relay timing observation to {path}: {error}")
+    });
 }
 
 impl std::fmt::Display for CellObservation {
@@ -673,7 +752,7 @@ async fn run_cell(
     let backpressure_events = metrics
         .websocket_backpressure_events
         .load(Ordering::Relaxed);
-    if traffic.enforce_pr_latency_limit {
+    if traffic.require_zero_backpressure {
         assert_eq!(
             backpressure_events, 0,
             "{cell_label}: bounded matrix cell must not enter backpressure"
@@ -778,7 +857,92 @@ fn resident_set_kib() -> Option<u64> {
 async fn clean_relay_matrix_is_complete_fast_and_backpressure_free() {
     let traffic = TrafficProfile::one_second_at(MESSAGES_PER_SENDER, true);
     for cell in matrix_cells() {
-        run_cell(cell, NetworkProfile::Clean, traffic).await;
+        let observation = run_cell(cell, NetworkProfile::Clean, traffic).await;
+        record_scheduled_observation(cell, &observation);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[serial_test::serial]
+#[ignore = "scheduled/manual-only (relay-timing-observations.yml): hosted timing distribution"]
+async fn hosted_relay_timing_observations_preserve_semantic_oracles() {
+    let traffic =
+        TrafficProfile::one_second_at(MESSAGES_PER_SENDER, true).without_wall_clock_gate();
+    for cell in matrix_cells() {
+        let observation = run_cell(cell, NetworkProfile::Clean, traffic).await;
+        record_scheduled_observation(cell, &observation);
+    }
+}
+
+#[test]
+fn hosted_timing_profile_keeps_backpressure_gate_without_wall_clock_gate() {
+    let traffic =
+        TrafficProfile::one_second_at(MESSAGES_PER_SENDER, true).without_wall_clock_gate();
+    assert!(traffic.require_zero_backpressure);
+    assert!(!traffic.enforce_pr_latency_limit);
+}
+
+#[test]
+fn relay_timing_records_are_machine_readable_and_append_only() {
+    let temp = tempfile::tempdir().expect("temporary observation directory");
+    let path = temp.path().join("relay-observations.jsonl");
+    let observation = CellObservation {
+        target_deliveries_per_second: 60,
+        completed_deliveries: 60,
+        achieved_ingress_messages_per_second: 60.0,
+        sender_completion_millis: 1_000,
+        observed_deliveries_per_second: 60.0,
+        completion_millis: 1_000,
+        p50_micros: 100,
+        p95_micros: 200,
+        p99_micros: 300,
+        max_micros: 400,
+        backpressure_events: 0,
+        rss_kib: Some(1_024),
+    };
+    let record = RelayTimingRecord {
+        schema_version: 1,
+        event_name: Some("schedule"),
+        run_id: Some("123"),
+        run_attempt: Some("1"),
+        commit_sha: Some("abc"),
+        runner_os: Some("Linux"),
+        runner_image_os: Some("ubuntu24"),
+        runner_image_version: Some("20260801.1"),
+        rust_toolchain: Some("1.91.0"),
+        workload_version: Some("relay-clean-v1"),
+        target_os: "linux",
+        target_arch: "x86_64",
+        sample: 1,
+        encoding: "json",
+        players: 2,
+        profile: "clean",
+        observation: &observation,
+    };
+
+    append_relay_timing_record(&path, &record).expect("first observation append");
+    append_relay_timing_record(&path, &record).expect("second observation append");
+
+    let content = std::fs::read_to_string(path).expect("observation artifact");
+    let rows: Vec<serde_json::Value> = content
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("valid JSONL row"))
+        .collect();
+    assert_eq!(
+        rows.len(),
+        2,
+        "each append must preserve an independent row"
+    );
+    for row in rows {
+        assert_eq!(row["schema_version"], 1);
+        assert_eq!(row["event_name"], "schedule");
+        assert_eq!(row["rust_toolchain"], "1.91.0");
+        assert_eq!(row["workload_version"], "relay-clean-v1");
+        assert_eq!(row["sample"], 1);
+        assert_eq!(row["encoding"], "json");
+        assert_eq!(row["players"], 2);
+        assert_eq!(row["observation"]["p99_micros"], 300);
+        assert_eq!(row["observation"]["backpressure_events"], 0);
     }
 }
 


### PR DESCRIPTION
## Summary

- reject generated room-code settings that can create rooms the join path refuses
- enforce the invariant in both top-level startup validation and direct library construction
- prove the exact generated prefixed code works through a real two-client create/join flow
- add a scheduled/manual Linux, Windows, and macOS relay-timing observation lane for the remaining #274 decision
- retain unbiased all-feature JSONL, raw logs, and attempt manifests with a pre-registered non-survivorship-biased cohort policy
- stabilize H10's live terminal-accounting wait at the loaded-runner boundary without weakening its relay or termination oracles

## Root cause and impact

The server accepted `protocol.room_code_length = 0` and prefixes containing join-invalid punctuation or consuming the configured length. Automatic room creation could therefore return an empty or punctuated code that no second client could submit successfully. The new validation closes generation under the join validator before the server performs initialization work.

The remaining #274 timing decision had only isolated hosted log lines. The new observation lane preserves every semantic relay oracle while removing only the wall-clock assertion, records incomplete/RED attempts, and explicitly limits any future threshold to an equivalently isolated all-feature PR job rather than the concurrently loaded broad Nextest lane.

The first published head exposed H10's post-fault accounting ceiling on a loaded hosted runner. Both reliable slow-consumer/reconnect cycles completed before terminal volatile accounting missed the 60-second ceiling by under one second. The exact selector reproduced at 158.399 seconds on one CPU while remaining connected and conserving every offer. H10 now uses its existing 90-second phase ceiling only for that event-driven frontier, prints the full counter snapshot on timeout, and uses a biased race so Close/reset/EOF still wins immediately over accounting or deadline readiness.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- focused config, generator/join closure, constructor, two-client E2E, JSONL, profile, and workflow-policy tests
- exact hosted H10 Nextest selector, including a one-CPU 158.399-second reproduction and the final 102.315-second run
- CI config, documentation, MSRV, workflow hygiene, LLM, tooling-parity, Actionlint, YAML lint, markdown, and link checks
- hook readiness, pre-commit, and pre-push preflights
- adversarial workflow, production/config, and H10 termination-race reviews; final result: zero findings

Closes #283.
Advances #274; P53 intentionally remains collecting until the pre-registered hosted cohort is complete.
Follow-up collision retry work is tracked in #284.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup and library construction now reject some previously accepted room-code configs (behavior change for misconfigured deployments); CI and long-running E2E timing boundaries changed but production relay paths are unchanged.
> 
> **Overview**
> **Room-code generation** now fails fast when settings could produce codes the join validator would reject: `protocol.room_code_length` must be nonzero, and optional `server.room_code_prefix` must be a nonblank ASCII-alphanumeric string shorter than the total code length. The same invariant runs through top-level config validation and direct `EnhancedGameServer` construction; tests and docs replace invalid hyphenated prefix examples with valid ones, and E2E proves a second client can join the exact normalized generated code.
> 
> **Relay timing (#274)** gains a daily **Relay Timing Observations** workflow on Linux, Windows, and macOS: five all-feature repetitions of the clean six-cell matrix append versioned JSONL, logs, and attempt manifests (semantic oracles kept; wall-clock gate disabled for unbiased samples). Verification Nightly’s broad matrix run now **skips** that observation-only test to avoid duplicate contended work; a structural CI test pins both workflows’ exact Cargo invocations.
> 
> **H10 asymmetric-bandwidth E2E** extends the post-fault volatile fanout accounting wait to the experiment’s **90-second** phase budget and races accounting against early victim termination so loaded single-core runners do not flake without weakening delivery, eviction, or conservation checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6adc1bc3943e6805940acf0c695e58029f5ca9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->