### PR TITLE
ci: retain unbiased H14 nightly evidence

### DIFF
--- a/.github/workflows/relay-timing-observations.yml
+++ b/.github/workflows/relay-timing-observations.yml
@@ -163,5 +163,5 @@ jobs:
             relay-timing-observations.jsonl
             relay-timing-output.log
             relay-timing-attempt.json
-          retention-days: 90
+          retention-days: 30
           if-no-files-found: error

--- a/.github/workflows/verification-nightly.yml
+++ b/.github/workflows/verification-nightly.yml
@@ -90,6 +90,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  SIGNAL_FISH_H14_CONTRACT_VERSION: h14-capacity-v1
 
 jobs:
   soak:
@@ -437,6 +438,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
+        id: checkout
         uses: actions/checkout@v7.0.1
       - name: Read Rust toolchain
         id: toolchain
@@ -449,6 +451,7 @@ jobs:
           fi
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
       - name: Install Rust toolchain
+        id: install-rust
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ steps.toolchain.outputs.channel }}
@@ -457,6 +460,7 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - name: Install cargo-nextest
+        id: install-nextest
         uses: taiki-e/install-action@v2.85.7
         with:
           tool: cargo-nextest
@@ -482,12 +486,103 @@ jobs:
             --skip hosted_relay_timing_observations_preserve_semantic_oracles \
             2>&1 | tee relay-matrix-output.txt
       - name: Run mixed-encoding amplification experiment
+        id: h14
+        if: >-
+          ${{ always() && !cancelled() &&
+              steps.checkout.outcome == 'success' &&
+              steps.toolchain.outcome == 'success' &&
+              steps.install-rust.outcome == 'success' &&
+              steps.install-nextest.outcome == 'success' }}
         shell: bash
         run: |
-          set -o pipefail
+          set -euo pipefail
+          : > mixed-encoding-output.txt
+          : > h14-started
+          set +e
           cargo nextest run --profile ci --locked --all-features \
             --test mixed_encoding_relay_e2e --run-ignored ignored-only \
+            -E 'test(=unsupported_message_pack_fallback_does_not_flap_weaker_recipient)' \
+            --no-tests fail \
             --success-output final 2>&1 | tee mixed-encoding-output.txt
+          h14_status=$?
+          set -e
+          printf '%s\n' "$h14_status" > h14-exit-code.txt
+          exit "$h14_status"
+      - name: Write H14 attempt manifest
+        if: always()
+        shell: bash
+        env:
+          H14_OUTCOME: ${{ steps.h14.outcome }}
+          JOB_STATUS: ${{ job.status }}
+          SIGNAL_FISH_RUST_TOOLCHAIN: ${{ steps.toolchain.outputs.channel }}
+        run: |
+          set -euo pipefail
+          h14_started=false
+          if [ -f h14-started ]; then
+            h14_started=true
+          fi
+          h14_finished=false
+          h14_exit_code=null
+          if [ -f h14-exit-code.txt ]; then
+            h14_finished=true
+            read -r h14_exit_code < h14-exit-code.txt
+          fi
+          raw_log_present=false
+          raw_log_bytes=0
+          if [ -f mixed-encoding-output.txt ]; then
+            raw_log_present=true
+            raw_log_bytes=$(wc -c < mixed-encoding-output.txt | tr -d ' ')
+          fi
+          terminal_outcome=false
+          if [ "$H14_OUTCOME" = "success" ] || [ "$H14_OUTCOME" = "failure" ]; then
+            terminal_outcome=true
+          fi
+          evidence_complete=false
+          if [ "$h14_started" = true ] && [ "$h14_finished" = true ] \
+            && [ "$raw_log_present" = true ] && [ "$raw_log_bytes" -gt 0 ] \
+            && [ "$terminal_outcome" = true ]; then
+            evidence_complete=true
+          fi
+          passed=false
+          if [ "$evidence_complete" = true ] && [ "$H14_OUTCOME" = "success" ] \
+            && [ "$h14_exit_code" = "0" ]; then
+            passed=true
+          fi
+          eligible=false
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] && [ "$GITHUB_RUN_ATTEMPT" = "1" ]; then
+            eligible=true
+          fi
+          {
+            printf '{"schema_version":1,'
+            printf '"contract_version":"%s",' "$SIGNAL_FISH_H14_CONTRACT_VERSION"
+            printf '"event_name":"%s","run_id":"%s",' \
+              "$GITHUB_EVENT_NAME" "$GITHUB_RUN_ID"
+            printf '"run_attempt":"%s","commit_sha":"%s",' \
+              "$GITHUB_RUN_ATTEMPT" "$GITHUB_SHA"
+            printf '"runner_os":"%s","runner_image_os":"%s",' \
+              "$RUNNER_OS" "${ImageOS:-unknown}"
+            printf '"runner_image_version":"%s","rust_toolchain":"%s",' \
+              "${ImageVersion:-unknown}" "${SIGNAL_FISH_RUST_TOOLCHAIN:-unknown}"
+            printf '"h14_outcome":"%s","job_status":"%s",' \
+              "$H14_OUTCOME" "$JOB_STATUS"
+            printf '"h14_started":%s,"h14_finished":%s,' \
+              "$h14_started" "$h14_finished"
+            printf '"h14_exit_code":%s,"raw_log_present":%s,' \
+              "$h14_exit_code" "$raw_log_present"
+            printf '"raw_log_bytes":%s,"evidence_complete":%s,' \
+              "$raw_log_bytes" "$evidence_complete"
+            printf '"passed":%s,"eligible":%s}\n' "$passed" "$eligible"
+          } > h14-attempt.json
+      - name: Upload H14 attempt evidence
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: h14-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            mixed-encoding-output.txt
+            h14-attempt.json
+          retention-days: 30
+          if-no-files-found: error
       - name: Run asymmetric-bandwidth flap experiment
         shell: bash
         run: |

--- a/docs/development.md
+++ b/docs/development.md
@@ -304,9 +304,13 @@ all-feature clean-grid repetitions in a dedicated process on Linux, Windows,
 and macOS, keeps every delivery, conformance, zero-backpressure, and
 zero-eviction oracle, but deliberately does not gate the observed wall clock.
 Each job retains raw output, one JSONL row per completed cell, and an explicit
-attempt manifest for 90 days, including RED-run artifacts. Records identify the
-event, attempt, commit, exact Rust toolchain, workload schema, runner image, and
-completion state.
+attempt manifest for 30 days, the repository's configured maximum, including
+RED-run artifacts. At the nominal daily cadence, that covers the 20-allocation
+cohort plus a 10-day audit margin. Because missed or delayed schedules can
+stretch the cohort, maintainers audit it incrementally and download an attempt
+before its artifact expires when collection will exceed 30 days. Records
+identify the event, attempt, commit, exact Rust toolchain, workload schema,
+runner image, and completion state.
 
 Issue #274's platform decision uses the first 20 consecutive scheduled,
 first-attempt allocations per operating system after `relay-clean-v1` lands
@@ -324,6 +328,30 @@ isolated job only if every eligible observation is below it and the largest
 retains at least 2x headroom (at most 125 ms). Otherwise the platform stays
 correctness-only. A new ceiling must not be invented from one outlier or one
 shared-runner sample.
+
+P56's H14 validation uses the existing `scenario-profiles` job in
+`Verification Nightly`, preserving the same profile-CI runner and precursor
+context as the post-fix baseline. The exact
+`unsupported_message_pack_fallback_does_not_flap_weaker_recipient` selector
+runs after unrelated scenario or relay-matrix failures when checkout, the Rust
+toolchain, and Nextest setup succeeded. Its raw log and versioned attempt
+manifest are uploaded immediately afterward for the repository's 30-day
+maximum, before a later experiment can fail or consume the job timeout.
+That retention covers the 20-allocation cohort plus a 10-day margin only at the
+nominal daily cadence; maintainers audit incrementally and download attempts
+before expiry if schedule gaps stretch collection beyond 30 days.
+
+The fixed cohort is `h14-capacity-v1`: the first 20 consecutive scheduled,
+first-attempt allocations after the P56 production fix. Eligibility depends
+only on the scheduled event and first run attempt, never on test outcome,
+artifact presence, or completeness. A RED, cancelled, skipped, missing, or
+incomplete attempt therefore breaks acceptance instead of creating a sliding
+green-only window; reruns and manual/PR runs are diagnostic. Scheduled run
+`31070254464` was manually audited before manifests existed and remains the
+first eligible observation because this evidence-only instrumentation changes
+neither production code, workload, runner context, nor test oracle. A cohort
+restart requires a documented causal fix or workload change and a new contract
+version.
 
 ## Code Coverage
 

--- a/progress/session-100-h14-evidence-integrity.md
+++ b/progress/session-100-h14-evidence-integrity.md
@@ -1,0 +1,81 @@
+# Session 100 — H14 hosted evidence integrity
+
+## Scope and prioritization
+
+Remote triage found no open or dependency pull requests. Exact `main` head
+`72313f0` had newly started push workflows, and six setup jobs failed while
+GitHub could not resolve action download metadata. Those hosted failures are
+infrastructure errors rather than evidence for a repository code change, but
+the exact head is not called green until its reruns finish. Failed-job reruns
+were requested for all 11 affected workflow runs because 15 dependent jobs had
+been cancelled; attempt 2 showed no new failures at the last pre-publication
+snapshot.
+
+P53 and P56 each have one of 20 eligible scheduled first attempts. Issue #290
+was accidentally closed when PR #292's prose said it "does not close #290";
+the issue was reopened because its explicit hosted acceptance gate remains
+incomplete. P56 was the highest-impact bounded work: its H14 selector ran third
+inside a broad nightly job, so an unrelated earlier failure could skip the
+attempt, and it retained neither a machine-readable outcome nor raw evidence.
+
+## Failure-first evidence
+
+A parser-based workflow guard first failed because `Verification Nightly` had
+no stable H14 contract identifier, setup-aware execution condition, exact named
+selector, attempt manifest, or artifact step. The existing P53 guard separately
+failed after authoritative hosted logs showed that its requested 90-day
+artifact retention is capped to 30 days by repository settings. The first P53
+scheduled run succeeded on Linux, Windows, and macOS, but all three artifacts
+expire after 30 days, contradicting PLAN and development documentation.
+
+## Evidence contract
+
+- `h14-capacity-v1` preserves the existing Nextest `profile ci`, all-feature
+  binary, hosted job, precursor context, fixed workload, and every semantic
+  oracle. An equality filter pins the one H14 test and fails if it selects no
+  test.
+- H14 runs after unrelated scenario/matrix failures only when checkout,
+  toolchain, and Nextest setup succeeded and the job was not cancelled. Its
+  exit code is captured and re-propagated, so a RED test still fails the job.
+- An always-run manifest records event, run, attempt, SHA, runner image,
+  toolchain, contract version, H14 outcome/exit, raw-log presence and size,
+  evidence completeness, pass state, and eligibility. Eligibility depends only
+  on a scheduled first attempt; RED, skipped, cancelled, incomplete, and
+  missing attempts cannot disappear from the denominator.
+- Manifest and raw log upload immediately after H14, before the later H10
+  experiment can fail or consume the job timeout. Thirty days is the effective
+  repository maximum and covers the 20-allocation cohort plus a 10-day margin
+  at nominal daily cadence. The cohort is audited incrementally; artifacts must
+  be downloaded before expiry if missed schedules stretch collection beyond
+  30 days.
+- Scheduled run `31070254464`, manually audited before the manifest existed,
+  remains observation 1/20 because instrumentation changes no production,
+  workload, runner, or oracle context. A future causal fix or workload change
+  requires a documented cohort version bump.
+
+## Validation and publication
+
+The failure-first H14 and P53 retention guards are green after the workflow
+changes. Local validation passed:
+
+- the exact H14 Nextest selector under the CI profile;
+- successful and upstream-skipped manifest smoke fixtures, including JSON
+  parsing and eligibility/completeness assertions;
+- `actionlint`, workflow hygiene, CI configuration, Markdown, documentation,
+  LLM policy, and hook-readiness checks;
+- worktree pre-commit and pre-push policy checks;
+- locked all-target/all-feature Clippy with warnings denied; and
+- the full locked all-feature test suite.
+
+Adversarial review, publication, and exact-head hosted CI/reviewer evidence are
+recorded before this session closes. The implementation review found and closed
+three gaps before publication: retention language now distinguishes nominal
+daily cadence from scheduled allocations, empty logs cannot be complete or
+passing evidence, and executable fixtures cover success after an unrelated job
+failure, H14 failure, upstream skip, and an empty-log false positive. A second
+adversarial pass reported no remaining blocking, important, or moderate
+findings.
+
+This is an internal CI/evidence change. It changes no server API,
+configuration, wire behavior, runtime behavior, performance, or security
+contract, so no changelog entry is required.

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -2349,7 +2349,9 @@ fn test_relay_timing_observations_workflow_is_bounded_complete_and_retainable() 
     assert_eq!(
         with.as_mapping_get("retention-days")
             .and_then(Yaml::as_integer),
-        Some(90)
+        Some(30),
+        "the repository caps artifact retention at 30 days; the workflow must request the \n\
+         effective value instead of emitting a warning while claiming 90 days"
     );
     assert_eq!(
         with.as_mapping_get("if-no-files-found")
@@ -2393,6 +2395,356 @@ fn test_relay_timing_observations_workflow_is_bounded_complete_and_retainable() 
         "nightly must retain its complete matrix/fault/knee selection and exclude only the \
          dedicated hosted observation selector"
     );
+}
+
+#[test]
+fn test_verification_nightly_retains_h14_hosted_attempt_evidence() {
+    let root = repo_root();
+    let workflow_path = root.join(".github/workflows/verification-nightly.yml");
+    let workflow = read_live_file(&workflow_path);
+    let documents = Yaml::load_from_str(&workflow).expect("verification nightly must parse");
+    let document = documents.first().expect("workflow YAML document");
+    let job = document
+        .as_mapping_get("jobs")
+        .and_then(|jobs| jobs.as_mapping_get("scenario-profiles"))
+        .expect("verification nightly must retain the scenario-profiles job");
+    assert!(
+        job.as_mapping_get("needs").is_none(),
+        "a skipped dependency must not erase an eligible H14 attempt"
+    );
+    assert_eq!(
+        document
+            .as_mapping_get("env")
+            .and_then(|env| env.as_mapping_get("SIGNAL_FISH_H14_CONTRACT_VERSION"))
+            .and_then(Yaml::as_str),
+        Some("h14-capacity-v1"),
+        "the hosted cohort needs a stable contract identifier"
+    );
+
+    let steps = job
+        .as_mapping_get("steps")
+        .and_then(Yaml::as_sequence)
+        .expect("scenario-profiles steps");
+    let named_step_index = |name: &str| {
+        steps
+            .iter()
+            .position(|step| step.as_mapping_get("name").and_then(Yaml::as_str) == Some(name))
+            .unwrap_or_else(|| panic!("missing `{name}` step"))
+    };
+    for (name, id) in [
+        ("Checkout repository", "checkout"),
+        ("Read Rust toolchain", "toolchain"),
+        ("Install Rust toolchain", "install-rust"),
+        ("Install cargo-nextest", "install-nextest"),
+    ] {
+        let step = &steps[named_step_index(name)];
+        assert_eq!(
+            step.as_mapping_get("id").and_then(Yaml::as_str),
+            Some(id),
+            "`{name}` needs a stable id so H14 can distinguish setup failure from a test RED"
+        );
+    }
+
+    let h14_index = named_step_index("Run mixed-encoding amplification experiment");
+    let h14 = &steps[h14_index];
+    assert_eq!(h14.as_mapping_get("id").and_then(Yaml::as_str), Some("h14"));
+    let h14_condition = h14
+        .as_mapping_get("if")
+        .and_then(Yaml::as_str)
+        .expect("H14 condition");
+    assert_eq!(
+        h14_condition.split_whitespace().collect::<Vec<_>>(),
+        "${{ always() && !cancelled() && steps.checkout.outcome == 'success' && \
+         steps.toolchain.outcome == 'success' && steps.install-rust.outcome == 'success' && \
+         steps.install-nextest.outcome == 'success' }}"
+            .split_whitespace()
+            .collect::<Vec<_>>(),
+        "H14 must survive unrelated test failures without running after cancellation or missing setup"
+    );
+    assert!(
+        h14.as_mapping_get("continue-on-error").is_none(),
+        "a RED H14 result must still fail the nightly job"
+    );
+    let h14_run = h14
+        .as_mapping_get("run")
+        .and_then(Yaml::as_str)
+        .expect("H14 command");
+    for required in ["set -euo pipefail", ": > h14-started", "h14-exit-code.txt"] {
+        assert!(h14_run.contains(required), "H14 step lost `{required}`");
+    }
+    assert!(
+        !h14_run.contains("|| true"),
+        "H14 must propagate the exact selector's exit status"
+    );
+    let h14_cargo_commands: Vec<String> = shell_logical_lines(h14_run)
+        .into_iter()
+        .filter(|line| line.contains("cargo nextest"))
+        .collect();
+    assert_eq!(
+        h14_cargo_commands,
+        vec![
+            "cargo nextest run --profile ci --locked --all-features --test \
+             mixed_encoding_relay_e2e --run-ignored ignored-only -E \
+             'test(=unsupported_message_pack_fallback_does_not_flap_weaker_recipient)' \
+             --no-tests fail --success-output final 2>&1 | tee mixed-encoding-output.txt"
+        ],
+        "the hosted cohort must retain its existing Nextest context and exact H14 selector"
+    );
+    let selector_occurrences = steps
+        .iter()
+        .filter_map(|step| step.as_mapping_get("run").and_then(Yaml::as_str))
+        .map(|run| {
+            run.matches("unsupported_message_pack_fallback_does_not_flap_weaker_recipient")
+                .count()
+        })
+        .sum::<usize>();
+    assert_eq!(
+        selector_occurrences, 1,
+        "H14 must execute exactly once per scenario-profiles job"
+    );
+
+    let manifest_index = named_step_index("Write H14 attempt manifest");
+    assert_eq!(
+        manifest_index,
+        h14_index + 1,
+        "capture H14 metadata before a later experiment can fail or time out"
+    );
+    let manifest = &steps[manifest_index];
+    assert_eq!(
+        manifest.as_mapping_get("if").and_then(Yaml::as_str),
+        Some("always()")
+    );
+    let manifest_env = manifest
+        .as_mapping_get("env")
+        .expect("manifest environment");
+    assert_eq!(
+        manifest_env
+            .as_mapping_get("H14_OUTCOME")
+            .and_then(Yaml::as_str),
+        Some("${{ steps.h14.outcome }}"),
+        "aggregate job.status would misclassify H14 after an unrelated precursor failure"
+    );
+    let manifest_run = manifest
+        .as_mapping_get("run")
+        .and_then(Yaml::as_str)
+        .expect("manifest command");
+    for required in [
+        "GITHUB_EVENT_NAME",
+        "GITHUB_RUN_ID",
+        "GITHUB_RUN_ATTEMPT",
+        "GITHUB_SHA",
+        "SIGNAL_FISH_H14_CONTRACT_VERSION",
+        "SIGNAL_FISH_RUST_TOOLCHAIN",
+        "ImageOS",
+        "ImageVersion",
+        "H14_OUTCOME",
+        "raw_log_present",
+        "raw_log_bytes",
+        "evidence_complete",
+        "passed",
+        "eligible",
+        "h14-attempt.json",
+        "[ \"$raw_log_bytes\" -gt 0 ]",
+        "[ \"$evidence_complete\" = true ]",
+    ] {
+        assert!(
+            manifest_run.contains(required),
+            "H14 attempt manifest lost `{required}`"
+        );
+    }
+    assert!(
+        manifest_run.contains(
+            "if [ \"$GITHUB_EVENT_NAME\" = \"schedule\" ] && [ \"$GITHUB_RUN_ATTEMPT\" = \"1\" ]"
+        ),
+        "eligibility must depend only on a scheduled first attempt, never its outcome"
+    );
+
+    let upload_index = named_step_index("Upload H14 attempt evidence");
+    assert_eq!(
+        upload_index,
+        manifest_index + 1,
+        "upload H14 evidence immediately after writing its manifest"
+    );
+    let upload = &steps[upload_index];
+    assert_eq!(
+        upload.as_mapping_get("if").and_then(Yaml::as_str),
+        Some("always()")
+    );
+    assert_eq!(
+        upload.as_mapping_get("uses").and_then(Yaml::as_str),
+        Some("actions/upload-artifact@v7.0.1")
+    );
+    let upload_with = upload.as_mapping_get("with").expect("H14 upload settings");
+    assert_eq!(
+        upload_with.as_mapping_get("name").and_then(Yaml::as_str),
+        Some("h14-${{ github.run_id }}-${{ github.run_attempt }}")
+    );
+    let paths = upload_with
+        .as_mapping_get("path")
+        .and_then(Yaml::as_str)
+        .expect("H14 artifact paths");
+    assert_eq!(
+        paths.lines().map(str::trim).collect::<Vec<_>>(),
+        vec!["mixed-encoding-output.txt", "h14-attempt.json"]
+    );
+    assert_eq!(
+        upload_with
+            .as_mapping_get("retention-days")
+            .and_then(Yaml::as_integer),
+        Some(30),
+        "request the repository's effective retention maximum"
+    );
+    assert_eq!(
+        upload_with
+            .as_mapping_get("if-no-files-found")
+            .and_then(Yaml::as_str),
+        Some("error")
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_h14_attempt_manifest_classifies_behavioral_fixtures() {
+    let workflow = read_live_file(&repo_root().join(".github/workflows/verification-nightly.yml"));
+    let documents = Yaml::load_from_str(&workflow).expect("verification nightly must parse");
+    let steps = documents[0]
+        .as_mapping_get("jobs")
+        .and_then(|jobs| jobs.as_mapping_get("scenario-profiles"))
+        .and_then(|job| job.as_mapping_get("steps"))
+        .and_then(Yaml::as_sequence)
+        .expect("scenario-profiles steps");
+    let manifest_run = steps
+        .iter()
+        .find(|step| {
+            step.as_mapping_get("name").and_then(Yaml::as_str) == Some("Write H14 attempt manifest")
+        })
+        .and_then(|step| step.as_mapping_get("run"))
+        .and_then(Yaml::as_str)
+        .expect("H14 attempt manifest command");
+
+    struct Case {
+        name: &'static str,
+        started: bool,
+        exit_code: Option<i32>,
+        raw_log: Option<&'static str>,
+        h14_outcome: &'static str,
+        job_status: &'static str,
+        expected_complete: bool,
+        expected_passed: bool,
+    }
+
+    let cases = [
+        Case {
+            name: "success_after_unrelated_failure",
+            started: true,
+            exit_code: Some(0),
+            raw_log: Some("nextest H14 passed\n"),
+            h14_outcome: "success",
+            job_status: "failure",
+            expected_complete: true,
+            expected_passed: true,
+        },
+        Case {
+            name: "h14_failure",
+            started: true,
+            exit_code: Some(101),
+            raw_log: Some("nextest H14 failed\n"),
+            h14_outcome: "failure",
+            job_status: "failure",
+            expected_complete: true,
+            expected_passed: false,
+        },
+        Case {
+            name: "upstream_skipped",
+            started: false,
+            exit_code: None,
+            raw_log: None,
+            h14_outcome: "skipped",
+            job_status: "failure",
+            expected_complete: false,
+            expected_passed: false,
+        },
+        Case {
+            name: "empty_log_cannot_pass",
+            started: true,
+            exit_code: Some(0),
+            raw_log: Some(""),
+            h14_outcome: "success",
+            job_status: "success",
+            expected_complete: false,
+            expected_passed: false,
+        },
+    ];
+
+    for case in cases {
+        let temp_dir = unique_temp_dir(&format!("h14-manifest-{}", case.name));
+        if case.started {
+            write_file(&temp_dir.path().join("h14-started"), "");
+        }
+        if let Some(exit_code) = case.exit_code {
+            write_file(
+                &temp_dir.path().join("h14-exit-code.txt"),
+                &format!("{exit_code}\n"),
+            );
+        }
+        if let Some(raw_log) = case.raw_log {
+            write_file(&temp_dir.path().join("mixed-encoding-output.txt"), raw_log);
+        }
+
+        let output = bash_command()
+            .arg("-c")
+            .arg(manifest_run)
+            .current_dir(temp_dir.path())
+            .env("H14_OUTCOME", case.h14_outcome)
+            .env("JOB_STATUS", case.job_status)
+            .env("SIGNAL_FISH_RUST_TOOLCHAIN", "1.91.0")
+            .env("SIGNAL_FISH_H14_CONTRACT_VERSION", "h14-capacity-v1")
+            .env("GITHUB_EVENT_NAME", "schedule")
+            .env("GITHUB_RUN_ID", "123456")
+            .env("GITHUB_RUN_ATTEMPT", "1")
+            .env("GITHUB_SHA", "0123456789abcdef")
+            .env("RUNNER_OS", "Linux")
+            .env("ImageOS", "ubuntu24")
+            .env("ImageVersion", "20260801.1")
+            .output()
+            .unwrap_or_else(|e| panic!("{}: failed to run manifest script: {e}", case.name));
+        assert!(
+            output.status.success(),
+            "{}: manifest script failed:\nstdout:\n{}\nstderr:\n{}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let manifest_text = read_file(&temp_dir.path().join("h14-attempt.json"));
+        let manifest: serde_json::Value = serde_json::from_str(&manifest_text)
+            .unwrap_or_else(|e| panic!("{}: invalid manifest JSON: {e}", case.name));
+        assert_eq!(manifest["eligible"].as_bool(), Some(true), "{}", case.name);
+        assert_eq!(
+            manifest["evidence_complete"].as_bool(),
+            Some(case.expected_complete),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            manifest["passed"].as_bool(),
+            Some(case.expected_passed),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            manifest["h14_outcome"].as_str(),
+            Some(case.h14_outcome),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            manifest["job_status"].as_str(),
+            Some(case.job_status),
+            "{}",
+            case.name
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- run the exact P56 H14 selector after unrelated scenario-profile failures when checkout and test tooling are available
- retain a versioned attempt manifest and raw log immediately after H14, with outcome-independent scheduled-first-attempt eligibility
- align P53 artifact retention and documentation with the repository's effective 30-day maximum
- add structural and executable CI-config guards for success, H14 failure, upstream skip, and empty-log false-positive paths

## Why

P56's post-fix H14 cohort is currently 1/20. H14 previously ran after two unrelated nightly workloads and retained neither a machine-readable attempt record nor its raw log. A precursor failure could therefore erase an allocated attempt and create survivor bias.

The P53 workflow also requested and documented 90-day retention, while GitHub caps this repository at 30 days and emitted a warning on the first scheduled observation. The docs now state the effective limit and the incremental audit/download duty if schedule gaps stretch collection beyond 30 days.

This is internal CI/evidence hardening only. It changes no server API, configuration, wire behavior, runtime behavior, performance, or security contract, so no changelog entry is required.

Refs #290.
Refs #274.

## Evidence contract

- Contract: `h14-capacity-v1`
- Cohort: first 20 consecutive scheduled first attempts
- Eligibility: schedule + attempt 1 only, independent of result or artifact completeness
- Acceptance: any RED, cancelled, skipped, missing, empty-log, or incomplete attempt breaks the green cohort
- Baseline: manually audited scheduled run `31070254464` remains observation 1/20 because this instrumentation changes no production code, workload, runner context, selector, or oracle

## Validation

- exact H14 Nextest selector under profile `ci`
- manifest smoke tests and four executable behavioral fixtures
- `cargo check --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `actionlint`
- workflow hygiene, CI config, Markdown, doc-consistency, LLM policy, hook-readiness, and worktree pre-commit/pre-push checks
- two adversarial review passes; no remaining blocking, important, or moderate findings

## Main-branch audit

Exact main SHA `72313f0` had six setup failures caused by GitHub action-resolution `Service Unavailable` before checkout and 15 cancelled dependents. Failed-job reruns were requested for all 11 affected workflow runs. Attempt 2 had no new failure at the last pre-publication snapshot; the exact head is not considered green until every rerun is terminal and successful.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow, documentation, and CI guard changes only; no server runtime, API, or security behavior is modified.
> 
> **Overview**
> **Hardens hosted acceptance evidence for P56 H14** so scheduled cohort runs are not skipped or lost when earlier nightly steps fail, and documents the effective GitHub artifact retention cap.
> 
> In **Verification Nightly** `scenario-profiles`, the mixed-encoding step now runs the single pinned test `unsupported_message_pack_fallback_does_not_flap_weaker_recipient` under a setup-aware `always()` condition (checkout, toolchain, Nextest must succeed), still fails the job on RED, and writes **`h14-attempt.json`** plus uploads **`mixed-encoding-output.txt`** immediately—before later experiments—under contract **`h14-capacity-v1`**. Eligibility is schedule + first attempt only, independent of pass/fail.
> 
> **Relay timing observations** and H14 uploads request **30-day** retention instead of 90, matching the repo maximum; **development.md** and **ci_config_tests** are updated accordingly, with new structural and executable manifest fixture guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98b2ba94a2fa696f18d1afef8646abd82ee7ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->