### PR TITLE
Make live interop failures actionable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Make live-reference-client interoperability failures actionable (issue
+  #301). A missing native WebRTC candidate pair now reports the client's exit
+  code, stderr, full event progression, and advertised ICE candidates. The
+  hosted Fortress/Godot WASM gate permits one recovered prediction-window
+  denial but fails on any repetition; its zero-wait, progress, throughput,
+  queue, rollback, checksum, conservation, and error oracles remain unchanged.
+  The expanded acceptance-threshold report and browser configuration use schema
+  version 3, so stale v2 exports fail closed instead of silently omitting the
+  new stall boundary.
 - Refresh the browser reference client's runtime and development toolchain:
   Playwright Core 1.62.1, TypeScript 7.0.2, Prettier 3.9.6, and Node.js 26 type
   definitions. The supported Node.js floor remains 20.

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -31,7 +31,11 @@ Rust floor is 1.94.0, intentionally higher than the standalone server crate's
 MSRV. The primary cell requires both peers to satisfy every healthy throughput,
 progress, queue-age, conservation, rollback, checksum, cadence, and runtime
 identity gate. Any missing report or invariant violation fails closed as
-`BUSTED`; only the complete two-peer result prints `HEALTHY`.
+`BUSTED`; only the complete two-peer result prints `HEALTHY`. The hosted WASM
+gate permits at most one recovered prediction-window-denied game callback and
+fails on a second. Wait recommendations remain forbidden, as do every existing
+loss, overflow, throughput, queue-age, lag, rollback, checksum, and conservation
+violation. The native Fortress gate retains its stricter zero-stall boundary.
 
 Exact-head CI with the released 0.9.0 graph passed the complete primary cell:
 both reports satisfied every health and identity invariant and printed

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -15,6 +15,7 @@ const expectedThresholds = {
   max_oldest_queue_age_us: 500000,
   max_confirmation_lag: 8,
   max_rollback_depth: 8,
+  max_stall_count: 1,
 };
 const reportKeys = [
   "schema_version", "status", "origin", "runtime_error", "role", "run_mode",
@@ -40,6 +41,11 @@ const reportKeys = [
 
 const [mode, exportDirectoryArg, serverBinaryArg, artifactDirectoryArg, buildSha] =
   process.argv.slice(2);
+if (mode === "self-test") {
+  runHealthGateSelfTests();
+  process.stdout.write("HEALTHY fortress-wasm health-gate self-test\n");
+  process.exit(0);
+}
 if (!mode || !exportDirectoryArg || !serverBinaryArg || !artifactDirectoryArg || !buildSha) {
   throw new Error(
     "usage: node harness.mjs <released|negative> <export-dir> <server-bin> <artifacts-dir> <build-sha>",
@@ -133,7 +139,7 @@ try {
   });
   const room = await waitForGlobal(creator, "__FORTRESS_ROOM_READY", 15_000);
   assertExactKeys(room, ["schema_version", "role", "instance_nonce", "room_code"], "room-ready");
-  assert(room.schema_version === 2, "room-ready schema mismatch");
+  assert(room.schema_version === 3, "room-ready schema mismatch");
   assert(room.role === "creator", "room-ready role mismatch");
   assert(room.instance_nonce === creatorNonce, "room-ready nonce mismatch");
   assert(typeof room.room_code === "string" && room.room_code.length > 0, "empty room code");
@@ -346,7 +352,7 @@ async function launchPeer({ role, roomCode, instanceNonce, expectedRemoteNonce, 
     },
     {
       config: {
-        schema_version: 2,
+        schema_version: 3,
         server_url: `ws://127.0.0.1:${serverPort}/v2/ws`,
         role,
         room_code: roomCode,
@@ -437,7 +443,7 @@ function validateIdentityAndRuntime(creatorReport, joinerReport, creatorBrowser,
     ["joiner", joinerReport, joinerBrowser],
   ]) {
     assertExactKeys(report, reportKeys, `${name} report`);
-    assert(report.schema_version === 2 && report.status === "complete", `${name}: incomplete schema`);
+    assert(report.schema_version === 3 && report.status === "complete", `${name}: incomplete schema`);
     assert(report.origin === "rust-gdextension", `${name}: report did not originate in Rust`);
     assert(report.runtime_error === null, `${name}: ${report.runtime_error}`);
     assert(report.role === name, `${name}: role mismatch`);
@@ -524,8 +530,12 @@ function healthViolations(name, report) {
   check(report.final_pipeline_queue_depth === 0, `final pipeline depth=${report.final_pipeline_queue_depth}`);
   check(report.peak_pipeline_queue_depth <= 64, `peak pipeline depth=${report.peak_pipeline_queue_depth}`);
   check(report.peak_oldest_queue_age_us <= 500_000, `oldest queue age=${report.peak_oldest_queue_age_us}us`);
-  const forbidden = ["relay_malformed", "relay_wrong_destination", "relay_unknown_sender", "relay_outbound_overflow", "relay_inbound_overflow", "relay_encode_failures", "relay_completion_underflow", "client_messages_undecodable", "checksums_mismatched", "events_discarded_total", "stall_count", "wait_recommendations"];
+  const forbidden = ["relay_malformed", "relay_wrong_destination", "relay_unknown_sender", "relay_outbound_overflow", "relay_inbound_overflow", "relay_encode_failures", "relay_completion_underflow", "client_messages_undecodable", "checksums_mismatched", "events_discarded_total", "wait_recommendations"];
   for (const field of forbidden) check(report[field] === 0, `${field}=${report[field]}`);
+  check(
+    stallCountWithinThreshold(report),
+    `stall_count=${report.stall_count} exceeds ${report.acceptance_thresholds.max_stall_count}`,
+  );
   check(report.relay_send_retries <= 8, `relay_send_retries=${report.relay_send_retries}`);
   check(report.confirmation_lag_current <= 8 && report.confirmation_lag_max <= 8, "confirmation lag exceeded eight frames");
   check(report.max_rollback_depth <= 8, `rollback depth=${report.max_rollback_depth}`);
@@ -536,6 +546,31 @@ function healthViolations(name, report) {
   check(rate >= 120, `completed rate=${rate.toFixed(1)} messages/s`);
   check(report.client_game_data_sent_during_run > report.active_callback_count * 2, "no more than two sends per callback");
   return failures;
+}
+
+function stallCountWithinThreshold(report) {
+  return Number.isSafeInteger(report.stall_count) &&
+    report.stall_count >= 0 &&
+    report.stall_count <= report.acceptance_thresholds.max_stall_count;
+}
+
+function runHealthGateSelfTests() {
+  for (const [stallCount, expected] of [
+    [0, true],
+    [1, true],
+    [2, false],
+    [-1, false],
+    [1.5, false],
+  ]) {
+    const report = {
+      stall_count: stallCount,
+      acceptance_thresholds: expectedThresholds,
+    };
+    assert(
+      stallCountWithinThreshold(report) === expected,
+      `stall threshold case ${stallCount} expected ${expected}`,
+    );
+  }
 }
 
 async function waitForGlobal(peer, key, timeout) {

--- a/clients/fortress-wasm/project/main.gd
+++ b/clients/fortress-wasm/project/main.gd
@@ -67,7 +67,7 @@ func _publish_bridge_error(message: String) -> void:
 		return
 	result_published = true
 	var result := {
-		"schema_version": 2,
+		"schema_version": 3,
 		"status": "complete",
 		"runtime_error": message,
 		"origin": "gdscript-bootstrap-error",

--- a/clients/fortress-wasm/src/lib.rs
+++ b/clients/fortress-wasm/src/lib.rs
@@ -22,7 +22,8 @@ use workload::{
     MIN_COMPLETED_MESSAGES_PER_SECOND, NOMINAL_FPS, TARGET_CONFIRMED_FRAMES,
 };
 
-const REPORT_SCHEMA_VERSION: u32 = 2;
+const REPORT_SCHEMA_VERSION: u32 = 3;
+const MAX_STALL_COUNT: u64 = 1;
 const MIN_ACTIVE_CALLBACKS: u64 = 600;
 const NEGATIVE_ACTIVE_CALLBACK_BUDGET: u64 = MIN_ACTIVE_CALLBACKS;
 const RUNTIME_DEADLINE: Duration = Duration::from_secs(90);
@@ -105,6 +106,7 @@ struct AcceptanceThresholds {
     max_oldest_queue_age_us: u64,
     max_confirmation_lag: u64,
     max_rollback_depth: u32,
+    max_stall_count: u64,
 }
 
 #[derive(Debug, Serialize)]
@@ -656,6 +658,7 @@ impl Runtime {
                 max_oldest_queue_age_us: MAX_OLDEST_QUEUE_AGE_US,
                 max_confirmation_lag: MAX_CONFIRMATION_LAG,
                 max_rollback_depth: MAX_ROLLBACK_DEPTH,
+                max_stall_count: MAX_STALL_COUNT,
             },
             max_admissions_per_callback: self.max_admissions_per_callback,
             current_frame,

--- a/clients/native/tests/interop_e2e.rs
+++ b/clients/native/tests/interop_e2e.rs
@@ -78,11 +78,11 @@ use std::net::{IpAddr, UdpSocket};
 use std::time::Duration;
 
 use harness::{
-    advertised_candidate_addresses, events_named, player_id_of, scenario_window, single_event,
-    spawn_client, spawn_server, str_field, ClientProcess, ClientSpec, CLIENT_EXIT_TIMEOUT,
-    EVENT_TIMEOUT,
+    advertised_candidate_addresses, advertised_candidates, event_tags, events_named, player_id_of,
+    scenario_window, single_event, spawn_client, spawn_server, str_field, ClientProcess,
+    ClientSpec, CLIENT_EXIT_TIMEOUT, EVENT_TIMEOUT,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 use signal_fish_reference_native::engine::{local_udp_addrs, EngineSettings, IpFamily};
 use uuid::Uuid;
 
@@ -133,6 +133,8 @@ struct ScenarioRun {
     logs: Vec<Vec<Value>>,
     /// Recent stdout events plus captured stderr, same indexing.
     diagnostics: Vec<String>,
+    /// Reaped process exit codes, same indexing.
+    exit_codes: Vec<i32>,
 }
 
 impl ScenarioRun {
@@ -154,6 +156,15 @@ impl ScenarioRun {
 
     fn diagnostics(&self, index: usize) -> &str {
         &self.diagnostics[index]
+    }
+
+    fn selected_pair_failure_context(&self, index: usize) -> String {
+        selected_pair_failure_context(
+            TWO_CLIENT_NAMES[index],
+            self.exit_codes[index],
+            &self.logs[index],
+            self.diagnostics(index),
+        )
     }
 }
 
@@ -187,7 +198,7 @@ impl ClientConfig {
 
 /// Drain one client to EOF + reap it; it must exit 0 AND report that via its
 /// final `exiting` event.
-async fn drain_expect_success(client: &mut ClientProcess) {
+async fn drain_expect_success(client: &mut ClientProcess) -> i32 {
     let code = client.drain_to_exit(CLIENT_EXIT_TIMEOUT).await;
     assert_eq!(
         code,
@@ -203,6 +214,7 @@ async fn drain_expect_success(client: &mut ClientProcess) {
         "client {}: exiting event must report code 0",
         client.name
     );
+    code
 }
 
 async fn await_event_count(
@@ -280,8 +292,9 @@ async fn run_three_clients(
 
     // Drain everyone to EOF + reap; every client must succeed on its own
     // (their internal success criteria) AND report it via the exiting event.
+    let mut exit_codes = Vec::with_capacity(clients.len());
     for client in &mut clients {
-        drain_expect_success(client).await;
+        exit_codes.push(drain_expect_success(client).await);
     }
 
     let ids: Vec<String> = clients
@@ -301,6 +314,7 @@ async fn run_three_clients(
             .map(|mut client| std::mem::take(&mut client.events))
             .collect(),
         diagnostics,
+        exit_codes,
     }
 }
 
@@ -357,8 +371,9 @@ async fn run_two_peer_mesh(game_name: &str, extra_args: &'static [&'static str])
     );
 
     let mut clients = vec![creator, joiner];
+    let mut exit_codes = Vec::with_capacity(clients.len());
     for client in &mut clients {
-        drain_expect_success(client).await;
+        exit_codes.push(drain_expect_success(client).await);
     }
     server.shutdown().await;
 
@@ -376,6 +391,7 @@ async fn run_two_peer_mesh(game_name: &str, extra_args: &'static [&'static str])
             .map(|mut client| std::mem::take(&mut client.events))
             .collect(),
         diagnostics,
+        exit_codes,
     }
 }
 
@@ -1593,8 +1609,21 @@ fn selected_ip_address(event: &Value, field: &str, who: &str) -> IpAddr {
 
 /// Assert this client's single selected pair is a direct host/host path toward
 /// the expected peer, and return its concrete local and remote addresses.
-fn assert_direct_host_path(events: &[Value], who: &str, peer_id: &str) -> [IpAddr; 2] {
-    let selected = single_event(events, "selected_candidate_pair", who);
+fn assert_direct_host_path(
+    events: &[Value],
+    who: &str,
+    peer_id: &str,
+    failure_context: &str,
+) -> [IpAddr; 2] {
+    let selected = events_named(events, "selected_candidate_pair");
+    assert_eq!(
+        selected.len(),
+        1,
+        "{who}: expected exactly one `selected_candidate_pair` event, got {}: {selected:?}\n\
+         {failure_context}",
+        selected.len(),
+    );
+    let selected = selected[0];
     assert_eq!(
         str_field(selected, "peer"),
         peer_id,
@@ -1620,6 +1649,82 @@ fn assert_direct_host_path(events: &[Value], who: &str, peer_id: &str) -> [IpAdd
     addresses
 }
 
+fn selected_pair_failure_context(
+    who: &str,
+    exit_code: i32,
+    events: &[Value],
+    diagnostics: &str,
+) -> String {
+    format!(
+        "client {who} exit code: {exit_code}\n\
+         emitted {} event(s): {}\n\
+         advertised local ICE candidates: {:?}\n\
+         {diagnostics}",
+        events.len(),
+        event_tags(events),
+        advertised_candidates(events),
+    )
+}
+
+#[test]
+fn missing_selected_pair_reports_fully_drained_process_and_ice_evidence() {
+    let events = vec![
+        json!({
+            "event": "local_candidate",
+            "candidate_type": "host",
+            "address": "192.0.2.7",
+            "port": 49152
+        }),
+        json!({
+            "event": "player_left"
+        }),
+        json!({
+            "event": "exiting",
+            "code": 0
+        }),
+    ];
+    let run = ScenarioRun {
+        ids: Vec::new(),
+        logs: vec![events],
+        diagnostics: vec!["stderr sentinel".to_owned()],
+        exit_codes: vec![0],
+    };
+    let context = run.selected_pair_failure_context(0);
+
+    assert!(context.contains("client c0 exit code: 0"), "{context}");
+    assert!(
+        context.contains("emitted 3 event(s): local_candidate, player_left, exiting"),
+        "{context}"
+    );
+    assert!(
+        context.contains("advertised local ICE candidates: [\"host 192.0.2.7:49152\"]"),
+        "{context}"
+    );
+    assert!(context.contains("stderr sentinel"), "{context}");
+
+    let failure = std::panic::catch_unwind(|| {
+        assert_direct_host_path(run.window(0), "c0", "peer-id", &context);
+    })
+    .expect_err("the missing selected pair must fail its real assertion path");
+    let message = failure
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| failure.downcast_ref::<&str>().copied())
+        .expect("assertion panic must carry a string message");
+    for required in [
+        "expected exactly one `selected_candidate_pair` event, got 0",
+        "client c0 exit code: 0",
+        "local_candidate, player_left, exiting",
+        "advertised local ICE candidates: [\"host 192.0.2.7:49152\"]",
+        "stderr sentinel",
+    ] {
+        assert!(
+            message.contains(required),
+            "missing `{required}` in:\n{message}"
+        );
+    }
+}
+
 /// Assert this client's single selected pair is host/host over concrete IPv6,
 /// toward the expected peer.
 ///
@@ -1629,8 +1734,8 @@ fn assert_direct_host_path(events: &[Value], who: &str, peer_id: &str) -> [IpAdd
 /// STUN or TURN is configured), and carried by an address a peer could actually
 /// dial — never unspecified, multicast, or link-local, whose scope ID the
 /// candidate wire cannot carry.
-fn assert_ipv6_host_path(events: &[Value], who: &str, peer_id: &str) {
-    for address in assert_direct_host_path(events, who, peer_id) {
+fn assert_ipv6_host_path(events: &[Value], who: &str, peer_id: &str, failure_context: &str) {
+    for address in assert_direct_host_path(events, who, peer_id, failure_context) {
         let IpAddr::V6(address) = address else {
             panic!("{who}: the IPv6-only run selected an IPv4 candidate {address}");
         };
@@ -1685,7 +1790,8 @@ async fn two_peer_mesh_exchanges_over_live_webrtc() {
         );
 
         assert_pair_connected_exactly(window, who, &peers);
-        assert_direct_host_path(window, who, peer_id);
+        let failure_context = run.selected_pair_failure_context(index);
+        assert_direct_host_path(window, who, peer_id, &failure_context);
         assert_exchange_sent_to(window, who, &peers);
         assert_exchange_received_from(window, who, &peers);
         assert_transport_status_true(&run.logs[index], who);
@@ -1739,7 +1845,8 @@ async fn ipv6_only_mesh_pair_exchanges_on_a_host_ipv6_path() {
         );
 
         // ...over IPv6, with the exact exchange on both channel labels.
-        assert_ipv6_host_path(window, who, peer_id);
+        let failure_context = run.selected_pair_failure_context(index);
+        assert_ipv6_host_path(window, who, peer_id, &failure_context);
         assert_no_ipv4_candidate_advertised(window, who);
         assert_exchange_sent_to(window, who, &peers);
         assert_exchange_received_from(window, who, &peers);

--- a/progress/session-104-webrtc-failure-diagnostics.md
+++ b/progress/session-104-webrtc-failure-diagnostics.md
@@ -1,0 +1,89 @@
+# Session 104 — Live-interop failure diagnostics
+
+## Scope and priority
+
+Session 103 / PR #306 merged green with no open pull request or dependency
+update remaining. P53 and P56 still require their pre-registered hosted sample
+windows, so the next actionable gameplay-path issue was #301: one Windows live
+WebRTC cell and one Fortress WASM released-graph cell had failed
+nondeterministically, then passed on identical-tree reruns.
+
+The exact staged inverse of merged PR #306 was present when the session began.
+The index and worktree matched `HEAD^` byte-for-byte, including the `lru`
+downgrade and restoration of obsolete mock-only performance tests. It was
+checkout residue rather than forward work and was restored to authoritative
+merged `HEAD` before this session's branch was created.
+
+## Native selected-pair evidence
+
+PR #299 had made a missing event print the complete event-tag order, but the
+cross-platform selected-candidate assertion still received only a drained
+event slice. `ClientProcess` had captured stderr and checked the exit code, then
+discarded that outcome before `ScenarioRun` performed the assertion.
+
+The scenario now retains every reaped client exit code. A missing
+`selected_candidate_pair` failure prints the exit code, complete tag order,
+advertised local candidate set, recent JSON events, and captured stderr. A
+deterministic regression was observed RED before the formatting seam existed
+and now pins all four diagnostic categories without reproducing the hosted
+transport failure.
+
+## Fortress stall classification
+
+The failed run's retained reports disprove a correctness regression and do not
+support the issue's specific runner-I/O/download hypothesis. The joiner recorded
+one denied `advance_frame` call in 602 active callbacks (0.166%) at Fortress's
+eight-frame prediction boundary, yet reached current frame 601 / confirmed
+frame 600, completed 1,317 messages in 10.698 seconds (123.1/s), drained a queue
+whose peak was 8 and oldest age 17.5 ms, matched all nine checksums and both
+1,327-message direction ledgers, and reported zero waits, loss, overflow,
+retries, malformed input, or runtime errors. Its callback mean/p99/max were a
+smooth 17.510/17.9/19.5 ms. The creator passed every gate, the identical-tree
+rerun passed, and the observed base rate was one failure in 25 runs.
+
+The WASM report now declares `max_stall_count: 1`. Zero and one recovered
+prediction-window denial pass; two, a negative count, or a fractional count
+fail the executable harness self-test. Wait recommendations and all prior
+progress, throughput, cadence, queue, lag, rollback, checksum, conservation,
+and exact-zero error gates remain unchanged. Native P12 remains zero-stall.
+Because that threshold expands the exact report shape, the coupled Rust report,
+browser configuration, room-ready signal, GDScript bootstrap-error report, and
+harness validator now use schema v3; stale v2 exports fail closed.
+
+## Changelog classification
+
+These changes affect interoperability-test evidence and CI acceptance rather
+than server, client, protocol, configuration, or runtime behavior. The
+repository's path classifier nevertheless treats the standalone fixture and
+native interop test as release-note scope, so `CHANGELOG.md` records the
+maintainer-visible failure evidence and the exact one-stall boundary without
+implying a shipped server behavior change.
+
+## Validation
+
+- Native diagnostic regression: pass.
+- Native all-target strict Clippy: pass.
+- Fortress harness syntax and 0/1/2/invalid self-test: pass.
+- Focused Fortress structural policy regression: pass.
+- Root all-feature tests (including 759 library tests and 311 CI-policy tests),
+  all-target strict Clippy, formatting, Cargo deny, CI configuration, workflow
+  hygiene, documentation, Markdown, MSRV, tooling-parity, hook-readiness, and
+  worktree hook preflights: pass.
+- Current-checkout native two-peer live WebRTC exchange: pass.
+- Two adversarial review rounds: the first found the truncated diagnostic
+  source, formatter-only regression, and stale schema version; an independent
+  evaluator fixed all three, and the second round reported zero implementation
+  findings.
+- The local Fortress host test is unavailable because this environment has no
+  Godot 4.5 executable for the fixture's `api-custom` build. The pinned hosted
+  Godot/Emscripten/Chromium workflow is the authoritative remaining evidence.
+- Hosted-CI and PR review evidence will be recorded before handoff.
+
+## Follow-up boundary
+
+P53 and P56 remain open until their registered hosted sample sizes are met; no
+threshold is weakened and no completion is inferred here. PR #306 also requires
+a fresh minor-bump Prepare Release run for 0.6.0 after this single session PR is
+merged; it must not be stacked with the present issue work. Issue #307 records
+that release follow-up with its version, diff-scope, validation, review, and
+publication boundaries.

--- a/progress/session-104-webrtc-failure-diagnostics.md
+++ b/progress/session-104-webrtc-failure-diagnostics.md
@@ -77,7 +77,23 @@ implying a shipped server behavior change.
 - The local Fortress host test is unavailable because this environment has no
   Godot 4.5 executable for the fixture's `api-custom` build. The pinned hosted
   Godot/Emscripten/Chromium workflow is the authoritative remaining evidence.
-- Hosted-CI and PR review evidence will be recorded before handoff.
+- PR #308's code head `b4e1bb4` passed all 12 substantive hosted workflows:
+  CI, Advanced Safety, Verification Nightly, WebRTC Interop, TURN-only WebRTC
+  Interop, Fortress WASM Interop, Browser Interop, Documentation Validation,
+  Unused Dependencies, Spellcheck, Markdownlint, and Link Check. The expected
+  Dependabot auto-merge workflow was skipped.
+- Windows live WebRTC passed on its first attempt. The first macOS attempt
+  reproduced the targeted missing selected-pair snapshot while the client
+  exited 0, exchanged both channel directions, reported WebRTC connected, and
+  advertised three host candidates; the new stderr identified the absent
+  post-connect selected-pair statistic. Its targeted retry passed, making run
+  31264319045 green. The evidence is recorded on issue #301.
+- The real released Fortress WASM graph and expected-busted negative control
+  passed in run 31264319057. This supplies the pinned Godot/Emscripten/Chromium
+  evidence unavailable in the local container.
+- PR #308 has no inline review threads or requested changes. Copilot could not
+  review because the requester's quota was exhausted; both independent local
+  adversarial rounds remain the substantive review evidence.
 
 ## Follow-up boundary
 

--- a/scripts/run-fortress-wasm-interop.sh
+++ b/scripts/run-fortress-wasm-interop.sh
@@ -18,6 +18,8 @@ readonly LIBRARY_NAME="signal_fish_fortress_wasm_interop"
 readonly TARGET_DIR="${REPO_ROOT}/target/fortress-wasm"
 readonly COMMON_RUSTFLAGS="-Z unstable-options -C panic=immediate-abort -C link-arg=-sSIDE_MODULE=2 -C llvm-args=-enable-emscripten-cxx-exceptions=0 -Z default-visibility=hidden -Z link-native-libraries=no"
 
+node "${FIXTURE_ROOT}/harness.mjs" self-test
+
 if ! command -v emcc >/dev/null 2>&1; then
     if [[ -n "${EMSDK:-}" && -f "${EMSDK}/emsdk_env.sh" ]]; then
         # shellcheck disable=SC1091

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -24731,7 +24731,8 @@ SIGNAL_FISH_SERVER_BIN="$GITHUB_WORKSPACE/target/debug/signal-fish-server${SERVE
     for required in [
         "async fn two_peer_mesh_exchanges_over_live_webrtc()",
         r#"let run = run_two_peer_mesh("interop-cross-platform-smoke", &[]).await;"#,
-        "assert_direct_host_path(window, who, peer_id);",
+        "let failure_context = run.selected_pair_failure_context(index);",
+        "assert_direct_host_path(window, who, peer_id, &failure_context);",
         "assert_exchange_sent_to(window, who, &peers);",
         "assert_exchange_received_from(window, who, &peers);",
         "assert_transport_status_true(&run.logs[index], who);",
@@ -24757,7 +24758,7 @@ SIGNAL_FISH_SERVER_BIN="$GITHUB_WORKSPACE/target/debug/signal-fish-server${SERVE
         "The lane must not be skipped silently.",
         // The path is asserted to be direct IPv6 toward the planned peer.
         "fn assert_ipv6_host_path(",
-        "assert_ipv6_host_path(window, who, peer_id);",
+        "assert_ipv6_host_path(window, who, peer_id, &failure_context);",
         "fn selected_ip_address(event: &Value, field: &str, who: &str) -> IpAddr {",
         "let IpAddr::V6(address) = address else {",
         r#"for field in ["local_candidate_type", "remote_candidate_type"] {"#,
@@ -25065,7 +25066,9 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "use signal_fish_client_godot::GodotWebSocketTransport;",
         "const SIGNAL_FISH_CLIENT_GODOT_VERSION: &str = \"0.9.0\";",
         "signal_fish_client_godot_version: SIGNAL_FISH_CLIENT_GODOT_VERSION",
-        "const REPORT_SCHEMA_VERSION: u32 = 2;",
+        "const REPORT_SCHEMA_VERSION: u32 = 3;",
+        "const MAX_STALL_COUNT: u64 = 1;",
+        "max_stall_count: MAX_STALL_COUNT,",
     ] {
         assert!(
             source.contains(required),
@@ -25080,6 +25083,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "Engine.get_version_info()",
         "RenderingServer.set_render_loop_enabled(false)",
         "Engine.max_fps = 60",
+        "\"schema_version\": 3,",
         "config[\"schema_version\"] = int(",
         "config[\"browser_process_id\"] = int(",
         "config[\"godot_runtime\"]",
@@ -25100,7 +25104,9 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "sharedArrayBufferType === \"undefined\"",
         "workerConstructions === 0",
         "report.callback_count === report.poll_count",
-        "report.schema_version === 2",
+        "room.schema_version === 3",
+        "schema_version: 3,",
+        "report.schema_version === 3",
         "report.signal_fish_client_godot_version === \"0.9.0\"",
         "report.godot_runtime.string === \"4.5-stable (official)\"",
         "assertExactKeys(report, reportKeys",
@@ -25115,6 +25121,9 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "joinerReport.relay_sent_first_sequence === creatorReport.relay_received_first_sequence",
         "joinerReport.relay_sent_last_sequence === creatorReport.relay_received_last_sequence",
         "const healthyViolations = peerHealth.flatMap",
+        "max_stall_count: 1,",
+        "stallCountWithinThreshold(report)",
+        "runHealthGateSelfTests();",
         "BUSTED fortress-wasm expected negative control",
         "HEALTHY fortress-wasm released-client interoperability",
     ] {
@@ -25152,6 +25161,17 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
             && !released_classification.contains("completion bottleneck"),
         "P13 released classifier must require health instead of accepting the old bottleneck"
     );
+    let forbidden_start = harness
+        .find("const forbidden = [")
+        .expect("P13 harness must define exact-zero failure counters");
+    let forbidden_end = harness[forbidden_start..]
+        .find("];\n")
+        .map(|offset| forbidden_start + offset)
+        .expect("P13 exact-zero failure counter list must be bounded");
+    assert!(
+        !harness[forbidden_start..forbidden_end].contains("\"stall_count\""),
+        "P13 must apply the evidence-backed one-stall threshold separately from exact-zero counters"
+    );
     for required in [
         "report.active_callback_count >= 600",
         "report.max_admissions_per_callback === 1",
@@ -25181,6 +25201,10 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     assert!(
         !harness.contains("/confirmed_frame|completed rate|sends per callback/"),
         "P13 negative control must not accept shortened confirmed-frame progress as expected BUSTED evidence"
+    );
+    assert!(
+        runner.contains("node \"${FIXTURE_ROOT}/harness.mjs\" self-test"),
+        "P13 runner must execute the data-driven health-threshold regression before the expensive build"
     );
     let persist_before_close = harness
         .find("await persistPeerArtifacts(joiner, joinerReport)")


### PR DESCRIPTION
## Summary

- preserve native reference-client exit codes and include fully drained event tags, advertised ICE candidates, recent events, and stderr when the live WebRTC selected-pair assertion fails
- make that diagnostic contract deterministic by exercising and catching the real missing-pair assertion path
- classify the retained Fortress WASM failure artifact and permit exactly one recovered prediction-window denial while keeping every independent progress, throughput, queue, rollback, checksum, conservation, zero-wait, and error oracle
- bump the coupled Fortress browser/report contract to schema v3 so stale v2 exports fail closed
- record P63/session evidence and the follow-up release boundary

## Why

Issue #301 combined two same-SHA transient failures. The Windows native failure did not retain enough process and ICE evidence to diagnose a recurrence. The Fortress artifact showed one denied `advance_frame` call in 602 active callbacks, while the run still confirmed frame 600, completed 1,317 messages at 123.1/s, matched every checksum and ledger, drained cleanly, and recorded zero waits, loss, overflow, retries, malformed input, or runtime errors. A repeated stall still fails.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- current-checkout native two-peer live WebRTC exchange
- native all-target strict Clippy and focused failure-context regression
- Fortress harness syntax and 0/1/2/invalid self-test
- focused native/Fortress CI-policy regressions
- Cargo deny, CI config, MSRV, workflow hygiene, tooling parity, documentation, Markdown, hook readiness, pre-commit, and pre-push gates
- two adversarial review rounds; the final round reported zero implementation findings

The full local Fortress host build is unavailable because this environment has no Godot 4.5 executable for `api-custom`; the pinned hosted Godot/Emscripten/Chromium workflow is the authoritative environment-specific gate.

Closes #301

Follow-up: #307

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to interop test diagnostics, CI acceptance thresholds, and schema v3 reporting—no production server or client runtime behavior.
> 
> **Overview**
> Makes **live interoperability CI failures** easier to diagnose and adjusts **Fortress WASM acceptance** for rare, recovered prediction-window stalls.
> 
> For **native reference-client live WebRTC**, scenario runs now keep each client’s **exit code**. When `selected_candidate_pair` is missing or wrong, assertions include **exit code**, **full event tag order**, **advertised local ICE candidates**, and **stderr** via `selected_pair_failure_context` / `assert_direct_host_path`. A unit test pins that diagnostic bundle on the real assertion path.
> 
> For **Fortress/Godot WASM**, the healthy gate no longer treats `stall_count` as a hard zero: reports expose **`acceptance_thresholds.max_stall_count: 1`**, so **0–1** recovered prediction-window denials pass and **2+** fail. Other P13 oracles (waits, throughput, queues, checksums, conservation, etc.) are unchanged; the **native Fortress gate stays zero-stall**. The browser config, room-ready signal, GDScript bootstrap errors, Rust reports, and harness validator move to **schema version 3** so stale v2 exports fail closed. The harness adds **`stallCountWithinThreshold`**, a **`self-test` mode**, and the interop runner invokes that self-test before the expensive build; CI policy tests lock the new markers.
> 
> **CHANGELOG** and fixture README document the behavior; session progress notes capture validation context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717b9218fdb9ba79478ca7d62e5e4231654076b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->