### PR TITLE
Upgrade Fortress Rollback to 0.12.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,12 +416,30 @@ jobs:
           # before executing cargo-deny. This avoids relying on preinstalled
           # aliases like `stable` that may be absent in the container image.
           rust-version: ${{ steps.deny-msrv.outputs.version }}
+      - name: Run cargo-deny (native reference client)
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        with:
+          manifest-path: clients/native/Cargo.toml
+          arguments: --all-features
+          rust-version: ${{ steps.deny-msrv.outputs.version }}
       - name: Run cargo-deny (fuzz package)
         uses: EmbarkStudios/cargo-deny-action@v2.1.1
         with:
           manifest-path: fuzz/Cargo.toml
           arguments: --all-features
           rust-version: ${{ steps.deny-msrv.outputs.version }}
+      - name: Run cargo-deny (Fortress fixture)
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        with:
+          manifest-path: clients/fortress/Cargo.toml
+          arguments: --all-features
+          rust-version: ${{ steps.deny-msrv.outputs.version }}
+      - name: Run cargo-deny (Fortress WASM fixture)
+        uses: EmbarkStudios/cargo-deny-action@v2.1.1
+        with:
+          manifest-path: clients/fortress-wasm/Cargo.toml
+          arguments: --all-features
+          rust-version: 1.94.0
 
   audit:
     name: Audit (cargo-audit)
@@ -471,6 +489,10 @@ jobs:
         run: cargo audit --file clients/native/Cargo.lock
       - name: Run cargo-audit (fuzz package)
         run: cargo audit --file fuzz/Cargo.lock
+      - name: Run cargo-audit (Fortress fixture)
+        run: cargo audit --file clients/fortress/Cargo.lock
+      - name: Run cargo-audit (Fortress WASM fixture)
+        run: cargo audit --file clients/fortress-wasm/Cargo.lock
 
   msrv:
     name: MSRV Verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Advance both pinned Fortress Rollback compatibility fixtures to 0.12.0
+  (issue #309), preserving the native multiprocess and Godot no-thread WASM
+  gameplay oracles while replacing the unmaintained `bincode` graph with
+  `bincode-next` and removing the obsolete advisory exceptions. The daily and
+  pull-request security jobs now apply both Cargo policy and RustSec scans to
+  every tracked Cargo lockfile, including exact-release fixtures.
 - Make live-reference-client interoperability failures actionable (issue
   #301). A missing native WebRTC candidate pair now reports the client's exit
   code, stderr, full event progression, and advertised ICE candidates. The

--- a/clients/README.md
+++ b/clients/README.md
@@ -17,8 +17,8 @@ context.
 |--------|-----------|-------|--------|
 | Native | [`native/`](native/README.md) | Rust + [webrtc-rs](https://github.com/webrtc-rs/webrtc) 0.20 (real DTLS/SCTP data channels) | ✅ In-repo, CI-enforced (`.github/workflows/webrtc-interop.yml`) |
 | Browser | [`browser/`](browser/README.md) | TypeScript + real headless-Chromium `RTCPeerConnection` (playwright-core) | ✅ In-repo, CI-enforced (`.github/workflows/browser-interop.yml`) |
-| Fortress | [`fortress/`](fortress/README.md) | Rust + `fortress-rollback` 0.10.0 + released Signal Fish Rust client 0.8.0 | ✅ In-repo issue-242 regression, CI-enforced (`.github/workflows/fortress-interop.yml`) |
-| Fortress WASM | [`fortress-wasm/`](fortress-wasm/README.md) | Godot 4.5 no-thread WASM + Fortress 0.10.0 + released client/adapter 0.9.0 | CI-enforced healthy Chromium acceptance plus expected-`BUSTED` negative control (`.github/workflows/fortress-wasm-interop.yml`) |
+| Fortress | [`fortress/`](fortress/README.md) | Rust + `fortress-rollback` 0.12.0 + released Signal Fish Rust client 0.8.0 | ✅ In-repo issue-242 regression, CI-enforced (`.github/workflows/fortress-interop.yml`) |
+| Fortress WASM | [`fortress-wasm/`](fortress-wasm/README.md) | Godot 4.5 no-thread WASM + Fortress 0.12.0 + released client/adapter 0.9.0 | CI-enforced healthy Chromium acceptance plus expected-`BUSTED` negative control (`.github/workflows/fortress-wasm-interop.yml`) |
 
 Both clients speak the same JSONL stdout event contract and exit codes (the
 [native README](native/README.md) is canonical), so one Rust interop harness asserts over native and browser

--- a/clients/fortress-wasm/Cargo.lock
+++ b/clients/fortress-wasm/Cargo.lock
@@ -18,23 +18,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
- "bincode_derive",
  "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
+ "unty-next",
 ]
 
 [[package]]
@@ -133,11 +123,11 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fortress-rollback"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65410c9563f7a4dff7221c8e250bd632317a932a2ff52943e7d74be5b25d9470"
+checksum = "f496791c003ef7688d643bad8a382547f977db6bbc31469e23779fbae52e44fb"
 dependencies = [
- "bincode",
+ "bincode-next",
  "loom",
  "parking_lot",
  "serde",
@@ -858,10 +848,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
+name = "unty-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "uuid"
@@ -890,12 +880,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasm-bindgen"

--- a/clients/fortress-wasm/Cargo.toml
+++ b/clients/fortress-wasm/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-fortress-rollback = "=0.10.0"
+fortress-rollback = "=0.12.0"
 godot = { version = "=0.4.5", features = ["api-custom", "experimental-wasm", "experimental-wasm-nothreads", "lazy-function-tables"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/clients/fortress-wasm/README.md
+++ b/clients/fortress-wasm/README.md
@@ -1,7 +1,7 @@
 # Fortress + Signal Fish Godot/WASM interoperability fixture
 
 This standalone fixture is the browser half of the issue-242 regression. It
-compiles the registry releases `fortress-rollback` 0.10.0,
+compiles the registry releases `fortress-rollback` 0.12.0,
 `signal-fish-client` 0.9.0, and `signal-fish-client-godot` 0.9.0 into a Godot
 4.5 GDExtension for
 `wasm32-unknown-emscripten`, exports with the official no-thread web template,

--- a/clients/fortress-wasm/deny.toml
+++ b/clients/fortress-wasm/deny.toml
@@ -6,12 +6,7 @@ targets = ["wasm32-unknown-emscripten"]
 [advisories]
 version = 2
 yanked = "deny"
-ignore = [
-    # fortress-rollback 0.10.0 directly uses bincode 2.0.1. This is an
-    # unmaintained notice with no safe compatible upgrade for the exact issue
-    # reproduction. Remove it when the acceptance pin can advance.
-    "RUSTSEC-2025-0141",
-]
+ignore = []
 
 [licenses]
 version = 2

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -451,7 +451,7 @@ function validateIdentityAndRuntime(creatorReport, joinerReport, creatorBrowser,
     assert(report.build_sha === buildSha, `${name}: current-checkout identity mismatch`);
     assert(report.signal_fish_client_version === "0.9.0", `${name}: client version drift`);
     assert(report.signal_fish_client_godot_version === "0.9.0", `${name}: Godot adapter version drift`);
-    assert(report.fortress_rollback_version === "0.10.0", `${name}: Fortress version drift`);
+    assert(report.fortress_rollback_version === "0.12.0", `${name}: Fortress version drift`);
     assert(report.godot_rust_version === "0.4.5", `${name}: godot-rust version drift`);
     assertExactKeys(
       report.godot_runtime,

--- a/clients/fortress-wasm/src/lib.rs
+++ b/clients/fortress-wasm/src/lib.rs
@@ -29,7 +29,7 @@ const NEGATIVE_ACTIVE_CALLBACK_BUDGET: u64 = MIN_ACTIVE_CALLBACKS;
 const RUNTIME_DEADLINE: Duration = Duration::from_secs(90);
 const SIGNAL_FISH_CLIENT_VERSION: &str = "0.9.0";
 const SIGNAL_FISH_CLIENT_GODOT_VERSION: &str = "0.9.0";
-const FORTRESS_ROLLBACK_VERSION: &str = "0.10.0";
+const FORTRESS_ROLLBACK_VERSION: &str = "0.12.0";
 const GODOT_RUST_VERSION: &str = "0.4.5";
 const WASM_TARGET: &str = "wasm32-unknown-emscripten";
 

--- a/clients/fortress/Cargo.lock
+++ b/clients/fortress/Cargo.lock
@@ -18,23 +18,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
+name = "bincode-next"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+checksum = "dbe9e7e6d14aeb39557f226bff158a30e367fac279d0e69b8b42fb41999f9a86"
 dependencies = [
- "bincode_derive",
  "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
+ "unty-next",
 ]
 
 [[package]]
@@ -123,11 +113,11 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fortress-rollback"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65410c9563f7a4dff7221c8e250bd632317a932a2ff52943e7d74be5b25d9470"
+checksum = "f496791c003ef7688d643bad8a382547f977db6bbc31469e23779fbae52e44fb"
 dependencies = [
- "bincode",
+ "bincode-next",
  "loom",
  "parking_lot",
  "serde",
@@ -813,10 +803,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
+name = "unty-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+checksum = "16062d030850f35054e37746427b9febb74a2f24c9c6dd6fa2d0c13c5f53221e"
 
 [[package]]
 name = "uuid"
@@ -841,12 +831,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wasi"

--- a/clients/fortress/Cargo.toml
+++ b/clients/fortress/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 unsafe_code = "forbid"
 
 [dependencies]
-fortress-rollback = "=0.10.0"
+fortress-rollback = "=0.12.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 signal-fish-client = { version = "=0.8.0", features = ["polling-client"] }

--- a/clients/fortress/README.md
+++ b/clients/fortress/README.md
@@ -7,7 +7,7 @@ the current checkout:
 
 - one separately spawned signaling-server process;
 - two separately spawned `fortress-relay-peer` game processes;
-- `fortress-rollback` exactly `0.10.0` in each game;
+- `fortress-rollback` exactly `0.12.0` in each game;
 - `signal-fish-client` exactly `0.8.0` using
   `SignalFishPollingClient<WebSocketTransport>`;
 - protocol-v3 MessagePack game-data relay over real loopback WebSockets.
@@ -38,8 +38,5 @@ bash scripts/run-fortress-interop.sh
 The runner builds the server from this checkout, verifies this crate's lockfile,
 formats and lints it, and supplies an absolute server binary path to the test.
 
-The fixture's supply-chain policy narrowly ignores `RUSTSEC-2025-0141` because
-Fortress 0.10.0 directly depends on unmaintained `bincode` 2.0.1 and the
-advisory offers no safe upgrade. This is not a production server dependency;
-the exception must be removed when the issue reproduction can move to a
-maintained Fortress release.
+Fortress 0.12.0 uses the maintained `bincode-next` codec line, so the fixture's
+supply-chain policy no longer needs the former `RUSTSEC-2025-0141` exception.

--- a/clients/fortress/deny.toml
+++ b/clients/fortress/deny.toml
@@ -12,13 +12,7 @@ targets = [
 [advisories]
 version = 2
 yanked = "deny"
-ignore = [
-    # fortress-rollback 0.10.0 directly uses bincode 2.0.1. The advisory is an
-    # unmaintained notice, not a memory/correctness vulnerability, and states
-    # that no safe upgrade is available. Remove this exception when the pinned
-    # issue-242 reproduction can move to a maintained Fortress release.
-    "RUSTSEC-2025-0141",
-]
+ignore = []
 
 [licenses]
 version = 2

--- a/progress/session-105-fortress-012-upgrade.md
+++ b/progress/session-105-fortress-012-upgrade.md
@@ -71,11 +71,24 @@ under Unreleased without implying a Signal Fish Server wire or runtime change.
   WASM runtime-identity coverage, all-lockfile `cargo audit` coverage, exact
   workflow-trigger coverage, and the ignored progress file. All five were
   corrected. The independent follow-up review reported zero findings.
-- Exact-head hosted CI and GitHub review evidence are appended before the
-  session closes.
+- PR #310 code head `fcb9d4d` completed all 13 substantive hosted workflows
+  successfully. This includes the full [CI run][ci-run], [Advanced Safety
+  run][safety-run], exact native Fortress gate, and authoritative [Fortress
+  WASM run][wasm-run]. The latter compiled the 0.12.0 graph with the pinned
+  Godot/Emscripten toolchain and passed both healthy Chromium acceptance and
+  the expected-`BUSTED` negative control. Both Dependabot-only runs skipped as
+  designed.
+- GitHub review inspection on PR #310 found no inline threads, requested
+  changes, or actionable comments. The only hosted review was a Copilot quota
+  notice; the two independent adversarial reviews remain the substantive review
+  evidence.
 
 ## Follow-up boundary
 
 P53 and P56 keep their existing hosted sample requirements. After this PR is
 merged green, issue #307 prepares the fresh 0.6.0 candidate from the updated
 main tree; this session does not stack a release PR.
+
+[ci-run]: https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/31267300438
+[safety-run]: https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/31267300446
+[wasm-run]: https://github.com/Ambiguous-Interactive/signal-fish-server/actions/runs/31267300461

--- a/progress/session-105-fortress-012-upgrade.md
+++ b/progress/session-105-fortress-012-upgrade.md
@@ -1,0 +1,81 @@
+# Session 105 — Fortress Rollback 0.12 upgrade
+
+## Scope and prioritization
+
+Session 104 / PR #308 merged with no open pull request. P53 and P56 remain
+registered hosted-evidence cohorts rather than deterministic in-repo work. The
+new issue #309 was the next concrete dependency task on a real gameplay path:
+both rollback-netcode compatibility fixtures pinned Fortress Rollback 0.10.0
+while crates.io had released 0.12.0.
+
+The separately tracked 0.6.0 preparation in issue #307 follows this work so the
+fresh release candidate contains the updated compatibility graph. It remains a
+separate session and PR under the repository's no-stacking policy.
+
+## Failure-first contract
+
+The native and WASM structural policy tests were first changed to require the
+0.12.0 exact pins and lock identity. Both failed against the old manifests,
+proving the repository guard observed the requested dependency boundary before
+the implementation changed.
+
+The completed guard also rejects the full obsolete supply-chain state in both
+standalone graphs: original `bincode`, a missing `bincode-next` 2.1.0 package,
+or restoration of `RUSTSEC-2025-0141` in either deny policy.
+
+## Dependency and compatibility closure
+
+- Both exact crates.io pins advance from Fortress Rollback 0.10.0 to 0.12.0.
+- The native Signal Fish client remains exactly 0.8.0. The WASM client and
+  Godot adapter remain exactly 0.9.0, and Godot-Rust remains exactly 0.4.5.
+- Both lockfiles replace unmaintained `bincode` 2.0.1, `bincode_derive`,
+  `virtue`, and `unty` with `bincode-next` 2.1.0 and `unty-next` 0.1.2.
+- The two narrow advisory exceptions are removed rather than carried forward.
+- The central push, pull-request, and daily security jobs now run `cargo deny`
+  and `cargo audit` over every tracked Cargo lockfile. Dynamic inventory guards
+  keep exact-release fixtures covered even though they intentionally opt out of
+  Dependabot.
+- Rust report identity, JavaScript validation, runner feature-tree validation,
+  fixture documentation, PLAN, and the Unreleased changelog all name the new
+  exact version.
+
+No application adapter change was needed: Fortress 0.12.0 retains the socket,
+session, event, frame, and metrics interfaces exercised by both fixtures.
+
+## Changelog classification
+
+This dependency update changes the maintained compatibility and supply-chain
+guarantees of release-enforced gameplay fixtures. `CHANGELOG.md` records it
+under Unreleased without implying a Signal Fish Server wire or runtime change.
+
+## Validation
+
+- The focused native/WASM structural policy tests pass after observed RED
+  failures against the old pins.
+- Both standalone `cargo deny` policies pass with no advisory exceptions.
+- Both standalone lockfiles pass the independent `cargo audit` RustSec scan.
+- The native crate checks and lints against Fortress Rollback 0.12.0.
+- The real native two-process interoperability gate passes: both games confirm
+  frame 601, exchange matching 1,323-message ledgers, compare nine matching
+  checksums, drain their queues, and report zero stalls, waits, loss, overflow,
+  retries, malformed input, or runtime errors.
+- The local WASM build reaches the unchanged Godot-Rust custom-API boundary but
+  cannot complete because this container has no Godot 4.5 executable. The
+  pinned hosted Godot/Emscripten/Chromium workflow is the authoritative proof.
+- Root formatting, strict all-target/all-feature Clippy, and the full locked
+  all-feature test suite pass. The 313-test CI policy suite, documentation
+  policy suites, workflow hygiene, actionlint, markdown, MSRV, tooling parity,
+  diff, hook-readiness, pre-commit, and pre-push gates also pass. The profiled
+  pre-commit rerun completed in 919 ms.
+- The first adversarial review found five gaps: exact lock edge/source proof,
+  WASM runtime-identity coverage, all-lockfile `cargo audit` coverage, exact
+  workflow-trigger coverage, and the ignored progress file. All five were
+  corrected. The independent follow-up review reported zero findings.
+- Exact-head hosted CI and GitHub review evidence are appended before the
+  session closes.
+
+## Follow-up boundary
+
+P53 and P56 keep their existing hosted sample requirements. After this PR is
+merged green, issue #307 prepares the fresh 0.6.0 candidate from the updated
+main tree; this session does not stack a release PR.

--- a/scripts/run-fortress-wasm-interop.sh
+++ b/scripts/run-fortress-wasm-interop.sh
@@ -56,7 +56,7 @@ feature_tree="${ARTIFACT_DIR}/cargo-feature-tree.txt"
 cargo +"${NIGHTLY}" tree --manifest-path "${MANIFEST_PATH}" --locked -e features >"${feature_tree}"
 grep -F 'signal-fish-client v0.9.0' "${feature_tree}" >/dev/null
 grep -F 'signal-fish-client-godot v0.9.0' "${feature_tree}" >/dev/null
-grep -F 'fortress-rollback v0.10.0' "${feature_tree}" >/dev/null
+grep -F 'fortress-rollback v0.12.0' "${feature_tree}" >/dev/null
 grep -F 'godot v0.4.5' "${feature_tree}" >/dev/null
 if grep -Eq 'transport-websocket-emscripten|sync-send' "${feature_tree}"; then
     printf 'BUSTED: forbidden raw-WebSocket or Send+Sync feature in released graph\n' >&2

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -1576,6 +1576,32 @@ fn tracked_package_manifests(root: &Path) -> Vec<String> {
     manifests
 }
 
+fn tracked_cargo_lockfiles(root: &Path) -> BTreeSet<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z", "--", "Cargo.lock", "*/Cargo.lock"])
+        .output()
+        .unwrap_or_else(|error| {
+            panic!("`git ls-files` failed ({error}); this guard requires a git checkout")
+        });
+    assert!(
+        output.status.success(),
+        "`git ls-files` exited with {}; this guard requires a git checkout",
+        output.status
+    );
+    let lockfiles = String::from_utf8_lossy(&output.stdout)
+        .split('\0')
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| entry.replace('\\', "/"))
+        .collect::<BTreeSet<_>>();
+    assert!(
+        lockfiles.contains("Cargo.lock"),
+        "the tracked Cargo lockfile inventory must include the server graph"
+    );
+    lockfiles
+}
+
 #[test]
 fn test_msrv_consistency_across_config_files() {
     // This test prevents the MSRV inconsistency issue that was fixed in commit d9eac0f
@@ -16385,12 +16411,6 @@ fn assert_dependabot_cargo_holds(directory: &str, expected: &[(&str, &str)]) {
     }
 }
 
-fn dependabot_cargo_directories() -> BTreeSet<String> {
-    let path = repo_root().join(".github/dependabot.yml");
-    let content = read_live_file(&path);
-    dependabot_cargo_directories_from_yaml(&content)
-}
-
 fn dependabot_cargo_directories_from_yaml(content: &str) -> BTreeSet<String> {
     let documents = Yaml::load_from_str(content).expect("dependabot.yml must parse as YAML");
     let updates = documents
@@ -21857,10 +21877,9 @@ fn test_audit_job_installs_cargo_audit() {
 }
 
 #[test]
-fn test_audit_job_covers_every_dependabot_managed_cargo_graph() {
-    // Every graph that Dependabot advances needs the scheduled cargo-audit
-    // second opinion. Otherwise a standalone lockfile can receive updates
-    // without ever being scanned by this daily job.
+fn test_audit_job_covers_every_tracked_cargo_graph() {
+    // Exact-release compatibility fixtures intentionally opt out of automatic
+    // updates, but they still need the scheduled cargo-audit second opinion.
 
     let root = repo_root();
     let ci_content = read_file(&root.join(".github/workflows/ci.yml"));
@@ -21872,23 +21891,17 @@ fn test_audit_job_covers_every_dependabot_managed_cargo_graph() {
         .filter_map(|line| line.trim().strip_prefix("run: "))
         .collect::<BTreeSet<_>>();
 
-    for directory in dependabot_cargo_directories() {
-        let lockfile = if directory == "/" {
-            "Cargo.lock".to_owned()
-        } else {
-            format!("{}/Cargo.lock", directory.trim_start_matches('/'))
-        };
-        let expected_command = if directory == "/" {
+    for lockfile in tracked_cargo_lockfiles(&root) {
+        let expected_command = if lockfile == "Cargo.lock" {
             "cargo audit".to_owned()
         } else {
             format!("cargo audit --file {lockfile}")
         };
         assert!(
             audit_commands.contains(expected_command.as_str()),
-            "The scheduled cargo-audit job must scan every Dependabot-managed Cargo graph.\n\
+            "The scheduled cargo-audit job must scan every tracked Cargo graph.\n\
              Missing command: {expected_command}\n\
-             Uncovered lockfile: {lockfile}\n\
-             Dependabot directory: {directory}"
+             Uncovered lockfile: {lockfile}"
         );
     }
 
@@ -21896,6 +21909,44 @@ fn test_audit_job_covers_every_dependabot_managed_cargo_graph() {
         !audit_section.contains("cargo audit --locked"),
         "cargo-audit reads Cargo.lock directly and does not support --locked.\n\
          Fix: use `cargo audit` without --locked in .github/workflows/ci.yml."
+    );
+}
+
+#[test]
+fn test_deny_job_covers_every_tracked_cargo_graph() {
+    let root = repo_root();
+    let ci_content = read_live_file(&root.join(".github/workflows/ci.yml"));
+    let documents = Yaml::load_from_str(&ci_content).expect("ci.yml must parse as YAML");
+    let steps = documents
+        .first()
+        .and_then(|document| document.as_mapping_get("jobs"))
+        .and_then(|jobs| jobs.as_mapping_get("deny"))
+        .and_then(|job| job.as_mapping_get("steps"))
+        .and_then(Yaml::as_sequence)
+        .unwrap_or_else(|| panic!("ci.yml must define jobs.deny.steps"));
+    let configured = steps
+        .iter()
+        .filter(|step| {
+            step.as_mapping_get("uses")
+                .and_then(Yaml::as_str)
+                .is_some_and(|uses| uses.starts_with("EmbarkStudios/cargo-deny-action@"))
+        })
+        .map(|step| {
+            step.as_mapping_get("with")
+                .and_then(|with| with.as_mapping_get("manifest-path"))
+                .and_then(Yaml::as_str)
+                .unwrap_or("Cargo.toml")
+                .to_owned()
+        })
+        .collect::<BTreeSet<_>>();
+    let expected = tracked_cargo_lockfiles(&root)
+        .into_iter()
+        .map(|lockfile| lockfile.replace("Cargo.lock", "Cargo.toml"))
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        configured, expected,
+        "the push/PR/daily cargo-deny job must enforce every tracked Cargo graph"
     );
 }
 
@@ -23988,16 +24039,29 @@ fn test_run_local_ci_excludes_check_outdated() {
     );
 }
 
+fn cargo_lock_package<'a>(lockfile: &'a str, name: &str, version: &str) -> &'a str {
+    let marker = format!("name = \"{name}\"\nversion = \"{version}\"");
+    let start = lockfile
+        .find(&marker)
+        .unwrap_or_else(|| panic!("Cargo.lock is missing `{marker}`"));
+    &lockfile[start
+        ..lockfile[start..]
+            .find("\n\n")
+            .map_or(lockfile.len(), |offset| start + offset)]
+}
+
 #[test]
 fn test_fortress_interop_gate_is_pinned_and_runs_current_server() {
     let root = repo_root();
     let root_manifest = read_file(&root.join("Cargo.toml"));
-    let manifest = read_file(&root.join("clients/fortress/Cargo.toml"));
+    let manifest = read_live_file(&root.join("clients/fortress/Cargo.toml"));
+    let lockfile = read_file(&root.join("clients/fortress/Cargo.lock"));
+    let deny = read_file(&root.join("clients/fortress/deny.toml"));
     let workflow = read_live_file(&root.join(".github/workflows/fortress-interop.yml"));
     let runner = read_file(&root.join("scripts/run-fortress-interop.sh"));
 
     for dependency in [
-        "fortress-rollback = \"=0.10.0\"",
+        "fortress-rollback = \"=0.12.0\"",
         "signal-fish-client = { version = \"=0.8.0\"",
     ] {
         assert!(
@@ -24005,6 +24069,37 @@ fn test_fortress_interop_gate_is_pinned_and_runs_current_server() {
             "clients/fortress must exact-pin its production interoperability dependency: {dependency}"
         );
     }
+
+    let fortress_package = cargo_lock_package(&lockfile, "fortress-rollback", "0.12.0");
+    let codec_package = cargo_lock_package(&lockfile, "bincode-next", "2.1.0");
+    let fixture_package = cargo_lock_package(&lockfile, "signal-fish-fortress-interop", "0.1.0");
+    for package in [fortress_package, codec_package] {
+        assert!(
+            package.contains("source = \"registry+https://github.com/rust-lang/crates.io-index\""),
+            "the native Fortress graph must resolve exact releases from crates.io: {package}"
+        );
+    }
+    assert!(
+        fixture_package.contains(" \"fortress-rollback\","),
+        "the native fixture must directly lock Fortress Rollback: {fixture_package}"
+    );
+    assert_eq!(
+        lockfile.matches("name = \"fortress-rollback\"\n").count(),
+        1,
+        "the native fixture must resolve exactly one Fortress Rollback release"
+    );
+    assert!(
+        fortress_package.contains(" \"bincode-next\","),
+        "Fortress 0.12.0 must directly use the maintained codec: {fortress_package}"
+    );
+    assert!(
+        !lockfile.contains("name = \"bincode\"\n"),
+        "the native Fortress graph must not restore unmaintained bincode"
+    );
+    assert!(
+        !deny.contains("RUSTSEC-2025-0141"),
+        "the native Fortress policy must not restore the obsolete bincode advisory exception"
+    );
 
     assert_eq!(
         extract_toml_version(&manifest, "rust-version"),
@@ -24995,17 +25090,18 @@ fn test_ice_bind_set_and_advertised_candidate_oracles_are_pinned() {
 #[test]
 fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
     let root = repo_root();
-    let manifest = read_file(&root.join("clients/fortress-wasm/Cargo.toml"));
+    let manifest = read_live_file(&root.join("clients/fortress-wasm/Cargo.toml"));
     let lockfile = read_file(&root.join("clients/fortress-wasm/Cargo.lock"));
     let source = read_file(&root.join("clients/fortress-wasm/src/lib.rs"));
     let harness = read_file(&root.join("clients/fortress-wasm/harness.mjs"));
     let project = read_file(&root.join("clients/fortress-wasm/project/export_presets.cfg"));
     let bridge = read_file(&root.join("clients/fortress-wasm/project/main.gd"));
     let runner = read_file(&root.join("scripts/run-fortress-wasm-interop.sh"));
+    let deny = read_file(&root.join("clients/fortress-wasm/deny.toml"));
     let workflow = read_live_file(&root.join(".github/workflows/fortress-wasm-interop.yml"));
 
     for dependency in [
-        "fortress-rollback = \"=0.10.0\"",
+        "fortress-rollback = \"=0.12.0\"",
         "signal-fish-client = { version = \"=0.9.0\", default-features = false, features = [\"polling-client\"] }",
         "signal-fish-client-godot = \"=0.9.0\"",
         "godot = { version = \"=0.4.5\", features = [\"api-custom\", \"experimental-wasm\", \"experimental-wasm-nothreads\", \"lazy-function-tables\"] }",
@@ -25019,24 +25115,43 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         extract_toml_version(&manifest, "rust-version"),
         Some("1.94.0".to_owned())
     );
-    for locked in [
-        "name = \"fortress-rollback\"\nversion = \"0.10.0\"",
-        "name = \"signal-fish-client\"\nversion = \"0.9.0\"",
-        "name = \"signal-fish-client-godot\"\nversion = \"0.9.0\"",
-        "name = \"godot\"\nversion = \"0.4.5\"",
+    for (name, version) in [
+        ("fortress-rollback", "0.12.0"),
+        ("bincode-next", "2.1.0"),
+        ("signal-fish-client", "0.9.0"),
+        ("signal-fish-client-godot", "0.9.0"),
+        ("godot", "0.4.5"),
     ] {
-        let start = lockfile
-            .find(locked)
-            .unwrap_or_else(|| panic!("Fortress WASM lockfile is missing `{locked}`"));
-        let package = &lockfile[start
-            ..lockfile[start..]
-                .find("\n\n")
-                .map_or(lockfile.len(), |offset| start + offset)];
+        let package = cargo_lock_package(&lockfile, name, version);
         assert!(
             package.contains("source = \"registry+https://github.com/rust-lang/crates.io-index\""),
             "P13 production dependencies must resolve from crates.io without path/Git overrides: {package}"
         );
     }
+    let fortress_package = cargo_lock_package(&lockfile, "fortress-rollback", "0.12.0");
+    let fixture_package =
+        cargo_lock_package(&lockfile, "signal-fish-fortress-wasm-interop", "0.1.0");
+    assert!(
+        fixture_package.contains(" \"fortress-rollback\","),
+        "the WASM fixture must directly lock Fortress Rollback: {fixture_package}"
+    );
+    assert_eq!(
+        lockfile.matches("name = \"fortress-rollback\"\n").count(),
+        1,
+        "the WASM fixture must resolve exactly one Fortress Rollback release"
+    );
+    assert!(
+        fortress_package.contains(" \"bincode-next\","),
+        "Fortress 0.12.0 must directly use the maintained codec: {fortress_package}"
+    );
+    assert!(
+        !lockfile.contains("name = \"bincode\"\n"),
+        "the Fortress WASM graph must not restore unmaintained bincode"
+    );
+    assert!(
+        !deny.contains("RUSTSEC-2025-0141"),
+        "the Fortress WASM policy must not restore the obsolete bincode advisory exception"
+    );
 
     assert!(project.contains("variant/thread_support=false"));
     assert!(project.contains("variant/extensions_support=true"));
@@ -25065,6 +25180,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "relay_received_sequence_hash",
         "use signal_fish_client_godot::GodotWebSocketTransport;",
         "const SIGNAL_FISH_CLIENT_GODOT_VERSION: &str = \"0.9.0\";",
+        "const FORTRESS_ROLLBACK_VERSION: &str = \"0.12.0\";",
         "signal_fish_client_godot_version: SIGNAL_FISH_CLIENT_GODOT_VERSION",
         "const REPORT_SCHEMA_VERSION: u32 = 3;",
         "const MAX_STALL_COUNT: u64 = 1;",
@@ -25108,6 +25224,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "schema_version: 3,",
         "report.schema_version === 3",
         "report.signal_fish_client_godot_version === \"0.9.0\"",
+        "report.fortress_rollback_version === \"0.12.0\"",
         "report.godot_runtime.string === \"4.5-stable (official)\"",
         "assertExactKeys(report, reportKeys",
         "report.relay_send_retries <= 8",
@@ -25251,6 +25368,7 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         "timeout --foreground",
         "signal-fish-client v0.9.0",
         "signal-fish-client-godot v0.9.0",
+        "fortress-rollback v0.12.0",
         "HEALTHY: released Signal Fish client 0.9.0",
     ] {
         assert!(
@@ -25273,23 +25391,23 @@ fn test_fortress_wasm_interop_gate_is_exact_single_threaded_and_fail_closed() {
         );
     }
 
-    for required_path in [
-        "src/**",
-        "Cargo.toml",
-        "Cargo.lock",
-        "clients/fortress/src/relay.rs",
-        "clients/fortress/src/workload.rs",
-        "clients/fortress-wasm/**",
-        "clients/browser/package-lock.json",
-        "scripts/run-fortress-wasm-interop.sh",
-        ".github/workflows/fortress-wasm-interop.yml",
-    ] {
-        assert_eq!(
-            workflow.matches(&format!("- \"{required_path}\"")).count(),
-            2,
-            "fortress-wasm-interop.yml must trigger on `{required_path}` for push and pull_request"
-        );
-    }
+    assert_workflow_triggers_on_paths(
+        &workflow,
+        "fortress-wasm-interop.yml",
+        &[
+            "src/**",
+            "Cargo.toml",
+            "Cargo.lock",
+            "rust-toolchain.toml",
+            "clients/fortress/src/relay.rs",
+            "clients/fortress/src/workload.rs",
+            "clients/fortress-wasm/**",
+            "clients/browser/package.json",
+            "clients/browser/package-lock.json",
+            "scripts/run-fortress-wasm-interop.sh",
+            ".github/workflows/fortress-wasm-interop.yml",
+        ],
+    );
     for required in [
         "GODOT_EDITOR_SHA512:",
         "GODOT_TEMPLATES_SHA512:",


### PR DESCRIPTION
## Summary

- upgrade both exact Fortress Rollback compatibility fixtures from 0.10.0 to 0.12.0
- replace the obsolete `bincode` graph with `bincode-next` and remove both RustSec advisory exceptions
- extend PR/push/daily cargo-deny and cargo-audit coverage to every tracked Cargo lockfile
- add fail-closed policy guards for the exact dependency edge, crates.io source, runtime identity, and WASM workflow triggers

## Why

Fortress Rollback 0.12.0 is the current release and removes the unmaintained `bincode` dependency that required `RUSTSEC-2025-0141` exceptions in both compatibility graphs. Completing this before the separately tracked 0.6.0 release preparation keeps the release candidate on the maintained graph.

## Validation

- observed RED from the native and WASM structural tests against the old pins
- root formatting, strict all-target/all-feature Clippy, and full locked all-feature test suite
- all 313 CI configuration tests and both documentation policy suites
- standalone cargo-deny and cargo-audit for both Fortress lockfiles
- real native two-process interop: frame 601, 1,323-message ledgers, nine matching checksums, zero runtime errors
- workflow hygiene, actionlint, markdown, MSRV, tooling parity, hook readiness, and hook preflights
- two adversarial review rounds; the follow-up review reported zero findings

The hosted Godot 4.5/Emscripten/Chromium workflow is the authoritative WASM build and runtime proof because this container does not include Godot 4.5.

Closes #309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to compatibility fixture dependency pins, supply-chain policy, and CI guards; the server runtime and wire protocol are unchanged.
> 
> **Overview**
> **Upgrades both Fortress compatibility fixtures** (native multiprocess and Godot WASM) from **Fortress Rollback 0.10.0 → 0.12.0**, keeping the same gameplay oracles and exact Signal Fish client pins. The new Fortress release pulls in **`bincode-next`** instead of unmaintained **`bincode`**, so both fixtures’ **`deny.toml`** files drop the **`RUSTSEC-2025-0141`** advisory ignore.
> 
> **CI supply-chain coverage widens:** push/PR/daily **`cargo-deny`** and **`cargo-audit`** now run against **every git-tracked `Cargo.lock`** (including the Fortress fixtures), not only Dependabot-managed graphs. New policy tests inventory lockfiles via **`git ls-files`** and assert **`clients/native`**, **`clients/fortress`**, and **`clients/fortress-wasm`** are included; Fortress interop guards also enforce **0.12.0** pins, **crates.io** resolution, **`bincode-next`**, and no restored bincode exception.
> 
> Docs, changelog, harness/runtime version constants, and the WASM interop runner’s feature-tree grep are updated to **0.12.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab391bd0d4ca9ac6063f0929899a0bb19d061316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->