### PR TITLE
release: 0.6.0

### DIFF
--- a/.llm/context.md
+++ b/.llm/context.md
@@ -10,7 +10,7 @@
 - **Repository:** `signal-fish-server` — extracted from the matchbox-signaling-server with
   production-ready signaling stripped down to a single self-contained binary
 - **Crate name:** Binary: `signal-fish-server` | Library: `signal_fish_server`
-- **Version:** 0.5.2
+- **Version:** 0.6.0
 - **Code name:** Signal Fish
 - **Not Matchbox:** This project is built by Ambiguous Interactive, not the upstream Matchbox team.
   The upstream `matchbox` crate/project (by Johan Helsing) is a dependency we build upon,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-08
+
 ### Added
 
 - Add exhaustive formal verification for classified outbound queue
@@ -1918,7 +1920,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional TLS/mTLS support via `rustls` (`tls` feature).
 - Optional legacy full-mesh mode (`legacy-fullmesh` feature).
 
-[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Ambiguous-Interactive/signal-fish-server/compare/v0.4.1...v0.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,7 +2663,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-server"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-fish-server"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ambiguous Interactive <eli@theambiguous.co>"]

--- a/clients/native/Cargo.lock
+++ b/clients/native/Cargo.lock
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "signal-fish-server"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes-gcm 0.11.0",
  "anyhow",

--- a/docs/library-usage.md
+++ b/docs/library-usage.md
@@ -7,7 +7,7 @@ Rust application.
 
 ```toml
 [dependencies]
-signal-fish-server = "0.5.2"
+signal-fish-server = "0.6.0"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"
 
@@ -309,7 +309,7 @@ Enable optional features:
 
 ```toml
 [dependencies]
-signal-fish-server = { version = "0.5.2", features = ["tls", "legacy-fullmesh"] }
+signal-fish-server = { version = "0.6.0", features = ["tls", "legacy-fullmesh"] }
 
 ```
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1332,7 +1332,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-fish-server"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { version = "1.23", features = ["v4"] }
 
 [dependencies.signal-fish-server]
 path = ".."
-version = "0.5.2"
+version = "0.6.0"
 
 # Detach from the parent crate so the nightly fuzz build is fully independent of
 # the pinned-stable workspace.


### PR DESCRIPTION
Release preparation for Signal Fish Server 0.6.0.

## Summary

- advance the server and standalone path-package identities from 0.5.2 to 0.6.0
- publish the accumulated Unreleased changelog as the dated 0.6.0 section
- update public dependency examples and comparison links to the new release identity
- keep the change restricted to the eight canonical release-preparation files

## Why

The discarded 0.5.3 candidate exposed release-preparation integrity and semver defects that were fixed before this fresh candidate. This minor release is prepared from current green `main` after the remaining planned compatibility work landed.

## Preparation provenance

This branch and PR were created manually from green `main` at `6a065e0` after the user directed local Git and GitHub-app operations. Issue #307 separately requires a successful **Prepare Release** dispatch with `bump=minor` and `dry_run=false`. That dispatch is pending; do not merge this PR until the workflow regenerates the candidate, verifies an exact tree match with `7afa0bd`, reuses PR #311, and completes successfully.

Tracks #307.

## Validation

- `git diff --check`
- `cargo test --locked --test release_prepare_tests --test workspace_lockfile_consistency` (26 passed)
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- documentation, workflow-hygiene, agent-policy, and hook preflight gates
- exact parent `main` tree completed all 14 hosted workflows successfully
- independent adversarial release-file reviews found no metadata defects; workflow provenance remains pending

## After merge

Publication remains a separately reviewed second phase. Do not create tags, publish crates or containers, or create a GitHub Release from this PR. Run **Release - Publish Crate** from `main` only after this preparation PR merges green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version, changelog, and lockfile/documentation sync only; no server behavior or API surface changes in this diff.
> 
> **Overview**
> **Release preparation** for **Signal Fish Server 0.6.0** (minor bump from 0.5.2). No runtime or protocol code changes—only canonical release metadata.
> 
> The root crate version moves to **0.6.0** in `Cargo.toml`, with matching updates in **Cargo.lock**, **clients/native/Cargo.lock**, **fuzz/Cargo.lock**, and the path dependency in **fuzz/Cargo.toml**. **CHANGELOG.md** publishes the former `[Unreleased]` notes under **`[0.6.0] - 2026-08-08`**, leaves `[Unreleased]` empty, and refreshes compare links. **docs/library-usage.md** and **.llm/context.md** dependency examples now cite **0.6.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afa0bd9eb0e34549f6a7527eca7c7bec88a32b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->