### PR TITLE
fix: preserve prepared release source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve the reviewed release-preparation source when documentation or
+  workflow changes reach the default branch before publication. Manual releases
+  now select the unique first-parent commit that introduced the package version
+  and reject shallow history or reused version boundaries instead of publishing
+  a later tree under the prepared version.
+
 ## [0.6.0] - 2026-08-08
 
 ### Added

--- a/docs/development.md
+++ b/docs/development.md
@@ -688,12 +688,17 @@ Enable git hooks as a final last-resort guard:
 
 ## Release Process
 
-1. Update version in `Cargo.toml`
-2. Update `CHANGELOG.md`
-3. Run full test suite: `cargo test --all-features`
-4. Build release: `cargo build --release`
-5. Tag release: `git tag v0.x.x`
-6. Push: `git push origin v0.x.x`
+Use the two reviewed workflows in the [release runbook](releasing.md):
+
+1. Dispatch **Prepare Release**, review its generated version/changelog pull
+   request, and merge only after required checks pass.
+2. Dispatch **Release - Publish Crate** from the default branch. It selects the
+   reviewed version-introduction commit and creates the immutable annotated tag,
+   crate, GitHub Release, binaries, SBOM, and versioned container artifacts.
+3. Run the independent public-artifact verification from the release runbook.
+
+Do not edit release metadata or create and push version tags by hand during the
+normal release path.
 
 ## Next Steps
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -35,10 +35,15 @@ bash scripts/prepare-release.sh --bump patch
 Do not create or move the version tag by hand for the normal manual path. Run
 the **Release - Publish Crate** workflow from the default branch without a
 version input. It derives the reviewed version from `Cargo.toml`, eliminating a
-second operator-entered identity. If the matching tag already exists after a
-partial run, the workflow requires that it is annotated, reachable from the
-dispatched default-branch commit, and consistent with the tagged Cargo and
-changelog metadata; the retry then publishes that immutable source commit.
+second operator-entered identity. When the tag is absent, it walks the complete
+first-parent history and selects the unique commit that introduced that package
+version. This preserves the reviewed release candidate if documentation or
+workflow fixes reach the default branch before publication, and it fails closed
+if history is shallow or a version was reused. If the matching tag already
+exists after a partial run, the workflow requires that it is annotated,
+reachable from the dispatched default-branch commit, and consistent with the
+tagged Cargo and changelog metadata; the retry then publishes that immutable
+source commit.
 
 The release workflow directly calls the reusable container workflow. It does
 not depend on a tag created with `GITHUB_TOKEN` starting a second workflow.

--- a/progress/session-107-prepared-release-source.md
+++ b/progress/session-107-prepared-release-source.md
@@ -70,5 +70,27 @@ Unreleased `Fixed`; runtime server and wire behavior are unchanged.
   safety, shell portability, fixture validity, documentation, changelog, PLAN,
   and session scope.
 
-Hosted CI, merge, and the subsequent issue #312 publication remain pending at
-this point in the session.
+## Hosted review and CI
+
+PR #315's first exact code head,
+`0a1cb0745f509f0c9544c33531bb913269b4828d`, completed every applicable hosted
+gate successfully:
+
+- CI run `31275860685` passed all 16 jobs, including the three-platform lint and
+  Nextest matrix, coverage, MSRV, dependency/audit checks, Docker, SBOM, panic
+  policy, documentation consistency, and relay allocation ceilings.
+- Advanced Safety run `31275860643` passed both Miri and AddressSanitizer.
+- Unused Dependencies `31275860648`, Markdownlint `31275860646`, Link Check
+  `31275860645`, Spellcheck `31275860661`, and Documentation Validation
+  `31275860669` all passed. The Dependabot-only auto-merge workflow skipped as
+  expected for a non-dependency pull request.
+- GitHub reported the pull request mergeable with no review threads or change
+  requests. The only review submission was a non-actionable Copilot quota
+  notice.
+
+The exact pre-PR `main` head,
+`5545daf1435374df8a913b5ec533f387076ebd08`, also completed its eight applicable
+push workflows successfully, including CI and Docker Publish. The progress-only
+follow-up commit that records this evidence must retain the same green hosted
+state before merge. The subsequent issue #312 publication remains a separate
+operation after this repair lands.

--- a/progress/session-107-prepared-release-source.md
+++ b/progress/session-107-prepared-release-source.md
@@ -1,0 +1,74 @@
+# Session 107 — Prepared release source integrity
+
+## Scope and prioritization
+
+Remote triage found no open pull requests, drafts, or dependency updates. The
+latest exact `main` checks had no failures, while P53 and P56 remained fixed
+hosted-evidence cohorts at 3/20 attempts. Issue #312 was therefore the next
+bounded release dependency: publish 0.6.0 from the reviewed preparation commit
+`3b1ad61eb3657fa910a9390ea144725fd464e0df`.
+
+Publication could not safely start. Documentation PR #313 had advanced `main`
+to `5545daf1435374df8a913b5ec533f387076ebd08`, no `v0.6.0` tag existed, and the
+manual resolver selected the dispatch revision whenever the tag was absent.
+That would publish a different source than issue #312 permits. Issue #314
+records this release-orchestration defect.
+
+## Failure-first evidence
+
+The executable release fixture previously asserted that an absent tag used the
+dispatched head. A new case added a later documentation commit after the
+prepared version and failed RED: the resolver returned the later commit instead
+of the version-introduction commit. Independent RED cases covered a later
+same-version `Cargo.toml` edit and a shallow first-parent history.
+
+## Fix
+
+- Manual publication remains restricted to the default branch and derives the
+  version from its reviewed `Cargo.toml`; there is no new operator-entered
+  version or source identity.
+- When the tag is absent, the resolver scans only first-parent commits that
+  changed `Cargo.toml` and selects the unique boundary whose version differs
+  from its first parent.
+- Shallow history and multiple introductions of the same version fail closed
+  before tag or registry mutation.
+- Existing annotated-tag retries and direct-tag validation retain their prior
+  immutable-source checks.
+- The canonical runbook explains source selection, and the development guide no
+  longer instructs maintainers to bypass the workflows with a hand-pushed tag.
+
+## Changelog classification
+
+This changes maintainer-visible release behavior and prevents public artifacts
+from acquiring the wrong source identity. `CHANGELOG.md` records it under
+Unreleased `Fixed`; runtime server and wire behavior are unchanged.
+
+## Validation
+
+- The exact resolver regression was observed RED before the fix and passes
+  after it.
+- Additional executable absent-tag cases prove that zero matching introduction
+  commits fail closed and that release notes added or corrected only after the
+  selected introduction cannot make missing or mismatched changelog metadata
+  publishable. These cases passed against the fixed resolver without another
+  production change.
+- The complete `release_publish_tests` suite passes, including registry,
+  release, clean-worktree, retry, and direct-tag boundaries.
+- Focused release workflow policy tests pass.
+- Root formatting, strict all-target/all-feature Clippy, and the complete locked
+  all-feature test suite pass. Cargo deny, CI configuration, MSRV, workflow
+  hygiene, documentation, Markdown, LLM policy, hook readiness, and worktree
+  pre-commit/pre-push checks also pass. Profiled pre-commit runs completed in
+  947 ms and 921 ms; an intervening 1,230 ms run was traced to transient Git
+  changed-file discovery rather than a changed hook path.
+- The first adversarial review found missing absent-tag failure coverage; the
+  evaluator added zero-match and missing/mismatched changelog cases. The second
+  review found that the zero-match symlink target was untracked; it is now
+  committed, with assertions proving a clean fixture and preserved historical
+  symlink-blob semantics.
+- The final independent adversarial pass reported zero findings across release
+  safety, shell portability, fixture validity, documentation, changelog, PLAN,
+  and session scope.
+
+Hosted CI, merge, and the subsequent issue #312 publication remain pending at
+this point in the session.

--- a/scripts/resolve-release-source.sh
+++ b/scripts/resolve-release-source.sh
@@ -7,20 +7,18 @@ DEFAULT_BRANCH=${RELEASE_DEFAULT_BRANCH:-}
 EVENT_REF=${RELEASE_EVENT_REF:-${GITHUB_REF:-}}
 OUTPUT_FILE=${RELEASE_OUTPUT_FILE:-${GITHUB_OUTPUT:-}}
 
-# Preserve the dispatch revision's parser before a retry detaches the worktree
-# to a historical tag. Tests may inject an already-isolated helper explicitly.
-resolver_scratch=
+# Preserve the dispatch revision's parser and historical manifest snapshots
+# outside the checkout before detaching to the immutable release source. Tests
+# may inject an already-isolated helper explicitly.
+scratch_base=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+resolver_scratch=$(mktemp -d "${scratch_base}/release-resolver.XXXXXX")
 cleanup() {
-    if [ -n "$resolver_scratch" ]; then
-        rm -rf -- "$resolver_scratch"
-    fi
+    rm -rf -- "$resolver_scratch"
 }
 trap cleanup EXIT
 if [ -n "${READ_TOML_SCRIPT:-}" ]; then
     readonly READ_TOML_SCRIPT
 else
-    scratch_base=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
-    resolver_scratch=$(mktemp -d "${scratch_base}/release-resolver.XXXXXX")
     cp scripts/read-toml-string.sh "${resolver_scratch}/read-toml-string.sh"
     readonly READ_TOML_SCRIPT="${resolver_scratch}/read-toml-string.sh"
 fi
@@ -32,6 +30,54 @@ fi
 
 read_cargo_version() {
     bash "$READ_TOML_SCRIPT" Cargo.toml version package 2>/dev/null || true
+}
+
+read_cargo_version_at() {
+    local candidate=$1
+    local manifest="${resolver_scratch}/Cargo.${candidate}.toml"
+    if ! git show "${candidate}:Cargo.toml" > "$manifest" 2>/dev/null; then
+        return 1
+    fi
+    bash "$READ_TOML_SCRIPT" "$manifest" version package 2>/dev/null || true
+}
+
+find_version_introduction() {
+    local dispatch_revision=$1
+    local expected_version=$2
+    local candidate candidate_version parent parent_version
+    local match_count=0
+    local matched_revision=
+
+    if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+        echo "ERROR: Release source selection requires complete first-parent history." >&2
+        return 1
+    fi
+
+    while IFS= read -r candidate; do
+        candidate_version=$(read_cargo_version_at "$candidate" || true)
+        [ "$candidate_version" = "$expected_version" ] || continue
+
+        parent=$(git rev-parse "${candidate}^1" 2>/dev/null || true)
+        parent_version=
+        if [ -n "$parent" ]; then
+            parent_version=$(read_cargo_version_at "$parent" || true)
+        fi
+        [ "$parent_version" != "$expected_version" ] || continue
+
+        matched_revision=$candidate
+        match_count=$((match_count + 1))
+    done < <(git rev-list --first-parent "$dispatch_revision" -- Cargo.toml)
+
+    if [ "$match_count" -eq 0 ]; then
+        echo "ERROR: No first-parent commit introduces release version ${expected_version}." >&2
+        return 1
+    fi
+    if [ "$match_count" -ne 1 ]; then
+        echo "ERROR: Release version ${expected_version} has multiple first-parent introduction commits; refusing ambiguous source selection." >&2
+        return 1
+    fi
+
+    printf '%s\n' "$matched_revision"
 }
 
 validate_annotated_tag() {
@@ -70,7 +116,8 @@ if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
         fi
         echo "Reusing existing annotated tag ${tag} at ${source_revision}."
     elif [ "$tag_status" -eq 2 ]; then
-        source_revision=$dispatch_revision
+        source_revision=$(find_version_introduction "$dispatch_revision" "$version")
+        echo "Resolved prepared ${version} source at ${source_revision}."
     else
         echo "ERROR: Failed to check release tag ${tag}: ${tag_result}" >&2
         exit "$tag_status"

--- a/tests/ci_config_tests.rs
+++ b/tests/ci_config_tests.rs
@@ -5132,6 +5132,10 @@ fn test_release_dispatch_derives_identity_and_reuses_only_safe_tags() {
         "dispatch_revision=$(git rev-parse \"HEAD^{commit}\")",
         "version=$(read_cargo_version)",
         "tag=\"v${version}\"",
+        "find_version_introduction \"$dispatch_revision\" \"$version\"",
+        "git rev-parse --is-shallow-repository",
+        "git rev-list --first-parent \"$dispatch_revision\" -- Cargo.toml",
+        "multiple first-parent introduction commits",
         "git ls-remote --exit-code --tags origin \"refs/tags/${tag}\"",
         "Existing release tag ${candidate_tag} is lightweight",
         "source_revision=$(git rev-parse \"refs/tags/${tag}^{commit}\")",
@@ -5149,6 +5153,11 @@ fn test_release_dispatch_derives_identity_and_reuses_only_safe_tags() {
              Resolver:\n{resolver}"
         );
     }
+    assert!(
+        !resolver.contains("source_revision=$dispatch_revision"),
+        "An absent release tag must resolve the reviewed version-introduction commit, not a \
+         later default-branch tip.\nResolver:\n{resolver}"
+    );
 }
 
 #[test]

--- a/tests/release_publish_tests.rs
+++ b/tests/release_publish_tests.rs
@@ -106,6 +106,84 @@ impl ReleaseFixture {
         self.head()
     }
 
+    fn commit_version(&self, version: &str, message: &str) -> String {
+        write_release_metadata(&self.root, version);
+        git(&self.root, &["add", "Cargo.toml", "CHANGELOG.md"]);
+        git(&self.root, &["commit", "-m", message]);
+        git(&self.root, &["push", "origin", "main"]);
+        self.head()
+    }
+
+    fn commit_version_with_changelog(
+        &self,
+        version: &str,
+        changelog: &str,
+        message: &str,
+    ) -> String {
+        write_file(
+            &self.root.join("Cargo.toml"),
+            &format!("[package]\nname = \"fixture\"\nversion = \"{version}\"\n"),
+        );
+        write_file(&self.root.join("CHANGELOG.md"), changelog);
+        git(&self.root, &["add", "Cargo.toml", "CHANGELOG.md"]);
+        git(&self.root, &["commit", "-m", message]);
+        git(&self.root, &["push", "origin", "main"]);
+        self.head()
+    }
+
+    fn commit_symlinked_version(&self, version: &str, message: &str) -> String {
+        let manifest_target = "actual-Cargo.toml";
+        write_file(
+            &self.root.join(manifest_target),
+            &format!("[package]\nname = \"fixture\"\nversion = \"{version}\"\n"),
+        );
+        fs::remove_file(self.root.join("Cargo.toml")).expect("remove fixture Cargo.toml");
+        std::os::unix::fs::symlink(manifest_target, self.root.join("Cargo.toml"))
+            .expect("symlink fixture Cargo.toml");
+        git(&self.root, &["add", "Cargo.toml", manifest_target]);
+        git(&self.root, &["commit", "-m", message]);
+        git(&self.root, &["push", "origin", "main"]);
+        assert_eq!(
+            git(&self.root, &["status", "--porcelain=v1"]),
+            "",
+            "symlink fixture must represent a clean checkout"
+        );
+        assert_eq!(
+            git(&self.root, &["show", "HEAD:Cargo.toml"]),
+            manifest_target,
+            "historical Cargo.toml lookup must read the symlink blob, not its target"
+        );
+        self.head()
+    }
+
+    fn commit_changelog(&self, changelog: &str, message: &str) -> String {
+        write_file(&self.root.join("CHANGELOG.md"), changelog);
+        git(&self.root, &["add", "CHANGELOG.md"]);
+        git(&self.root, &["commit", "-m", message]);
+        git(&self.root, &["push", "origin", "main"]);
+        self.head()
+    }
+
+    fn commit_same_version_manifest_edit(&self, message: &str) -> String {
+        let manifest =
+            fs::read_to_string(self.root.join("Cargo.toml")).expect("read fixture Cargo.toml");
+        write_file(
+            &self.root.join("Cargo.toml"),
+            &format!("{manifest}description = \"reviewed metadata edit\"\n"),
+        );
+        git(&self.root, &["add", "Cargo.toml"]);
+        git(&self.root, &["commit", "-m", message]);
+        git(&self.root, &["push", "origin", "main"]);
+        self.head()
+    }
+
+    fn make_head_shallow(&self) {
+        write_file(
+            &self.root.join(".git/shallow"),
+            &format!("{}\n", self.head()),
+        );
+    }
+
     fn tag(&self, annotated: bool, target: &str) {
         let mut args = vec!["tag"];
         if annotated {
@@ -160,6 +238,7 @@ impl ReleaseFixture {
 fn release_source_resolver_covers_retry_and_rejection_states() {
     struct Case {
         name: &'static str,
+        initial_version: &'static str,
         arrange: fn(&ReleaseFixture) -> String,
         event: &'static str,
         event_ref: &'static str,
@@ -169,6 +248,58 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
 
     fn no_tag(fixture: &ReleaseFixture) -> String {
         fixture.head()
+    }
+    fn no_tag_after_later_commit(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.commit("document prepared release");
+        release
+    }
+    fn no_tag_after_same_version_manifest_edit(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.commit_same_version_manifest_edit("edit package metadata without a version bump");
+        release
+    }
+    fn repeated_version_boundary(fixture: &ReleaseFixture) -> String {
+        let original = fixture.head();
+        fixture.commit_version("1.2.4", "advance past candidate version");
+        fixture.commit_version("1.2.3", "illegally reuse candidate version");
+        original
+    }
+    fn incomplete_first_parent_history(fixture: &ReleaseFixture) -> String {
+        let release = fixture.head();
+        fixture.commit("later commit hidden from its parent history");
+        fixture.make_head_shallow();
+        release
+    }
+    fn no_version_introduction_match(fixture: &ReleaseFixture) -> String {
+        fixture.commit_symlinked_version(
+            "1.2.3",
+            "make the working manifest version unavailable to historical reads",
+        )
+    }
+    fn introduction_missing_changelog_section(fixture: &ReleaseFixture) -> String {
+        let introduction = fixture.commit_version_with_changelog(
+            "1.2.3",
+            "# Changelog\n\n## [Unreleased]\n",
+            "introduce version without release notes",
+        );
+        fixture.commit_changelog(
+            "# Changelog\n\n## [Unreleased]\n\n## [1.2.3] - 2026-07-18\n",
+            "add release notes too late",
+        );
+        introduction
+    }
+    fn introduction_mismatches_changelog_section(fixture: &ReleaseFixture) -> String {
+        let introduction = fixture.commit_version_with_changelog(
+            "1.2.3",
+            "# Changelog\n\n## [Unreleased]\n\n## [1.2.4] - 2026-07-18\n",
+            "introduce version with mismatched release notes",
+        );
+        fixture.commit_changelog(
+            "# Changelog\n\n## [Unreleased]\n\n## [1.2.3] - 2026-07-18\n",
+            "correct release notes too late",
+        );
+        introduction
     }
     fn matching_ancestor(fixture: &ReleaseFixture) -> String {
         let release = fixture.head();
@@ -215,7 +346,8 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
 
     let cases = [
         Case {
-            name: "manual without tag uses dispatched head",
+            name: "manual without tag uses version-introduction head",
+            initial_version: "1.2.3",
             arrange: no_tag,
             event: "workflow_dispatch",
             event_ref: "refs/heads/main",
@@ -223,7 +355,71 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
             diagnostic: "",
         },
         Case {
+            name: "manual without tag ignores a later documentation commit",
+            initial_version: "1.2.3",
+            arrange: no_tag_after_later_commit,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: true,
+            diagnostic: "",
+        },
+        Case {
+            name: "manual without tag ignores a later same-version manifest edit",
+            initial_version: "1.2.3",
+            arrange: no_tag_after_same_version_manifest_edit,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: true,
+            diagnostic: "",
+        },
+        Case {
+            name: "manual without tag rejects a reused version boundary",
+            initial_version: "1.2.3",
+            arrange: repeated_version_boundary,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "multiple first-parent introduction commits",
+        },
+        Case {
+            name: "manual without tag rejects incomplete first-parent history",
+            initial_version: "1.2.3",
+            arrange: incomplete_first_parent_history,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "complete first-parent history",
+        },
+        Case {
+            name: "manual without tag rejects zero version-introduction matches",
+            initial_version: "1.2.2",
+            arrange: no_version_introduction_match,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "No first-parent commit introduces release version 1.2.3",
+        },
+        Case {
+            name: "manual without tag rejects an introduction missing changelog metadata",
+            initial_version: "1.2.2",
+            arrange: introduction_missing_changelog_section,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "CHANGELOG.md has no ## [1.2.3] release section",
+        },
+        Case {
+            name: "manual without tag rejects mismatched introduction changelog metadata",
+            initial_version: "1.2.2",
+            arrange: introduction_mismatches_changelog_section,
+            event: "workflow_dispatch",
+            event_ref: "refs/heads/main",
+            succeeds: false,
+            diagnostic: "CHANGELOG.md has no ## [1.2.3] release section",
+        },
+        Case {
             name: "manual retry reuses matching annotated ancestor",
+            initial_version: "1.2.3",
             arrange: matching_ancestor,
             event: "workflow_dispatch",
             event_ref: "refs/heads/main",
@@ -232,6 +428,7 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
         },
         Case {
             name: "lightweight tag is rejected",
+            initial_version: "1.2.3",
             arrange: lightweight,
             event: "workflow_dispatch",
             event_ref: "refs/heads/main",
@@ -240,6 +437,7 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
         },
         Case {
             name: "unrelated tag is rejected",
+            initial_version: "1.2.3",
             arrange: non_ancestor,
             event: "workflow_dispatch",
             event_ref: "refs/heads/main",
@@ -248,6 +446,7 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
         },
         Case {
             name: "tagged metadata mismatch is rejected",
+            initial_version: "1.2.3",
             arrange: metadata_mismatch,
             event: "workflow_dispatch",
             event_ref: "refs/heads/main",
@@ -256,6 +455,7 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
         },
         Case {
             name: "direct matching annotated tag passes",
+            initial_version: "1.2.3",
             arrange: direct_match,
             event: "push",
             event_ref: "refs/tags/v1.2.3",
@@ -264,6 +464,7 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
         },
         Case {
             name: "direct tag event commit mismatch is rejected",
+            initial_version: "1.2.3",
             arrange: direct_event_mismatch,
             event: "push",
             event_ref: "refs/tags/v1.2.3",
@@ -273,7 +474,7 @@ fn release_source_resolver_covers_retry_and_rejection_states() {
     ];
 
     for case in cases {
-        let fixture = ReleaseFixture::new("1.2.3");
+        let fixture = ReleaseFixture::new(case.initial_version);
         let expected_source = (case.arrange)(&fixture);
         let output = fixture.resolve(case.event, case.event_ref);
         assert_eq!(


### PR DESCRIPTION
## Summary

- resolve an absent release tag to the unique first-parent commit that introduced the current package version
- fail closed on shallow history and reused version-introduction boundaries
- retain the existing annotated-tag retry and direct-tag validation paths
- replace stale manual-tag development guidance with the reviewed two-workflow release process
- add executable coverage for later docs, same-version manifest edits, zero/ambiguous boundaries, and missing/mismatched source changelog metadata

## Root cause

PR #311 prepared Signal Fish Server 0.6.0 at `3b1ad61eb3657fa910a9390ea144725fd464e0df`. Documentation PR #313 then advanced `main` to `5545daf1435374df8a913b5ec533f387076ebd08` before publication. With no `v0.6.0` tag, the manual resolver used the dispatch revision as the source, so a default-branch dispatch would have violated issue #312's exact-source requirement.

The release workflow already separates dispatch-revision tooling from immutable tagged source on retries. This change applies the same separation to first publication without adding an operator-entered version or source input.

## Release behavior

A manual dispatch still:

- must run from the default branch
- derives version `0.6.0` from reviewed `Cargo.toml`
- selects prepared source `3b1ad61eb3657fa910a9390ea144725fd464e0df`
- checks required CI on that source
- creates or verifies one immutable annotated tag
- uses the existing idempotent crate, GitHub Release, binary/SBOM, and GHCR paths

No server runtime, wire protocol, configuration schema, or permissions change.

## Validation

- observed RED regression: a later documentation commit was selected instead of the prepared version boundary
- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- complete release-publish and CI-policy suites
- CI configuration, MSRV, workflow hygiene, documentation, Markdown, LLM policy, hook-readiness, and pre-push gates
- profiled pre-commit: 947 ms and 921 ms
- three adversarial review rounds; all findings resolved and final verdict zero findings

## Follow-up

After this merges green, dispatch **Release - Publish Crate** from `main` and complete the immutable public-artifact verification tracked by #312.

Closes #314.
Blocks #312.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes maintainer-only release source selection for first publication without a tag; mistakes could block or mis-target publishes, but runtime server behavior is unchanged and failure modes are fail-closed with broad regression tests.
> 
> **Overview**
> Fixes release orchestration so **Release - Publish Crate** does not publish the default-branch tip when docs or workflow commits land after the reviewed prepare-release merge but before the tag exists.
> 
> **`scripts/resolve-release-source.sh`** no longer sets `source_revision` to the dispatch commit when the version tag is missing. It walks first-parent history for `Cargo.toml` changes, picks the sole commit where `[package].version` first equals the version read from tip `Cargo.toml`, and rejects shallow clones, zero matches, or ambiguous re-introductions of the same version. Historical manifest reads use scratch copies so checkout can detach safely. Annotated-tag retry and push-tag paths are unchanged.
> 
> **Tests** extend `release_publish_tests` (later docs, same-version manifest edits, shallow history, zero-match symlink fixture, changelog-only fixes after introduction) and **CI policy** asserts the resolver script contains the new logic and must not use `source_revision=$dispatch_revision` for absent tags.
> 
> **Docs**: `CHANGELOG.md` Unreleased **Fixed**, `docs/releasing.md` and `docs/development.md` describe workflow-based release and source selection; hand-pushed tags are removed from the normal path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0c13b26016aa14b692be8fb61a364f18aa56c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->