### PR TITLE
perf: compact shared relay frame cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce the shared relay-frame cache from 680 to 472 allocated bytes whenever
+  projection work repeats across a relay's recipients (issue #207). JSON,
+  direct MessagePack, and mixed MessagePack projections retain the same
+  allocation-operation counts, codec work, and exact wire output while
+  allocating 208 fewer bytes per shared-cache relay.
+
 ### Fixed
 
 - Preserve the reviewed release-preparation source when documentation or

--- a/benches/relay_serialization_allocations.rs
+++ b/benches/relay_serialization_allocations.rs
@@ -82,18 +82,15 @@ fn print_sample(scenario: Scenario, room_size: usize, sample: &Sample) {
 fn assert_allocation_ceiling(scenario: Scenario, room_size: usize, sample: &Sample) {
     let (maximum_operations_per_relay, maximum_reallocations_per_relay, maximum_bytes_per_relay) =
         match (scenario, room_size) {
-            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 2) => (3, 0, 425),
-            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 8) => (3, 0, 665),
-            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 16) => (3, 0, 985),
-            (Scenario::V3JsonText, 2) => (8, 3, 2_587),
-            (Scenario::V3JsonText, 8) => (9, 3, 3_507),
-            (Scenario::V3JsonText, 16) => (9, 3, 3_827),
-            (Scenario::V3MessagePackBinary, 2) => (5, 0, 1_581),
-            (Scenario::V3MessagePackBinary, 8) => (6, 0, 2_501),
-            (Scenario::V3MessagePackBinary, 16) => (6, 0, 2_821),
-            (Scenario::MixedMessagePackSource, 2) => (15, 0, 3_572),
-            (Scenario::MixedMessagePackSource, 8) => (22, 0, 8_090),
-            (Scenario::MixedMessagePackSource, 16) => (22, 0, 8_410),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 2) => (2, 0, 425),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 8) => (2, 0, 665),
+            (Scenario::V2JsonBinary | Scenario::V2RkyvBinary, 16) => (2, 0, 985),
+            (Scenario::V3JsonText, 2) => (7, 3, 2_587),
+            (Scenario::V3JsonText, 8 | 16) => (8, 3, 3_059),
+            (Scenario::V3MessagePackBinary, 2) => (4, 0, 1_581),
+            (Scenario::V3MessagePackBinary, 8 | 16) => (5, 0, 2_053),
+            (Scenario::MixedMessagePackSource, 2) => (14, 0, 3_572),
+            (Scenario::MixedMessagePackSource, 8 | 16) => (21, 0, 7_642),
             _ => panic!("room-{room_size} has no checked-in allocation baseline"),
         };
     let allocation_operations = sample.stats.allocations + sample.stats.reallocations;

--- a/docs/development.md
+++ b/docs/development.md
@@ -268,6 +268,22 @@ receiver-drain ledgers do not prove every expected delivery. Its allocator uses
 sequentially consistent counters, so its output is an allocation baseline, not
 a latency benchmark; use the ordinary Criterion benchmarks for timing.
 
+Measure the complete ingress-to-wire projection across frozen-v2 raw binary,
+protocol-v3 JSON and MessagePack, and mixed-format recipient cohorts:
+
+```bash
+
+cargo bench --locked --bench relay_serialization_allocations --features allocation-tracking
+
+```
+
+This required CI benchmark checks five identical samples per 2-, 8-, and
+16-player cell. It proves exact wire digests, codec-operation counts, delivery
+ledgers, queue drainage, and allocation-operation, reallocation, and allocated-
+byte ceilings. When projection work repeats within a relay's recipient set, it
+uses one 472-byte lazy frame cache; single-recipient, non-repeating, and
+frozen-v2 raw-passthrough relays do not allocate it.
+
 The ignored real-WebSocket saturation diagnostic retains the exact 16-player
 rates used for release-profile comparisons without adding them to default CI:
 

--- a/progress/session-109-compact-relay-frame-cache.md
+++ b/progress/session-109-compact-relay-frame-cache.md
@@ -1,0 +1,108 @@
+# Session 109 — Compact shared relay frame cache
+
+## Scope and prioritization
+
+Remote triage found no open or draft pull requests and no dependency update to
+incorporate. Main's applicable checks had no observed failure. P56/#290 remains
+the highest gameplay-risk item, but its production fix and deterministic RED
+regression are already merged; closure is correctly gated on the unchanged
+20-attempt hosted cohort, currently 3/20. P53/#274 is likewise fixed at 3/20
+hosted timing allocations per OS. The highest-impact immediately actionable
+work was therefore a bounded, measured #207 relay optimization increment.
+
+## Failure-first baseline and prediction
+
+The unchanged `relay_serialization_allocations` production-seam benchmark ran
+1,024 relays per cell across 15 JSON, direct-binary, mixed-format, and frozen-v2
+cells, repeating each cell five times. It showed that each 8-/16-player
+v3/mixed cell with repeated projection work added exactly one 680-byte
+`RelayFrameCache` allocation:
+
+| Scenario | 2 players | 8 players | 16 players |
+| --- | ---: | ---: | ---: |
+| v3 JSON | 2,538 B | 3,218 B | 3,218 B |
+| v3 MessagePack | 1,533 B | 2,213 B | 2,213 B |
+| mixed MessagePack source | 3,524 B | 7,802 B | 7,802 B |
+
+The cache reserved six full `OnceLock<Result<MaterializedFrame, _>>` slots even
+though a logical relay is exclusively JSON or binary. The pre-registered
+prediction was that sharing the text/binary v2/v3 primary storage would remove
+two slots and reduce every shared-cache relay by the same fixed byte count,
+without changing any allocation-operation, reallocation, codec-work, wire, or
+delivery ledger.
+
+## Implementation and measured result
+
+`RelayFrameCache` is now constructed for the logical message kind. Text-v2 and
+binary-direct-v2 share one primary slot; their v3 counterparts share another;
+binary fallbacks retain separate v2/v3 slots and the shared decoded-value cell.
+The materializer verifies the cache kind and safely uses the uncached path for
+a mismatch, so mutually exclusive slot storage cannot return a frame for a
+different message kind. Non-game-data messages do not receive a relay cache.
+
+Five exact post-change repeats matched the prediction. Allocation operations,
+reallocations, codec counts, delivery counts, queue drainage, and all 15 wire
+digests were unchanged. Every shared relay allocated 208 fewer bytes:
+
+| Scenario | 2 players | 8 players | 16 players | Shared-relay change |
+| --- | ---: | ---: | ---: | ---: |
+| v3 JSON | 2,538 B | 3,010 B | 3,010 B | -208 B (-6.5% total) |
+| v3 MessagePack | 1,533 B | 2,005 B | 2,005 B | -208 B (-9.4% total) |
+| mixed MessagePack source | 3,524 B | 7,594 B | 7,594 B | -208 B (-2.7% total) |
+
+The cache itself falls from 680 to 472 bytes, a 30.6% reduction. Frozen-v2 raw
+passthrough and two-player cells remain unchanged because they correctly skip
+the shared cache. The checked-in operation ceilings now equal the deterministic
+measurement, and the byte ceilings retain the existing roughly 49-byte
+per-relay margin while removing stale room-size growth already eliminated by
+P38.
+
+## Changelog classification and verification boundary
+
+The deterministic reduction affects the universal WebSocket relay hot path and
+is user-visible performance work, so `[Unreleased] / Changed` records it. No
+latency claim is made: the instrumented allocator adds sequentially consistent
+atomics and this experiment targeted retained heap bytes, not wall-clock time.
+
+P53 and P56 retain their pre-registered 20-attempt hosted thresholds. This work
+does not reset, weaken, or infer a result from either cohort.
+
+## Adversarial review loop
+
+The first cache review found that kind filtering covered frame materialization
+but not binary fallback preflight. A wrongly supplied text cache could therefore
+retain decoded data from one binary message, reuse it for another, and strand
+the MessagePack decode attribution even though materialization later bypassed
+the frame slots. The fix applies the immutable binary-kind guard at preflight
+and adds a two-payload regression proving uncached-equivalent wire frames and
+codec work after repeated wrong-kind use.
+
+The same review found that strengthening the race to cover simultaneous v2/v3
+fallback slots had removed same-slot initialization coverage. The final suite
+now proves both cases: cross-slot initialization emits two distinct frames with
+one shared decode, while a barrier-synchronized same-slot race emits one frame
+encode, one decode attribution, and identical results for both writers.
+
+The evidence review narrowed overbroad “multi-recipient” wording to the actual
+repeated-projection predicate, removed a duplicated completed P67 narrative from
+the local PLAN, and found that P38-era operation ceilings still permitted one
+extra operation per relay. All operation ceilings now equal the deterministic
+measurement plus the separately documented sample-scoped operation. Two final
+adversarial passes and an independent finding evaluator reported zero remaining
+issues.
+
+## Validation
+
+The final tree passed formatting, Clippy with warnings denied, the complete
+all-features test suite, `cargo deny`, CI/MSRV/document/workflow policy checks,
+LLM file and example checks, tooling parity, markdown validation, hook readiness,
+both worktree hook preflights, the focused documentation policy suites, and all
+313 CI configuration tests (312 passed, one intentionally ignored). The
+allocation benchmark also passed its tightened byte, operation, reallocation,
+codec, delivery, and wire-digest bounds. The pre-commit worktree preflight
+remained functionally green but reported a non-gating speed warning under the
+concurrent validation load; its existing 1-second target was not changed.
+
+At the final pre-branch snapshot, all 29 applicable check runs on remote `main`
+were successful. No draft, dependency, or other open pull request required
+incorporation before this work.

--- a/src/coordination/outbound_queue.rs
+++ b/src/coordination/outbound_queue.rs
@@ -85,9 +85,10 @@ impl DeliveryMessage {
     }
 
     pub(crate) fn shared_relay(message: Arc<ServerMessage>) -> Self {
+        let relay_frame_cache = RelayFrameCache::for_message(message.as_ref()).map(Arc::new);
         Self {
             message,
-            relay_frame_cache: Some(Arc::new(RelayFrameCache::default())),
+            relay_frame_cache,
         }
     }
 

--- a/src/websocket/sending.rs
+++ b/src/websocket/sending.rs
@@ -51,7 +51,7 @@ pub(super) fn preflight_binary_fallback(
     if *encoding == recipient_format {
         return BinaryFallbackPreflight::NotNeeded;
     }
-    if let Some(cache) = relay_cache {
+    if let Some(cache) = relay_cache.filter(|cache| cache.kind == RelayFrameKind::Binary) {
         return match cache.decoded_fallback.get_or_init(|| {
             let decoded = decode_binary_to_json(*encoding, payload).map(Arc::new);
             if decoded.is_ok() && *encoding == GameDataEncoding::MessagePack {
@@ -108,30 +108,69 @@ enum RelayFrameCohort {
     BinaryFallbackV3,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RelayFrameKind {
+    Text,
+    Binary,
+}
+
+impl RelayFrameCohort {
+    const fn kind(self) -> RelayFrameKind {
+        match self {
+            Self::TextV2 | Self::TextV3 => RelayFrameKind::Text,
+            Self::BinaryDirectV2
+            | Self::BinaryDirectV3
+            | Self::BinaryFallbackV2
+            | Self::BinaryFallbackV3 => RelayFrameKind::Binary,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct RelayFrameCache {
-    text_v2: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
-    text_v3: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
-    binary_direct_v2: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
-    binary_direct_v3: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
-    binary_fallback_v2: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
-    binary_fallback_v3: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
+    kind: RelayFrameKind,
+    // Text and binary relays are mutually exclusive for one logical message,
+    // so their v2/v3 slots can share storage instead of reserving six full
+    // MaterializedFrame results for every shared relay.
+    primary_v2: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
+    primary_v3: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
+    fallback_v2: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
+    fallback_v3: OnceLock<Result<MaterializedFrame, GameDataMaterializationError>>,
     decoded_fallback: OnceLock<Result<Arc<serde_json::Value>, String>>,
     message_pack_decode_unreported: AtomicBool,
 }
 
 impl RelayFrameCache {
+    pub(crate) fn for_message(message: &ServerMessage) -> Option<Self> {
+        let kind = match message {
+            ServerMessage::GameData { .. } => RelayFrameKind::Text,
+            ServerMessage::GameDataBinary { .. } => RelayFrameKind::Binary,
+            _ => return None,
+        };
+        Some(Self {
+            kind,
+            primary_v2: OnceLock::new(),
+            primary_v3: OnceLock::new(),
+            fallback_v2: OnceLock::new(),
+            fallback_v3: OnceLock::new(),
+            decoded_fallback: OnceLock::new(),
+            message_pack_decode_unreported: AtomicBool::new(false),
+        })
+    }
+
+    fn supports(&self, cohort: RelayFrameCohort) -> bool {
+        self.kind == cohort.kind()
+    }
+
     fn slot(
         &self,
         cohort: RelayFrameCohort,
     ) -> &OnceLock<Result<MaterializedFrame, GameDataMaterializationError>> {
         match cohort {
-            RelayFrameCohort::TextV2 => &self.text_v2,
-            RelayFrameCohort::TextV3 => &self.text_v3,
-            RelayFrameCohort::BinaryDirectV2 => &self.binary_direct_v2,
-            RelayFrameCohort::BinaryDirectV3 => &self.binary_direct_v3,
-            RelayFrameCohort::BinaryFallbackV2 => &self.binary_fallback_v2,
-            RelayFrameCohort::BinaryFallbackV3 => &self.binary_fallback_v3,
+            RelayFrameCohort::TextV2 | RelayFrameCohort::BinaryDirectV2 => &self.primary_v2,
+            RelayFrameCohort::TextV3 | RelayFrameCohort::BinaryDirectV3 => &self.primary_v3,
+            RelayFrameCohort::BinaryFallbackV2 => &self.fallback_v2,
+            RelayFrameCohort::BinaryFallbackV3 => &self.fallback_v3,
         }
     }
 
@@ -199,7 +238,7 @@ pub(super) fn materialize_game_data_frame(
             ));
         }
     };
-    if let Some(cache) = relay_cache {
+    if let Some(cache) = relay_cache.filter(|cache| cache.supports(cohort)) {
         return cache.materialize(cohort, || {
             materialize_game_data_frame_uncached(
                 message,
@@ -1404,7 +1443,10 @@ mod tests {
             class: Some(crate::protocol::DeliveryClass::Reliable),
             key: None,
         };
-        let text_cache = RelayFrameCache::default();
+        let text_cache = RelayFrameCache::for_message(&text).expect("text relay cache");
+        assert!(text_cache.supports(RelayFrameCohort::TextV2));
+        assert!(text_cache.supports(RelayFrameCohort::TextV3));
+        assert!(!text_cache.supports(RelayFrameCohort::BinaryDirectV3));
         for supports_v3 in [false, true] {
             let first = materialize_game_data_frame(
                 &text,
@@ -1435,7 +1477,11 @@ mod tests {
             seq: Some(42),
             epoch: Some(3),
         };
-        let binary_cache = RelayFrameCache::default();
+        let binary_cache = RelayFrameCache::for_message(&binary).expect("binary relay cache");
+        assert!(binary_cache.supports(RelayFrameCohort::BinaryDirectV2));
+        assert!(binary_cache.supports(RelayFrameCohort::BinaryFallbackV3));
+        assert!(!binary_cache.supports(RelayFrameCohort::TextV3));
+        assert!(RelayFrameCache::for_message(&ServerMessage::RoomLeft).is_none());
         for (index, supports_v3) in [false, true].into_iter().enumerate() {
             let preflight =
                 preflight_binary_fallback(&binary, GameDataEncoding::Json, Some(&binary_cache));
@@ -1488,7 +1534,61 @@ mod tests {
     }
 
     #[test]
-    fn relay_cache_attributes_shared_decode_to_the_winning_concurrent_cohort() {
+    fn wrong_kind_cache_bypasses_binary_preflight_and_materialization() {
+        let text = ServerMessage::GameData {
+            from_player: player_a(),
+            data: serde_json::json!({"kind": "text"}),
+            seq: Some(1),
+            epoch: Some(1),
+            class: None,
+            key: None,
+        };
+        let text_cache = RelayFrameCache::for_message(&text).expect("text relay cache");
+
+        for (index, data) in [
+            serde_json::json!({"move": "up", "n": 3}),
+            serde_json::json!({"move": "down", "n": 9}),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let payload = rmp_serde::to_vec_named(&data).expect("MessagePack fixture");
+            let binary = ServerMessage::GameDataBinary {
+                from_player: player_a(),
+                encoding: GameDataEncoding::MessagePack,
+                payload: payload.into(),
+                seq: Some(index as u64 + 1),
+                epoch: Some(1),
+            };
+            let expected_preflight =
+                preflight_binary_fallback(&binary, GameDataEncoding::Json, None);
+            let expected = materialize_game_data_frame(
+                &binary,
+                true,
+                GameDataEncoding::Json,
+                expected_preflight,
+                None,
+            )
+            .expect("uncached fallback projection");
+
+            let mismatched_preflight =
+                preflight_binary_fallback(&binary, GameDataEncoding::Json, Some(&text_cache));
+            let actual = materialize_game_data_frame(
+                &binary,
+                true,
+                GameDataEncoding::Json,
+                mismatched_preflight,
+                Some(&text_cache),
+            )
+            .expect("wrong-kind cache must use the uncached projection");
+
+            assert_eq!(actual.frame, expected.frame, "message {index} wire frame");
+            assert_eq!(actual.work, expected.work, "message {index} codec work");
+        }
+    }
+
+    #[test]
+    fn relay_cache_attributes_one_decode_across_concurrent_fallback_cohorts() {
         let data = serde_json::json!({"move": "up", "n": 3});
         let payload = rmp_serde::to_vec_named(&data).expect("MessagePack fixture");
         let binary = Arc::new(ServerMessage::GameDataBinary {
@@ -1498,7 +1598,7 @@ mod tests {
             seq: Some(42),
             epoch: Some(3),
         });
-        let cache = Arc::new(RelayFrameCache::default());
+        let cache = Arc::new(RelayFrameCache::for_message(&binary).expect("binary relay cache"));
         let (preflight_ready_tx, preflight_ready_rx) = std::sync::mpsc::channel();
         let (release_tx, release_rx) = std::sync::mpsc::channel();
 
@@ -1533,7 +1633,7 @@ mod tests {
             preflight_binary_fallback(&binary, GameDataEncoding::Json, Some(&cache));
         let winning = materialize_game_data_frame(
             &binary,
-            false,
+            true,
             GameDataEncoding::Json,
             winning_preflight,
             Some(&cache),
@@ -1544,17 +1644,84 @@ mod tests {
             .expect("delayed thread must still be waiting");
         let delayed = delayed.join().expect("delayed projection must not panic");
 
-        assert_eq!(winning.frame, delayed.frame);
+        assert_ne!(
+            winning.frame, delayed.frame,
+            "v3 and frozen-v2 fallbacks must initialize distinct wire cohorts"
+        );
         assert_eq!(
             winning.work.message_pack_decodes + delayed.work.message_pack_decodes,
             1,
-            "the shared MessagePack decode must be attributed exactly once even when \
-             a different thread wins cohort initialization"
+            "the shared MessagePack decode must be attributed exactly once across \
+             concurrent v2/v3 fallback initialization"
         );
         assert_eq!(
             winning.work.json_encodes + delayed.work.json_encodes,
+            2,
+            "both exact fallback cohorts must serialize once"
+        );
+    }
+
+    #[test]
+    fn relay_cache_initializes_one_frame_across_same_fallback_cohort_race() {
+        let data = serde_json::json!({"move": "up", "n": 3});
+        let payload = rmp_serde::to_vec_named(&data).expect("MessagePack fixture");
+        let binary = Arc::new(ServerMessage::GameDataBinary {
+            from_player: player_a(),
+            encoding: GameDataEncoding::MessagePack,
+            payload: payload.into(),
+            seq: Some(42),
+            epoch: Some(3),
+        });
+        let cache = Arc::new(RelayFrameCache::for_message(&binary).expect("binary relay cache"));
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let mut threads = Vec::new();
+
+        for _ in 0..2 {
+            let binary = Arc::clone(&binary);
+            let cache = Arc::clone(&cache);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                let preflight = preflight_binary_fallback(
+                    binary.as_ref(),
+                    GameDataEncoding::Json,
+                    Some(&cache),
+                );
+                barrier.wait();
+                materialize_game_data_frame(
+                    binary.as_ref(),
+                    false,
+                    GameDataEncoding::Json,
+                    preflight,
+                    Some(&cache),
+                )
+                .expect("racing fallback projection")
+            }));
+        }
+
+        barrier.wait();
+        let frames: [MaterializedFrame; 2] = threads
+            .into_iter()
+            .map(|thread| thread.join().expect("fallback projection must not panic"))
+            .collect::<Vec<_>>()
+            .try_into()
+            .expect("exactly two fallback projections");
+        let [left, right] = frames;
+        assert_eq!(left.frame, right.frame);
+        assert_eq!(
+            [&left, &right]
+                .into_iter()
+                .map(|frame| frame.work.json_encodes)
+                .sum::<u64>(),
             1,
-            "one exact fallback cohort must serialize exactly once"
+            "one same-cohort racer must initialize the JSON frame"
+        );
+        assert_eq!(
+            [&left, &right]
+                .into_iter()
+                .map(|frame| frame.work.message_pack_decodes)
+                .sum::<u64>(),
+            1,
+            "the shared MessagePack decode must be attributed exactly once"
         );
     }
 


### PR DESCRIPTION
## Summary

- shrink the lazily shared relay-frame cache from 680 to 472 allocated bytes when projection work repeats across recipients
- preserve exact wire output and codec work while guarding text/binary cache identity at both preflight and materialization
- add wrong-kind and concurrent same-/cross-cohort regressions, tighten deterministic allocation ceilings, and document the benchmark contract

## Measured impact

Across the checked 8- and 16-player repeated-projection cells, each relay allocates 208 fewer bytes. That is a 30.6% reduction in the cache itself, with unchanged allocation-operation counts, reallocations, codec counts, delivery ledgers, queue drainage, and all 15 wire digests.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`
- `cargo deny --all-features check`
- allocation benchmark with tightened byte/operation/reallocation/codec/delivery/digest bounds
- CI, MSRV, documentation, workflow, LLM, tooling-parity, markdown, and hook policy suites
- two final adversarial reviews plus an independent finding evaluation: no remaining findings

The hooks were functionally green. Their existing non-gating 1-second speed target was exceeded on repeated runs and is tracked separately in #318.

Refs #207.