### PR TITLE
fix: enforce interop evidence and WebSocket Origin integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wait for the native WebRTC statistics accumulator at the bounded
+  connected-data-channel boundary before declaring selected candidate-pair
+  evidence missing. Live interop still requires exactly one concrete pair and
+  fails after the one-second evidence deadline (issue #301).
 - Preserve the reviewed release-preparation source when documentation or
   workflow changes reach the default branch before publication. Manual releases
   now select the unique first-parent commit that introduced the package version
   and reject shallow history or reused version boundaries instead of publishing
   a later tree under the prepared version.
+
+### Security
+
+- Enforce `security.cors_origins` on browser WebSocket upgrades at both
+  `/v2/ws` and `/v3/ws`, using the same parsed policy as HTTP CORS responses.
+  Disallowed origins now receive HTTP 403 and malformed allowlists fail
+  configuration validation; origin-less native clients remain compatible
+  (issue #319).
 
 ## [0.6.0] - 2026-08-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,6 +2714,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "trybuild",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ rmp-serde = "1.3"
 uuid = { version = "1.23", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 semver = "1.0"
+# Parse configured browser origins with the URL Standard's canonical host,
+# port, and IP-address rules before comparing their serialized form exactly.
+url = "2.5"
 
 # Error handling & logging
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ complete reference.
 | `SIGNAL_FISH__LOGGING__LEVEL`                     | `logging.level`                    | `null`    | Log level override (`trace`, `debug`, `info`, `warn`, `error`) |
 | `SIGNAL_FISH__LOGGING__ENABLE_FILE_LOGGING`       | `logging.enable_file_logging`      | `true`    | Enable rolling file logs                            |
 | `SIGNAL_FISH__LOGGING__FORMAT`                    | `logging.format`                   | `json`    | Log output format (`json` or `text`)                |
-| `SIGNAL_FISH__SECURITY__CORS_ORIGINS`             | `security.cors_origins`            | `http://localhost:3000,http://localhost:5173` | Allowed CORS origins (comma-separated or `*`)       |
+| `SIGNAL_FISH__SECURITY__CORS_ORIGINS`             | `security.cors_origins`            | `http://localhost:3000,http://localhost:5173` | Allowed HTTP and browser WebSocket origins (comma-separated or `*`) |
 | `SIGNAL_FISH__SECURITY__ENFORCE_APP_ID_ALLOWLIST`   | `security.enforce_app_id_allowlist`  | `true`    | Require the public app ID to appear in `allowed_apps` |
 | `SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH`     | `security.require_metrics_auth`    | `true`    | Require auth token for metrics endpoints            |
 | `SIGNAL_FISH__SECURITY__MAX_MESSAGE_SIZE`         | `security.max_message_size`        | `65536`   | Max WebSocket message size in bytes                 |

--- a/clients/fortress-wasm/harness.mjs
+++ b/clients/fortress-wasm/harness.mjs
@@ -85,7 +85,7 @@ const serverPort = await freePort();
 const httpPort = await freePort();
 const serverLog = join(artifactDirectory, "server.log");
 const server = spawn(serverBinaryArg, [], {
-  env: cleanServerEnvironment(serverPort),
+  env: cleanServerEnvironment(serverPort, httpPort),
   stdio: ["ignore", "pipe", "pipe"],
 });
 const serverChunks = [];
@@ -646,7 +646,7 @@ async function closePeer(peer) {
   await peer.server?.close().catch(() => {});
 }
 
-function cleanServerEnvironment(port) {
+function cleanServerEnvironment(port, browserOriginPort) {
   const environment = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (!key.startsWith("SIGNAL_FISH")) environment[key] = value;
@@ -659,6 +659,7 @@ function cleanServerEnvironment(port) {
     SIGNAL_FISH__TURN__ENABLED: "false",
     SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH: "false",
     SIGNAL_FISH__SECURITY__ENFORCE_APP_ID_ALLOWLIST: "false",
+    SIGNAL_FISH__SECURITY__CORS_ORIGINS: `http://127.0.0.1:${browserOriginPort}`,
     SIGNAL_FISH__PROTOCOL__SDK_COMPATIBILITY__ENFORCE: "false",
   };
 }

--- a/clients/native/Cargo.lock
+++ b/clients/native/Cargo.lock
@@ -2802,6 +2802,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/clients/native/Cargo.toml
+++ b/clients/native/Cargo.toml
@@ -63,7 +63,7 @@ browser-interop = []
 [dev-dependencies]
 # The interop harness spawns the server binary + N client binaries as real
 # child processes; `process` mirrors the root crate's test-only tokio features.
-tokio = { version = "1.52", features = ["process"] }
+tokio = { version = "1.52", features = ["process", "test-util"] }
 tempfile = "3.27"
 rmp = "0.8"
 rmp-serde = "1.3"

--- a/clients/native/src/engine.rs
+++ b/clients/native/src/engine.rs
@@ -25,6 +25,7 @@
 //! they forward through an unbounded [`EngineEvent`] channel back to the orchestrator.
 
 use std::collections::{BTreeSet, HashMap};
+use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::sync::Arc;
 use std::time::Duration;
@@ -39,10 +40,13 @@ use webrtc::data_channel::{DataChannel, DataChannelEvent, RTCDataChannelInit};
 use webrtc::peer_connection::{
     PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCConfigurationBuilder,
     RTCIceCandidateInit, RTCIceGatheringState, RTCIceServer, RTCIceTransportPolicy,
-    RTCPeerConnectionIceEvent, RTCPeerConnectionState, RTCSessionDescription, RTCStatsReportEntry,
-    SettingEngine, StatsSelector,
+    RTCPeerConnectionIceEvent, RTCPeerConnectionState, RTCSessionDescription, RTCStatsReport,
+    RTCStatsReportEntry, SettingEngine, StatsSelector,
 };
 use webrtc::runtime::{default_runtime, Runtime};
+
+const SELECTED_PAIR_STATS_BUDGET: Duration = Duration::from_secs(1);
+const SELECTED_PAIR_STATS_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Label of the ordered, reliable data channel (commands / critical events).
 pub const RELIABLE_LABEL: &str = "reliable";
@@ -543,36 +547,86 @@ impl Engine {
     /// carried the data channels.
     pub async fn selected_candidate_pair(&self, peer: PlayerId) -> Option<SelectedCandidatePair> {
         let pc = self.peers.get(&peer)?.pc.clone();
-        let report = pc
-            .get_stats(std::time::Instant::now(), StatsSelector::None)
-            .await;
-        let selected_pair_id = &report.transport()?.selected_candidate_pair_id;
-        let RTCStatsReportEntry::IceCandidatePair(pair) = report.get(selected_pair_id)? else {
-            return None;
-        };
-        // rtc 0.20 records raw ICE-agent IDs on the candidate-pair entry but
-        // prefixes the standalone candidate report IDs. Accept the direct ID
-        // first so this remains compatible if that internal mismatch is fixed.
-        let local_id = format!("RTCLocalIceCandidate_{}", pair.local_candidate_id);
-        let remote_id = format!("RTCRemoteIceCandidate_{}", pair.remote_candidate_id);
-        let RTCStatsReportEntry::LocalCandidate(local) = report
-            .get(&pair.local_candidate_id)
-            .or_else(|| report.get(&local_id))?
-        else {
-            return None;
-        };
-        let RTCStatsReportEntry::RemoteCandidate(remote) = report
-            .get(&pair.remote_candidate_id)
-            .or_else(|| report.get(&remote_id))?
-        else {
-            return None;
-        };
-        Some(SelectedCandidatePair {
-            local_candidate_type: local.candidate_type.to_string(),
-            remote_candidate_type: remote.candidate_type.to_string(),
-            local_candidate_address: local.address.clone(),
-            remote_candidate_address: remote.address.clone(),
+        observe_eventually(SELECTED_PAIR_STATS_BUDGET, || {
+            let pc = Arc::clone(&pc);
+            async move {
+                let report = pc
+                    .get_stats(std::time::Instant::now(), StatsSelector::None)
+                    .await;
+                selected_candidate_pair_from_report(&report)
+            }
         })
+        .await
+    }
+}
+
+fn selected_candidate_pair_from_report(report: &RTCStatsReport) -> Option<SelectedCandidatePair> {
+    let selected_pair_id = &report.transport()?.selected_candidate_pair_id;
+    let RTCStatsReportEntry::IceCandidatePair(pair) = report.get(selected_pair_id)? else {
+        return None;
+    };
+    // rtc 0.20 records raw ICE-agent IDs on the candidate-pair entry but
+    // prefixes the standalone candidate report IDs. Accept the direct ID
+    // first so this remains compatible if that internal mismatch is fixed.
+    let local_id = format!("RTCLocalIceCandidate_{}", pair.local_candidate_id);
+    let remote_id = format!("RTCRemoteIceCandidate_{}", pair.remote_candidate_id);
+    let RTCStatsReportEntry::LocalCandidate(local) = report
+        .get(&pair.local_candidate_id)
+        .or_else(|| report.get(&local_id))?
+    else {
+        return None;
+    };
+    let RTCStatsReportEntry::RemoteCandidate(remote) = report
+        .get(&pair.remote_candidate_id)
+        .or_else(|| report.get(&remote_id))?
+    else {
+        return None;
+    };
+    Some(SelectedCandidatePair {
+        local_candidate_type: local.candidate_type.to_string(),
+        remote_candidate_type: remote.candidate_type.to_string(),
+        local_candidate_address: local.address.clone(),
+        remote_candidate_address: remote.address.clone(),
+    })
+}
+
+/// Observe an eventually consistent WebRTC statistic until it exists or the
+/// fixed evidence deadline expires.
+///
+/// webrtc-rs can report open data channels before its driver has drained the
+/// earlier ICE selected-pair event into the statistics accumulator. The pair
+/// is already carrying gameplay traffic at that point; only the stats snapshot
+/// lags. Polling the observable postcondition closes that scheduler boundary
+/// without weakening the harness's exact selected-path assertion.
+async fn observe_eventually<T, Observe, Observation>(
+    budget: Duration,
+    mut observe: Observe,
+) -> Option<T>
+where
+    Observe: FnMut() -> Observation,
+    Observation: Future<Output = Option<T>>,
+{
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        // `timeout_at` polls its inner future before checking the deadline. Do
+        // both checks ourselves so an immediately-ready snapshot cannot start
+        // or become accepted at the exact evidence boundary.
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        let observation = tokio::time::timeout_at(deadline, observe()).await.ok()?;
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        if let Some(value) = observation {
+            return Some(value);
+        }
+
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            return None;
+        }
+        tokio::time::sleep_until((now + SELECTED_PAIR_STATS_INTERVAL).min(deadline)).await;
     }
 }
 
@@ -1057,7 +1111,90 @@ fn convert_ice_servers(ice_servers: &[IceServer]) -> Vec<RTCIceServer> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+
+    #[tokio::test(start_paused = true)]
+    async fn selected_pair_observation_waits_for_delayed_stats() {
+        let attempts = AtomicUsize::new(0);
+
+        let observed = observe_eventually(Duration::from_millis(100), || {
+            let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+            async move { (attempt == 2).then_some("selected-pair") }
+        })
+        .await;
+
+        assert_eq!(observed, Some("selected-pair"));
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            3,
+            "issue #301's connected-before-stats schedule must be observed again, not lost"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn selected_pair_observation_stops_at_evidence_deadline() {
+        let attempts = AtomicUsize::new(0);
+        let observation = observe_eventually(Duration::from_millis(20), || {
+            attempts.fetch_add(1, Ordering::Relaxed);
+            async { None::<()> }
+        })
+        .await;
+
+        assert_eq!(observation, None);
+        assert!(
+            attempts.load(Ordering::Relaxed) >= 1,
+            "the deadline path must take at least one real stats snapshot"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn selected_pair_observation_cancels_a_snapshot_at_the_absolute_deadline() {
+        let started_at = tokio::time::Instant::now();
+        let observation = observe_eventually(Duration::from_secs(1), || async {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            Some("too-late")
+        })
+        .await;
+
+        assert_eq!(observation, None);
+        assert_eq!(
+            tokio::time::Instant::now().duration_since(started_at),
+            Duration::from_secs(1),
+            "a slow stats snapshot must not extend the evidence budget"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn selected_pair_observation_rejects_a_snapshot_ready_at_the_exact_deadline() {
+        let observation = observe_eventually(Duration::from_secs(1), || async {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            Some("boundary-evidence")
+        })
+        .await;
+
+        assert_eq!(
+            observation, None,
+            "evidence that becomes ready at the deadline is outside the strict budget"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn selected_pair_observation_does_not_retry_at_the_evidence_deadline() {
+        let attempts = AtomicUsize::new(0);
+        let observation = observe_eventually(SELECTED_PAIR_STATS_INTERVAL, || {
+            let attempt = attempts.fetch_add(1, Ordering::Relaxed);
+            async move { (attempt == 1).then_some("too-late") }
+        })
+        .await;
+
+        assert_eq!(observation, None);
+        assert_eq!(
+            attempts.load(Ordering::Relaxed),
+            1,
+            "a would-be retry at the exact deadline must never start"
+        );
+    }
 
     /// Payload of the routing probes below. Its exact bytes are compared on
     /// arrival, so a datagram from anything else cannot be mistaken for it.

--- a/clients/native/src/engine.rs
+++ b/clients/native/src/engine.rs
@@ -606,7 +606,7 @@ where
     Observe: FnMut() -> Observation,
     Observation: Future<Output = Option<T>>,
 {
-    let deadline = tokio::time::Instant::now() + budget;
+    let deadline = tokio::time::Instant::now().checked_add(budget)?;
     loop {
         // `timeout_at` polls its inner future before checking the deadline. Do
         // both checks ourselves so an immediately-ready snapshot cannot start
@@ -626,7 +626,10 @@ where
         if now >= deadline {
             return None;
         }
-        tokio::time::sleep_until((now + SELECTED_PAIR_STATS_INTERVAL).min(deadline)).await;
+        let next_attempt = now
+            .checked_add(SELECTED_PAIR_STATS_INTERVAL)
+            .map_or(deadline, |next| next.min(deadline));
+        tokio::time::sleep_until(next_attempt).await;
     }
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -150,7 +150,7 @@ Complete reference of all configuration options with environment variable overri
 | `SIGNAL_FISH__LOGGING__LEVEL` | `logging.level` | `null` | Log level override (`trace`, `debug`, `info`, `warn`, `error`) |
 | `SIGNAL_FISH__LOGGING__ENABLE_FILE_LOGGING` | `logging.enable_file_logging` | `true` | Enable rolling file logs |
 | `SIGNAL_FISH__LOGGING__FORMAT` | `logging.format` | `json` | Log output format (`json` or `text`) |
-| `SIGNAL_FISH__SECURITY__CORS_ORIGINS` | `security.cors_origins` | `http://localhost:3000,http://localhost:5173` | Allowed CORS origins (comma-separated or `*`) |
+| `SIGNAL_FISH__SECURITY__CORS_ORIGINS` | `security.cors_origins` | `http://localhost:3000,http://localhost:5173` | Allowed HTTP and browser WebSocket origins (comma-separated or `*`) |
 | `SIGNAL_FISH__SECURITY__ENFORCE_APP_ID_ALLOWLIST` | `security.enforce_app_id_allowlist` | `true` | Require the public client app ID to appear in `allowed_apps` |
 | `SIGNAL_FISH__SECURITY__REQUIRE_METRICS_AUTH` | `security.require_metrics_auth` | `true` | Require auth token for metrics endpoints |
 | `SIGNAL_FISH__SECURITY__METRICS_AUTH_TOKEN` | `security.metrics_auth_token` | `null` | Bearer token for metrics endpoints |

--- a/docs/features.md
+++ b/docs/features.md
@@ -618,9 +618,17 @@ sequence. Supplemental `UNSUPPORTED_GAME_DATA_FORMAT` prose errors are limited
 to one per sender per second so a malformed stream cannot amplify advisory
 traffic; clients use the reports, not those advisory errors, for gap accounting.
 
-## CORS Support
+## Browser Origin Policy
 
-Configure allowed origins:
+`security.cors_origins` controls both HTTP CORS responses and the `Origin`
+header accepted on `/v2/ws` and `/v3/ws` WebSocket upgrades. Use serialized
+HTTP(S) origins without paths or queries; invalid configuration is rejected at
+startup. The browser-standard opaque origin `null` is also accepted when it is
+listed explicitly. Enable `null` only for trusted sandboxed or local-file
+clients: unrelated opaque origins share that value, so it is broader than a
+named HTTP(S) origin.
+
+Configure an allowed origin:
 
 ```json
 
@@ -655,6 +663,10 @@ Allow all (development only):
 }
 
 ```
+
+Browser WebSocket clients send `Origin` and receive HTTP 403 when it is not in
+an explicit allowlist. Native clients that omit `Origin` remain supported;
+this setting is a browser cross-site control, not client authentication.
 
 ## Connection Limits
 

--- a/docs/pre-deployment-checklist.md
+++ b/docs/pre-deployment-checklist.md
@@ -27,8 +27,8 @@ cargo run -- --print-config
 - [ ] App-ID allowlist enabled — `security.enforce_app_id_allowlist=true`.
 - [ ] At least one real app registered in `security.allowed_apps` with a
   meaningful `app_id` / `app_name`.
-- [ ] CORS locked down — `security.cors_origins` set to your origin(s), **not**
-  `*`.
+- [ ] Browser origins locked down — `security.cors_origins` set to your HTTP and
+  WebSocket origin(s), **not** `*`.
 - [ ] `security.max_connections_per_ip` set to a sane ceiling (default `24`).
 
 ## Secrets protected

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -523,6 +523,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +841,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +1006,12 @@ dependencies = [
  "arbitrary",
  "cc",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1044,6 +1164,15 @@ dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
  "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1365,6 +1494,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -1420,6 +1550,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1600,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "thiserror"
@@ -1522,6 +1669,16 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1735,6 +1892,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,6 +2074,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +2116,60 @@ name = "zerocopy-derive"
 version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/progress/session-110-interop-and-origin-integrity.md
+++ b/progress/session-110-interop-and-origin-integrity.md
@@ -1,0 +1,99 @@
+# Session 110 — Native interop and browser-origin integrity
+
+## Scope and prioritization
+
+Remote triage found no open or draft pull request and no dependency update to
+incorporate. P53/#274 and P56/#290 remain correctly gated on their unchanged
+20-attempt hosted cohorts, both at 3/20; their deterministic fixes are already
+merged, so this session did not reset or weaken either oracle.
+
+Current `main` was not green. WebRTC Interop run `31282596854` failed on macOS
+after both native data channels opened and exact reliable/unreliable traffic
+crossed them: one client emitted no selected-candidate-pair event. This was the
+third recurrence of issue #301's evidence race, so #301 was reopened with the
+new production-seam evidence. A separate safety audit then reproduced a
+browser-origin defect: with only `https://allowed.example` configured, valid
+WebSocket upgrade requests carrying `Origin: https://evil.example` received
+HTTP 101 and registered clients on both enhanced protocol paths. Issue #319
+tracks that newly confirmed security gap.
+
+## Failure-first evidence and root causes
+
+The native reference client took one WebRTC statistics snapshot as soon as
+both SCTP channels opened. Inspection of the pinned webrtc-rs 0.20 event loop
+showed that data-channel readiness can become observable before the driver
+drains the earlier selected-candidate-pair event into its statistics
+accumulator. The transport and gameplay path were healthy; the independent
+evidence snapshot was eventually consistent.
+
+The server parsed `security.cors_origins` only into `tower_http::CorsLayer`.
+HTTP CORS response headers do not authorize a WebSocket handshake, and neither
+the shared handler nor either production router checked the upgrade request's
+`Origin`. Invalid configured values could also degrade to permissive CORS.
+
+## Implementation
+
+The native client now observes the exact selected-pair statistics
+postcondition for at most one second, retaining the immediate snapshot as its
+fast path and the existing exact type/address oracle as the acceptance result.
+Deterministic tests prove a delayed third snapshot succeeds and a permanently
+missing observation stops at the evidence deadline.
+
+`OriginPolicy` now strictly parses one wildcard, an explicitly configured
+opaque `null` origin, or a comma-separated set of canonical serialized HTTP(S)
+origins. The same parsed value builds HTTP CORS behavior and
+authorizes `/v2/ws` plus `/v3/ws` before connection registration. Disallowed
+browser origins receive HTTP 403, ambiguous duplicate headers are rejected,
+and malformed configuration fails validation instead of becoming permissive.
+The public router helpers install the required policy on every enhanced route;
+a raw handler without that extension denies browser origins. Origin-less native
+clients remain intentionally compatible because an Origin header is a browser
+cross-site control, not non-browser authentication. The development wildcard
+retains its documented open behavior.
+
+## Regression boundary
+
+Real loopback WebSocket upgrades cover explicit allow, explicit deny, absent
+Origin, wildcard, and both enhanced protocol paths. The HTTP health route also
+proves the same exact allowlist emits CORS response headers only for an allowed
+origin. Configuration cases reject blank values and origin URIs with paths.
+Every v3 integration fixture now uses the policy-bearing route constructor, so
+tests cannot silently reintroduce an ungoverned production-shaped alias.
+
+The complete Linux native reference-client workflow passed: formatting,
+zero-warning Clippy, 94 unit tests, and all eight live multi-process interop
+scenarios. Those scenarios exercised exact selected-pair evidence, reliable and
+unreliable data channels, IPv6, host-star and mesh plans, late replanning,
+partial ICE failure with relay fallback, and the mixed v2/v3 relay floor.
+
+## Documentation and compatibility
+
+README/configuration tables, the feature guide, the deployment checklist,
+source comments, and `[Unreleased]` now state that `security.cors_origins`
+governs both HTTP and browser WebSocket origins. They also state the exact
+native-client exception and avoid presenting this policy as authentication.
+P68 records the bounded work without changing P53 or P56's hosted evidence
+thresholds.
+
+## Adversarial review and final validation
+
+Three failure-and-review rounds closed every reported boundary. The first
+review required policy extraction at the raw handler boundary, fail-closed
+library constructors, strict observation-future cancellation, standalone-route
+coverage, and canonical browser serialization. The second caught Tokio's
+inner-first timeout polling at the exact deadline, noncanonical port/IP forms,
+and detached test-server lifecycle. The final pass found one undocumented
+`Origin: null` branch; its explicit-policy regression and opaque-origin warning
+were added, after which the reviewer reported zero actionable findings.
+
+The exact final tree passed root and native formatting; warnings-denied Clippy
+for every target and feature; `cargo test --locked --all-features` (770 library
+tests plus every integration target); `cargo deny --all-features check`; CI,
+MSRV, documentation, workflow-hygiene, LLM-policy, tooling-parity, Markdown,
+README-badge, source-hygiene, and hook-readiness gates; and the real native
+WebRTC workflow with all 94 unit tests and all eight multi-process scenarios.
+The pre-commit worktree preflight also passed; its existing 1000 ms advisory
+remains tracked separately by issue #318 and is unrelated to this change.
+
+Hosted pull-request validation and final review state will be appended after
+publication.

--- a/progress/session-110-interop-and-origin-integrity.md
+++ b/progress/session-110-interop-and-origin-integrity.md
@@ -95,5 +95,20 @@ WebRTC workflow with all 94 unit tests and all eight multi-process scenarios.
 The pre-commit worktree preflight also passed; its existing 1000 ms advisory
 remains tracked separately by issue #318 and is unrelated to this change.
 
-Hosted pull-request validation and final review state will be appended after
-publication.
+PR #320 reached ready-for-review at implementation head
+`a24ddaab6d844bbab203bdea19cf0a054524b404`. All 15 applicable hosted
+workflows succeeded: the core CI matrix, WebRTC and browser interop, TURN-only,
+Fortress native and WASM interop, verification-nightly fault profiles, formal
+verification, fuzzing, AddressSanitizer/Miri, unused-dependency, documentation,
+link, spelling, and Markdown gates. The Dependabot-only workflow skipped as
+designed. The first WASM attempt exposed one legitimate fixture integration
+gap—the Chromium page's concrete loopback origin was not configured—and the
+harness now derives that exact allowlist entry from its allocated HTTP port;
+the pinned Godot/Emscripten/Chromium rerun passed.
+
+The final GitHub audit found no review threads or PR comments. Cursor Bugbot
+reviewed exact head `a24ddaa` without an actionable finding; Copilot's review
+requests reported only the repository owner's exhausted quota. The repeated
+independent adversarial loop ended with zero findings. The PR is mergeable and
+non-draft; P68 remains open in PLAN.md only for merge, while P53 and P56 retain
+their unchanged 3/20 hosted evidence cohorts.

--- a/src/config/security.rs
+++ b/src/config/security.rs
@@ -12,7 +12,8 @@ use std::fmt;
 /// Security configuration.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SecurityConfig {
-    /// Allowed CORS origins (comma-separated, or "*" for any)
+    /// Allowed HTTP CORS and browser WebSocket origins (comma-separated, or
+    /// "*" for any). Origin-less native WebSocket clients remain compatible.
     #[serde(default = "default_cors_origins")]
     pub cors_origins: String,
     /// Require the public client `app_id` to match a configured application.

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 pub fn validate_config_security(config: &Config) -> anyhow::Result<()> {
     let is_prod = is_production_mode();
 
+    crate::security::OriginPolicy::parse(&config.security.cors_origins)?;
+
     if config.server.event_buffer_size > super::server::MAX_EVENT_BUFFER_SIZE {
         anyhow::bail!(
             "server.event_buffer_size must not exceed {} (configured: {})",

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use signal_fish_server::config;
 use signal_fish_server::database::DatabaseConfig;
 use signal_fish_server::logging;
 use signal_fish_server::security::{
-    ClientCertificateFingerprint, CLIENT_FINGERPRINT_HEADER_CANDIDATES,
+    ClientCertificateFingerprint, OriginPolicy, CLIENT_FINGERPRINT_HEADER_CANDIDATES,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
 use signal_fish_server::websocket;
@@ -179,33 +179,12 @@ async fn main() -> anyhow::Result<()> {
     let shutdown_server = game_server.clone();
     let shutdown_task = tokio::spawn(run_shutdown_drain(shutdown_server, shutdown_tx.clone()));
 
-    // Create enhanced protocol router with CORS configuration
-    let enhanced_router =
-        websocket::create_router(&cfg.security.cors_origins).with_state(game_server.clone());
-
-    // Parse CORS origins for top-level router
-    use tower_http::cors::{Any, CorsLayer};
-
-    let cors = if cfg.security.cors_origins == "*" {
-        CorsLayer::permissive()
-    } else {
-        let origins: Vec<_> = cfg
-            .security
-            .cors_origins
-            .split(',')
-            .filter_map(|s| s.trim().parse::<axum::http::HeaderValue>().ok())
-            .collect();
-
-        if origins.is_empty() {
-            tracing::warn!("No valid CORS origins configured, using permissive CORS");
-            CorsLayer::permissive()
-        } else {
-            CorsLayer::new()
-                .allow_origin(origins)
-                .allow_methods(Any)
-                .allow_headers(Any)
-        }
-    };
+    // One parsed policy governs HTTP CORS responses and both WebSocket
+    // upgrades, so the browser-facing allowlist cannot drift between layers.
+    let origin_policy = OriginPolicy::parse(&cfg.security.cors_origins)?;
+    let cors = origin_policy.cors_layer();
+    let enhanced_router = websocket::create_router_with_origin_policy(origin_policy.clone())
+        .with_state(game_server.clone());
 
     use axum::routing::get;
 
@@ -251,7 +230,10 @@ async fn main() -> anyhow::Result<()> {
     // byte-for-byte unchanged.
     let combined_router = combined_router
         .nest("/v2", enhanced_router) // Enhanced protocol under /v2
-        .route("/v3/ws", get(websocket::websocket_handler_v3)) // v3 alias, shared handler
+        .route(
+            "/v3/ws",
+            websocket::websocket_route_v3_with_origin_policy(origin_policy.clone()),
+        ) // v3 alias, shared handler
         .fallback(|| async {
             "Signal Fish Server. Use /v2/ws (or /v3/ws) for WebSocket protocol, /v1/metrics for metrics, /metrics/prom for Prometheus."
         })

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -5,11 +5,13 @@
 /// - Envelope encryption (AES-GCM)
 /// - Token binding and channel security
 pub mod crypto;
+pub mod origin;
 pub mod tls;
 pub mod token_binding; // Always include tls module (ClientCertificateFingerprint is always needed)
 pub mod turn_credentials;
 
 pub use crypto::EnvelopeEncryptor;
+pub use origin::{OriginPolicy, OriginPolicyError};
 pub use token_binding::{
     derive_session_secret, ActiveTokenBinding, TokenBindingError, TokenBindingProof,
 };

--- a/src/security/origin.rs
+++ b/src/security/origin.rs
@@ -1,0 +1,266 @@
+//! Shared HTTP CORS and WebSocket upgrade Origin policy.
+
+use axum::http::header::ORIGIN;
+use axum::http::{HeaderMap, HeaderValue};
+use std::sync::Arc;
+use tower_http::cors::{Any, CorsLayer};
+use url::Url;
+
+/// A configuration error in `security.cors_origins`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid security.cors_origins: {0}")]
+pub struct OriginPolicyError(String);
+
+/// One parsed policy shared by HTTP CORS responses and WebSocket upgrades.
+///
+/// Missing `Origin` is accepted deliberately for native/non-browser clients.
+/// Browser WebSocket implementations send `Origin`, so configured allowlists
+/// still reject cross-site browser upgrades. This is a browser-origin control,
+/// not client authentication: non-browser clients can choose or omit headers.
+#[derive(Clone, Debug)]
+pub struct OriginPolicy {
+    allow_any: bool,
+    allow_originless: bool,
+    allowed_origins: Arc<[HeaderValue]>,
+}
+
+impl OriginPolicy {
+    /// Parse `*`, `null`, or a comma-separated list of serialized HTTP(S)
+    /// origins.
+    pub fn parse(configured: &str) -> Result<Self, OriginPolicyError> {
+        let configured = configured.trim();
+        if configured == "*" {
+            return Ok(Self {
+                allow_any: true,
+                allow_originless: true,
+                allowed_origins: Arc::from([]),
+            });
+        }
+        if configured.is_empty() {
+            return Err(OriginPolicyError("value must not be blank".to_string()));
+        }
+
+        let mut allowed_origins = Vec::new();
+        for entry in configured.split(',') {
+            let origin = entry.trim();
+            if origin.is_empty() {
+                return Err(OriginPolicyError(
+                    "comma-separated entries must not be blank".to_string(),
+                ));
+            }
+            if origin == "*" {
+                return Err(OriginPolicyError(
+                    "wildcard `*` must be the entire value".to_string(),
+                ));
+            }
+            validate_serialized_origin(origin)?;
+            let header = origin.parse::<HeaderValue>().map_err(|error| {
+                OriginPolicyError(format!(
+                    "{origin:?} is not a valid HTTP header value: {error}"
+                ))
+            })?;
+            if !allowed_origins.contains(&header) {
+                allowed_origins.push(header);
+            }
+        }
+
+        Ok(Self {
+            allow_any: false,
+            allow_originless: true,
+            allowed_origins: allowed_origins.into(),
+        })
+    }
+
+    /// A fail-closed policy for compatibility constructors given invalid
+    /// configuration. Unlike a valid explicit allowlist, this rejects native
+    /// clients that omit `Origin` as well as browser-originated upgrades.
+    pub(crate) fn deny_all_upgrades() -> Self {
+        Self {
+            allow_any: false,
+            allow_originless: false,
+            allowed_origins: Arc::from([]),
+        }
+    }
+
+    /// Whether this upgrade's browser Origin is allowed.
+    #[must_use]
+    pub fn allows_upgrade(&self, headers: &HeaderMap) -> bool {
+        if self.allow_any {
+            return true;
+        }
+
+        let mut origins = headers.get_all(ORIGIN).iter();
+        let Some(origin) = origins.next() else {
+            // Native clients do not send Origin. This is intentional
+            // compatibility, not authentication of the origin-less caller.
+            return self.allow_originless;
+        };
+        if origins.next().is_some() {
+            return false;
+        }
+        self.allowed_origins.contains(origin)
+    }
+
+    /// Build HTTP response CORS behavior from the same parsed allowlist used
+    /// by [`Self::allows_upgrade`].
+    pub fn cors_layer(&self) -> CorsLayer {
+        if self.allow_any {
+            CorsLayer::permissive()
+        } else {
+            CorsLayer::new()
+                .allow_origin(self.allowed_origins.iter().cloned().collect::<Vec<_>>())
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
+    }
+}
+
+fn validate_serialized_origin(origin: &str) -> Result<(), OriginPolicyError> {
+    if origin == "null" {
+        return Ok(());
+    }
+
+    let url = Url::parse(origin).map_err(|error| {
+        OriginPolicyError(format!("{origin:?} is not a valid origin URL: {error}"))
+    })?;
+    let scheme = url.scheme();
+    if !matches!(scheme, "http" | "https") || !origin.starts_with(&format!("{scheme}://")) {
+        return Err(OriginPolicyError(format!(
+            "{origin:?} must use a lowercase http or https scheme"
+        )));
+    }
+    if url.host().is_none() {
+        return Err(OriginPolicyError(format!(
+            "{origin:?} must include a host authority"
+        )));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(OriginPolicyError(format!(
+            "{origin:?} must not include user information"
+        )));
+    }
+    let serialized_origin = url.origin().ascii_serialization();
+    if origin != serialized_origin {
+        return Err(OriginPolicyError(format!(
+            "{origin:?} is not a canonical serialized browser origin; use {serialized_origin:?}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn origin_policy_matches_exact_configured_browser_origins() {
+        let policy = OriginPolicy::parse("https://game.example, http://localhost:3000")
+            .expect("parse explicit origin allowlist");
+
+        for (origin, expected) in [
+            (Some("https://game.example"), true),
+            (Some("http://localhost:3000"), true),
+            (Some("https://evil.example"), false),
+            (None, true),
+        ] {
+            let mut headers = HeaderMap::new();
+            if let Some(origin) = origin {
+                headers.insert(ORIGIN, HeaderValue::from_static(origin));
+            }
+            assert_eq!(
+                policy.allows_upgrade(&headers),
+                expected,
+                "origin={origin:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wildcard_origin_policy_accepts_every_upgrade_origin() {
+        let policy = OriginPolicy::parse("*").expect("parse wildcard policy");
+        let mut headers = HeaderMap::new();
+        headers.append(ORIGIN, HeaderValue::from_static("https://one.example"));
+        headers.append(ORIGIN, HeaderValue::from_static("https://two.example"));
+
+        assert!(policy.allows_upgrade(&headers));
+    }
+
+    #[test]
+    fn explicit_origin_policy_rejects_ambiguous_duplicate_headers() {
+        let policy = OriginPolicy::parse("https://game.example").expect("parse policy");
+        let mut headers = HeaderMap::new();
+        headers.append(ORIGIN, HeaderValue::from_static("https://game.example"));
+        headers.append(ORIGIN, HeaderValue::from_static("https://game.example"));
+
+        assert!(!policy.allows_upgrade(&headers));
+    }
+
+    #[test]
+    fn opaque_null_origin_must_be_configured_explicitly() {
+        let null_policy = OriginPolicy::parse("null").expect("parse opaque Origin policy");
+        let http_policy = OriginPolicy::parse("https://game.example").expect("parse HTTP policy");
+        let mut headers = HeaderMap::new();
+        headers.insert(ORIGIN, HeaderValue::from_static("null"));
+
+        assert!(null_policy.allows_upgrade(&headers));
+        assert!(!http_policy.allows_upgrade(&headers));
+    }
+
+    #[test]
+    fn invalid_origin_configuration_fails_closed() {
+        for (configured, reason) in [
+            ("", "blank value"),
+            ("https://game.example,", "blank list entry"),
+            ("https://game.example,*", "mixed wildcard"),
+            ("ws://game.example", "WebSocket rather than page scheme"),
+            (
+                "HTTPS://game.example",
+                "uppercase scheme is not browser-canonical",
+            ),
+            ("https://game.example/path", "path"),
+            ("https://game.example?query", "query"),
+            ("https://user@game.example", "user information"),
+            (
+                "https://GAME.example",
+                "uppercase host is not browser-canonical",
+            ),
+            (
+                "https://game.example:443",
+                "default port is omitted by browsers",
+            ),
+            (
+                "http://game.example:80",
+                "default port is omitted by browsers",
+            ),
+            ("https://game.example:", "empty trailing port"),
+            ("https://game.example:65536", "out-of-range port"),
+            ("http://127.1", "IPv4 shorthand"),
+            ("http://0x7f000001", "hexadecimal IPv4"),
+            ("http://[0:0:0:0:0:0:0:1]:3000", "uncompressed IPv6"),
+        ] {
+            assert!(
+                OriginPolicy::parse(configured).is_err(),
+                "{reason}: {configured:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_non_default_ports_and_ipv6_origins_are_accepted() {
+        for configured in [
+            "https://game.example:8443",
+            "http://localhost:3000",
+            "http://[::1]:3000",
+        ] {
+            assert!(
+                OriginPolicy::parse(configured).is_ok(),
+                "canonical serialized origin must be accepted: {configured:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_configuration_fallback_rejects_originless_upgrades() {
+        assert!(!OriginPolicy::deny_all_upgrades().allows_upgrade(&HeaderMap::new()));
+    }
+}

--- a/src/security/origin.rs
+++ b/src/security/origin.rs
@@ -208,6 +208,12 @@ mod tests {
 
     #[test]
     fn invalid_origin_configuration_fails_closed() {
+        let out_of_range_port = format!("https://game.example:{}", u32::from(u16::MAX) + 1);
+        assert!(
+            OriginPolicy::parse(&out_of_range_port).is_err(),
+            "out-of-range port: {out_of_range_port:?} must be rejected"
+        );
+
         for (configured, reason) in [
             ("", "blank value"),
             ("https://game.example,", "blank list entry"),
@@ -233,7 +239,6 @@ mod tests {
                 "default port is omitted by browsers",
             ),
             ("https://game.example:", "empty trailing port"),
-            ("https://game.example:65536", "out-of-range port"),
             ("http://127.1", "IPv4 shorthand"),
             ("http://0x7f000001", "hexadecimal IPv4"),
             ("http://[0:0:0:0:0:0:0:1]:3000", "uncompressed IPv6"),

--- a/src/websocket/handler.rs
+++ b/src/websocket/handler.rs
@@ -1,4 +1,4 @@
-use crate::security::ClientCertificateFingerprint;
+use crate::security::{ClientCertificateFingerprint, OriginPolicy};
 use crate::server::EnhancedGameServer;
 use axum::extract::ws::WebSocketUpgrade;
 use axum::extract::{ConnectInfo, Extension, State};
@@ -20,8 +20,18 @@ pub async fn websocket_handler(
     state: State<Arc<EnhancedGameServer>>,
     headers: HeaderMap,
     fingerprint: Option<Extension<ClientCertificateFingerprint>>,
+    origin_policy: Extension<OriginPolicy>,
 ) -> Response {
-    websocket_handler_with_default(ws, connect_info, state, headers, fingerprint, 2).await
+    websocket_handler_with_default(
+        ws,
+        connect_info,
+        state,
+        headers,
+        fingerprint,
+        origin_policy,
+        2,
+    )
+    .await
 }
 
 /// WebSocket handler for the `/v3/ws` alias.
@@ -36,8 +46,18 @@ pub async fn websocket_handler_v3(
     state: State<Arc<EnhancedGameServer>>,
     headers: HeaderMap,
     fingerprint: Option<Extension<ClientCertificateFingerprint>>,
+    origin_policy: Extension<OriginPolicy>,
 ) -> Response {
-    websocket_handler_with_default(ws, connect_info, state, headers, fingerprint, 3).await
+    websocket_handler_with_default(
+        ws,
+        connect_info,
+        state,
+        headers,
+        fingerprint,
+        origin_policy,
+        3,
+    )
+    .await
 }
 
 async fn websocket_handler_with_default(
@@ -46,8 +66,14 @@ async fn websocket_handler_with_default(
     State(server): State<Arc<EnhancedGameServer>>,
     headers: HeaderMap,
     fingerprint: Option<Extension<ClientCertificateFingerprint>>,
+    Extension(origin_policy): Extension<OriginPolicy>,
     default_protocol_version: u16,
 ) -> Response {
+    if !origin_policy.allows_upgrade(&headers) {
+        tracing::warn!(client_ip = %addr.ip(), "WebSocket upgrade rejected: Origin not allowed");
+        return (StatusCode::FORBIDDEN, "WebSocket Origin is not allowed").into_response();
+    }
+
     if server.is_draining() {
         return (StatusCode::SERVICE_UNAVAILABLE, "server is draining").into_response();
     }

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -108,7 +108,10 @@ pub use metrics::{metrics_handler, prometheus_metrics_handler, MetricsQuery};
 #[cfg(feature = "tls")]
 pub use routes::ConfiguredAcceptor;
 pub use routes::{
-    bind_serve_listener, bind_tcp_listener, create_router, create_standalone_router, run_server,
+    bind_serve_listener, bind_tcp_listener, create_router, create_router_with_origin_policy,
+    create_standalone_router, create_standalone_router_with_origin_policy, run_server,
+    try_create_router, try_create_standalone_router, try_websocket_route_v3, websocket_route_v3,
+    websocket_route_v3_with_origin_policy,
 };
 
 /// Upper bound on each best-effort WebSocket close-path write.

--- a/src/websocket/routes.rs
+++ b/src/websocket/routes.rs
@@ -1,6 +1,7 @@
 use crate::database::DatabaseConfig;
+use crate::security::{OriginPolicy, OriginPolicyError};
 use crate::server::{EnhancedGameServer, ServerConfig};
-use axum::extract::State;
+use axum::extract::{Extension, State};
 use axum::routing::get;
 use axum::serve::ListenerExt;
 use std::net::SocketAddr;
@@ -110,41 +111,72 @@ impl<S> axum_server::accept::Accept<TcpStream, S> for ConfiguredAcceptor {
 /// [`create_standalone_router`] or by the top-level production router so nesting
 /// never creates an undocumented `/v2/v3/ws` endpoint.
 pub fn create_router(cors_origins: &str) -> axum::Router<Arc<EnhancedGameServer>> {
-    create_router_inner(cors_origins, false)
+    create_router_with_origin_policy(parse_origin_policy_or_deny(cors_origins))
+}
+
+/// Create the nestable router, returning invalid Origin configuration to the
+/// library caller instead of installing the compatibility deny-all policy.
+pub fn try_create_router(
+    cors_origins: &str,
+) -> Result<axum::Router<Arc<EnhancedGameServer>>, OriginPolicyError> {
+    OriginPolicy::parse(cors_origins).map(create_router_with_origin_policy)
+}
+
+/// Create the nestable router from a policy already validated by the caller.
+pub fn create_router_with_origin_policy(
+    origin_policy: OriginPolicy,
+) -> axum::Router<Arc<EnhancedGameServer>> {
+    create_router_inner(origin_policy, false)
 }
 
 /// Create a standalone router for library users that serve Signal Fish at the
 /// HTTP root rather than nesting [`create_router`] under `/v2`.
 pub fn create_standalone_router(cors_origins: &str) -> axum::Router<Arc<EnhancedGameServer>> {
-    create_router_inner(cors_origins, true)
+    create_standalone_router_with_origin_policy(parse_origin_policy_or_deny(cors_origins))
+}
+
+/// Create the standalone router or return invalid Origin configuration.
+pub fn try_create_standalone_router(
+    cors_origins: &str,
+) -> Result<axum::Router<Arc<EnhancedGameServer>>, OriginPolicyError> {
+    OriginPolicy::parse(cors_origins).map(create_standalone_router_with_origin_policy)
+}
+
+/// Create the standalone router from a policy already validated by the caller.
+pub fn create_standalone_router_with_origin_policy(
+    origin_policy: OriginPolicy,
+) -> axum::Router<Arc<EnhancedGameServer>> {
+    create_router_inner(origin_policy, true)
+}
+
+/// Build the top-level `/v3/ws` route with its required Origin policy.
+pub fn websocket_route_v3(
+    cors_origins: &str,
+) -> axum::routing::MethodRouter<Arc<EnhancedGameServer>> {
+    websocket_route_v3_with_origin_policy(parse_origin_policy_or_deny(cors_origins))
+}
+
+/// Build the `/v3/ws` route or return invalid Origin configuration.
+pub fn try_websocket_route_v3(
+    cors_origins: &str,
+) -> Result<axum::routing::MethodRouter<Arc<EnhancedGameServer>>, OriginPolicyError> {
+    OriginPolicy::parse(cors_origins).map(websocket_route_v3_with_origin_policy)
+}
+
+/// Build the top-level `/v3/ws` route from a pre-validated Origin policy.
+pub fn websocket_route_v3_with_origin_policy(
+    origin_policy: OriginPolicy,
+) -> axum::routing::MethodRouter<Arc<EnhancedGameServer>> {
+    get(websocket_handler_v3).layer(Extension(origin_policy))
 }
 
 fn create_router_inner(
-    cors_origins: &str,
+    origin_policy: OriginPolicy,
     include_v3_alias: bool,
 ) -> axum::Router<Arc<EnhancedGameServer>> {
-    use tower_http::cors::{Any, CorsLayer};
     use tower_http::trace::TraceLayer;
 
-    // Parse CORS origins
-    let cors = if cors_origins == "*" {
-        CorsLayer::permissive()
-    } else {
-        let origins: Vec<_> = cors_origins
-            .split(',')
-            .filter_map(|s| s.trim().parse::<axum::http::HeaderValue>().ok())
-            .collect();
-
-        if origins.is_empty() {
-            tracing::warn!("No valid CORS origins configured, using permissive CORS");
-            CorsLayer::permissive()
-        } else {
-            CorsLayer::new()
-                .allow_origin(origins)
-                .allow_methods(Any)
-                .allow_headers(Any)
-        }
-    };
+    let cors = origin_policy.cors_layer();
 
     let router = axum::Router::new()
         .route("/ws", get(websocket_handler))
@@ -158,7 +190,17 @@ fn create_router_inner(
         router
     };
 
-    router.layer(cors).layer(TraceLayer::new_for_http())
+    router
+        .layer(Extension(origin_policy))
+        .layer(cors)
+        .layer(TraceLayer::new_for_http())
+}
+
+fn parse_origin_policy_or_deny(cors_origins: &str) -> OriginPolicy {
+    OriginPolicy::parse(cors_origins).unwrap_or_else(|error| {
+        tracing::error!(%error, "invalid Origin policy; rejecting all WebSocket upgrades");
+        OriginPolicy::deny_all_upgrades()
+    })
 }
 
 /// Health check endpoint
@@ -179,6 +221,7 @@ pub async fn run_server(
     server_config: ServerConfig,
     cors_origins: String,
 ) -> anyhow::Result<()> {
+    let origin_policy = OriginPolicy::parse(&cors_origins)?;
     let socket_send_buffer_bytes = server_config.websocket_config.socket_send_buffer_bytes;
     // Create storage configuration
     let database_config = DatabaseConfig::from_env()?;
@@ -204,7 +247,7 @@ pub async fn run_server(
     });
 
     // Create router with CORS configuration
-    let app = create_standalone_router(&cors_origins).with_state(game_server);
+    let app = create_standalone_router_with_origin_policy(origin_policy).with_state(game_server);
 
     // Accepted sockets are configured for low-latency relay (issue #197).
     let listener = bind_serve_listener(addr, socket_send_buffer_bytes)?;
@@ -229,6 +272,39 @@ pub async fn run_server(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn fallible_router_constructors_return_invalid_origin_configuration() {
+        for result in [
+            try_create_router("https://game.example/path").map(|_| ()),
+            try_create_standalone_router("https://game.example/path").map(|_| ()),
+            try_websocket_route_v3("https://game.example/path").map(|_| ()),
+        ] {
+            let error = result.expect_err("invalid Origin configuration must be returned");
+            assert!(
+                error
+                    .to_string()
+                    .contains("not a canonical serialized browser origin"),
+                "unexpected validation error: {error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn run_server_rejects_invalid_origin_configuration_before_side_effects() {
+        let error = run_server(
+            "127.0.0.1:0".parse().expect("parse loopback address"),
+            ServerConfig::default(),
+            "https://game.example/path".to_string(),
+        )
+        .await
+        .expect_err("invalid Origin configuration must stop server startup");
+
+        assert!(
+            error.to_string().contains("invalid security.cors_origins"),
+            "unexpected startup error: {error}"
+        );
+    }
 
     #[tokio::test]
     #[cfg_attr(miri, ignore)]

--- a/tests/config_and_endpoints_tests.rs
+++ b/tests/config_and_endpoints_tests.rs
@@ -8,20 +8,20 @@
 
 mod test_helpers;
 
-use axum::routing::get;
 use regex::Regex;
 use signal_fish_server::config::{
     AppRegistrationEntry, ClientAuthMode, Config, DashboardHistoryField, LogFormat,
 };
 use signal_fish_server::security::token_binding::TokenBindingScheme;
 use signal_fish_server::websocket::{
-    create_router, create_standalone_router, websocket_handler_v3,
+    create_router, create_router_with_origin_policy, create_standalone_router, websocket_handler,
+    websocket_handler_v3, websocket_route_v3, websocket_route_v3_with_origin_policy,
 };
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-use test_helpers::{create_test_server, test_server_config};
+use test_helpers::{create_test_server, test_server_config, RunningTestServer};
 
 fn repo_path(path: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
@@ -1685,7 +1685,7 @@ async fn test_production_style_router_has_top_level_v3_only() {
     let enhanced_router = create_router("*").with_state(server.clone());
     let app = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("*"))
         .with_state(server);
 
     let test_server = axum_test::TestServer::new(app);
@@ -1752,8 +1752,225 @@ async fn test_specific_cors_origins() {
     let app = create_router("http://localhost:3000,http://example.com").with_state(server);
 
     let test_server = axum_test::TestServer::new(app);
-    let response = test_server.get("/health").await;
-    response.assert_status_ok();
+    let allowed = test_server
+        .get("/health")
+        .add_header(
+            axum::http::header::ORIGIN,
+            axum::http::HeaderValue::from_static("http://example.com"),
+        )
+        .await;
+    allowed.assert_status_ok().assert_header(
+        axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+        "http://example.com",
+    );
+
+    let disallowed = test_server
+        .get("/health")
+        .add_header(
+            axum::http::header::ORIGIN,
+            axum::http::HeaderValue::from_static("https://evil.example"),
+        )
+        .await;
+    disallowed.assert_status_ok();
+    assert!(
+        !disallowed.contains_header(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        "the HTTP CORS response must use the same explicit allowlist"
+    );
+}
+
+async fn start_origin_policy_test_server(configured_origins: &str) -> RunningTestServer {
+    use axum::Router;
+    use signal_fish_server::security::OriginPolicy;
+
+    let server = create_test_server().await;
+    let policy = OriginPolicy::parse(configured_origins).expect("parse test Origin policy");
+    let app = Router::new()
+        .nest("/v2", create_router_with_origin_policy(policy.clone()))
+        .route(
+            "/v3/ws",
+            websocket_route_v3_with_origin_policy(policy.clone()),
+        )
+        .with_state(server.clone());
+    start_router_test_server(server, app).await
+}
+
+async fn start_router_test_server(
+    server: std::sync::Arc<signal_fish_server::server::EnhancedGameServer>,
+    app: axum::Router,
+) -> RunningTestServer {
+    RunningTestServer::spawn(server, app).await
+}
+
+async fn connect_with_origin(
+    addr: std::net::SocketAddr,
+    path: &str,
+    origin: Option<&'static str>,
+) -> Result<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    tokio_tungstenite::tungstenite::Error,
+> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    let mut request = format!("ws://{addr}{path}")
+        .into_client_request()
+        .expect("build WebSocket request");
+    if let Some(origin) = origin {
+        request.headers_mut().insert(
+            axum::http::header::ORIGIN,
+            axum::http::HeaderValue::from_static(origin),
+        );
+    }
+    tokio_tungstenite::connect_async(request)
+        .await
+        .map(|(socket, _response)| socket)
+}
+
+#[tokio::test]
+async fn regression_319_websocket_upgrades_enforce_explicit_origin_policy() {
+    use tokio_tungstenite::tungstenite::Error;
+
+    let running = start_origin_policy_test_server("https://allowed.example").await;
+    let addr = running.addr();
+    for path in ["/v2/ws", "/v3/ws"] {
+        let error = connect_with_origin(addr, path, Some("https://evil.example"))
+            .await
+            .expect_err("disallowed browser Origin must not receive a WebSocket upgrade");
+        let Error::Http(response) = error else {
+            panic!("{path}: expected an HTTP rejection, got {error}");
+        };
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::FORBIDDEN,
+            "{path}"
+        );
+
+        for origin in [Some("https://allowed.example"), None] {
+            let mut socket = connect_with_origin(addr, path, origin)
+                .await
+                .unwrap_or_else(|error| panic!("{path}, origin={origin:?}: {error}"));
+            socket
+                .close(None)
+                .await
+                .unwrap_or_else(|error| panic!("{path}: close test WebSocket: {error}"));
+        }
+    }
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn wildcard_origin_policy_preserves_development_websocket_access() {
+    let running = start_origin_policy_test_server("*").await;
+    let addr = running.addr();
+    for path in ["/v2/ws", "/v3/ws"] {
+        let mut socket = connect_with_origin(addr, path, Some("https://any.example"))
+            .await
+            .unwrap_or_else(|error| panic!("{path}: wildcard policy rejected Origin: {error}"));
+        socket
+            .close(None)
+            .await
+            .unwrap_or_else(|error| panic!("{path}: close test WebSocket: {error}"));
+    }
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn standalone_router_enforces_origin_policy_on_both_websocket_aliases() {
+    use tokio_tungstenite::tungstenite::Error;
+
+    let server = create_test_server().await;
+    let app = create_standalone_router("https://allowed.example").with_state(server.clone());
+    let running = start_router_test_server(server, app).await;
+    let addr = running.addr();
+
+    for path in ["/ws", "/v3/ws"] {
+        let error = connect_with_origin(addr, path, Some("https://evil.example"))
+            .await
+            .expect_err("standalone router must reject a disallowed browser Origin");
+        let Error::Http(response) = error else {
+            panic!("{path}: expected an HTTP rejection, got {error}");
+        };
+        assert_eq!(response.status(), axum::http::StatusCode::FORBIDDEN);
+
+        for origin in [Some("https://allowed.example"), None] {
+            let mut socket = connect_with_origin(addr, path, origin)
+                .await
+                .unwrap_or_else(|error| panic!("{path}, origin={origin:?}: {error}"));
+            socket
+                .close(None)
+                .await
+                .unwrap_or_else(|error| panic!("{path}: close test WebSocket: {error}"));
+        }
+    }
+
+    running.shutdown().await;
+}
+
+#[tokio::test]
+async fn invalid_legacy_router_configuration_denies_every_upgrade_shape() {
+    use axum::Router;
+    use tokio_tungstenite::tungstenite::Error;
+
+    let nested_server = create_test_server().await;
+    let nested = Router::new()
+        .nest("/v2", create_router("https://allowed.example/path"))
+        .route("/v3/ws", websocket_route_v3("https://allowed.example/path"))
+        .with_state(nested_server.clone());
+    let standalone_server = create_test_server().await;
+    let standalone = create_standalone_router("https://allowed.example/path")
+        .with_state(standalone_server.clone());
+
+    for (server, app, paths) in [
+        (nested_server, nested, &["/v2/ws", "/v3/ws"][..]),
+        (standalone_server, standalone, &["/ws", "/v3/ws"][..]),
+    ] {
+        let running = start_router_test_server(server, app).await;
+        let addr = running.addr();
+        for path in paths {
+            for origin in [Some("https://allowed.example"), None] {
+                let error = connect_with_origin(addr, path, origin)
+                    .await
+                    .expect_err("invalid legacy configuration must deny every upgrade");
+                let Error::Http(response) = error else {
+                    panic!("{path}, origin={origin:?}: expected HTTP rejection, got {error}");
+                };
+                assert_eq!(
+                    response.status(),
+                    axum::http::StatusCode::FORBIDDEN,
+                    "{path}, origin={origin:?}"
+                );
+            }
+        }
+        running.shutdown().await;
+    }
+}
+
+#[tokio::test]
+async fn raw_websocket_handlers_without_origin_policy_cannot_upgrade() {
+    use axum::routing::get;
+    use tokio_tungstenite::tungstenite::Error;
+
+    let server = create_test_server().await;
+    let app = axum::Router::new()
+        .route("/ws", get(websocket_handler))
+        .route("/v3/ws", get(websocket_handler_v3))
+        .with_state(server.clone());
+    let running = start_router_test_server(server, app).await;
+    let addr = running.addr();
+    for path in ["/ws", "/v3/ws"] {
+        let error = connect_with_origin(addr, path, None)
+            .await
+            .expect_err("a raw handler without required policy state must not upgrade");
+        let Error::Http(response) = error else {
+            panic!("{path}: expected an HTTP rejection, got {error}");
+        };
+        assert_eq!(
+            response.status(),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "{path}"
+        );
+    }
+
+    running.shutdown().await;
 }
 
 // ===========================================================================
@@ -1853,6 +2070,22 @@ fn test_config_validation_scenarios() {
                 c.security.enforce_app_id_allowlist = false;
             }),
             true,
+        ),
+        (
+            "blank CORS/WebSocket Origin policy → fails",
+            Box::new(|c: &mut Config| {
+                c.security.require_metrics_auth = false;
+                c.security.cors_origins = " ".to_string();
+            }),
+            false,
+        ),
+        (
+            "origin URI with a path → fails",
+            Box::new(|c: &mut Config| {
+                c.security.require_metrics_auth = false;
+                c.security.cors_origins = "https://game.example/path".to_string();
+            }),
+            false,
         ),
         (
             "metrics auth enabled, app-ID policy open → fails without token",

--- a/tests/reconnect_window_races_e2e.rs
+++ b/tests/reconnect_window_races_e2e.rs
@@ -92,7 +92,7 @@ use signal_fish_server::protocol::{
     ClientMessage, ErrorCode, PlayerId, ReconnectedPayload, RoomId, ServerMessage,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use std::sync::Arc;
 use std::time::Duration;
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
@@ -140,8 +140,6 @@ async fn start_server(
     window: Duration,
     cleanup_interval: Duration,
 ) -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     let mut server_config: ServerConfig = test_server_config();
     server_config.app_id_allowlist_enabled = true;
     server_config.reconnection_window = window;
@@ -177,7 +175,7 @@ async fn start_server(
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/reconnection_replay_e2e.rs
+++ b/tests/reconnection_replay_e2e.rs
@@ -21,7 +21,7 @@ use futures_util::{SinkExt, StreamExt};
 use signal_fish_server::config::AppRegistrationEntry;
 use signal_fish_server::protocol::{ClientMessage, PlayerId, ReplayStatus, RoomId, ServerMessage};
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
@@ -79,12 +79,10 @@ async fn start_server_default() -> (RunningTestServer, Arc<EnhancedGameServer>) 
 }
 
 async fn start_server(game_server: Arc<EnhancedGameServer>) -> RunningTestServer {
-    use axum::routing::get;
-
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/scenario_realworld_e2e.rs
+++ b/tests/scenario_realworld_e2e.rs
@@ -45,7 +45,7 @@ use signal_fish_server::protocol::{
     ClientMessage, ErrorCode, PlayerId, ReplayStatus, RoomId, ServerMessage,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{
     create_test_server, create_test_server_with_config, test_server_config, RunningTestServer,
 };
@@ -721,8 +721,6 @@ const RECONNECT_APP_ID: &str = "scenario-reconnect-app";
 /// `tests/reconnection_replay_e2e.rs`, the proven reconnect harness), and
 /// the in-process handle kept for `register_reconnect_token`.
 async fn start_reconnect_server() -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     let mut server_config = test_server_config();
     server_config.app_id_allowlist_enabled = true;
 
@@ -753,7 +751,7 @@ async fn start_reconnect_server() -> (RunningTestServer, Arc<EnhancedGameServer>
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .with_state(game_server.clone());
     let running_server = RunningTestServer::spawn(game_server.clone(), combined_router).await;
     (running_server, game_server)

--- a/tests/v3_edge_cases_e2e.rs
+++ b/tests/v3_edge_cases_e2e.rs
@@ -37,7 +37,7 @@ use signal_fish_server::protocol::{
     ClientMessage, ErrorCode, LobbyState, RoomJoinedPayload, ServerMessage, Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::connect_async;
 use v3_conformance_helpers::{ready, send, start_game, SERVER_MESSAGE_TIMEOUT};
@@ -80,8 +80,6 @@ async fn start_server() -> (RunningTestServer, Arc<EnhancedGameServer>) {
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     let mut server_config: ServerConfig = test_server_config();
     server_config.app_id_allowlist_enabled = true;
 
@@ -106,7 +104,7 @@ async fn start_server_with_session(
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_ice_pregather_e2e.rs
+++ b/tests/v3_ice_pregather_e2e.rs
@@ -28,7 +28,7 @@ use signal_fish_server::protocol::{
     ClientMessage, IceServer, PlayerId, RoomId, ServerMessage, Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
@@ -133,12 +133,10 @@ async fn start_server_with(
 }
 
 async fn start_server(game_server: Arc<EnhancedGameServer>) -> RunningTestServer {
-    use axum::routing::get;
-
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_interop_downgrade_e2e.rs
+++ b/tests/v3_interop_downgrade_e2e.rs
@@ -46,7 +46,7 @@ use signal_fish_server::protocol::{
     SessionPlanPayload, Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::connect_async;
 use v3_conformance_helpers::{await_ready_count, expect_session_plan_strict, ready, send};
@@ -111,8 +111,6 @@ fn host_session_config() -> SessionConfig {
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     let mut server_config: ServerConfig = test_server_config();
     server_config.app_id_allowlist_enabled = true;
 
@@ -137,7 +135,7 @@ async fn start_server_with_session(
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_multipeer_e2e.rs
+++ b/tests/v3_multipeer_e2e.rs
@@ -54,7 +54,7 @@ use signal_fish_server::protocol::{
     SessionPlanPayload, Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::connect_async;
 use v3_conformance_helpers::{
@@ -139,8 +139,6 @@ fn assert_static_then_default_stun_ice(ice_servers: &[IceServer]) {
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     let mut server_config: ServerConfig = test_server_config();
     server_config.app_id_allowlist_enabled = true;
 
@@ -165,7 +163,7 @@ async fn start_server_with_session(
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_negotiation_e2e.rs
+++ b/tests/v3_negotiation_e2e.rs
@@ -13,7 +13,7 @@ use signal_fish_server::protocol::{
     ClientMessage, ErrorCode, ServerMessage, Topology, Transport, PROTOCOL_INFO_TRANSPORT_WEBSOCKET,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use std::sync::Arc;
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -103,14 +103,12 @@ async fn start_v3_only_server(app_id_allowlist_enabled: bool) -> RunningTestServ
 }
 
 async fn start_server(game_server: Arc<EnhancedGameServer>) -> RunningTestServer {
-    use axum::routing::get;
-
     // Mirror main.rs wiring: enhanced router nested under /v2, plus a top-level
     // /v3/ws alias sharing the same connection handler.
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_replan_e2e.rs
+++ b/tests/v3_replan_e2e.rs
@@ -30,7 +30,7 @@ use signal_fish_server::protocol::{
     Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use websocket_test_helpers::{
@@ -108,8 +108,6 @@ fn assert_static_then_default_stun_ice(ice_servers: &[IceServer]) {
 }
 
 async fn start_server_with_session(session: SessionConfig) -> RunningTestServer {
-    use axum::routing::get;
-
     let mut server_config: ServerConfig = test_server_config();
     server_config.app_id_allowlist_enabled = true;
 
@@ -134,7 +132,7 @@ async fn start_server_with_session(session: SessionConfig) -> RunningTestServer 
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_session_plan_e2e.rs
+++ b/tests/v3_session_plan_e2e.rs
@@ -19,7 +19,7 @@ use signal_fish_server::protocol::{
     Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use std::sync::Arc;
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -99,12 +99,10 @@ async fn start_server_with_session(session: SessionConfig) -> RunningTestServer 
 }
 
 async fn start_server(game_server: Arc<EnhancedGameServer>) -> RunningTestServer {
-    use axum::routing::get;
-
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_signal_errors_e2e.rs
+++ b/tests/v3_signal_errors_e2e.rs
@@ -39,7 +39,7 @@ use signal_fish_server::protocol::{
     ClientMessage, ErrorCode, PlayerId, RoomId, ServerMessage, Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::connect_async;
 use v3_conformance_helpers::{send, SERVER_MESSAGE_TIMEOUT};
@@ -71,8 +71,6 @@ fn app_entry() -> AppRegistrationEntry {
 async fn start_server_with_config(
     mut server_config: ServerConfig,
 ) -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     server_config.app_id_allowlist_enabled = true;
 
     let mut protocol_config = test_protocol_config();
@@ -96,7 +94,7 @@ async fn start_server_with_config(
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_signaling_e2e.rs
+++ b/tests/v3_signaling_e2e.rs
@@ -21,7 +21,7 @@ use signal_fish_server::protocol::{
     ClientMessage, PlayerId, RoomId, ServerMessage, Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use std::sync::Arc;
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
@@ -78,12 +78,10 @@ async fn start_allowlist_server_with_config(
 }
 
 async fn start_server(game_server: Arc<EnhancedGameServer>) -> RunningTestServer {
-    use axum::routing::get;
-
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 

--- a/tests/v3_transport_status_e2e.rs
+++ b/tests/v3_transport_status_e2e.rs
@@ -50,7 +50,7 @@ use signal_fish_server::protocol::{
     Topology, Transport,
 };
 use signal_fish_server::server::{EnhancedGameServer, ServerConfig};
-use signal_fish_server::websocket::{create_router, websocket_handler_v3};
+use signal_fish_server::websocket::{create_router, websocket_route_v3};
 use test_helpers::{test_protocol_config, test_server_config, RunningTestServer};
 use tokio_tungstenite::connect_async;
 use v3_conformance_helpers::{
@@ -95,8 +95,6 @@ fn mesh_session_config() -> SessionConfig {
 async fn start_server_with_session(
     session: SessionConfig,
 ) -> (RunningTestServer, Arc<EnhancedGameServer>) {
-    use axum::routing::get;
-
     let mut server_config: ServerConfig = test_server_config();
     server_config.app_id_allowlist_enabled = true;
 
@@ -121,7 +119,7 @@ async fn start_server_with_session(
     let enhanced_router = create_router("http://localhost:3000").with_state(game_server.clone());
     let combined_router = axum::Router::new()
         .nest("/v2", enhanced_router)
-        .route("/v3/ws", get(websocket_handler_v3))
+        .route("/v3/ws", websocket_route_v3("http://localhost:3000"))
         .fallback(|| async { "Use /v2/ws or /v3/ws" })
         .with_state(game_server.clone());
 


### PR DESCRIPTION
## Summary

- wait up to one strict second for the native WebRTC statistics accumulator to expose the already-selected ICE pair, without weakening the exact candidate type/address oracle
- parse one canonical browser-Origin policy for HTTP CORS and every enhanced WebSocket upgrade path
- reject disallowed or malformed Origins before connection registration while preserving documented origin-less native clients and explicit wildcard/opaque-origin compatibility
- add deterministic deadline tests, production-shaped loopback upgrade coverage, source-hygienic server shutdown, and synchronized operator documentation

## Root causes

The native client sampled WebRTC statistics immediately after both SCTP channels opened. webrtc-rs can expose channel readiness before its driver drains the selected-pair event into the statistics accumulator, so healthy gameplay traffic could still produce a missing diagnostic event.

The server used `security.cors_origins` only to build HTTP response CORS headers. CORS middleware does not authorize browser WebSocket handshakes, so a configured disallowed Origin could still receive HTTP 101 on `/v2/ws` and `/v3/ws`.

## Validation

- root and native `cargo fmt --check`
- root and native warnings-denied Clippy across all targets/features
- `cargo test --locked --all-features` (770 library tests plus all integration targets)
- `cargo deny --all-features check`
- real `scripts/run-webrtc-interop.sh`: 94 native unit tests and all 8 live multi-process scenarios
- CI/MSRV/docs/workflow/LLM/tooling/Markdown/badge/source-hygiene policy gates
- hook readiness, pre-commit, and pre-push preflights
- repeated adversarial review ending with zero actionable findings

Closes #301.
Closes #319.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes browser WebSocket upgrade authorization (previously ignored Origin) and startup config validation; incorrect allowlists can block legitimate clients or leave deployments misconfigured until fixed.
> 
> **Overview**
> Fixes flaky native WebRTC interop (#301) and closes a browser WebSocket origin bypass (#319).
> 
> The **native reference client** no longer treats a single `get_stats` snapshot as proof of the selected ICE pair. It **polls for up to one second** (10 ms intervals) until the same type/address oracle succeeds, with strict deadline semantics so slow snapshots cannot extend the budget. Unit tests cover delayed success and boundary cancellation.
> 
> The **server** introduces shared **`OriginPolicy`** (parsed via the `url` crate) so `security.cors_origins` drives **both** HTTP CORS and **`Origin` checks on `/v2/ws` and `/v3/ws`** before upgrade. Disallowed browser origins get **HTTP 403**; malformed allowlists fail **startup validation** instead of falling back to permissive CORS. Router helpers attach the policy extension; origin-less native clients stay allowed. Docs, changelog, Fortress WASM harness CORS for the test page origin, and v3 e2e fixtures are aligned with the policy-bearing routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1886ff2fe55c81f14d0caf90e3729a083814ed6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->